### PR TITLE
Follow-up: coordinator setup centralization

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -14,7 +14,6 @@
 
 - On slot changes, trigger a partial coordinator refresh (or update coordinator data from value updates) so polling only corrects drift/out-of-HA changes.
 - Deduplicate coordinator refresh vs `hard_refresh_usercodes` cache refresh logic for Z-Wave JS.
-- Simplify coordinator storage: since `lock.coordinator` now exists on BaseLock instances (which are global to LCM), `hass_data[COORDINATORS]` and `runtime_data.coordinators` may be redundant.
 - Review dispatcher usage and simplify if a smaller pattern works.
 - Track entity registry updates and warn if LCM entities change entity IDs (reload required).
 - Explore using HA's scheduler instead of direct sleeps, with task tracking managed by HA.

--- a/custom_components/lock_code_manager/binary_sensor.py
+++ b/custom_components/lock_code_manager/binary_sensor.py
@@ -85,7 +85,16 @@ async def async_setup_entry(
         lock: BaseLock, slot_num: int, ent_reg: er.EntityRegistry
     ):
         """Add code slot sensor entities for slot."""
-        coordinator = config_entry.runtime_data.coordinators[lock.lock.entity_id]
+        coordinator = lock.coordinator
+        if coordinator is None:
+            _LOGGER.warning(
+                "%s (%s): Coordinator missing for lock %s when adding slot %s entities",
+                config_entry.entry_id,
+                config_entry.title,
+                lock.lock.entity_id,
+                slot_num,
+            )
+            return
         async_add_entities(
             [
                 LockCodeManagerCodeSlotInSyncEntity(

--- a/custom_components/lock_code_manager/const.py
+++ b/custom_components/lock_code_manager/const.py
@@ -25,9 +25,6 @@ ATTR_LCM_CONFIG_ENTRY_ID = "lock_code_manager_config_entry_id"
 ATTR_LOCK_CONFIG_ENTRY_ID = "lock_config_entry_id"
 ATTR_EXTRA_DATA = "extra_data"
 
-# hass.data attributes
-COORDINATORS = "coordinators"
-
 # Events
 EVENT_LOCK_STATE_CHANGED = f"{DOMAIN}_lock_state_changed"
 

--- a/custom_components/lock_code_manager/data.py
+++ b/custom_components/lock_code_manager/data.py
@@ -13,7 +13,6 @@ from homeassistant.const import Platform
 from .const import CONF_SLOTS
 
 if TYPE_CHECKING:
-    from .coordinator import LockUsercodeUpdateCoordinator
     from .providers import BaseLock
 
 _LOGGER = logging.getLogger(__name__)
@@ -24,7 +23,6 @@ class LockCodeManagerConfigEntryData:
     """Runtime data for a Lock Code Manager config entry."""
 
     locks: dict[str, BaseLock] = field(default_factory=dict)
-    coordinators: dict[str, LockUsercodeUpdateCoordinator] = field(default_factory=dict)
     setup_tasks: dict[str | Platform, asyncio.Task[Any]] = field(default_factory=dict)
 
 

--- a/custom_components/lock_code_manager/sensor.py
+++ b/custom_components/lock_code_manager/sensor.py
@@ -33,7 +33,16 @@ async def async_setup_entry(
         lock: BaseLock, slot_num: int, ent_reg: er.EntityRegistry
     ) -> None:
         """Add code slot sensor entities for slot."""
-        coordinator = config_entry.runtime_data.coordinators[lock.lock.entity_id]
+        coordinator = lock.coordinator
+        if coordinator is None:
+            _LOGGER.warning(
+                "%s (%s): Coordinator missing for lock %s when adding slot %s entities",
+                config_entry.entry_id,
+                config_entry.title,
+                lock.lock.entity_id,
+                slot_num,
+            )
+            return
         async_add_entities(
             [
                 LockCodeManagerCodeSlotSensorEntity(

--- a/tests/_base/test_provider.py
+++ b/tests/_base/test_provider.py
@@ -11,7 +11,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
-from custom_components.lock_code_manager.const import COORDINATORS, DOMAIN
+from custom_components.lock_code_manager.const import DOMAIN
 from custom_components.lock_code_manager.exceptions import LockDisconnected
 from custom_components.lock_code_manager.providers._base import BaseLock
 
@@ -25,9 +25,6 @@ async def test_base(hass: HomeAssistant):
     entity_reg = er.async_get(hass)
     config_entry = MockConfigEntry(domain=DOMAIN)
     config_entry.add_to_hass(hass)
-
-    # Set up hass.data structure needed for coordinator setup
-    hass.data.setdefault(DOMAIN, {})[COORDINATORS] = {}
 
     # Create a proper registry entry for the mock lock
     lock_entity = entity_reg.async_get_or_create(
@@ -84,9 +81,7 @@ async def test_set_usercode_when_disconnected(
 ):
     """Test that async_internal_set_usercode raises LockDisconnected when lock is disconnected."""
     # Arrange: get the provider and force it offline
-    lock_provider = lock_code_manager_config_entry.runtime_data.coordinators[
-        LOCK_1_ENTITY_ID
-    ].lock
+    lock_provider = lock_code_manager_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
 
     # Simulate disconnected lock
     lock_provider.set_connected(False)
@@ -106,9 +101,7 @@ async def test_clear_usercode_when_disconnected(
 ):
     """Test that async_internal_clear_usercode raises LockDisconnected when lock is disconnected."""
     # Arrange: get the provider and force it offline
-    lock_provider = lock_code_manager_config_entry.runtime_data.coordinators[
-        LOCK_1_ENTITY_ID
-    ].lock
+    lock_provider = lock_code_manager_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
 
     # Simulate disconnected lock
     lock_provider.set_connected(False)
@@ -125,9 +118,7 @@ async def test_rate_limiting_set_usercode(
 ):
     """Test that operations are rate limited with minimum delay between calls."""
     # Arrange: shorter delay for faster assertions
-    lock_provider = lock_code_manager_config_entry.runtime_data.coordinators[
-        LOCK_1_ENTITY_ID
-    ].lock
+    lock_provider = lock_code_manager_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
 
     # Set a smaller delay for testing
     lock_provider._min_operation_delay = TEST_OPERATION_DELAY
@@ -165,9 +156,7 @@ async def test_rate_limiting_mixed_operations(
 ):
     """Test that rate limiting applies across different operation types."""
     # Arrange: shorter delay for faster assertions
-    lock_provider = lock_code_manager_config_entry.runtime_data.coordinators[
-        LOCK_1_ENTITY_ID
-    ].lock
+    lock_provider = lock_code_manager_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
 
     # Set a smaller delay for testing
     lock_provider._min_operation_delay = TEST_OPERATION_DELAY
@@ -193,9 +182,7 @@ async def test_rate_limiting_get_usercodes(
 ):
     """Test that get operations are also rate limited."""
     # Arrange: shorter delay for faster assertions
-    lock_provider = lock_code_manager_config_entry.runtime_data.coordinators[
-        LOCK_1_ENTITY_ID
-    ].lock
+    lock_provider = lock_code_manager_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
 
     # Set a smaller delay for testing
     lock_provider._min_operation_delay = TEST_OPERATION_DELAY
@@ -223,9 +210,7 @@ async def test_operations_are_serialized(
 ):
     """Test that multiple parallel operations are serialized by the lock."""
     # Arrange: shorter delay for faster assertions
-    lock_provider = lock_code_manager_config_entry.runtime_data.coordinators[
-        LOCK_1_ENTITY_ID
-    ].lock
+    lock_provider = lock_code_manager_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
 
     # Set a smaller delay for testing
     lock_provider._min_operation_delay = TEST_OPERATION_DELAY
@@ -261,9 +246,7 @@ async def test_connection_failure_does_not_rate_limit_next_operation(
     lock_code_manager_config_entry,
 ):
     """Test that failed connection checks do not advance rate limit timing."""
-    lock_provider = lock_code_manager_config_entry.runtime_data.coordinators[
-        LOCK_1_ENTITY_ID
-    ].lock
+    lock_provider = lock_code_manager_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
 
     # Tighten delay to keep test quick
     lock_provider._min_operation_delay = TEST_OPERATION_DELAY
@@ -293,9 +276,7 @@ async def test_async_call_service_raises_lock_disconnected_on_error(
     lock_code_manager_config_entry,
 ):
     """Test that async_call_service raises LockDisconnected when service call fails."""
-    lock_provider = lock_code_manager_config_entry.runtime_data.coordinators[
-        LOCK_1_ENTITY_ID
-    ].lock
+    lock_provider = lock_code_manager_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
 
     # Register a service that raises an error
     async def failing_service(call):

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -45,7 +45,6 @@ from custom_components.lock_code_manager.const import (
 from custom_components.lock_code_manager.coordinator import (
     LockUsercodeUpdateCoordinator,
 )
-from custom_components.lock_code_manager.data import LockCodeManagerConfigEntry
 
 from .common import (
     BASE_CONFIG,
@@ -62,12 +61,6 @@ from .common import (
 )
 
 _LOGGER = logging.getLogger(__name__)
-
-
-def _get_lock_context(hass: HomeAssistant, config_entry: LockCodeManagerConfigEntry):
-    """Return coordinator and provider for lock_1."""
-    coordinator = config_entry.runtime_data.coordinators[LOCK_1_ENTITY_ID]
-    return coordinator, coordinator.lock
 
 
 async def _async_force_sync_cycle(
@@ -479,7 +472,9 @@ async def test_entities_track_availability(
     assert active_entity_obj is not None
     assert in_sync_entity_obj is not None
 
-    coordinator, _ = _get_lock_context(hass, lock_code_manager_config_entry)
+    lock_provider = lock_code_manager_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
+    coordinator = lock_provider.coordinator
+    assert coordinator is not None
 
     assert active_entity_obj.available
     assert in_sync_entity_obj.available
@@ -526,7 +521,9 @@ async def test_handles_disconnected_lock_on_set(
     synced_state = hass.states.get(SLOT_1_IN_SYNC_ENTITY)
     assert synced_state.state == STATE_ON
 
-    coordinator, lock_provider = _get_lock_context(hass, lock_code_manager_config_entry)
+    lock_provider = lock_code_manager_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
+    coordinator = lock_provider.coordinator
+    assert coordinator is not None
     lock_provider.set_connected(False)
 
     # Change PIN to trigger sync
@@ -582,7 +579,9 @@ async def test_handles_disconnected_lock_on_clear(
     synced_state = hass.states.get(SLOT_1_IN_SYNC_ENTITY)
     assert synced_state.state == STATE_ON
 
-    coordinator, lock_provider = _get_lock_context(hass, lock_code_manager_config_entry)
+    lock_provider = lock_code_manager_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
+    coordinator = lock_provider.coordinator
+    assert coordinator is not None
     lock_provider.set_connected(False)
 
     # Disable the slot to trigger clear
@@ -620,7 +619,9 @@ async def test_coordinator_refresh_failure_schedules_retry(
     synced_state = hass.states.get(SLOT_1_IN_SYNC_ENTITY)
     assert synced_state.state == STATE_ON
 
-    coordinator, _ = _get_lock_context(hass, lock_code_manager_config_entry)
+    lock_provider = lock_code_manager_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
+    coordinator = lock_provider.coordinator
+    assert coordinator is not None
 
     entity_component = hass.data["entity_components"]["binary_sensor"]
     in_sync_entity_obj = entity_component.get_entity(SLOT_1_IN_SYNC_ENTITY)

--- a/tests/virtual/test_provider.py
+++ b/tests/virtual/test_provider.py
@@ -9,7 +9,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
-from custom_components.lock_code_manager.const import COORDINATORS, DOMAIN
+from custom_components.lock_code_manager.const import DOMAIN
 from custom_components.lock_code_manager.providers.virtual import VirtualLock
 
 
@@ -18,8 +18,6 @@ async def test_door_lock(hass: HomeAssistant):
     entity_reg = er.async_get(hass)
     config_entry = MockConfigEntry(domain=DOMAIN)
     config_entry.add_to_hass(hass)
-
-    hass.data.setdefault(DOMAIN, {})[COORDINATORS] = {}
 
     # Create a proper registry entry
     lock_entity = entity_reg.async_get_or_create(


### PR DESCRIPTION
## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Follow-up to #684. Centralizes coordinator setup in `BaseLock.async_setup()` (using the correct refresh path based on entry state), updates providers to pass `config_entry`, ensures virtual locks load persisted data before the initial refresh, and removes redundant coordinator storage by using `lock.coordinator` directly.

## Type of change

-   [ ] Dependency upgrade
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (which adds functionality)
-   [ ] Breaking change (fix/feature causing existing functionality to break)
-   [x] Code quality improvements to existing code or addition of tests

## Additional information

-   This PR fixes or closes issue: fixes #
-   This PR is related to issue:
