### PR TITLE
Add HA blueprints for slot usage limiting and calendar integration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,7 @@ repos:
       - id: check-merge-conflict
       - id: check-xml
       - id: check-yaml
+        exclude: ^blueprints/
       - id: debug-statements
       - id: end-of-file-fixer
       - id: requirements-txt-fixer

--- a/README.md
+++ b/README.md
@@ -15,18 +15,6 @@ Features:
   - `input_boolean` - code is active when the input boolean is `on`
 - Optionally define a maximum number of uses for a code before the code is disabled
 
-## Blueprints
-
-LCM provides blueprints for common automation patterns:
-
-| Blueprint | Description | Import |
-| --------- | ----------- | ------ |
-| Slot Usage Limiter | Limit PIN uses with a counter, auto-disable at 0 | [![Import](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Framan325%2Flock_code_manager%2Fblob%2Fmain%2Fblueprints%2Fautomation%2Flock_code_manager%2Fslot_usage_limiter.yaml) |
-| Calendar Condition | Binary sensor for advanced calendar-based access control | [![Import](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Framan325%2Flock_code_manager%2Fblob%2Fmain%2Fblueprints%2Ftemplate%2Flock_code_manager%2Fcalendar_condition.yaml) |
-| Calendar PIN Setter | Set PINs from calendar event data | [![Import](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Framan325%2Flock_code_manager%2Fblob%2Fmain%2Fblueprints%2Fautomation%2Flock_code_manager%2Fcalendar_pin_setter.yaml) |
-
-See the [Blueprints wiki page](https://github.com/raman325/lock_code_manager/wiki/Blueprints) for setup details.
-
 Locks from the following integrations are currently supported:
 
 - Z-Wave
@@ -78,6 +66,19 @@ The best way to install this integration is via HACS.
 4. Select Lock Code Manager
 5. Follow the prompts - additional information about the configuration options are
    available in the Wiki
+
+## Blueprints
+
+Pre-built automations for common patterns:
+
+- **Slot Usage Limiter** — Disable a slot after a set number of uses
+  [![Import Blueprint](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Framan325%2Flock_code_manager%2Fblob%2Fmain%2Fblueprints%2Fautomation%2Flock_code_manager%2Fslot_usage_limiter.yaml)
+- **Calendar PIN Setter** — Extract and set PINs from calendar event attributes
+  [![Import Blueprint](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Framan325%2Flock_code_manager%2Fblob%2Fmain%2Fblueprints%2Fautomation%2Flock_code_manager%2Fcalendar_pin_setter.yaml)
+- **Calendar Condition** — Control slot access based on calendar events
+  [![Import Blueprint](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Framan325%2Flock_code_manager%2Fblob%2Fmain%2Fblueprints%2Ftemplate%2Flock_code_manager%2Fcalendar_condition.yaml)
+
+See the [wiki](https://github.com/raman325/lock_code_manager/wiki/Blueprints) for detailed setup and configuration.
 
 ## Learn More
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ LCM provides blueprints for common automation patterns:
 | Blueprint | Description | Import |
 | --------- | ----------- | ------ |
 | Slot Usage Limiter | Limit PIN uses with a counter, auto-disable at 0 | [![Import](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Framan325%2Flock_code_manager%2Fblob%2Fmain%2Fblueprints%2Fautomation%2Flock_code_manager%2Fslot_usage_limiter.yaml) |
-| Calendar Condition | Binary sensor for calendar-based access control | [![Import](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Framan325%2Flock_code_manager%2Fblob%2Fmain%2Fblueprints%2Ftemplate%2Flock_code_manager%2Fcalendar_condition.yaml) |
+| Calendar Condition | Binary sensor for advanced calendar-based access control | [![Import](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Framan325%2Flock_code_manager%2Fblob%2Fmain%2Fblueprints%2Ftemplate%2Flock_code_manager%2Fcalendar_condition.yaml) |
 | Calendar PIN Setter | Set PINs from calendar event data | [![Import](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Framan325%2Flock_code_manager%2Fblob%2Fmain%2Fblueprints%2Fautomation%2Flock_code_manager%2Fcalendar_pin_setter.yaml) |
 
 See the [Blueprints wiki page](https://github.com/raman325/lock_code_manager/wiki/Blueprints) for setup details.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,18 @@ Features:
   - `input_boolean` - code is active when the input boolean is `on`
 - Optionally define a maximum number of uses for a code before the code is disabled
 
+## Blueprints
+
+LCM provides blueprints for common automation patterns:
+
+| Blueprint | Description | Import |
+| --------- | ----------- | ------ |
+| Slot Usage Limiter | Limit PIN uses with a counter, auto-disable at 0 | [![Import](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Framan325%2Flock_code_manager%2Fblob%2Fmain%2Fblueprints%2Fautomation%2Flock_code_manager%2Fslot_usage_limiter.yaml) |
+| Calendar Condition | Binary sensor for calendar-based access control | [![Import](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Framan325%2Flock_code_manager%2Fblob%2Fmain%2Fblueprints%2Ftemplate%2Flock_code_manager%2Fcalendar_condition.yaml) |
+| Calendar PIN Setter | Set PINs from calendar event data | [![Import](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Framan325%2Flock_code_manager%2Fblob%2Fmain%2Fblueprints%2Fautomation%2Flock_code_manager%2Fcalendar_pin_setter.yaml) |
+
+See the [Blueprints wiki page](https://github.com/raman325/lock_code_manager/wiki/Blueprints) for setup details.
+
 Locks from the following integrations are currently supported:
 
 - Z-Wave

--- a/blueprints/automation/lock_code_manager/calendar_pin_setter.yaml
+++ b/blueprints/automation/lock_code_manager/calendar_pin_setter.yaml
@@ -57,8 +57,9 @@ blueprint:
     slot_number:
       name: Slot number
       description: >
-        The code slot number. Can be a static number (e.g. `3`) or a Jinja2
-        template that resolves to a number using calendar event attributes
+        The Lock Code Manager code slot number. Can be a static number (e.g.
+        `3`) or a Jinja2 template that resolves to a number using calendar
+        event attributes
         (e.g. `{{ description | regex_findall('slot (\d+)') | first }}`).
       selector:
         template:
@@ -84,6 +85,15 @@ blueprint:
       default: true
       selector:
         boolean:
+    notify_target:
+      name: Notification service (optional)
+      description: >
+        A notify entity to send messages to when PINs are set or cleared.
+        Leave empty to skip notifications.
+      default: ""
+      selector:
+        entity:
+          domain: notify
 
 mode: single
 
@@ -91,6 +101,8 @@ variables:
   config_entry: !input config_entry
   calendar_entity: !input calendar_entity
   clear_on_end: !input clear_on_end
+  notify_target: !input notify_target
+  _slot_number: !input slot_number
   config_entry_title: >
     {{ config_entry_attr(config_entry, 'title') }}
   _all_entities: >
@@ -133,6 +145,21 @@ actions:
               entity_id: "{{ pin_entity }}"
             data:
               value: "{{ pin_value }}"
+          - if:
+              - condition: template
+                value_template: "{{ notify_target != '' }}"
+            then:
+              - action: notify.send_message
+                target:
+                  entity_id: "{{ notify_target }}"
+                data:
+                  title: >
+                    {{ config_entry_title }} — Slot {{ _slot_number }}
+                    PIN Set
+                  message: >
+                    {{ config_entry_title }} code slot {{ _slot_number }}
+                    PIN set from calendar event "{{ message }}"
+                    ({{ now().strftime('%Y-%m-%d %H:%M:%S') }}).
       - conditions:
           - condition: template
             value_template: >
@@ -145,3 +172,18 @@ actions:
               entity_id: "{{ pin_entity }}"
             data:
               value: ""
+          - if:
+              - condition: template
+                value_template: "{{ notify_target != '' }}"
+            then:
+              - action: notify.send_message
+                target:
+                  entity_id: "{{ notify_target }}"
+                data:
+                  title: >
+                    {{ config_entry_title }} — Slot {{ _slot_number }}
+                    PIN Cleared
+                  message: >
+                    {{ config_entry_title }} code slot {{ _slot_number }}
+                    PIN cleared after calendar event ended
+                    ({{ now().strftime('%Y-%m-%d %H:%M:%S') }}).

--- a/blueprints/automation/lock_code_manager/calendar_pin_setter.yaml
+++ b/blueprints/automation/lock_code_manager/calendar_pin_setter.yaml
@@ -102,7 +102,6 @@ variables:
   calendar_entity: !input calendar_entity
   clear_on_end: !input clear_on_end
   notify_target: !input notify_target
-  _slot_number: !input slot_number
   config_entry_title: >
     {{ config_entry_attr(config_entry, 'title') }}
   _all_entities: >
@@ -154,10 +153,10 @@ actions:
                   entity_id: "{{ notify_target }}"
                 data:
                   title: >
-                    {{ config_entry_title }} — Slot {{ _slot_number }}
+                    {{ config_entry_title }} — Slot {{ slot_number }}
                     PIN Set
                   message: >
-                    {{ config_entry_title }} code slot {{ _slot_number }}
+                    {{ config_entry_title }} code slot {{ slot_number }}
                     PIN set from calendar event "{{ message }}"
                     ({{ now().strftime('%Y-%m-%d %H:%M:%S') }}).
       - conditions:
@@ -181,9 +180,9 @@ actions:
                   entity_id: "{{ notify_target }}"
                 data:
                   title: >
-                    {{ config_entry_title }} — Slot {{ _slot_number }}
+                    {{ config_entry_title }} — Slot {{ slot_number }}
                     PIN Cleared
                   message: >
-                    {{ config_entry_title }} code slot {{ _slot_number }}
+                    {{ config_entry_title }} code slot {{ slot_number }}
                     PIN cleared after calendar event ended
                     ({{ now().strftime('%Y-%m-%d %H:%M:%S') }}).

--- a/blueprints/automation/lock_code_manager/calendar_pin_setter.yaml
+++ b/blueprints/automation/lock_code_manager/calendar_pin_setter.yaml
@@ -1,0 +1,147 @@
+---
+blueprint:
+  name: "Lock Code Manager: Calendar PIN Setter"
+  description: >
+    Extracts a PIN from calendar event attributes using a user-provided template
+    and sets it on a Lock Code Manager code slot. Optionally clears the PIN when
+    the calendar event ends.
+
+
+    **Available template variables**
+
+    Your PIN and slot number templates can use these variables:
+
+    - `message` — calendar event summary/title
+
+    - `description` — calendar event description
+
+    - `location` — calendar event location
+
+    - `start_time` — event start time
+
+    - `end_time` — event end time
+
+    - `all_day` — whether the event is an all-day event
+
+
+    **Example PIN templates**
+
+    - Extract a 4-digit PIN from description:
+      `{{ description | regex_findall('\\b\\d{4}\\b') | first | default('') }}`
+
+    - Use the first 4 characters of the event title:
+      `{{ message[:4] if message | length >= 4 else '' }}`
+
+
+    **Template debugging**
+
+    To test your PIN template, go to Developer Tools → Template and paste:
+
+    ```
+
+    {% set description = state_attr('calendar.YOUR_CALENDAR', 'description') | default('') %}
+
+    {{ description | regex_findall('\\b\\d{4}\\b') | first | default('') }}
+
+    ```
+  domain: automation
+  # yamllint disable-line rule:line-length
+  source_url: https://github.com/raman325/lock_code_manager/blob/main/blueprints/automation/lock_code_manager/calendar_pin_setter.yaml
+  input:
+    config_entry:
+      name: Lock Code Manager config entry
+      description: The Lock Code Manager config entry that manages your lock(s).
+      selector:
+        config_entry:
+          integration: lock_code_manager
+    slot_number:
+      name: Slot number
+      description: >
+        The code slot number. Can be a static number (e.g. `3`) or a Jinja2
+        template that resolves to a number using calendar event attributes
+        (e.g. `{{ description | regex_findall('slot (\d+)') | first }}`).
+      selector:
+        template:
+    calendar_entity:
+      name: Calendar entity
+      description: The calendar entity whose events provide PIN codes.
+      selector:
+        entity:
+          domain: calendar
+    pin_template:
+      name: PIN template
+      description: >
+        A Jinja2 template that extracts a PIN from calendar event attributes.
+        Must evaluate to a non-empty string to set the PIN, or empty string to
+        skip setting.
+      selector:
+        template:
+    clear_on_end:
+      name: Clear PIN when event ends
+      description: >
+        When enabled, the PIN is cleared (set to empty) when the calendar
+        event ends.
+      default: true
+      selector:
+        boolean:
+
+mode: single
+
+variables:
+  config_entry: !input config_entry
+  calendar_entity: !input calendar_entity
+  clear_on_end: !input clear_on_end
+  config_entry_title: >
+    {{ config_entry_attr(config_entry, 'title') }}
+  _all_entities: >
+    {{ integration_entities(config_entry_title) }}
+
+triggers:
+  - trigger: state
+    entity_id: !input calendar_entity
+
+actions:
+  - variables:
+      message: >
+        {{ state_attr(calendar_entity, 'message') | default('', true) }}
+      description: >
+        {{ state_attr(calendar_entity, 'description') | default('', true) }}
+      location: >
+        {{ state_attr(calendar_entity, 'location') | default('', true) }}
+      start_time: >
+        {{ state_attr(calendar_entity, 'start_time') | default('', true) }}
+      end_time: >
+        {{ state_attr(calendar_entity, 'end_time') | default('', true) }}
+      all_day: >
+        {{ state_attr(calendar_entity, 'all_day') | default(false, true) }}
+      slot_number: !input slot_number
+      pin_entity: >
+        {{ _all_entities
+           | select('match', 'text\\..*_code_slot_' ~ slot_number ~ '_pin')
+           | first | default('') }}
+      pin_value: !input pin_template
+  - choose:
+      - conditions:
+          - condition: template
+            value_template: >
+              {{ trigger.to_state.state == 'on'
+                 and pin_entity != ''
+                 and pin_value != '' }}
+        sequence:
+          - action: text.set_value
+            target:
+              entity_id: "{{ pin_entity }}"
+            data:
+              value: "{{ pin_value }}"
+      - conditions:
+          - condition: template
+            value_template: >
+              {{ trigger.to_state.state == 'off'
+                 and clear_on_end
+                 and pin_entity != '' }}
+        sequence:
+          - action: text.set_value
+            target:
+              entity_id: "{{ pin_entity }}"
+            data:
+              value: ""

--- a/blueprints/automation/lock_code_manager/slot_usage_limiter.yaml
+++ b/blueprints/automation/lock_code_manager/slot_usage_limiter.yaml
@@ -7,6 +7,13 @@ blueprint:
     Optionally resets the counter when the slot is re-enabled.
 
 
+    **Requirements**
+
+    This blueprint requires at least one lock that supports code slot events
+    (i.e. produces `*_code_slot_*_pin_used` events). If none of your locks
+    support this, the counter will never decrement.
+
+
     **Setup**
 
     1. Create an `input_number` helper (Settings → Devices & Services → Helpers)

--- a/blueprints/automation/lock_code_manager/slot_usage_limiter.yaml
+++ b/blueprints/automation/lock_code_manager/slot_usage_limiter.yaml
@@ -34,6 +34,14 @@ blueprint:
   # yamllint disable-line rule:line-length
   source_url: https://github.com/raman325/lock_code_manager/blob/main/blueprints/automation/lock_code_manager/slot_usage_limiter.yaml
   input:
+    config_entry:
+      name: Lock Code Manager config entry
+      description: >
+        The Lock Code Manager config entry that manages your lock(s).
+        Used to identify the setup in notifications.
+      selector:
+        config_entry:
+          integration: lock_code_manager
     pin_used_entity:
       name: PIN used event entity
       description: >
@@ -99,7 +107,9 @@ variables:
   initial_uses: !input initial_uses
   uses_counter: !input uses_counter
   notify_target: !input notify_target
-  _pin_used_entity: !input pin_used_entity
+  _config_entry: !input config_entry
+  _config_entry_title: >
+    {{ config_entry_attr(_config_entry, 'title') }}
   _enabled_switch: !input enabled_switch
 
 actions:
@@ -140,12 +150,12 @@ actions:
                     target:
                       entity_id: "{{ notify_target }}"
                     data:
-                      title: Lock Code Manager — Usage Limit Reached
+                      title: "{{ _config_entry_title }} — Usage Limit Reached"
                       message: >
                         {{ state_attr(_enabled_switch, 'friendly_name')
                            | default(_enabled_switch) }}
-                        has been disabled after reaching the usage limit.
-                        Last used at {{ now().strftime('%Y-%m-%d %H:%M:%S') }}.
+                        has been disabled after reaching the usage limit
+                        ({{ now().strftime('%Y-%m-%d %H:%M:%S') }}).
       - conditions:
           - condition: trigger
             id: slot_enabled

--- a/blueprints/automation/lock_code_manager/slot_usage_limiter.yaml
+++ b/blueprints/automation/lock_code_manager/slot_usage_limiter.yaml
@@ -85,16 +85,14 @@ max: 10
 trigger_variables:
   _config_entry: !input config_entry
   _slot: !input slot_number
-  _title: >
-    {{ config_entry_attr(_config_entry, 'title') }}
-  _all_entities: >
-    {{ integration_entities(_title) }}
   pin_used_entity: >
-    {{ _all_entities
+    {% set entities = integration_entities(config_entry_attr(_config_entry, 'title')) %}
+    {{ entities
        | select('match', 'event\\..*_code_slot_' ~ _slot ~ '_pin_used')
        | first | default('') }}
   enabled_switch: >
-    {{ _all_entities
+    {% set entities = integration_entities(config_entry_attr(_config_entry, 'title')) %}
+    {{ entities
        | select('match', 'switch\\..*_code_slot_' ~ _slot ~ '_enabled')
        | first | default('') }}
 

--- a/blueprints/automation/lock_code_manager/slot_usage_limiter.yaml
+++ b/blueprints/automation/lock_code_manager/slot_usage_limiter.yaml
@@ -8,6 +8,14 @@ blueprint:
     when the slot is re-enabled in Lock Code Manager.
 
 
+    **Special values**
+
+    - Set the counter to **-1** for unlimited uses (counter stays at -1,
+      slot is never disabled).
+
+    - Set the counter to **0** to immediately disable the slot on next use.
+
+
     **Requirements**
 
     This blueprint requires at least one lock that supports code slot events
@@ -18,7 +26,7 @@ blueprint:
     **Setup**
 
     1. Create an `input_number` helper (Settings → Devices & Services → Helpers)
-       with min=0, max=your desired limit, and step=1.
+       with min=-1, max=your desired limit, and step=1.
 
     2. Import this blueprint and configure it with the PIN used event entity,
        enabled switch entity, and the helper you just created.
@@ -47,8 +55,9 @@ blueprint:
     uses_counter:
       name: Uses counter
       description: >
-        An `input_number` helper that tracks remaining uses.
-        Create one via Settings → Devices & Services → Helpers.
+        An `input_number` helper that tracks remaining uses. Set to -1 for
+        unlimited uses. Create one via Settings → Devices & Services → Helpers
+        (set min to -1).
       selector:
         entity:
           domain: input_number
@@ -57,13 +66,22 @@ blueprint:
       description: >
         When greater than 0, the counter is automatically reset to this value
         each time the Lock Code Manager slot is re-enabled. Set to 0 to
-        disable auto-reset.
+        disable auto-reset. Set to -1 for unlimited uses on re-enable.
       default: 0
       selector:
         number:
-          min: 0
+          min: -1
           max: 999
           mode: box
+    notify_target:
+      name: Notification service (optional)
+      description: >
+        A notification service to call when uses are exhausted and the slot
+        is disabled (e.g. `notify.mobile_app_phone`). Leave empty to skip
+        notifications.
+      default: ""
+      selector:
+        text:
 
 mode: queued
 max: 10
@@ -80,6 +98,7 @@ triggers:
 variables:
   initial_uses: !input initial_uses
   uses_counter: !input uses_counter
+  notify_target: !input notify_target
 
 actions:
   - choose:
@@ -90,6 +109,13 @@ actions:
           - variables:
               current: >
                 {{ states(uses_counter) | int(0) }}
+          # -1 means unlimited — skip decrement and disable
+          - if:
+              - condition: template
+                value_template: "{{ current == -1 }}"
+            then:
+              - stop: "Unlimited uses — no action needed"
+          - variables:
               new_count: >
                 {{ [current - 1, 0] | max }}
           - action: input_number.set_value
@@ -104,11 +130,20 @@ actions:
               - action: switch.turn_off
                 target:
                   entity_id: !input enabled_switch
+              - if:
+                  - condition: template
+                    value_template: "{{ notify_target != '' }}"
+                then:
+                  - action: "{{ notify_target }}"
+                    data:
+                      title: Lock Code Manager
+                      message: >
+                        Code slot has been disabled — usage limit reached.
       - conditions:
           - condition: trigger
             id: slot_enabled
           - condition: template
-            value_template: "{{ initial_uses | int(0) > 0 }}"
+            value_template: "{{ initial_uses | int(0) != 0 }}"
         sequence:
           - action: input_number.set_value
             target:

--- a/blueprints/automation/lock_code_manager/slot_usage_limiter.yaml
+++ b/blueprints/automation/lock_code_manager/slot_usage_limiter.yaml
@@ -20,44 +20,30 @@ blueprint:
     1. Create an `input_number` helper (Settings → Devices & Services → Helpers)
        with min=0, max=your desired limit, and step=1.
 
-    2. Import this blueprint and configure it with your Lock Code Manager config
-       entry, slot number, and the helper you just created.
-
-
-    **Template debugging**
-
-    To test entity resolution, go to Developer Tools → Template and paste:
-
-    ```
-
-    {% set title = config_entry_attr('YOUR_CONFIG_ENTRY_ID', 'title') %}
-
-    {% set all = integration_entities(title) %}
-
-    {{ all | select('match', 'event\\..*_code_slot_1_pin_used') | list }}
-
-    ```
-
-    Replace YOUR_CONFIG_ENTRY_ID with your LCM config entry ID and 1 with your
-    slot number.
+    2. Import this blueprint and configure it with the PIN used event entity,
+       enabled switch entity, and the helper you just created.
   domain: automation
   # yamllint disable-line rule:line-length
   source_url: https://github.com/raman325/lock_code_manager/blob/main/blueprints/automation/lock_code_manager/slot_usage_limiter.yaml
   input:
-    config_entry:
-      name: Lock Code Manager config entry
-      description: The Lock Code Manager config entry that manages your lock(s).
+    pin_used_entity:
+      name: PIN used event entity
+      description: >
+        The Lock Code Manager event entity that fires when the PIN is used
+        (e.g. `event.front_door_code_slot_1_pin_used`).
       selector:
-        config_entry:
+        entity:
+          domain: event
           integration: lock_code_manager
-    slot_number:
-      name: Code slot number
-      description: The Lock Code Manager code slot number to monitor.
+    enabled_switch:
+      name: Slot enabled switch
+      description: >
+        The Lock Code Manager switch entity that enables/disables the code
+        slot (e.g. `switch.front_door_code_slot_1_enabled`).
       selector:
-        number:
-          min: 1
-          max: 999
-          mode: box
+        entity:
+          domain: switch
+          integration: lock_code_manager
     uses_counter:
       name: Uses counter
       description: >
@@ -82,26 +68,12 @@ blueprint:
 mode: queued
 max: 10
 
-trigger_variables:
-  _config_entry: !input config_entry
-  _slot: !input slot_number
-  pin_used_entity: >
-    {% set entities = integration_entities(config_entry_attr(_config_entry, 'title')) %}
-    {{ entities
-       | select('match', 'event\\..*_code_slot_' ~ _slot ~ '_pin_used')
-       | first | default('') }}
-  enabled_switch: >
-    {% set entities = integration_entities(config_entry_attr(_config_entry, 'title')) %}
-    {{ entities
-       | select('match', 'switch\\..*_code_slot_' ~ _slot ~ '_enabled')
-       | first | default('') }}
-
 triggers:
   - trigger: state
-    entity_id: "{{ pin_used_entity }}"
+    entity_id: !input pin_used_entity
     id: pin_used
   - trigger: state
-    entity_id: "{{ enabled_switch }}"
+    entity_id: !input enabled_switch
     id: slot_enabled
     to: "on"
 
@@ -131,7 +103,7 @@ actions:
             then:
               - action: switch.turn_off
                 target:
-                  entity_id: "{{ enabled_switch }}"
+                  entity_id: !input enabled_switch
       - conditions:
           - condition: trigger
             id: slot_enabled

--- a/blueprints/automation/lock_code_manager/slot_usage_limiter.yaml
+++ b/blueprints/automation/lock_code_manager/slot_usage_limiter.yaml
@@ -164,8 +164,9 @@ actions:
                       message: >
                         {{ _config_entry_title }} code slot {{ _slot_number }}
                         has been disabled after reaching the usage limit.
-                        Last used on
-                        {{ trigger.to_state.state | default('unknown lock') }}
+                        Last used on lock
+                        {{ state_attr(trigger.entity_id, 'event_type')
+                           | default('unknown') }}
                         at {{ now().strftime('%Y-%m-%d %H:%M:%S') }}.
       - conditions:
           - condition: trigger

--- a/blueprints/automation/lock_code_manager/slot_usage_limiter.yaml
+++ b/blueprints/automation/lock_code_manager/slot_usage_limiter.yaml
@@ -99,6 +99,8 @@ variables:
   initial_uses: !input initial_uses
   uses_counter: !input uses_counter
   notify_target: !input notify_target
+  _pin_used_entity: !input pin_used_entity
+  _enabled_switch: !input enabled_switch
 
 actions:
   - choose:
@@ -138,9 +140,12 @@ actions:
                     target:
                       entity_id: "{{ notify_target }}"
                     data:
-                      title: Lock Code Manager
+                      title: Lock Code Manager — Usage Limit Reached
                       message: >
-                        Code slot has been disabled — usage limit reached.
+                        {{ state_attr(_enabled_switch, 'friendly_name')
+                           | default(_enabled_switch) }}
+                        has been disabled after reaching the usage limit.
+                        Last used at {{ now().strftime('%Y-%m-%d %H:%M:%S') }}.
       - conditions:
           - condition: trigger
             id: slot_enabled

--- a/blueprints/automation/lock_code_manager/slot_usage_limiter.yaml
+++ b/blueprints/automation/lock_code_manager/slot_usage_limiter.yaml
@@ -158,10 +158,12 @@ actions:
                     target:
                       entity_id: "{{ notify_target }}"
                     data:
-                      title: "{{ _config_entry_title }} — Usage Limit Reached"
+                      title: >
+                        {{ _config_entry_title }} — Slot {{ _slot_number }}
+                        Usage Limit Reached
                       message: >
-                        Code slot {{ _slot_number }} has been disabled after
-                        reaching the usage limit
+                        {{ _config_entry_title }} code slot {{ _slot_number }}
+                        has been disabled after reaching the usage limit
                         ({{ now().strftime('%Y-%m-%d %H:%M:%S') }}).
       - conditions:
           - condition: trigger

--- a/blueprints/automation/lock_code_manager/slot_usage_limiter.yaml
+++ b/blueprints/automation/lock_code_manager/slot_usage_limiter.yaml
@@ -1,0 +1,138 @@
+---
+blueprint:
+  name: "Lock Code Manager: Slot Usage Limiter"
+  description: >
+    Decrements an `input_number` helper each time a code slot PIN is used.
+    When the counter reaches 0 the slot is automatically disabled.
+    Optionally resets the counter when the slot is re-enabled.
+
+
+    **Setup**
+
+    1. Create an `input_number` helper (Settings → Devices & Services → Helpers)
+       with min=0, max=your desired limit, and step=1.
+
+    2. Import this blueprint and configure it with your Lock Code Manager config
+       entry, slot number, and the helper you just created.
+
+
+    **Template debugging**
+
+    To test entity resolution, go to Developer Tools → Template and paste:
+
+    ```
+
+    {% set title = config_entry_attr('YOUR_CONFIG_ENTRY_ID', 'title') %}
+
+    {% set all = integration_entities(title) %}
+
+    {{ all | select('match', 'event\\..*_code_slot_1_pin_used') | list }}
+
+    ```
+
+    Replace YOUR_CONFIG_ENTRY_ID with your LCM config entry ID and 1 with your
+    slot number.
+  domain: automation
+  # yamllint disable-line rule:line-length
+  source_url: https://github.com/raman325/lock_code_manager/blob/main/blueprints/automation/lock_code_manager/slot_usage_limiter.yaml
+  input:
+    config_entry:
+      name: Lock Code Manager config entry
+      description: The Lock Code Manager config entry that manages your lock(s).
+      selector:
+        config_entry:
+          integration: lock_code_manager
+    slot_number:
+      name: Code slot number
+      description: The code slot number to monitor.
+      selector:
+        number:
+          min: 1
+          max: 999
+          mode: box
+    uses_counter:
+      name: Uses counter
+      description: >
+        An `input_number` helper that tracks remaining uses.
+        Create one via Settings → Devices & Services → Helpers.
+      selector:
+        entity:
+          domain: input_number
+    initial_uses:
+      name: Initial uses on re-enable
+      description: >
+        When greater than 0, the counter is automatically reset to this value
+        each time the slot is re-enabled. Set to 0 to disable auto-reset.
+      default: 0
+      selector:
+        number:
+          min: 0
+          max: 999
+          mode: box
+
+mode: queued
+max: 10
+
+trigger_variables:
+  _config_entry: !input config_entry
+  _slot: !input slot_number
+  _title: >
+    {{ config_entry_attr(_config_entry, 'title') }}
+  _all_entities: >
+    {{ integration_entities(_title) }}
+  pin_used_entity: >
+    {{ _all_entities
+       | select('match', 'event\\..*_code_slot_' ~ _slot ~ '_pin_used')
+       | first | default('') }}
+  enabled_switch: >
+    {{ _all_entities
+       | select('match', 'switch\\..*_code_slot_' ~ _slot ~ '_enabled')
+       | first | default('') }}
+
+triggers:
+  - trigger: state
+    entity_id: "{{ pin_used_entity }}"
+    id: pin_used
+  - trigger: state
+    entity_id: "{{ enabled_switch }}"
+    id: slot_enabled
+    to: "on"
+
+variables:
+  initial_uses: !input initial_uses
+  uses_counter: !input uses_counter
+
+actions:
+  - choose:
+      - conditions:
+          - condition: trigger
+            id: pin_used
+        sequence:
+          - variables:
+              current: >
+                {{ states(uses_counter) | int(0) }}
+              new_count: >
+                {{ [current - 1, 0] | max }}
+          - action: input_number.set_value
+            target:
+              entity_id: !input uses_counter
+            data:
+              value: "{{ new_count }}"
+          - if:
+              - condition: template
+                value_template: "{{ new_count == 0 }}"
+            then:
+              - action: switch.turn_off
+                target:
+                  entity_id: "{{ enabled_switch }}"
+      - conditions:
+          - condition: trigger
+            id: slot_enabled
+          - condition: template
+            value_template: "{{ initial_uses | int(0) > 0 }}"
+        sequence:
+          - action: input_number.set_value
+            target:
+              entity_id: !input uses_counter
+            data:
+              value: !input initial_uses

--- a/blueprints/automation/lock_code_manager/slot_usage_limiter.yaml
+++ b/blueprints/automation/lock_code_manager/slot_usage_limiter.yaml
@@ -42,6 +42,14 @@ blueprint:
       selector:
         config_entry:
           integration: lock_code_manager
+    slot_number:
+      name: Code slot number
+      description: The Lock Code Manager code slot number.
+      selector:
+        number:
+          min: 1
+          max: 999
+          mode: box
     pin_used_entity:
       name: PIN used event entity
       description: >
@@ -110,7 +118,7 @@ variables:
   _config_entry: !input config_entry
   _config_entry_title: >
     {{ config_entry_attr(_config_entry, 'title') }}
-  _enabled_switch: !input enabled_switch
+  _slot_number: !input slot_number
 
 actions:
   - choose:
@@ -152,9 +160,8 @@ actions:
                     data:
                       title: "{{ _config_entry_title }} — Usage Limit Reached"
                       message: >
-                        {{ state_attr(_enabled_switch, 'friendly_name')
-                           | default(_enabled_switch) }}
-                        has been disabled after reaching the usage limit
+                        Code slot {{ _slot_number }} has been disabled after
+                        reaching the usage limit
                         ({{ now().strftime('%Y-%m-%d %H:%M:%S') }}).
       - conditions:
           - condition: trigger

--- a/blueprints/automation/lock_code_manager/slot_usage_limiter.yaml
+++ b/blueprints/automation/lock_code_manager/slot_usage_limiter.yaml
@@ -76,12 +76,12 @@ blueprint:
     notify_target:
       name: Notification service (optional)
       description: >
-        A notification service to call when uses are exhausted and the slot
-        is disabled (e.g. `notify.mobile_app_phone`). Leave empty to skip
-        notifications.
+        A notify entity to send a message to when uses are exhausted and the
+        slot is disabled. Leave empty to skip notifications.
       default: ""
       selector:
-        text:
+        entity:
+          domain: notify
 
 mode: queued
 max: 10
@@ -134,7 +134,9 @@ actions:
                   - condition: template
                     value_template: "{{ notify_target != '' }}"
                 then:
-                  - action: "{{ notify_target }}"
+                  - action: notify.send_message
+                    target:
+                      entity_id: "{{ notify_target }}"
                     data:
                       title: Lock Code Manager
                       message: >

--- a/blueprints/automation/lock_code_manager/slot_usage_limiter.yaml
+++ b/blueprints/automation/lock_code_manager/slot_usage_limiter.yaml
@@ -2,9 +2,10 @@
 blueprint:
   name: "Lock Code Manager: Slot Usage Limiter"
   description: >
-    Decrements an `input_number` helper each time a code slot PIN is used.
-    When the counter reaches 0 the slot is automatically disabled.
-    Optionally resets the counter when the slot is re-enabled.
+    Decrements an `input_number` helper each time a Lock Code Manager code
+    slot PIN is used on the lock. When the counter reaches 0, the Lock Code
+    Manager slot is automatically disabled. Optionally resets the counter
+    when the slot is re-enabled in Lock Code Manager.
 
 
     **Requirements**
@@ -51,7 +52,7 @@ blueprint:
           integration: lock_code_manager
     slot_number:
       name: Code slot number
-      description: The code slot number to monitor.
+      description: The Lock Code Manager code slot number to monitor.
       selector:
         number:
           min: 1
@@ -69,7 +70,8 @@ blueprint:
       name: Initial uses on re-enable
       description: >
         When greater than 0, the counter is automatically reset to this value
-        each time the slot is re-enabled. Set to 0 to disable auto-reset.
+        each time the Lock Code Manager slot is re-enabled. Set to 0 to
+        disable auto-reset.
       default: 0
       selector:
         number:

--- a/blueprints/automation/lock_code_manager/slot_usage_limiter.yaml
+++ b/blueprints/automation/lock_code_manager/slot_usage_limiter.yaml
@@ -163,8 +163,10 @@ actions:
                         Usage Limit Reached
                       message: >
                         {{ _config_entry_title }} code slot {{ _slot_number }}
-                        has been disabled after reaching the usage limit
-                        ({{ now().strftime('%Y-%m-%d %H:%M:%S') }}).
+                        has been disabled after reaching the usage limit.
+                        Last used on
+                        {{ trigger.to_state.state | default('unknown lock') }}
+                        at {{ now().strftime('%Y-%m-%d %H:%M:%S') }}.
       - conditions:
           - condition: trigger
             id: slot_enabled

--- a/blueprints/template/lock_code_manager/calendar_condition.yaml
+++ b/blueprints/template/lock_code_manager/calendar_condition.yaml
@@ -29,7 +29,7 @@ blueprint:
 
     - `name_state` — the current name of the code slot
 
-    - `lock_entity_ids` — list of lock entity IDs managed by this slot
+    - `lock_entity_ids` — list of lock entity IDs that support code slot events for this slot
 
 
     **Example condition templates**

--- a/blueprints/template/lock_code_manager/calendar_condition.yaml
+++ b/blueprints/template/lock_code_manager/calendar_condition.yaml
@@ -1,0 +1,136 @@
+---
+blueprint:
+  name: "Lock Code Manager: Calendar Condition"
+  description: >
+    Creates a binary sensor that turns ON when a calendar event is active and
+    an optional condition template is truthy. Assign the resulting binary sensor
+    as the condition entity for a Lock Code Manager code slot.
+
+
+    **Available template variables**
+
+    Your condition template can use these variables:
+
+    - `message` — calendar event summary/title
+
+    - `description` — calendar event description
+
+    - `location` — calendar event location
+
+    - `start_time` — event start time
+
+    - `end_time` — event end time
+
+    - `all_day` — whether the event is an all-day event
+
+    - `slot_number` — the resolved slot number
+
+    - `config_entry_title` — the LCM config entry title
+
+    - `name_state` — the current name of the code slot
+
+    - `lock_entity_ids` — list of lock entity IDs managed by this slot
+
+
+    **Example condition templates**
+
+    - Allow when event title contains "Guest": `{{ 'Guest' in message }}`
+
+    - Allow only for a specific lock: `{{ 'lock.front_door' in lock_entity_ids }}`
+
+
+    **Note:** The condition template and calendar attributes are evaluated when the
+    sensor is first loaded and when Home Assistant reloads template entities. For
+    the default `{{ true }}`, the sensor dynamically tracks the calendar on/off
+    state. For conditions that reference event attributes, reload template entities
+    after calendar event changes to re-evaluate.
+
+
+    **Template debugging**
+
+    To test your condition template, go to Developer Tools → Template and paste:
+
+    ```
+
+    {% set message = state_attr('calendar.YOUR_CALENDAR', 'message') | default('', true) %}
+
+    {% set description = state_attr('calendar.YOUR_CALENDAR', 'description') | default('', true) %}
+
+    {% set location = state_attr('calendar.YOUR_CALENDAR', 'location') | default('', true) %}
+
+    {{ YOUR_CONDITION_TEMPLATE_HERE }}
+
+    ```
+  domain: template
+  # yamllint disable-line rule:line-length
+  source_url: https://github.com/raman325/lock_code_manager/blob/main/blueprints/template/lock_code_manager/calendar_condition.yaml
+  input:
+    config_entry:
+      name: Lock Code Manager config entry
+      description: The Lock Code Manager config entry that manages your lock(s).
+      selector:
+        config_entry:
+          integration: lock_code_manager
+    slot_number:
+      name: Slot number
+      description: >
+        The code slot number. Can be a static number (e.g. `3`) or a Jinja2
+        template that resolves to a number using calendar event attributes
+        (e.g. `{{ description | regex_findall('slot (\d+)') | first }}`).
+      selector:
+        template:
+    calendar_entity:
+      name: Calendar entity
+      description: The calendar entity whose events control this condition.
+      selector:
+        entity:
+          domain: calendar
+    condition_template:
+      name: Condition template
+      description: >
+        A Jinja2 template that must evaluate to truthy for the sensor to turn
+        ON (in addition to the calendar being active). Leave as `{{ true }}`
+        to activate whenever the calendar event is active.
+      default: "{{ true }}"
+      selector:
+        template:
+
+variables:
+  config_entry: !input config_entry
+  calendar_entity: !input calendar_entity
+  config_entry_title: >
+    {{ config_entry_attr(config_entry, 'title') }}
+  _all_entities: >
+    {{ integration_entities(config_entry_title) }}
+  message: >
+    {{ state_attr(calendar_entity, 'message') | default('', true) }}
+  description: >
+    {{ state_attr(calendar_entity, 'description') | default('', true) }}
+  location: >
+    {{ state_attr(calendar_entity, 'location') | default('', true) }}
+  start_time: >
+    {{ state_attr(calendar_entity, 'start_time') | default('', true) }}
+  end_time: >
+    {{ state_attr(calendar_entity, 'end_time') | default('', true) }}
+  all_day: >
+    {{ state_attr(calendar_entity, 'all_day') | default(false, true) }}
+  slot_number: !input slot_number
+  _name_entity: >
+    {{ _all_entities
+       | select('match', 'text\\..*_code_slot_' ~ slot_number ~ '_name')
+       | first | default('') }}
+  name_state: >
+    {{ states(_name_entity) if _name_entity else '' }}
+  _event_entity: >
+    {{ _all_entities
+       | select('match', 'event\\..*_code_slot_' ~ slot_number ~ '_pin_used')
+       | first | default('') }}
+  lock_entity_ids: >
+    {{ state_attr(_event_entity, 'event_types') | default([]) }}
+  _condition_result: !input condition_template
+
+binary_sensor:
+  state: >
+    {{ is_state(calendar_entity, 'on') and _condition_result }}
+  availability: >
+    {{ states(calendar_entity) not in ('unknown', 'unavailable') }}


### PR DESCRIPTION
## Proposed change

Add three Home Assistant blueprints that externalize slot usage tracking and calendar-based code slot management, keeping LCM lean while giving users more flexibility:

- **Slot Usage Limiter** (`automation`): Decrements a user-created `input_number` helper each time a code slot PIN is used. Automatically disables the slot when the counter reaches 0. Optionally resets the counter when the slot is re-enabled.
- **Calendar Condition** (`template`): Creates a `binary_sensor` that turns ON when a calendar event is active and an optional condition template is truthy. Users assign this sensor as the LCM slot's condition entity.
- **Calendar PIN Setter** (`automation`): Extracts PINs from calendar event attributes using a user-provided Jinja2 template and sets them on LCM code slots via `text.set_value`. Optionally clears the PIN when the event ends.

All blueprints derive LCM entity IDs automatically from a `config_entry` selector + slot number using `integration_entities()` and `config_entry_attr()`.

Also excludes `blueprints/` from the `check-yaml` pre-commit hook since HA's `!input` YAML tag is not recognized by standard YAML loaders.

## Type of change

- [x] New feature (which adds functionality)

## Additional information

- Blueprint files live in `blueprints/automation/lock_code_manager/` and `blueprints/template/lock_code_manager/`
- The Calendar Condition blueprint's `condition_template` variable is evaluated at template entity load time (and on HA template reload), not dynamically on each calendar event change. For the default `{{ true }}`, the sensor dynamically tracks calendar on/off state. This limitation is documented in the blueprint description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)