### PR TITLE
Refactor: Move sync logic ownership from binary sensor to coordinator

### DIFF
--- a/custom_components/lock_code_manager/coordinator.py
+++ b/custom_components/lock_code_manager/coordinator.py
@@ -3,21 +3,24 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from datetime import datetime
+from datetime import datetime, timedelta
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.helpers.event import async_call_later, async_track_time_interval
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DOMAIN
-from .exceptions import LockCodeManagerError
+from .exceptions import LockCodeManagerError, LockDisconnected
 
 if TYPE_CHECKING:
     from .providers import BaseLock
 
 _LOGGER = logging.getLogger(__name__)
+
+# Retry delay for failed sync operations
+RETRY_DELAY = timedelta(seconds=10)
 
 
 class LockUsercodeUpdateCoordinator(DataUpdateCoordinator[dict[int, int | str]]):
@@ -28,6 +31,10 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator[dict[int, int | str]])
         self._lock = lock
         self._drift_unsub: Callable[[], None] | None = None
         self._connection_unsub: Callable[[], None] | None = None
+        # Sync state tracking: slot_num -> is_synced (None = unknown)
+        self._sync_state: dict[int, bool] = {}
+        # Pending retry callbacks: slot_num -> cancel function
+        self._pending_retries: dict[int, Callable[[], None]] = {}
         # Disable periodic polling when push updates are supported.
         # Polling is still used for initial load.
         update_interval = None if lock.supports_push else lock.usercode_scan_interval
@@ -137,6 +144,153 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator[dict[int, int | str]])
             _LOGGER.debug(
                 "Connection check failed for %s: %s", self._lock.lock.entity_id, err
             )
+
+    # =========================================================================
+    # Sync Operation Methods
+    # =========================================================================
+
+    def get_sync_state(self, slot_num: int) -> bool | None:
+        """Get sync state for a slot.
+
+        Returns:
+            True if slot is synced, False if out of sync, None if unknown.
+
+        """
+        return self._sync_state.get(slot_num)
+
+    @callback
+    def mark_synced(self, slot_num: int) -> None:
+        """Mark slot as synced.
+
+        Called by binary sensor when it verifies the slot is in sync.
+        """
+        if self._sync_state.get(slot_num) is not True:
+            self._sync_state[slot_num] = True
+            self._cancel_retry(slot_num)
+            self.async_set_updated_data(self.data)
+
+    @callback
+    def mark_out_of_sync(self, slot_num: int) -> None:
+        """Mark slot as out of sync.
+
+        Called by binary sensor when it detects slot is out of sync on initial load.
+        This does NOT trigger a sync operation - use async_request_sync for that.
+        """
+        if self._sync_state.get(slot_num) is not False:
+            self._sync_state[slot_num] = False
+            self.async_set_updated_data(self.data)
+
+    async def async_request_sync(
+        self,
+        slot_num: int,
+        operation: Literal["set", "clear"],
+        usercode: str | None = None,
+        name: str | None = None,
+    ) -> bool:
+        """Request sync operation for a slot.
+
+        Args:
+            slot_num: The slot number to sync.
+            operation: "set" to set usercode, "clear" to clear it.
+            usercode: The usercode to set (required for "set" operation).
+            name: Optional name for the slot.
+
+        Returns:
+            True if operation succeeded, False if it failed (retry scheduled).
+
+        """
+        # Cancel any pending retry for this slot - new request takes precedence
+        self._cancel_retry(slot_num)
+
+        # Mark as out of sync and notify listeners
+        self._sync_state[slot_num] = False
+        self.async_set_updated_data(self.data)
+
+        _LOGGER.debug(
+            "Sync requested for %s slot %s: %s",
+            self._lock.lock.entity_id,
+            slot_num,
+            operation,
+        )
+
+        try:
+            if operation == "set":
+                if usercode is None:
+                    raise ValueError("usercode is required for 'set' operation")
+                await self._lock.async_internal_set_usercode(slot_num, usercode, name)
+            else:
+                await self._lock.async_internal_clear_usercode(slot_num)
+
+            # Refresh to verify the operation completed
+            await self.async_request_refresh()
+            return True
+
+        except LockDisconnected as err:
+            _LOGGER.debug(
+                "Sync failed for %s slot %s (%s): %s - scheduling retry",
+                self._lock.lock.entity_id,
+                slot_num,
+                operation,
+                err,
+            )
+            self._schedule_retry(slot_num, operation, usercode, name)
+            return False
+
+        except UpdateFailed as err:
+            _LOGGER.debug(
+                "Sync verification failed for %s slot %s: %s - scheduling retry",
+                self._lock.lock.entity_id,
+                slot_num,
+                err,
+            )
+            self._schedule_retry(slot_num, operation, usercode, name)
+            return False
+
+    def _schedule_retry(
+        self,
+        slot_num: int,
+        operation: Literal["set", "clear"],
+        usercode: str | None,
+        name: str | None,
+    ) -> None:
+        """Schedule retry for failed sync.
+
+        Retries infinitely until:
+        - Operation succeeds, OR
+        - A new sync request comes in (replaces pending operation)
+
+        This ensures the latest requested state always takes precedence.
+        E.g., if set fails and user disables the slot, we switch to clear.
+        """
+        self._cancel_retry(slot_num)
+
+        _LOGGER.debug(
+            "Scheduling retry for %s slot %s in %ss",
+            self._lock.lock.entity_id,
+            slot_num,
+            RETRY_DELAY.total_seconds(),
+        )
+
+        @callback
+        def _retry_callback(_now: datetime) -> None:
+            """Handle retry callback."""
+            self._pending_retries.pop(slot_num, None)
+            self.hass.async_create_task(
+                self.async_request_sync(slot_num, operation, usercode, name),
+                f"Retry sync for {self._lock.lock.entity_id} slot {slot_num}",
+            )
+
+        self._pending_retries[slot_num] = async_call_later(
+            self.hass,
+            RETRY_DELAY.total_seconds(),
+            _retry_callback,
+        )
+
+    @callback
+    def _cancel_retry(self, slot_num: int) -> None:
+        """Cancel pending retry for slot."""
+        if unsub := self._pending_retries.pop(slot_num, None):
+            unsub()
 
     async def async_shutdown(self) -> None:
         """Shut down the coordinator and clean up resources."""


### PR DESCRIPTION
## Proposed change

This refactoring addresses the "locks out of sync" issue by centralizing sync operations in the coordinator rather than having them scattered across the binary sensor entity.

**Key changes:**

**Coordinator (`coordinator.py`):**
- Add `async_request_sync()` to execute set/clear operations with automatic retries
- Add `mark_synced()` / `mark_out_of_sync()` for per-slot sync state management
- Add `get_sync_state()` for binary sensor to read sync status
- Add `_pending_retries` dict for per-slot retry tracking
- Infinite retries every 10 seconds until success or replaced by new request

**Binary sensor (`binary_sensor.py`):**
- Now read-only: displays sync state via `is_on` property from coordinator
- Detects out-of-sync conditions and requests sync via coordinator
- Removed: `_retry_unsub`, `_retry_active`, `_schedule_retry`, `_perform_sync_operation`, `_cancel_retry` - all moved to coordinator

**Init (`__init__.py`):**
- Split `async_update_listener` (~240 lines) into focused helper functions:
  - `_ConfigDiff` dataclass for computed differences
  - `_compute_config_diff()`, `_setup_new_platforms()`
  - `_handle_locks_removed()`, `_handle_locks_added()`
  - `_handle_slots_removed()`, `_handle_slots_added()`
  - `_handle_slots_modified()`
- Main function now ~35 lines

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: Addresses sync reliability concerns from PR review comments