### PR TITLE
Rebuild yarn package on release with updated version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,6 +26,13 @@ jobs:
           sed -i "/version/c\  \"version\": \"${VERSION}\"" "${WORKSPACE}/custom_components/lock_code_manager/manifest.json"
           sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"${VERSION}\"/" "${WORKSPACE}/package.json"
         # yamllint enable rule:line-length
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "yarn"
+      - name: Rebuild frontend with updated version
+        run: yarn install && yarn build
       # Pack the lock_code_manager dir as a zip and upload to the release
       - name: ZIP Lock Code Manager Dir
         run: |


### PR DESCRIPTION
## Proposed change

Adds Node.js setup and yarn build step to the release workflow to ensure the frontend bundle includes the correct version number in the release asset.

Without this, the built JS files in the release ZIP would still have version `0.0.0` even though `package.json` was updated.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: Follows up on #746
- This PR is related to issue: N/A