### PR TITLE
Make BaseLock an ABC with domain as abstract property

### DIFF
--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 import asyncio
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
@@ -49,7 +50,7 @@ _OPERATION_MESSAGES: dict[Literal["get", "set", "clear", "refresh"], str] = {
 
 
 @dataclass(repr=False, eq=False)
-class BaseLock:
+class BaseLock(ABC):
     """
     Base class for lock provider implementations.
 
@@ -202,9 +203,9 @@ class BaseLock:
         raise ProviderNotImplementedError(self, method_name, guidance)
 
     @property
+    @abstractmethod
     def domain(self) -> str:
         """Return integration domain."""
-        raise NotImplementedError()
 
     @property
     def usercode_scan_interval(self) -> timedelta:
@@ -476,7 +477,7 @@ class BaseLock:
         """
         self._raise_not_implemented(
             "set_usercode",
-            "Override this method to set a usercode on the lock.",
+            "Override this method or async_set_usercode to set a usercode on the lock.",
         )
 
     async def async_set_usercode(
@@ -519,7 +520,7 @@ class BaseLock:
         """
         self._raise_not_implemented(
             "clear_usercode",
-            "Override this method to clear a usercode from the lock.",
+            "Override this method or async_clear_usercode to clear a usercode from the lock.",
         )
 
     async def async_clear_usercode(self, code_slot: int) -> bool:
@@ -560,7 +561,7 @@ class BaseLock:
         """
         self._raise_not_implemented(
             "get_usercodes",
-            "Override this method to retrieve usercodes from the lock.",
+            "Override this method or async_get_usercodes to retrieve usercodes from the lock.",
         )
 
     async def async_get_usercodes(self) -> dict[int, int | str]:


### PR DESCRIPTION
## Proposed change

Make `BaseLock` inherit from `ABC` and mark the `domain` property as abstract. This catches missing implementations at class definition time rather than runtime, providing better IDE support and clearer contracts for provider authors.

**Why only `domain`?**

Both existing providers (ZWaveJSLock, VirtualLock) override the async methods directly (`async_get_usercodes`, `async_set_usercode`, etc.) rather than implementing the sync versions. The base class design allows either:
1. Implement sync methods → base async calls them via executor
2. Override async methods directly → sync never called

Making the sync methods abstract would require all providers to add stub implementations even when they only use async. The `domain` property is truly universal and always required, making it the right candidate for `@abstractmethod`.

**Changes:**
- Add `ABC` inheritance to `BaseLock` dataclass
- Add `@abstractmethod` decorator to `domain` property
- Update guidance text for sync methods to mention async alternatives
- Update tests to use `MockLCMLock` instead of `BaseLock` directly

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue: Provider model comparison with keymaster

🤖 Generated with [Claude Code](https://claude.ai/code)