### PR TITLE
Request refresh when reusing coordinator

### DIFF
--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -163,6 +163,7 @@ class BaseLock:
         # Reuse existing coordinator or create new one
         if lock_entity_id in hass_data[COORDINATORS]:
             self.coordinator = hass_data[COORDINATORS][lock_entity_id]
+            self.coordinator.async_request_refresh()
         else:
             self.coordinator = hass_data[COORDINATORS][lock_entity_id] = (
                 LockUsercodeUpdateCoordinator(self.hass, self, config_entry)


### PR DESCRIPTION
## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

When a coordinator is reused (shared lock across entries), request a refresh so newly attached entries don't wait on the next interval to see current lock data. Uses `async_request_refresh()` to avoid forcing immediate I/O.

## Type of change

-   [ ] Dependency upgrade
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (which adds functionality)
-   [ ] Breaking change (fix/feature causing existing functionality to break)
-   [ ] Code quality improvements to existing code or addition of tests

## Additional information

-   This PR fixes or closes issue: fixes #
-   This PR is related to issue:
