### PR TITLE
Add 90% target for patch coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -21,11 +21,13 @@ coverage:
         paths:
           - custom_components/
           - tests/
+        target: 90%
       typescript:
         flags:
           - typescript
         paths:
           - ts/
+        target: 90%
 
 flag_management:
   default_rules:


### PR DESCRIPTION
# Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Add a 90% target threshold for patch coverage in codecov. Previously, patch coverage had no explicit target, defaulting to strict behavior that required coverage not to decrease from the project baseline.

This caused PRs with good coverage (e.g., 95%) to fail when the baseline was slightly higher, even when the uncovered lines were defensive code, logging statements, or error handling that's difficult to test.

The 90% target provides reasonable tolerance while still ensuring good coverage of new/changed code.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: Fixes codecov/patch/python failures on PRs with >90% patch coverage
- This PR is related to issue: PR #785

🤖 Generated with [Claude Code](https://claude.com/claude-code)