### PR TITLE
Fix wrong variable in log message

### DIFF
--- a/custom_components/lock_code_manager/helpers.py
+++ b/custom_components/lock_code_manager/helpers.py
@@ -86,7 +86,7 @@ def get_locks_from_targets(
                     "Lock with entity ID %s does not have a Lock Code Manager entry, "
                     "skipping"
                 ),
-                entity_id,
+                lock_entity_id,
             )
 
     return locks


### PR DESCRIPTION
## Proposed change

Fixed incorrect variable usage in `get_locks_from_targets()` in `helpers.py`. The warning log message was using `entity_id` (from an outer loop that had already completed) instead of `lock_entity_id` (the current loop variable), which would log the wrong entity ID when a lock wasn't found in the Lock Code Manager entries.

## Type of change

-   [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

-   This PR fixes or closes issue: N/A (discovered during code review)
-   This PR is related to issue: N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)