### PR TITLE
Add fixes for Home Assistant 2025.7 and 2025.8 compatibility

### DIFF
--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -376,7 +376,7 @@ async def async_update_listener(hass: HomeAssistant, config_entry: ConfigEntry) 
     }:
         setup_tasks[platform] = config_entry.async_create_task(
             hass,
-            hass.config_entries.async_forward_entry_setup(config_entry, platform),
+            hass.config_entries.async_forward_entry_setups(config_entry, [platform]),
             "setup_new_platforms",
         )
     await asyncio.gather(*setup_tasks.values())

--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -78,13 +78,15 @@ async def async_setup(hass: HomeAssistant, config: Config) -> bool:
     # Expose strategy javascript
     from homeassistant.components.http import StaticPathConfig
 
-    await hass.http.async_register_static_paths([
-        StaticPathConfig(
-            STRATEGY_PATH,
-            str(Path(__file__).parent / "www" / STRATEGY_FILENAME),
-            True
-        )
-    ])
+    await hass.http.async_register_static_paths(
+        [
+            StaticPathConfig(
+                STRATEGY_PATH,
+                str(Path(__file__).parent / "www" / STRATEGY_FILENAME),
+                True,
+            )
+        ]
+    )
 
     _LOGGER.debug("Exposed strategy module at %s", STRATEGY_PATH)
 

--- a/custom_components/lock_code_manager/providers/zwave_js.py
+++ b/custom_components/lock_code_manager/providers/zwave_js.py
@@ -148,7 +148,9 @@ class ZWaveJSLock(BaseLock):
         if not zwave_data:
             return False
 
-        client_entry = getattr(zwave_data, "_client_driver_map", {}).get(self.lock_config_entry.entry_id)
+        client_entry = getattr(zwave_data, "_client_driver_map", {}).get(
+            self.lock_config_entry.entry_id
+        )
 
         if client_entry is None or client_entry.client is None:
             return False
@@ -158,7 +160,6 @@ class ZWaveJSLock(BaseLock):
             and client_entry.client.connected
             and client_entry.client.driver is not None
         )
-
 
     async def async_hard_refresh_codes(self) -> None:
         """

--- a/custom_components/lock_code_manager/providers/zwave_js.py
+++ b/custom_components/lock_code_manager/providers/zwave_js.py
@@ -23,7 +23,6 @@ from homeassistant.components.zwave_js.const import (
     ATTR_NODE_ID,
     ATTR_PARAMETERS,
     ATTR_TYPE,
-    DATA_CLIENT,
     DOMAIN as ZWAVE_JS_DOMAIN,
     SERVICE_CLEAR_LOCK_USERCODE,
     SERVICE_SET_LOCK_USERCODE,
@@ -152,7 +151,7 @@ class ZWaveJSLock(BaseLock):
                 else self.hass.data.get(ZWAVE_JS_DOMAIN, {})
             )
             .get(self.lock_config_entry.entry_id, {})
-            .get(DATA_CLIENT)
+            .get("client")
         ) is None:
             return False
         return (

--- a/custom_components/lock_code_manager/providers/zwave_js.py
+++ b/custom_components/lock_code_manager/providers/zwave_js.py
@@ -143,22 +143,22 @@ class ZWaveJSLock(BaseLock):
 
     async def async_is_connection_up(self) -> bool:
         """Return whether connection to lock is up."""
-        if (
-            client := (
-                self.lock_config_entry.runtime_data
-                if hasattr(self.lock_config_entry, "runtime_data")
-                and self.lock_config_entry.runtime_data
-                else self.hass.data.get(ZWAVE_JS_DOMAIN, {})
-            )
-            .get(self.lock_config_entry.entry_id, {})
-            .get("client")
-        ) is None:
+        zwave_data = self.hass.data.get(ZWAVE_JS_DOMAIN)
+
+        if not zwave_data:
             return False
+
+        client_entry = getattr(zwave_data, "_client_driver_map", {}).get(self.lock_config_entry.entry_id)
+
+        if client_entry is None or client_entry.client is None:
+            return False
+
         return (
             self.lock_config_entry.state == ConfigEntryState.LOADED
-            and client.connected
-            and client.driver is not None
+            and client_entry.client.connected
+            and client_entry.client.driver is not None
         )
+
 
     async def async_hard_refresh_codes(self) -> None:
         """


### PR DESCRIPTION
## Breaking change

This update contains a breaking change for users of the Z-Wave JS integration due to internal data structure changes in Home Assistant 2025.8.  
- The internal client object is now accessed differently, requiring updates in this integration’s code.  
- Users upgrading to 2025.8 should ensure they update this integration to avoid runtime errors related to Z-Wave JS client access.

## Proposed change

This PR includes fixes for compatibility with Home Assistant 2025.7 and 2025.8:

- Replaces deprecated `register_static_path` with `async_register_static_paths` for HA 2025.7 compatibility.  
- Removes the deprecated `DATA_CLIENT` import and updates how the Z-Wave JS client is accessed in 2025.8, replacing dictionary `.get()` calls with access to the internal `_client_driver_map` attribute.  
- Updates the `async_is_connection_up` method and related Z-Wave JS client usage to prevent `AttributeError` on 2025.8.

## Type of change

<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

-   [ ] Dependency upgrade
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (which adds functionality)
-   [ ] Breaking change (fix/feature causing existing functionality to break)
-   [ ] Code quality improvements to existing code or addition of tests

## Additional information

This PR depends on the separate PR that introduced the 2025.7 static path fix.  [PR#528](https://github.com/raman325/lock_code_manager/pull/528)
-   Fixes compatibility issues encountered when upgrading to Home Assistant 2025.8.  
-   No open issue linked.
