### PR TITLE
Fix AGENTS.md review comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Lock Code Manager is a Home Assistant custom integration that allows users to ma
 - Provider connection failures no longer advance rate-limit timing; see `test_connection_failure_does_not_rate_limit_next_operation` for regression coverage.
 - Lovelace strategy resource: only needs to be registered once globally; if HA is in YAML mode we skip removal on unload (mirrors ha_scrypted handling). New test `test_resource_unload_skips_yaml_mode` covers the YAML guard.
 - Claude and Codex collaborated on the startup flapping fix (see “Startup Code Flapping Issue” below). Connection handling is no longer regressed after this session, but keep an eye on `tests/_base/test_provider.py::test_*disconnected` and `tests/test_binary_sensor.py::test_handles_disconnected_lock_on_*` whenever touching provider logic.
-- A focused test command that confirms the connection/ retry behaviour is `source venv/bin/activate && pytest tests/_base/test_provider.py -k disconnected -q`.
+- A focused test command that confirms the connection/retry behaviour is `source venv/bin/activate && pytest tests/_base/test_provider.py -k disconnected -q`.
 - This session also added the `AGENTS.md` mirror of `CLAUDE.md` so future coding agents (e.g., GPT-based) can track their own context along with Claude’s notes. Keep both files updated when architecture/process guidance changes.
 
 ## Architecture
@@ -75,7 +75,7 @@ Lock Code Manager is a Home Assistant custom integration that allows users to ma
 ```bash
 scripts/setup
 ```
-Creates Python 3.12 venv, installs dependencies with uv, sets up pre-commit hooks, and installs Node dependencies.
+Creates Python 3.13 venv, installs dependencies with uv, sets up pre-commit hooks, and installs Node dependencies.
 
 ### Testing
 ```bash
@@ -420,7 +420,7 @@ This section tracks potential improvements, refactoring opportunities, and featu
 
 **Status:** Not started - Needs comprehensive audit first
 
-#### 3c. Move Sync Logic to Coordinator
+#### 4c. Move Sync Logic to Coordinator
 
 **Initial Analysis:** The startup flapping fix (see Bug Fixes section) added `_initial_state_loaded` flag to handle race conditions during startup. This complexity exists because the in-sync binary sensor reads state from other entities and compares with coordinator data, creating timing dependencies.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,3 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository. `AGENTS.md` is the master file for guidance for any coding agent, including Claude Code. Any agents expecting to reference `CLAUDE.md` should reference `AGENTS.md` instead and should keep it up to date as instructed.
+This file provides brief guidance to Claude Code (claude.ai/code) when working with code in this repository. `AGENTS.md` is the master file for guidance for any coding agent, including Claude Code. Claude Code users should also reference `AGENTS.md` for complete guidance and keep it up to date as instructed.


### PR DESCRIPTION
## Summary
Addresses review comments from PR #676:

- Fix typo: "connection/ retry" → "connection/retry" (line 17)
- Update Python version: 3.12 → 3.13 in setup description (line 78)
- Fix section numbering: "3c" → "4c" to match section 4 (line 423)
- Clarify CLAUDE.md wording to avoid circular reference logic

## Test plan
- [x] Documentation-only changes, no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)