### PR TITLE
Revert homeassistant to 2025.12.4 for test compatibility

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,7 +4,7 @@ aiofiles==25.1.0
 colorlog==6.10.1
 debugpy==1.8.19
 home-assistant-frontend==20251229.0
-homeassistant==2025.12.5
+homeassistant==2025.12.4
 pyserial==3.5
 pyudev==0.24.4
 uv


### PR DESCRIPTION
## Proposed change

Reverts the homeassistant dependency from 2025.12.5 to 2025.12.4 because `pytest-homeassistant-custom-component 0.13.301` requires `homeassistant==2025.12.4`.

This fixes CI test failures across all open PRs.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes CI failures in #698 and #699
- This PR is related to issue:

🤖 Generated with [Claude Code](https://claude.com/claude-code)