### PR TITLE
Remove unnecessary frontend rebuild from release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,15 +24,7 @@ jobs:
         run: |
           sed -i "/VERSION = /c\VERSION = \"${VERSION}\"" "${WORKSPACE}/custom_components/lock_code_manager/const.py"
           sed -i "/version/c\  \"version\": \"${VERSION}\"" "${WORKSPACE}/custom_components/lock_code_manager/manifest.json"
-          sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"${VERSION}\"/" "${WORKSPACE}/package.json"
         # yamllint enable rule:line-length
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: "20"
-          cache: "yarn"
-      - name: Rebuild frontend with updated version
-        run: yarn build
       # Pack the lock_code_manager dir as a zip and upload to the release
       - name: ZIP Lock Code Manager Dir
         run: |


### PR DESCRIPTION
## Proposed change

The release workflow was rebuilding the frontend after updating the `package.json` version, but the frontend code doesn't actually use the version anywhere. The committed generated JS bundle is already the final artifact.

This removes:
- Node.js setup step
- `yarn build` step  
- `package.json` version update

This simplifies the release process and reduces CI time.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A

🤖 Generated with [Claude Code](https://claude.ai/code)