### PR TITLE
Fix auto-merge workflow to use modern GitHub Actions best practices

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -1,0 +1,31 @@
+---
+name: auto-merge
+
+"on":
+  pull_request:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    # Only run on Dependabot PRs
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      # Auto-merge patch and minor updates after CI passes
+      - name: Enable auto-merge for Dependabot PRs
+        if: >-
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

The auto-merge workflow was failing with this error:
```
Error: Input required and not supplied: github-token
```

**Root Cause:** Dependabot PRs run in a restricted security context where custom secrets (like `mytoken`) are NOT available. This is a GitHub security feature to prevent token exposure in Dependabot PRs.

## Solution

Updated the workflow to use GitHub's officially recommended approach (as of 2025):

### Key Changes

1. **Use `GITHUB_TOKEN` instead of custom secrets**
   - Works in Dependabot's security context
   - No need to manage custom tokens

2. **Added proper permissions**
   ```yaml
   permissions:
     contents: write
     pull-requests: write
   ```

3. **Security best practices**
   - Check `github.event.pull_request.user.login == 'dependabot[bot]'` instead of relying on actor
   - Use official `dependabot/fetch-metadata@v2` action

4. **Smart auto-merge logic**
   - Uses `gh pr merge --auto` (enables auto-merge, waits for CI)
   - Only auto-merges **patch** and **minor** semver updates
   - Major updates still require manual review
   - Uses squash merge for cleaner history

## Benefits

- ✅ **Works correctly** - No more "github-token" errors
- ✅ **More secure** - No custom tokens needed
- ✅ **Safer** - Waits for all CI checks to pass before merging
- ✅ **More selective** - Only patch/minor updates (not major breaking changes)
- ✅ **Future-proof** - Follows GitHub's official 2025 best practices

## Testing

You can see the workflow was failing on recent Dependabot PRs:
- [Failed run example](https://github.com/raman325/lock_code_manager/actions/runs/18972134730)

The new workflow will enable auto-merge on Dependabot PRs, and they'll merge automatically once all required CI checks pass.

## Repository Requirements

For this to work, the repository must have **"Allow auto-merge"** enabled in:
> Settings → General → Pull Requests → ✅ Allow auto-merge

(This is likely already enabled, but worth verifying)

## References

- [GitHub Docs: Automating Dependabot with GitHub Actions](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions)
- [dependabot/fetch-metadata action](https://github.com/dependabot/fetch-metadata)

🤖 Generated with [Claude Code](https://claude.com/claude-code)