### PR TITLE
Skip resource removal when Lovelace is in YAML mode

### DIFF
--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -306,6 +306,14 @@ async def async_unload_entry(
         if lovelace_data := hass.data.get(LL_DOMAIN):
             resources = lovelace_data.resources
         if resources:
+            if isinstance(resources, ResourceYAMLCollection):
+                _LOGGER.debug(
+                    "Resources switched to YAML mode after registration, skipping "
+                    "automatic removal for %s",
+                    STRATEGY_PATH,
+                )
+                hass.data.pop(DOMAIN)
+                return unload_ok
             if hass_data["resources"]:
                 try:
                     resource_id = next(
@@ -318,15 +326,6 @@ async def async_unload_entry(
                         "Strategy module not found so there is nothing to remove"
                     )
                 else:
-                    if isinstance(resources, ResourceYAMLCollection):
-                        _LOGGER.debug(
-                            "Resources switched to YAML mode after registration, "
-                            "skipping automatic removal for %s",
-                            STRATEGY_PATH,
-                        )
-                        hass.data.pop(DOMAIN)
-                        return unload_ok
-
                     await resources.async_delete_item(resource_id)
                     _LOGGER.debug(
                         "Removed strategy module (resource ID %s)", resource_id


### PR DESCRIPTION
## Proposed change

- Exit early during unload when Lovelace resources are in YAML mode to avoid attempting removal.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
