### PR TITLE
Fix release-drafter workflow for fork PRs and concurrency

### DIFF
--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -13,13 +13,24 @@ on:
       - reopened
       - synchronize
       - unlabeled
+  # pull_request_target is needed for fork PRs - it runs in the base repo context
+  # with elevated permissions required for pull-requests: write
+  pull_request_target:
+    types:
+      - labeled
+      - opened
+      - reopened
+      - synchronize
+      - unlabeled
   workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: release-drafter-${{ github.ref }}
+  # Use head_ref for PRs (branch name) or ref for pushes (refs/heads/main)
+  # This ensures PR updates are serialized while different PRs run concurrently
+  group: release-drafter-${{ github.head_ref || github.ref }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Proposed change

Fixes two issues introduced in #728:

1. **Restore `pull_request_target` trigger** - Required for fork PRs because:
   - `pull_request` runs in the PR branch context with limited permissions
   - `pull_request_target` runs in the base repo context with elevated permissions needed for `pull-requests: write`
   - Without this, the workflow cannot add labels to PRs from forks

2. **Fix concurrency group** - Changed from `github.ref` to `github.head_ref || github.ref`:
   - For PRs: uses the head branch name (serializes updates to same PR)
   - For pushes: uses the ref (e.g., refs/heads/main)
   - This allows different PRs to run concurrently while serializing updates to the same PR

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes issues noted by Copilot in #728
- This PR is related to issue: #728