### PR TITLE
Fix hassfest URL validation by using description placeholder

### DIFF
--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -220,6 +220,10 @@ class LockCodeManagerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 ):
                     errors[CONF_ENTITY_ID] = "excluded_platform"
                     description_placeholders["integration"] = entity_entry.platform
+                    description_placeholders["docs_url"] = (
+                        "https://github.com/raman325/lock_code_manager/wiki/"
+                        "Unsupported-Condition-Entity-Integrations"
+                    )
 
             if not errors:
                 self.data[CONF_SLOTS][int(self.slots_to_configure.pop(0))] = (

--- a/custom_components/lock_code_manager/strings.json
+++ b/custom_components/lock_code_manager/strings.json
@@ -5,7 +5,7 @@
       "locks_updated": "The locks for your config entry have been updated."
     },
     "error": {
-      "excluded_platform": "Entities from the `{integration}` integration are not supported as condition entities. See the [wiki](https://github.com/raman325/lock_code_manager/wiki/Unsupported-Condition-Entity-Integrations) for details.",
+      "excluded_platform": "Entities from the `{integration}` integration are not supported as condition entities. See the [wiki]({docs_url}) for details.",
       "invalid_config": "Slots configuration is invalid. For more information, check the logs and the docs.",
       "missing_pin_if_enabled": "PIN must be set if slot is enabled.",
       "slots_already_configured": "The following slots for lock {lock} are already managed by another config entry ({entry_title}) and can't be added to this configuration without being removed from the other one: {common_slots}"

--- a/custom_components/lock_code_manager/translations/en.json
+++ b/custom_components/lock_code_manager/translations/en.json
@@ -5,7 +5,7 @@
       "locks_updated": "The locks for your config entry have been updated."
     },
     "error": {
-      "excluded_platform": "Entities from the `{integration}` integration are not supported as condition entities. See the [wiki](https://github.com/raman325/lock_code_manager/wiki/Unsupported-Condition-Entity-Integrations) for details.",
+      "excluded_platform": "Entities from the `{integration}` integration are not supported as condition entities. See the [wiki]({docs_url}) for details.",
       "invalid_config": "Slots configuration is invalid. For more information, check the logs and the docs.",
       "missing_pin_if_enabled": "PIN must be set if slot is enabled.",
       "slots_already_configured": "The following slots for lock {lock} are already managed by another config entry ({entry_title}) and can't be added to this configuration without being removed from the other one: {common_slots}"


### PR DESCRIPTION
## Proposed change

Hassfest doesn't allow URLs in translation strings directly. This PR uses a
`description_placeholder` to inject the wiki URL at runtime instead of
hardcoding it in the translation string.

**Changes:**
- `config_flow.py`: Add `docs_url` to description_placeholders when excluded platform error occurs
- `strings.json` / `translations/en.json`: Use `{docs_url}` placeholder in error message

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: PR #837

Fixes hassfest validation error:
```
[TRANSLATIONS] Invalid strings.json: the string should not contain URLs,
please use description placeholders instead
```

🤖 Generated with [Claude Code](https://claude.ai/code)