### PR TITLE
Add port forwarding and frontend for devcontainer UI testing

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,7 @@
 {
     "name": "lock_code_manager Dev",
     "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+    "forwardPorts": [8123],
     "features": {
         "ghcr.io/devcontainers/features/node:1": {
             "version": "lts"

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,6 +3,7 @@
 aiofiles==25.1.0
 colorlog==6.10.1
 debugpy==1.8.19
+home-assistant-frontend==20251229.0
 homeassistant==2025.12.4
 pyserial==3.5
 pyudev==0.24.4


### PR DESCRIPTION
## Summary
- Forward port 8123 for Home Assistant UI access from host machine
- Add `home-assistant-frontend` dependency for UI testing in devcontainer

## Test plan
- [ ] Rebuild devcontainer
- [ ] Start Home Assistant with `hass --config .ha`
- [ ] Access UI at http://localhost:8123

🤖 Generated with [Claude Code](https://claude.com/claude-code)