### PR TITLE
Fix Home Assistant Core 2025.7+ compatibility issues

### DIFF
--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -10,6 +10,7 @@ from typing import Any
 
 import voluptuous as vol
 
+from homeassistant.components.http import StaticPathConfig
 from homeassistant.components.lovelace.const import (
     CONF_RESOURCE_TYPE_WS,
     DOMAIN as LL_DOMAIN,
@@ -76,8 +77,12 @@ async def async_setup(hass: HomeAssistant, config: Config) -> bool:
     """Set up integration."""
     hass.data.setdefault(DOMAIN, {CONF_LOCKS: {}, COORDINATORS: {}, "resources": False})
     # Expose strategy javascript
-    hass.http.register_static_path(
-        STRATEGY_PATH, Path(__file__).parent / "www" / STRATEGY_FILENAME
+    await hass.http.async_register_static_paths(
+        [
+            StaticPathConfig(
+                STRATEGY_PATH, Path(__file__).parent / "www" / STRATEGY_FILENAME, False
+            )
+        ]
     )
     _LOGGER.debug("Exposed strategy module at %s", STRATEGY_PATH)
 

--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -31,13 +31,13 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_STARTED,
 )
 from homeassistant.core import (
-    Config,
     CoreState,
     Event,
     HomeAssistant,
     ServiceCall,
     callback,
 )
+from homeassistant.core_config import Config
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import (
     config_validation as cv,


### PR DESCRIPTION
## Summary

Fixes three critical compatibility issues to ensure the integration works with Home Assistant Core 2025.7, 2025.8, and 2025.11+.

## Issues Fixed

### Issue #531: Deprecated Config Import (HA Core 2025.11)

**Problem:** Integration was using deprecated `Config` import from `homeassistant.core`, which will be removed in HA Core 2025.11.

**Solution:** 
- Changed from: `from homeassistant.core import Config`
- Changed to: `from homeassistant.core_config import Config`

### Issue #530, #528: Deprecated register_static_path (HA Core 2025.7+)

**Problem:** Integration was using synchronous `hass.http.register_static_path()` which performs blocking I/O in the event loop.

**Solution:**
- Replaced with async API: `await hass.http.async_register_static_paths([StaticPathConfig(...)])`
- Added import: `from homeassistant.components.http import StaticPathConfig`

### Issue #530: Z-Wave JS DATA_CLIENT Deprecation (HA Core 2025.8+)

**Problem:** Integration was using deprecated `DATA_CLIENT` constant to access Z-Wave JS client objects.

**Solution:**
- Removed `DATA_CLIENT` import
- Changed to: `getattr(zwave_data, "_client_driver_map", {}).get(entry_id)`
- Updated client reference from `client` to `client_entry.client`

**Bonus:** Modernized imports by moving `Iterable` from `typing` to `collections.abc` (Python 3.9+ best practice)

## Files Changed

- `custom_components/lock_code_manager/__init__.py`: Config import and static path registration fixes
- `custom_components/lock_code_manager/providers/zwave_js.py`: Z-Wave JS client access pattern update

## Related Issues

Closes #531
Closes #530
Closes #528

🤖 Generated with [Claude Code](https://claude.com/claude-code)