### PR TITLE
Group homeassistant dependencies in Dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -22,6 +22,11 @@ updates:
     labels:
       - "dependencies"
       - "python"
+    groups:
+      homeassistant:
+        patterns:
+          - "homeassistant"
+          - "pytest-homeassistant-custom-component"
   - package-ecosystem: npm
     directory: "/" # Location of package manifests
     schedule:


### PR DESCRIPTION
## Proposed change

Groups `homeassistant` and `pytest-homeassistant-custom-component` in Dependabot configuration so they are updated together in a single PR instead of separately.

These packages need to stay in sync for compatibility - updating one without the other can cause test failures.

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue: PRs #821 and #822 need to be merged together
- After merging, close #821 and #822, then Dependabot will create a new grouped PR