### PR TITLE
Document unsupported integrations (Yale/August, ESPHome)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,24 @@ The code was written to make it (I think) easy to add support for locks in other
 integrations. Check the [Wiki](https://github.com/raman325/lock_code_manager/wiki) if you
 want to learn more about that and take a stab at it. Contributors welcome!
 
+## Integrations That Cannot Currently Be Supported
+
+Many lock integrations don't yet have Lock Code Manager providers, but could potentially be
+added in the future. The integrations listed below are different - they **cannot** be
+supported due to fundamental limitations in their underlying libraries or protocols.
+
+The Home Assistant lock platform only requires lock/unlock operations. User code management
+is optional, and these integrations don't expose it.
+
+| Integration | Reason |
+| ----------- | ------ |
+| **ESPHome** | The ESPHome lock component only supports lock/unlock/open commands. User code management would need to be implemented in ESPHome's firmware and API first. |
+| **Yale/August** (`august`, `yale`, `yalexs_ble`, `yale_smart_alarm`) | The underlying libraries have limited support. The `yalexs` library (used by both `august` and `yale`) can read PINs via `async_get_pins()` but has no methods to create, update, or delete them. The `yalexs-ble` and `yalesmartalarmclient` libraries don't expose any PIN management. Support would require upstream library changes. |
+
+If you're interested in adding support for one of these integrations, the blocker is
+typically the underlying Python library - not Lock Code Manager itself. Contributing user
+code management features to those libraries would enable LCM support.
+
 ## Installation
 
 The best way to install this integration is via HACS.

--- a/TODO.md
+++ b/TODO.md
@@ -436,11 +436,10 @@ and integrate relevant new features.
 **Smart Home Platforms:**
 
 - `deconz` - deCONZ (Zigbee/Z-Wave gateway)
-- `esphome` - ESPHome devices
 - `homematic` - Homematic (CCU)
 - `homematicip_cloud` - Homematic IP Cloud
 - `homekit_controller` - HomeKit accessories
-- `matter` - Matter protocol
+- `matter` - Matter protocol (PR open)
 - `mqtt` - MQTT locks
 - `smartthings` - SmartThings
 - `zha` - Zigbee Home Automation
@@ -450,7 +449,6 @@ and integrate relevant new features.
 **Brand-Specific Integrations:**
 
 - `abode` - Abode Security
-- `august` - August Smart Locks
 - `bmw_connected_drive` - BMW Connected Drive
 - `dormakaba_dkey` - Dormakaba dkey
 - `igloohome` - igloohome
@@ -462,15 +460,17 @@ and integrate relevant new features.
 - `switchbot` - SwitchBot Lock
 - `switchbot_cloud` - SwitchBot Cloud
 - `tedee` - Tedee Smart Lock
-- `yale` - Yale Access (August partnership)
-- `yalexs_ble` - Yale/August BLE
 - `yolink` - YoLink
 
 **Security Systems:**
 
 - `simplisafe` - SimpliSafe
 - `verisure` - Verisure
-- `yale_smart_alarm` - Yale Smart Alarm
+
+**Cannot Be Supported** (see README for details):
+
+- `esphome` - No user code API in ESPHome
+- `august`, `yale`, `yalexs_ble`, `yale_smart_alarm` - Library limitations
 
 **Vehicle Integrations:**
 
@@ -508,16 +508,14 @@ and integrate relevant new features.
 **High Priority** (popular, widely used):
 
 1. **ZHA (Zigbee Home Automation)** - Very popular, supports many lock brands
-2. **Matter** - Future-proof, industry standard
-3. **ESPHome** - DIY community, custom locks
-4. **MQTT** - Generic protocol, many custom implementations
+2. **Matter** - Future-proof, industry standard (PR open)
+3. **MQTT** - Generic protocol, many custom implementations
 
 **Medium Priority** (brand-specific, popular):
 
-1. **August/Yale** (`august`, `yale`, `yalexs_ble`) - Popular smart lock brand
-2. **Nuki** - Popular in Europe
-3. **Schlage** - Popular in North America
-4. **SwitchBot** - Growing popularity
+1. **Nuki** - Popular in Europe
+2. **Schlage** - Popular in North America
+3. **SwitchBot** - Growing popularity
 
 **Low Priority** (niche or less common):
 


### PR DESCRIPTION
## Proposed change

Add documentation about lock integrations that cannot be supported due to limitations in
underlying libraries or protocols.

**README changes:**
- Add "Integrations That Cannot Currently Be Supported" section
- Clarify distinction from integrations that simply don't have providers yet
- Document ESPHome and Yale/August (`august`, `yale`, `yalexs_ble`, `yale_smart_alarm`)

**TODO.md changes:**
- Remove ESPHome from high priority list (cannot be supported)
- Add "Cannot Be Supported" section to integrations list
- Note Matter has PR open

**Key findings:**
- **ESPHome**: Lock component only supports lock/unlock/open - no user code API exists
- **Yale/August**: `yalexs` library (used by both `august` and `yale` integrations) can READ
  PINs via `async_get_pins()` but has no create/update/delete methods. Other Yale libraries
  (`yalexs-ble`, `yalesmartalarmclient`) don't expose any PIN management.

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Additional information

This documentation helps users understand why their lock integration isn't supported and
what would need to happen for support to be added (typically upstream library changes).

Wiki page also created: https://github.com/raman325/lock_code_manager/wiki/Unsupported-Integrations