### PR TITLE
Fix release-drafter workflow configuration

### DIFF
--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -13,17 +13,14 @@ on:
       - reopened
       - synchronize
       - unlabeled
-  pull_request_target:
-    types:
-      - labeled
-      - opened
-      - reopened
-      - synchronize
-      - unlabeled
   workflow_dispatch:
 
 permissions:
   contents: read
+
+concurrency:
+  group: release-drafter-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   update_release_draft:


### PR DESCRIPTION
## Summary
- Remove duplicate `pull_request_target` trigger (already covered by `pull_request`)
- Add concurrency group to prevent race conditions when multiple PRs trigger the workflow

## Changes

### Removed duplicate trigger
The `pull_request_target` trigger was identical to the `pull_request` trigger above it. Having both causes the workflow to run twice for the same events.

### Added concurrency control
```yaml
concurrency:
  group: release-drafter-${{ github.ref }}
  cancel-in-progress: false
```

This ensures only one release-drafter run per ref at a time, preventing race conditions when updating the draft release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)