### PR TITLE
Fix auto-merge to wait for CI checks before merging

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -20,12 +20,22 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      # Auto-merge patch and minor updates after CI passes
-      - name: Enable auto-merge for Dependabot PRs
+      # Wait for all CI checks to pass before merging
+      - name: Wait for CI checks to pass
         if: >-
           steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
           steps.metadata.outputs.update-type == 'version-update:semver-minor'
-        run: gh pr merge --auto --squash "$PR_URL"
+        run: gh pr checks "$PR_URL" --watch --fail-fast
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Merge after CI passes
+      - name: Merge Dependabot PR
+        if: >-
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -35,9 +45,16 @@ jobs:
     # Only run on pre-commit-ci PRs
     if: github.event.pull_request.user.login == 'pre-commit-ci[bot]'
     steps:
-      # Auto-merge pre-commit-ci updates after CI passes
-      - name: Enable auto-merge for pre-commit-ci PRs
-        run: gh pr merge --auto --squash "$PR_URL"
+      # Wait for all CI checks to pass before merging
+      - name: Wait for CI checks to pass
+        run: gh pr checks "$PR_URL" --watch --fail-fast
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Merge after CI passes
+      - name: Merge pre-commit-ci PR
+        run: gh pr merge --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Proposed change

Fix the auto-merge workflow for pre-commit-ci PRs to wait for CI checks to complete before merging.

Previously, using `gh pr merge --auto` would merge immediately since there are no required status checks in branch protection rules. Now we:

1. Use `gh pr checks --watch --fail-fast` to wait for all checks to complete
2. Only merge (with `gh pr merge --squash`) after checks pass

This allows pre-commit-ci updates to auto-merge only when CI passes, while still allowing manual merges when checks fail for other PRs.

## Type of change

- [x] Maintenance (non-breaking change that improves the codebase)

## Additional information

- This PR is related to issue: N/A

🤖 Generated with [Claude Code](https://claude.ai/code)