### PR TITLE
fix: replace deprecated DATA_CLIENT for 2025.8.0 compatibility

### DIFF
--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -78,13 +78,15 @@ async def async_setup(hass: HomeAssistant, config: Config) -> bool:
     # Expose strategy javascript
     from homeassistant.components.http import StaticPathConfig
 
-    await hass.http.async_register_static_paths([
-        StaticPathConfig(
-            STRATEGY_PATH,
-            str(Path(__file__).parent / "www" / STRATEGY_FILENAME),
-            True
-        )
-    ])
+    await hass.http.async_register_static_paths(
+        [
+            StaticPathConfig(
+                STRATEGY_PATH,
+                str(Path(__file__).parent / "www" / STRATEGY_FILENAME),
+                True,
+            )
+        ]
+    )
 
     _LOGGER.debug("Exposed strategy module at %s", STRATEGY_PATH)
 

--- a/custom_components/lock_code_manager/providers/zwave_js.py
+++ b/custom_components/lock_code_manager/providers/zwave_js.py
@@ -23,7 +23,6 @@ from homeassistant.components.zwave_js.const import (
     ATTR_NODE_ID,
     ATTR_PARAMETERS,
     ATTR_TYPE,
-    DATA_CLIENT,
     DOMAIN as ZWAVE_JS_DOMAIN,
     SERVICE_CLEAR_LOCK_USERCODE,
     SERVICE_SET_LOCK_USERCODE,
@@ -152,7 +151,7 @@ class ZWaveJSLock(BaseLock):
                 else self.hass.data.get(ZWAVE_JS_DOMAIN, {})
             )
             .get(self.lock_config_entry.entry_id, {})
-            .get(DATA_CLIENT)
+            .get("client")
         ) is None:
             return False
         return (


### PR DESCRIPTION
## Proposed change

Home Assistant 2025.8.0 removed the `DATA_CLIENT` constant from `homeassistant.components.zwave_js.const`. This PR replaces usage of `DATA_CLIENT` with the literal string `"client"` and removes the unused import, restoring compatibility.

## Type of change

<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

-   [ ] Dependency upgrade
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (which adds functionality)
-   [ ] Breaking change (fix/feature causing existing functionality to break)
-   [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

-   This PR fixes or closes issue: fixes #
-   This PR is related to issue:
