### PR TITLE
Add provider diagnostic data method to TODO

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -285,6 +285,38 @@ vol.Optional("include_locks", default=True): bool,
 Track entity registry updates and warn if LCM entities change entity IDs (reload
 required).
 
+### Add Provider Diagnostic Data Method
+
+Add `get_diagnostic_data()` method to `BaseLock` for exposing provider-specific
+diagnostic information. Keymaster has this pattern with `get_platform_data()`.
+
+**Example Implementation:**
+
+```python
+# In BaseLock
+def get_diagnostic_data(self) -> dict[str, Any]:
+    """Return provider-specific diagnostic data."""
+    return {}
+
+# In ZWaveJSLock
+def get_diagnostic_data(self) -> dict[str, Any]:
+    return {
+        "node_id": self.node.node_id,
+        "home_id": self.node.client.driver.controller.home_id,
+        "client_connected": self.node.client.connected,
+        "config_entry_state": self.lock_config_entry.state.value,
+    }
+```
+
+**Benefits:**
+
+- Easier troubleshooting of provider-specific issues
+- Can be exposed via diagnostics platform or websocket
+
+**Estimated Effort:** Low (2-4 hours)
+**Priority:** Low
+**Status:** Not started
+
 ### Drift Detection Failure Alerting
 
 Add mechanism to alert users when drift detection consistently fails over


### PR DESCRIPTION
## Proposed change

Add TODO item for implementing `get_diagnostic_data()` method in `BaseLock` for exposing provider-specific diagnostic information. This was identified during a comparison with keymaster's provider model, which has a similar `get_platform_data()` pattern.

The method would allow providers to expose diagnostic data like node IDs, connection status, and config entry state for easier troubleshooting.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue: Provider model comparison with keymaster

🤖 Generated with [Claude Code](https://claude.ai/code)