### PR TITLE
Prefer options over data for config entry reads

### DIFF
--- a/custom_components/lock_code_manager/data.py
+++ b/custom_components/lock_code_manager/data.py
@@ -32,8 +32,12 @@ type LockCodeManagerConfigEntry = ConfigEntry[LockCodeManagerConfigEntryData]
 
 
 def get_entry_data(config_entry: ConfigEntry, key: str, default: Any) -> Any:
-    """Get data from config entry."""
-    return config_entry.data.get(key, config_entry.options.get(key, default))
+    """Get data from config entry.
+
+    Prefers options over data because during options flow updates, the new
+    configuration is in options while data still contains the old configuration.
+    """
+    return config_entry.options.get(key, config_entry.data.get(key, default))
 
 
 def get_slot_data(config_entry, slot_num: int) -> dict[str, Any]:


### PR DESCRIPTION
## Proposed change

- Prefer config entry options over data in `get_entry_data` so options-flow updates apply immediately.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
