### PR TITLE
Properly support ResourceYAMLCollection

### DIFF
--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -91,12 +91,24 @@ async def async_setup(hass: HomeAssistant, config: Config) -> bool:
                 if data[CONF_URL] == STRATEGY_PATH
             )
         except StopIteration:
-            # Register strategy module
-            data = await resources.async_create_item(
-                {CONF_RESOURCE_TYPE_WS: "module", CONF_URL: STRATEGY_PATH}
-            )
-            _LOGGER.debug("Registered strategy module (resource ID %s)", data[CONF_ID])
-            hass.data[DOMAIN]["resources"] = True
+            if isinstance(resources, ResourceYAMLCollection):
+                _LOGGER.warning(
+                    "Strategy module can't automatically be registered because this "
+                    "Home Assistant instance is running in YAML mode for resources. "
+                    "Please add a new entry in the list under the resources key in "
+                    "the lovelace section of your config as follows:\n  - url: %s"
+                    "\n    type: module",
+                    STRATEGY_PATH,
+                )
+            else:
+                # Register strategy module
+                data = await resources.async_create_item(
+                    {CONF_RESOURCE_TYPE_WS: "module", CONF_URL: STRATEGY_PATH}
+                )
+                _LOGGER.debug(
+                    "Registered strategy module (resource ID %s)", data[CONF_ID]
+                )
+                hass.data[DOMAIN]["resources"] = True
         else:
             _LOGGER.debug(
                 "Strategy module already registered with resource ID %s", res_id

--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -96,7 +96,7 @@ async def async_setup(hass: HomeAssistant, config: Config) -> bool:
                     "Strategy module can't automatically be registered because this "
                     "Home Assistant instance is running in YAML mode for resources. "
                     "Please add a new entry in the list under the resources key in "
-                    "the lovelace section of your config as follows:\n  - url: %s"
+                    'the lovelace section of your config as follows:\n  - url: "%s"'
                     "\n    type: module",
                     STRATEGY_PATH,
                 )

--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -69,15 +69,14 @@ CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 async def async_setup(hass: HomeAssistant, config: Config) -> bool:
     """Set up integration."""
     hass.data.setdefault(DOMAIN, {CONF_LOCKS: {}, COORDINATORS: {}, "resources": False})
+    # Expose strategy javascript
+    hass.http.register_static_path(
+        STRATEGY_PATH, Path(__file__).parent / "www" / STRATEGY_FILENAME
+    )
+    _LOGGER.debug("Exposed strategy module at %s", STRATEGY_PATH)
 
     resources: ResourceStorageCollection | ResourceYAMLCollection
     if resources := hass.data.get(LL_DOMAIN, {}).get("resources"):
-        # Expose strategy javascript
-        hass.http.register_static_path(
-            STRATEGY_PATH, Path(__file__).parent / "www" / STRATEGY_FILENAME
-        )
-        _LOGGER.debug("Exposed strategy module at %s", STRATEGY_PATH)
-
         # Load resources if needed
         if not resources.loaded:
             await resources.async_load()
@@ -86,7 +85,7 @@ async def async_setup(hass: HomeAssistant, config: Config) -> bool:
 
         try:
             res_id = next(
-                data[CONF_ID]
+                data.get(CONF_ID)
                 for data in resources.async_items()
                 if data[CONF_URL] == STRATEGY_PATH
             )
@@ -114,9 +113,9 @@ async def async_setup(hass: HomeAssistant, config: Config) -> bool:
                 "Strategy module already registered with resource ID %s", res_id
             )
 
-        # Set up websocket API
-        await async_websocket_setup(hass)
-        _LOGGER.debug("Finished setting up websocket API")
+    # Set up websocket API
+    await async_websocket_setup(hass)
+    _LOGGER.debug("Finished setting up websocket API")
 
     # Hard refresh usercodes
     async def _hard_refresh_usercodes(service: ServiceCall) -> None:
@@ -266,7 +265,7 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
         COORDINATORS: {},
     }:
         resources: ResourceStorageCollection
-        if resources := hass.data[LL_DOMAIN].get("resources"):
+        if resources := hass.data.get(LL_DOMAIN, {}).get("resources"):
             if hass_data["resources"]:
                 try:
                     resource_id = next(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Generator
+from typing import Any
 
 import pytest
 from pytest_homeassistant_custom_component.common import (
@@ -55,6 +56,20 @@ def config_flow_fixture(hass: HomeAssistant) -> Generator[None, None, None]:
 
     with mock_config_flow(TEST_DOMAIN, MockFlow):
         yield
+
+
+# @pytest.fixture(name="setup_lovelace_ui")
+# async def setup_lovelace_ui_fixture(hass: HomeAssistant):
+#     """Set up Lovelace in UI mode."""
+#     assert await async_setup_component(hass, LL_DOMAIN, {})
+#     yield
+
+
+@pytest.fixture(name="setup_lovelace_ui")
+async def setup_lovelace_ui_fixture(hass: HomeAssistant, config: dict[str, Any]):
+    """Set up Lovelace in UI mode."""
+    assert await async_setup_component(hass, LL_DOMAIN, {"lovelace": config})
+    yield
 
 
 @pytest.fixture(name="mock_lock_config_entry")
@@ -125,8 +140,6 @@ async def mock_lock_config_entry_fixture(hass: HomeAssistant, mock_config_flow):
     config_entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
-
-    assert await async_setup_component(hass, LL_DOMAIN, {})
 
     yield config_entry
 


### PR DESCRIPTION
## Proposed change
`ResourceYAMLCollection` is read only so we can't automatically add an entry for the resource. Instead, the code now logs a warning telling the user to add the following under `lovelace.resources`:

```yaml
  - url: "/lock_code_manager_files/lock-code-manager-strategy.js"
    type: module
```

Simple example in `configuration.yaml`:
```yaml
lovelace:
    resources:
      - url: "/lock_code_manager_files/lock-code-manager-strategy.js"
        type: module
```

## Type of change

<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

-   [ ] Dependency upgrade
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (which adds functionality)
-   [ ] Breaking change (fix/feature causing existing functionality to break)
-   [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

-   This PR fixes or closes issue: fixes https://github.com/raman325/lock_code_manager/issues/71
-   This PR is related to issue:
