### PR TITLE
Fix CI: Add apt-get update before installing libudev-dev

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -30,6 +30,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install libudev-dev
           python -m pip install --upgrade pip
           pip install -r requirements_dev.txt


### PR DESCRIPTION
## Summary

Fix CI workflow failure caused by stale apt package index.

## Problem

The pytest CI was failing with 404 errors:
```
E: Failed to fetch https://security.ubuntu.com/ubuntu/pool/main/s/systemd/libudev-dev_255.4-1ubuntu8.11_amd64.deb  404  Not Found
```

## Solution

Add `sudo apt-get update` before `sudo apt-get install libudev-dev` to ensure the package index is current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)