### PR TITLE
Fix issue-labeler patterns to use portable cross-line matching

### DIFF
--- a/.github/issue-labeler.yml
+++ b/.github/issue-labeler.yml
@@ -1,21 +1,21 @@
 # Configuration for github/issue-labeler - body-based labels
 # See: https://github.com/github/issue-labeler
 # Uses regex patterns to match PR/issue body content
-# All checkbox patterns require ## Type of change header first to avoid matching examples
+# Checkbox patterns use (.|[\r\n])*? for cross-line matching ([\s\S] may not work in all engines)
 ---
 bug:
-  - '## Type of change[\s\S]*?- \[[xX]\]\s*[Bb]ugfix'
+  - '## Type of change(.|[\r\n])*?- \[[xX]\]\s*[Bb]ugfix'
 
 enhancement:
-  - '## Type of change[\s\S]*?- \[[xX]\]\s*[Nn]ew [Ff]eature'
+  - '## Type of change(.|[\r\n])*?- \[[xX]\]\s*[Nn]ew [Ff]eature'
 
 breaking-change:
   # Checkbox in Type of change section
-  - '## Type of change[\s\S]*?- \[[xX]\]\s*[Bb]reaking [Cc]hange'
+  - '## Type of change(.|[\r\n])*?- \[[xX]\]\s*[Bb]reaking [Cc]hange'
   # Breaking change section with content after HTML comment
-  - '^[\s\S]*?# Breaking change[\s\S]*?-->\s*\n+[A-Z][a-z]+[\s\S]*?## Proposed change'
+  - '# Breaking change(.|[\r\n])*?-->\s*\n+[A-Z][a-z]+(.|[\r\n])*?## Proposed change'
   # Breaking change section with HTML comment removed
-  - '^[\s\S]*?# Breaking change\s*\n+[A-Z][a-z]+[\s\S]*?## Proposed change'
+  - '# Breaking change\s*\n+[A-Z][a-z]+(.|[\r\n])*?## Proposed change'
 
 code-quality:
-  - '## Type of change[\s\S]*?- \[[xX]\]\s*[Cc]ode [Qq]uality'
+  - '## Type of change(.|[\r\n])*?- \[[xX]\]\s*[Cc]ode [Qq]uality'


### PR DESCRIPTION
## Proposed change

Replace `[\s\S]*?` with `(.|[\r\n])*?` for matching across lines in issue-labeler patterns. The `[\s\S]` character class may not work in all regex engines, while `(.|[\r\n])` is more portable.

This should fix the issue where checkbox patterns weren't matching PRs with breaking change checked.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue: Follow-up to #796

🤖 Generated with [Claude Code](https://claude.com/claude-code)