### PR TITLE
Clarify _event_unsub field placement in provider docs

### DIFF
--- a/docs/development/adding-a-provider.md
+++ b/docs/development/adding-a-provider.md
@@ -257,9 +257,16 @@ def connection_check_interval(self) -> timedelta | None:
 
 ### Subscribe to Events
 
-```python
-_event_unsub: Callable[[], None] | None = field(init=False, default=None)
+First, add a class-level field to store the unsubscribe callback:
 
+```python
+# Add this field to your dataclass (before method definitions)
+_event_unsub: Callable[[], None] | None = field(init=False, default=None)
+```
+
+Then implement the subscription methods:
+
+```python
 @callback
 def subscribe_push_updates(self) -> None:
     """Subscribe to real-time value updates."""


### PR DESCRIPTION
## Summary
- Address Copilot review comment from PR #726
- Make it clear that `_event_unsub` is a class-level dataclass field, not part of the method definition

## Changes
- Added explanatory text before the field declaration
- Separated the field declaration from the method implementations with its own code block

🤖 Generated with [Claude Code](https://claude.com/claude-code)