### PR TITLE
Move coordinator setup into BaseLock

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -14,7 +14,7 @@
 
 - On slot changes, trigger a partial coordinator refresh (or update coordinator data from value updates) so polling only corrects drift/out-of-HA changes.
 - Deduplicate coordinator refresh vs `hard_refresh_usercodes` cache refresh logic for Z-Wave JS.
-- Move coordinator setup into `_async_setup()` where it reduces boilerplate.
+- Simplify coordinator storage: since `lock.coordinator` now exists on BaseLock instances (which are global to LCM), `hass_data[COORDINATORS]` and `runtime_data.coordinators` may be redundant.
 - Review dispatcher usage and simplify if a smaller pattern works.
 - Track entity registry updates and warn if LCM entities change entity IDs (reload required).
 - Explore using HA's scheduler instead of direct sleeps, with task tracking managed by HA.

--- a/custom_components/lock_code_manager/coordinator.py
+++ b/custom_components/lock_code_manager/coordinator.py
@@ -3,14 +3,16 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DOMAIN
-from .providers import BaseLock
+
+if TYPE_CHECKING:
+    from .providers import BaseLock
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/lock_code_manager/providers/virtual.py
+++ b/custom_components/lock_code_manager/providers/virtual.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 import logging
 from typing import TypedDict
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.storage import Store
 
@@ -34,12 +35,13 @@ class VirtualLock(BaseLock):
         """Return integration domain."""
         return "virtual"
 
-    async def async_setup(self) -> None:
+    async def async_setup(self, config_entry: ConfigEntry) -> None:
         """Set up lock."""
         self._store = Store(
             self.hass, 1, f"{self.domain}_{DOMAIN}_{self.lock.entity_id}"
         )
         await self.async_hard_refresh_codes()
+        await super().async_setup(config_entry)
 
     async def async_unload(self, remove_permanently: bool) -> None:
         """Unload lock."""

--- a/custom_components/lock_code_manager/providers/zwave_js.py
+++ b/custom_components/lock_code_manager/providers/zwave_js.py
@@ -149,8 +149,9 @@ class ZWaveJSLock(BaseLock):
         """Return integration domain."""
         return ZWAVE_JS_DOMAIN
 
-    async def async_setup(self) -> None:
+    async def async_setup(self, config_entry: ConfigEntry) -> None:
         """Set up lock."""
+        await super().async_setup(config_entry)
         self._listeners.append(
             self.hass.bus.async_listen(
                 ZWAVE_JS_NOTIFICATION_EVENT,


### PR DESCRIPTION
## Proposed change

Move coordinator setup into `BaseLock.async_setup()` so creation/refresh is centralized per lock, reuse existing coordinators, and avoid HA warnings by choosing the correct refresh path based on entry state. Update providers and tests accordingly, with virtual provider loading persisted codes before initial refresh.

## Type of change

-   [ ] Dependency upgrade
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (which adds functionality)
-   [ ] Breaking change (fix/feature causing existing functionality to break)
-   [x] Code quality improvements to existing code or addition of tests

## Additional information

-   This PR fixes or closes issue: fixes #
-   This PR is related to issue:
