### PR TITLE
Improve release drafter labels and autolabeler

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -48,13 +48,13 @@ autolabeler:
 version-resolver:
   major:
     labels:
-      - "major"
+      - "lcm-major"
   minor:
     labels:
-      - "minor"
+      - "lcm-minor"
   patch:
     labels:
-      - "patch"
+      - "lcm-patch"
   default: patch
 categories:
   - title: ":boom: Breaking Change :boom:"


### PR DESCRIPTION
## Summary
- Use `lcm-major`, `lcm-minor`, `lcm-patch` labels for release versioning (avoids conflict with Dependabot's automatic SemVer labels)
- Add file patterns to `dependencies` autolabeler for dependency files
- Separate language labels (`python`/`javascript`) from dependency file patterns
- Add `documentation` label for `*.md` and `docs/**` files
- Narrow `github_actions` to `.github/workflows/*` only

## Labels created
- `lcm-major` - Major version bump (red)
- `lcm-minor` - Minor version bump (yellow)
- `lcm-patch` - Patch version bump (green)
- `documentation` - Documentation changes (blue)

## Autolabeler changes

| Label | Before | After |
| ----- | ------ | ----- |
| `dependencies` | Body regex only | File patterns + body regex |
| `python` | Included dependency files | Code files only (*.py, tox.ini) |
| `javascript` | Included dependency files | Code files only (*.ts, *.js, config) |
| `github_actions` | `.github/*` (too broad) | `.github/workflows/*` |
| `documentation` | N/A | `*.md`, `docs/**/*` |

## Test plan
- [x] Labels created in repo
- [x] Pre-commit passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)