### PR TITLE
Add date range condition and condition linker blueprints

### DIFF
--- a/blueprints/automation/lock_code_manager/condition_linker.yaml
+++ b/blueprints/automation/lock_code_manager/condition_linker.yaml
@@ -56,11 +56,11 @@ blueprint:
 
 mode: single
 
-trigger:
+triggers:
   - trigger: event
     event_type: lock_code_manager_condition_linker
 
-action:
+actions:
   - action: lock_code_manager.set_slot_condition
     data:
       config_entry_id: !input config_entry

--- a/blueprints/automation/lock_code_manager/condition_linker.yaml
+++ b/blueprints/automation/lock_code_manager/condition_linker.yaml
@@ -1,0 +1,68 @@
+---
+blueprint:
+  name: "Lock Code Manager: Condition Linker"
+  description: >
+    A one-shot automation that calls `lock_code_manager.set_slot_condition`
+    to wire a condition entity to a code slot. This blueprint provides a
+    UI-friendly way to assign condition entities without editing YAML.
+
+
+    **Usage**
+
+    1. Import this blueprint and create an automation from it.
+
+    2. Configure the LCM config entry, slot number, and condition entity.
+
+    3. Manually run the automation once from the Automations page
+       (three-dot menu -> Run).
+
+    4. The condition entity is now assigned to the slot. You can delete
+       the automation afterward or keep it for reference.
+
+
+    **Note:** This automation uses a synthetic event trigger that never
+    fires on its own. You must manually run it from the UI.
+  domain: automation
+  # yamllint disable-line rule:line-length
+  source_url: https://github.com/raman325/lock_code_manager/blob/main/blueprints/automation/lock_code_manager/condition_linker.yaml
+  input:
+    config_entry:
+      name: Lock Code Manager config entry
+      description: The Lock Code Manager config entry that manages your lock(s).
+      selector:
+        config_entry:
+          integration: lock_code_manager
+    slot_number:
+      name: Slot number
+      description: The code slot number to assign the condition entity to (1-9999).
+      selector:
+        number:
+          min: 1
+          max: 9999
+          mode: box
+    condition_entity:
+      name: Condition entity
+      description: >
+        The entity to use as the condition for this slot. The slot's PIN
+        will only be active when this entity's state is `on`.
+      selector:
+        entity:
+          domain:
+            - binary_sensor
+            - calendar
+            - input_boolean
+            - schedule
+            - switch
+
+mode: single
+
+trigger:
+  - trigger: event
+    event_type: lock_code_manager_condition_linker
+
+action:
+  - action: lock_code_manager.set_slot_condition
+    data:
+      config_entry_id: !input config_entry
+      slot: !input slot_number
+      entity_id: !input condition_entity

--- a/blueprints/automation/lock_code_manager/condition_linker.yaml
+++ b/blueprints/automation/lock_code_manager/condition_linker.yaml
@@ -56,6 +56,8 @@ blueprint:
 
 mode: single
 
+# Synthetic trigger that never fires naturally. The user manually runs
+# this automation once from the Automations page to wire the condition.
 triggers:
   - trigger: event
     event_type: lock_code_manager_condition_linker

--- a/blueprints/template/lock_code_manager/date_range_condition.yaml
+++ b/blueprints/template/lock_code_manager/date_range_condition.yaml
@@ -51,8 +51,7 @@ variables:
   end_entity: !input end_datetime
 
 binary_sensor:
-  - name: "Date Range Condition"
-    state: >-
+  - state: >-
       {% set start = states(start_entity) %}
       {% set end = states(end_entity) %}
       {% if start in ['unknown', 'unavailable'] or end in ['unknown', 'unavailable'] %}

--- a/blueprints/template/lock_code_manager/date_range_condition.yaml
+++ b/blueprints/template/lock_code_manager/date_range_condition.yaml
@@ -57,7 +57,9 @@ binary_sensor:
       {% if start in ['unknown', 'unavailable'] or end in ['unknown', 'unavailable'] %}
         false
       {% else %}
-        {{ start <= now().strftime('%Y-%m-%d %H:%M:%S') <= end }}
+        {% set start_dt = as_datetime(start) %}
+        {% set end_dt = as_datetime(end) %}
+        {{ start_dt <= now() <= end_dt }}
       {% endif %}
     availability: >-
       {% set start = states(start_entity) %}

--- a/blueprints/template/lock_code_manager/date_range_condition.yaml
+++ b/blueprints/template/lock_code_manager/date_range_condition.yaml
@@ -57,9 +57,9 @@ binary_sensor:
       {% if start in ['unknown', 'unavailable'] or end in ['unknown', 'unavailable'] %}
         false
       {% else %}
-        {% set start_dt = as_datetime(start) %}
-        {% set end_dt = as_datetime(end) %}
-        {{ start_dt <= now() <= end_dt }}
+        {% set start_dt = start | as_datetime | as_utc %}
+        {% set end_dt = end | as_datetime | as_utc %}
+        {{ start_dt <= utcnow() <= end_dt }}
       {% endif %}
     availability: >-
       {% set start = states(start_entity) %}

--- a/blueprints/template/lock_code_manager/date_range_condition.yaml
+++ b/blueprints/template/lock_code_manager/date_range_condition.yaml
@@ -1,0 +1,66 @@
+---
+blueprint:
+  name: "Lock Code Manager: Date Range Condition"
+  description: >
+    Creates a binary sensor that turns ON when the current time is between
+    two `input_datetime` helper entities. Assign the resulting binary sensor
+    as the condition entity for a Lock Code Manager code slot.
+
+
+    **Setup**
+
+    1. Create two `input_datetime` helpers (Settings -> Devices & Services ->
+       Helpers) — one for the start date/time and one for the end date/time.
+       Enable both "Date" and "Time" on each helper.
+
+    2. Import this blueprint and configure it with your start and end
+       date/time helpers.
+
+    3. The blueprint creates a binary sensor — assign it as the condition
+       entity for your code slot.
+
+
+    **How it works**
+
+    The sensor is ON when `now()` is between the start and end date/times.
+    If either helper is `unknown` or `unavailable`, the sensor becomes
+    unavailable (condition blocks access).
+  domain: template
+  # yamllint disable-line rule:line-length
+  source_url: https://github.com/raman325/lock_code_manager/blob/main/blueprints/template/lock_code_manager/date_range_condition.yaml
+  input:
+    start_datetime:
+      name: Start date/time
+      description: >
+        An `input_datetime` helper that defines when the access window
+        begins.
+      selector:
+        entity:
+          domain: input_datetime
+    end_datetime:
+      name: End date/time
+      description: >
+        An `input_datetime` helper that defines when the access window
+        ends.
+      selector:
+        entity:
+          domain: input_datetime
+
+variables:
+  start_entity: !input start_datetime
+  end_entity: !input end_datetime
+
+binary_sensor:
+  - name: "Date Range Condition"
+    state: >-
+      {% set start = states(start_entity) %}
+      {% set end = states(end_entity) %}
+      {% if start in ['unknown', 'unavailable'] or end in ['unknown', 'unavailable'] %}
+        false
+      {% else %}
+        {{ start <= now().strftime('%Y-%m-%d %H:%M:%S') <= end }}
+      {% endif %}
+    availability: >-
+      {% set start = states(start_entity) %}
+      {% set end = states(end_entity) %}
+      {{ start not in ['unknown', 'unavailable'] and end not in ['unknown', 'unavailable'] }}


### PR DESCRIPTION
## Proposed change

Two new blueprints for managing condition entities on code slots.

**Date Range Condition** (`blueprints/template/lock_code_manager/date_range_condition.yaml`):
- Template blueprint that creates a binary sensor ON when \`now()\` is between two \`input_datetime\` helpers
- User creates the \`input_datetime\` helpers manually, then uses this blueprint to create the sensor
- Handles \`unknown\`/\`unavailable\` states gracefully

**Condition Linker** (`blueprints/automation/lock_code_manager/condition_linker.yaml`):
- Automation blueprint that calls \`lock_code_manager.set_slot_condition\` to wire a condition entity to a slot
- One-shot: user runs it manually once from the automations page
- Inputs: config entry, slot number, condition entity

## Type of change

- [x] New feature (which adds functionality)

## Additional information

- This PR is related to issue: #1003
- Requires services from #1006 to be released first (condition linker calls \`lock_code_manager.set_slot_condition\`)
- Wiki updates staged locally, will be pushed after this PR and #1006/#1007 are merged and released