### PR TITLE
Include codecov.yml in github-config label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -32,7 +32,9 @@ python:
 
 github-config:
   - changed-files:
-      - any-glob-to-any-file: '.github/**/*'
+      - any-glob-to-any-file:
+          - '.github/**/*'
+          - 'codecov.yml'
 
 dependencies:
   - changed-files:


### PR DESCRIPTION
## Proposed change

Add `codecov.yml` to the `github-config` labeler pattern so PRs modifying CI config get appropriately labeled.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: N/A
- This PR is related to issue: PR #805 wasn't auto-labeled

🤖 Generated with [Claude Code](https://claude.com/claude-code)