### PR TITLE
Add auto-merge for pre-commit-ci PRs

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -29,3 +29,15 @@ jobs:
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  pre-commit-ci:
+    runs-on: ubuntu-latest
+    # Only run on pre-commit-ci PRs
+    if: github.event.pull_request.user.login == 'pre-commit-ci[bot]'
+    steps:
+      # Auto-merge pre-commit-ci updates after CI passes
+      - name: Enable auto-merge for pre-commit-ci PRs
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Proposed change

Enable auto-merge for pre-commit-ci bot PRs that pass CI checks, similar to the existing dependabot auto-merge functionality.

This will automatically merge pre-commit hook version updates when all CI checks pass.

## Type of change

- [x] Maintenance (non-breaking change that improves the codebase)

## Additional information

- This PR is related to issue: N/A

🤖 Generated with [Claude Code](https://claude.ai/code)