### PR TITLE
Remove scheduling TODO after analysis

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -16,7 +16,6 @@
 - Deduplicate coordinator refresh vs `hard_refresh_usercodes` cache refresh logic for Z-Wave JS.
 - Review dispatcher usage and simplify if a smaller pattern works.
 - Track entity registry updates and warn if LCM entities change entity IDs (reload required).
-- Explore using HA's scheduler instead of direct sleeps, with task tracking managed by HA.
 
 ## Features
 


### PR DESCRIPTION
## Proposed change

Remove the TODO item about exploring HA's scheduler after analyzing the current implementation and determining no changes are needed.

### Analysis Summary

Investigated the scheduling patterns in the codebase:

| Location | Mechanism | Purpose |
|----------|-----------|---------|
| `binary_sensor.py:305` | `async_call_later` | Schedule retry with cancellation |
| `providers/_base.py:104` | `asyncio.sleep` | Rate-limiting delay within locked operation |

### Findings

**Pattern 1: `async_call_later` in binary_sensor.py** - Already optimal for:
- Scheduling a retry callback after a delay
- Storing the unsubscribe function for cancellation
- Cleaning up on entity removal

**Pattern 2: `asyncio.sleep` in _base.py** - Appropriate because:
- The sleep is inside an `asyncio.Lock` context manager (simple inline delay)
- Short delays (max 2 seconds) within already-serialized operations
- Task tracking is already handled by coordinator refreshes / config entry tasks
- Matches HA core's own approach for similar inline rate-limiting

### When to use each approach

| Use `asyncio.sleep` when: | Use `async_call_later` when: |
|---------------------------|------------------------------|
| Inline delay within a coroutine | Scheduling independent callback |
| Short delays (< few seconds) | Need cancellation capability |
| Inside a lock/transaction | Retries or recurring checks |
| Simple "wait then continue" | Long delays where shutdown matters |

### Conclusion

The current code uses the right tool for each job. No refactoring needed.

## Type of change

-   [ ] Dependency upgrade
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (which adds functionality)
-   [ ] Breaking change (fix/feature causing existing functionality to break)
-   [x] Code quality improvements to existing code or addition of tests

## Additional information

-   This PR closes the TODO item: "Explore using HA's scheduler instead of direct sleeps, with task tracking managed by HA."