### PR TITLE
Fix issue-labeler version (v3 tag doesn't exist)

### DIFF
--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -27,7 +27,7 @@ jobs:
     name: Label by Body
     runs-on: ubuntu-latest
     steps:
-      - uses: github/issue-labeler@v3
+      - uses: github/issue-labeler@v3.4
         with:
           configuration-path: .github/issue-labeler.yml
           enable-versioned-regex: 0


### PR DESCRIPTION
## Proposed change

Fix the issue-labeler GitHub Action version. The action uses specific version tags (v3.4) not major version tags (v3).

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A