### PR TITLE
Fix custom card UI issue

### DIFF
--- a/ts/hacs-card.ts
+++ b/ts/hacs-card.ts
@@ -38,4 +38,4 @@ class HacsCard extends LitElement {
     }
 }
 
-customElements.define('hacs-card', HacsCard);
+customElements.define('custom:hacs-card', HacsCard);


### PR DESCRIPTION
## Proposed change

The `hacs-card`, which isn't used anywhere but is defined in the code, did not have the `custom:` prefix before it. I am not sure if this resolves the issue mentioned in https://github.com/raman325/lock_code_manager/issues/575 because I was able to reproduce it, this resolved it, but now I can't reproduce it when I revert the changes... @Wraeyth are you able to test this PR before I merge? If not, I will release this as a new pre-release (sorry downgraded back to the version number that actually fit semantic versioning) 

## Type of change

<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

-   [ ] Dependency upgrade
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (which adds functionality)
-   [ ] Breaking change (fix/feature causing existing functionality to break)
-   [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

-   This PR fixes or closes issue: fixes #
-   This PR is related to issue: https://github.com/raman325/lock_code_manager/issues/575
