### PR TITLE
ci: add path filtering to codecov status checks

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,17 +4,35 @@ coverage:
       python:
         flags:
           - python
+        paths:
+          - custom_components/
+          - tests/
       typescript:
         flags:
           - typescript
+        paths:
+          - ts/
     patch:
       python:
         flags:
           - python
+        paths:
+          - custom_components/
+          - tests/
       typescript:
         flags:
           - typescript
+        paths:
+          - ts/
 
 flag_management:
   default_rules:
     carryforward: true
+  individual_flags:
+    - name: python
+      paths:
+        - custom_components/
+        - tests/
+    - name: typescript
+      paths:
+        - ts/


### PR DESCRIPTION
## Proposed change

Configure path filtering in `codecov.yml` so that Codecov status checks only appear on PRs when relevant files change:

- **Python checks** (`project/python`, `patch/python`): Only shown when `custom_components/` or `tests/` files change
- **TypeScript checks** (`project/typescript`, `patch/typescript`): Only shown when `ts/` files change

This reduces noise in PR status checks - you'll only see the codecov checks relevant to the language(s) you changed.

The `carryforward: true` setting ensures that when only one language changes, the other language's coverage is preserved from the previous commit.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue: Improving CI/CD experience

🤖 Generated with [Claude Code](https://claude.com/claude-code)