### PR TITLE
Add auto-relock, door lock on close, and slot usage notifier blueprints

### DIFF
--- a/BLUEPRINTS.md
+++ b/BLUEPRINTS.md
@@ -9,14 +9,18 @@ for additional setup guides and examples.
 
 ## Table of Contents
 
-1. [Slot Usage Limiter](#slot-usage-limiter) *(automation)*
-1. [Calendar Condition](#calendar-condition) *(template)*
-1. [Date Range Condition](#date-range-condition) *(template)*
-1. [Calendar PIN Setter](#calendar-pin-setter) *(automation)*
-1. [Auto Re-lock](#auto-re-lock) *(automation)*
-1. [Lock on Door Close](#lock-on-door-close) *(automation)*
-1. [Slot Usage Notifier](#slot-usage-notifier) *(automation)*
-1. [Condition Linker](#condition-linker) *(automation)*
+1. Access Control
+   - [Slot Usage Limiter](#slot-usage-limiter) *(automation)*
+   - [Calendar Condition](#calendar-condition) *(template)*
+   - [Date Range Condition](#date-range-condition) *(template)*
+   - [Calendar PIN Setter](#calendar-pin-setter) *(automation)*
+1. Lock Automation
+   - [Auto Re-lock](#auto-re-lock) *(automation)*
+   - [Lock on Door Close](#lock-on-door-close) *(automation)*
+1. Notifications
+   - [Slot Usage Notifier](#slot-usage-notifier) *(automation)*
+1. Setup Helpers
+   - [Condition Linker](#condition-linker) *(automation)*
 
 ---
 

--- a/BLUEPRINTS.md
+++ b/BLUEPRINTS.md
@@ -7,6 +7,17 @@ Home Assistant with one click.
 See the [wiki](https://github.com/raman325/lock_code_manager/wiki/Blueprints)
 for additional setup guides and examples.
 
+## Table of Contents
+
+1. [Slot Usage Limiter](#slot-usage-limiter) *(automation)*
+1. [Calendar Condition](#calendar-condition) *(template)*
+1. [Date Range Condition](#date-range-condition) *(template)*
+1. [Calendar PIN Setter](#calendar-pin-setter) *(automation)*
+1. [Auto Re-lock](#auto-re-lock) *(automation)*
+1. [Lock on Door Close](#lock-on-door-close) *(automation)*
+1. [Slot Usage Notifier](#slot-usage-notifier) *(automation)*
+1. [Condition Linker](#condition-linker) *(automation)*
+
 ---
 
 ## Access Control

--- a/BLUEPRINTS.md
+++ b/BLUEPRINTS.md
@@ -7,20 +7,20 @@ See the [wiki](https://github.com/raman325/lock_code_manager/wiki/Blueprints) fo
 ## Table of Contents
 
 **Access Control**
-- [Slot Usage Limiter](#slot-usage-limiter) — Disable a slot after a set number of uses
-- [Calendar Condition](#calendar-condition) — Control slot access based on calendar events
-- [Date Range Condition](#date-range-condition) — Control slot access based on start/end dates
-- [Calendar PIN Setter](#calendar-pin-setter) — Extract and set PINs from calendar events
+- [Slot Usage Limiter](#slot-usage-limiter) *(automation)* — Disable a slot after a set number of uses
+- [Calendar Condition](#calendar-condition) *(template)* — Control slot access based on calendar events
+- [Date Range Condition](#date-range-condition) *(template)* — Control slot access based on start/end dates
+- [Calendar PIN Setter](#calendar-pin-setter) *(automation)* — Extract and set PINs from calendar events
 
 **Lock Automation**
-- [Auto Re-lock](#auto-re-lock) — Automatically re-lock after a configurable delay
-- [Lock on Door Close](#lock-on-door-close) — Lock when a door sensor detects the door closed
+- [Auto Re-lock](#auto-re-lock) *(automation)* — Automatically re-lock after a configurable delay
+- [Lock on Door Close](#lock-on-door-close) *(automation)* — Lock when a door sensor detects the door closed
 
 **Notifications**
-- [Slot Usage Notifier](#slot-usage-notifier) — Send a notification when a code slot PIN is used
+- [Slot Usage Notifier](#slot-usage-notifier) *(automation)* — Send a notification when a code slot PIN is used
 
 **Setup Helpers**
-- [Condition Linker](#condition-linker) — Assign a condition entity to a slot via the UI
+- [Condition Linker](#condition-linker) *(automation)* — Assign a condition entity to a slot via the UI
 
 ---
 

--- a/BLUEPRINTS.md
+++ b/BLUEPRINTS.md
@@ -1,30 +1,11 @@
 # Blueprints
 
-Lock Code Manager includes pre-built blueprints for common lock management patterns. Each blueprint can be imported directly into Home Assistant with one click.
+Lock Code Manager includes pre-built blueprints for common lock
+management patterns. Each blueprint can be imported directly into
+Home Assistant with one click.
 
-See the [wiki](https://github.com/raman325/lock_code_manager/wiki/Blueprints) for additional setup guides and examples.
-
-## Table of Contents
-
-**Access Control**
-
-- [Slot Usage Limiter](#slot-usage-limiter) *(automation)* — Disable a slot after a set number of uses
-- [Calendar Condition](#calendar-condition) *(template)* — Control slot access based on calendar events
-- [Date Range Condition](#date-range-condition) *(template)* — Control slot access based on start/end dates
-- [Calendar PIN Setter](#calendar-pin-setter) *(automation)* — Extract and set PINs from calendar events
-
-**Lock Automation**
-
-- [Auto Re-lock](#auto-re-lock) *(automation)* — Automatically re-lock after a configurable delay
-- [Lock on Door Close](#lock-on-door-close) *(automation)* — Lock when a door sensor detects the door closed
-
-**Notifications**
-
-- [Slot Usage Notifier](#slot-usage-notifier) *(automation)* — Send a notification when a code slot PIN is used
-
-**Setup Helpers**
-
-- [Condition Linker](#condition-linker) *(automation)* — Assign a condition entity to a slot via the UI
+See the [wiki](https://github.com/raman325/lock_code_manager/wiki/Blueprints)
+for additional setup guides and examples.
 
 ---
 
@@ -32,7 +13,9 @@ See the [wiki](https://github.com/raman325/lock_code_manager/wiki/Blueprints) fo
 
 ### Slot Usage Limiter
 
-Decrements an `input_number` helper each time a code slot PIN is used. When the counter reaches 0, the slot is automatically disabled. Optionally resets the counter when the slot is re-enabled.
+Decrements an `input_number` helper each time a code slot PIN is
+used. When the counter reaches 0, the slot is automatically disabled.
+Optionally resets the counter when the slot is re-enabled.
 
 - Set counter to **-1** for unlimited uses
 - Set counter to **0** to disable on next use
@@ -41,7 +24,7 @@ Decrements an `input_number` helper each time a code slot PIN is used. When the 
 [![Import Blueprint](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Framan325%2Flock_code_manager%2Fblob%2Fmain%2Fblueprints%2Fautomation%2Flock_code_manager%2Fslot_usage_limiter.yaml)
 
 | Input | Description | Default |
-|-------|-------------|---------|
+| ----- | ----------- | ------- |
 | Config entry | LCM config entry that manages your locks | Required |
 | Slot number | Code slot to monitor (1-9999) | Required |
 | Uses counter | `input_number` helper for tracking remaining uses | Required |
@@ -49,7 +32,10 @@ Decrements an `input_number` helper each time a code slot PIN is used. When the 
 
 ### Calendar Condition
 
-Creates a template binary sensor that turns ON when a calendar event is active and an optional condition template evaluates to true. Assign the sensor as a condition entity on a code slot to control when the PIN is active.
+Creates a template binary sensor that turns ON when a calendar
+event is active and an optional condition template evaluates to
+true. Assign the sensor as a condition entity on a code slot to
+control when the PIN is active.
 
 - Filter by event title, description, or location using Jinja2 templates
 - Supports any HA calendar integration (local, Google, CalDAV, etc.)
@@ -57,14 +43,16 @@ Creates a template binary sensor that turns ON when a calendar event is active a
 [![Import Blueprint](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Framan325%2Flock_code_manager%2Fblob%2Fmain%2Fblueprints%2Ftemplate%2Flock_code_manager%2Fcalendar_condition.yaml)
 
 | Input | Description | Default |
-|-------|-------------|---------|
+| ----- | ----------- | ------- |
 | Config entry | LCM config entry | Required |
 | Calendar entity | Calendar to monitor | Required |
 | Condition template | Jinja2 template to filter events | `{{ true }}` |
 
 ### Date Range Condition
 
-Creates a template binary sensor that turns ON when the current time is between two `input_datetime` helpers. Use for rental-style access windows with specific check-in/check-out times.
+Creates a template binary sensor that turns ON when the current
+time is between two `input_datetime` helpers. Use for rental-style
+access windows with specific check-in/check-out times.
 
 - Create `input_datetime` helpers first (Settings > Helpers)
 - Enable both "Date" and "Time" on each helper for date+time ranges
@@ -73,13 +61,16 @@ Creates a template binary sensor that turns ON when the current time is between 
 [![Import Blueprint](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Framan325%2Flock_code_manager%2Fblob%2Fmain%2Fblueprints%2Ftemplate%2Flock_code_manager%2Fdate_range_condition.yaml)
 
 | Input | Description | Default |
-|-------|-------------|---------|
+| ----- | ----------- | ------- |
 | Start date/time | `input_datetime` helper for access window start | Required |
 | End date/time | `input_datetime` helper for access window end | Required |
 
 ### Calendar PIN Setter
 
-Extracts a PIN from calendar event attributes using a Jinja2 template and sets it on a code slot. Optionally clears the PIN when the event ends. Useful for automated guest access via shared calendars.
+Extracts a PIN from calendar event attributes using a Jinja2
+template and sets it on a code slot. Optionally clears the PIN
+when the event ends. Useful for automated guest access via shared
+calendars.
 
 - Extract PINs from event title, description, or location
 - Optionally set the slot number dynamically from the event
@@ -88,7 +79,7 @@ Extracts a PIN from calendar event attributes using a Jinja2 template and sets i
 [![Import Blueprint](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Framan325%2Flock_code_manager%2Fblob%2Fmain%2Fblueprints%2Fautomation%2Flock_code_manager%2Fcalendar_pin_setter.yaml)
 
 | Input | Description | Default |
-|-------|-------------|---------|
+| ----- | ----------- | ------- |
 | Config entry | LCM config entry | Required |
 | Calendar entity | Calendar to monitor for events | Required |
 | PIN template | Jinja2 template to extract PIN from event | Required |
@@ -101,32 +92,35 @@ Extracts a PIN from calendar event attributes using a Jinja2 template and sets i
 
 ### Auto Re-lock
 
-Automatically re-locks a lock after it has been unlocked for a configurable amount of time. Supports separate day and night delays based on the sun entity's state (sunrise/sunset).
+Automatically re-locks a lock after it has been unlocked for a
+configurable amount of time. Supports separate day and night delays
+based on the sun entity's state (sunrise/sunset).
 
-- If the lock is manually locked before the timer expires, the timer is cancelled
+- If the lock is manually locked before the timer expires, it cancels
 - Set night delay to 0 to use the same delay for both day and night
 - Uses `mode: restart` so a new unlock resets the timer
 
 [![Import Blueprint](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Framan325%2Flock_code_manager%2Fblob%2Fmain%2Fblueprints%2Fautomation%2Flock_code_manager%2Fauto_relock.yaml)
 
 | Input | Description | Default |
-|-------|-------------|---------|
+| ----- | ----------- | ------- |
 | Lock | Lock entity to auto-relock | Required |
 | Day delay | Minutes to wait before re-locking during the day | 5 |
 | Night delay | Minutes to wait at night (0 = use day delay) | 0 |
 
 ### Lock on Door Close
 
-Automatically locks a lock when a door sensor detects the door has closed while the lock is unlocked. Useful for ensuring the door is always locked when closed.
+Automatically locks a lock when a door sensor detects the door
+has closed while the lock is unlocked.
 
-- Only locks if the lock is currently unlocked when the door closes
+- Only locks if the lock is currently unlocked when door closes
 - Optional delay to allow the door to fully close before locking
 - Uses `mode: single` to prevent duplicate lock commands
 
 [![Import Blueprint](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Framan325%2Flock_code_manager%2Fblob%2Fmain%2Fblueprints%2Fautomation%2Flock_code_manager%2Fdoor_lock_on_close.yaml)
 
 | Input | Description | Default |
-|-------|-------------|---------|
+| ----- | ----------- | ------- |
 | Lock | Lock entity to control | Required |
 | Door sensor | Binary sensor (door class) for open/closed state | Required |
 | Lock delay | Seconds to wait after door closes before locking | 5 |
@@ -137,16 +131,18 @@ Automatically locks a lock when a door sensor detects the door has closed while 
 
 ### Slot Usage Notifier
 
-Sends a notification when a code slot PIN is used on a lock. Works with any Home Assistant notification service (mobile app, email, Slack, etc.) and supports customizable message templates.
+Sends a notification when a code slot PIN is used on a lock.
+Works with any Home Assistant notification service (mobile app,
+email, Slack, etc.) and supports customizable message templates.
 
 - Requires a lock that supports code slot events
-- Message template can include slot name, number, lock name, and timestamp
+- Message template includes slot name, number, lock name, timestamp
 - Uses `mode: queued` to handle rapid successive uses
 
 [![Import Blueprint](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Framan325%2Flock_code_manager%2Fblob%2Fmain%2Fblueprints%2Fautomation%2Flock_code_manager%2Fslot_usage_notifier.yaml)
 
 | Input | Description | Default |
-|-------|-------------|---------|
+| ----- | ----------- | ------- |
 | Event entity | Code slot event entity (fires on PIN use) | Required |
 | Notification service | HA notify service (e.g., `notify.mobile_app_phone`) | Required |
 | Message template | Notification message with template variables | See default |
@@ -158,7 +154,10 @@ Sends a notification when a code slot PIN is used on a lock. Works with any Home
 
 ### Condition Linker
 
-A one-shot automation that assigns a condition entity to a code slot via the `lock_code_manager.set_slot_condition` service. Run it once from the Automations page, then delete or keep for reference.
+A one-shot automation that assigns a condition entity to a code
+slot via the `lock_code_manager.set_slot_condition` service. Run
+it once from the Automations page, then delete or keep for
+reference.
 
 - Uses a synthetic event trigger that never fires automatically
 - Manually run from the Automations page (three-dot menu > Run)
@@ -166,7 +165,7 @@ A one-shot automation that assigns a condition entity to a code slot via the `lo
 [![Import Blueprint](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Framan325%2Flock_code_manager%2Fblob%2Fmain%2Fblueprints%2Fautomation%2Flock_code_manager%2Fcondition_linker.yaml)
 
 | Input | Description | Default |
-|-------|-------------|---------|
+| ----- | ----------- | ------- |
 | Config entry | LCM config entry | Required |
 | Slot number | Code slot to assign the condition to (1-9999) | Required |
 | Condition entity | Entity to use as the condition | Required |

--- a/BLUEPRINTS.md
+++ b/BLUEPRINTS.md
@@ -41,7 +41,7 @@ Optionally resets the counter when the slot is re-enabled.
 | Input | Description | Default |
 | ----- | ----------- | ------- |
 | Config entry | LCM config entry that manages your locks | Required |
-| Slot number | Code slot to monitor (1-9999) | Required |
+| Slot number | Code slot to monitor | Required |
 | Uses counter | `input_number` helper for tracking remaining uses | Required |
 | Initial uses | Number of uses to reset to when slot is re-enabled (0 = no reset) | 0 |
 
@@ -111,7 +111,7 @@ Automatically re-locks a lock after it has been unlocked for a
 configurable amount of time. Supports separate day and night delays
 based on the sun entity's state (sunrise/sunset).
 
-- If the lock is manually locked before the timer expires, it cancels
+- If the lock is locked before the timer expires, the lock is skipped
 - Set night delay to 0 to use the same delay for both day and night
 - Uses `mode: restart` so a new unlock resets the timer
 
@@ -146,12 +146,11 @@ has closed while the lock is unlocked.
 
 ### Slot Usage Notifier
 
-Sends a notification when a code slot PIN is used on a lock.
-Works with any Home Assistant notification service (mobile app,
-email, Slack, etc.) and supports customizable message templates.
+Runs actions when a code slot PIN is used on a lock. Use it to
+send notifications, trigger scripts, or run any HA action.
 
 - Requires a lock that supports code slot events
-- Message template includes slot name, number, lock name, timestamp
+- Template variables: `slot_name`, `slot_num`, `lock_name`, `timestamp`
 - Uses `mode: queued` to handle rapid successive uses
 
 [![Import Blueprint](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Framan325%2Flock_code_manager%2Fblob%2Fmain%2Fblueprints%2Fautomation%2Flock_code_manager%2Fslot_usage_notifier.yaml)
@@ -159,9 +158,7 @@ email, Slack, etc.) and supports customizable message templates.
 | Input | Description | Default |
 | ----- | ----------- | ------- |
 | Event entity | Code slot event entity (fires on PIN use) | Required |
-| Notification service | HA notify service (e.g., `notify.mobile_app_phone`) | Required |
-| Message template | Notification message with template variables | See default |
-| Notification title | Title for the notification | `Lock Code Used` |
+| Actions | HA actions to run (notifications, scripts, etc.) | Required |
 
 ---
 

--- a/BLUEPRINTS.md
+++ b/BLUEPRINTS.md
@@ -7,19 +7,23 @@ See the [wiki](https://github.com/raman325/lock_code_manager/wiki/Blueprints) fo
 ## Table of Contents
 
 **Access Control**
+
 - [Slot Usage Limiter](#slot-usage-limiter) *(automation)* — Disable a slot after a set number of uses
 - [Calendar Condition](#calendar-condition) *(template)* — Control slot access based on calendar events
 - [Date Range Condition](#date-range-condition) *(template)* — Control slot access based on start/end dates
 - [Calendar PIN Setter](#calendar-pin-setter) *(automation)* — Extract and set PINs from calendar events
 
 **Lock Automation**
+
 - [Auto Re-lock](#auto-re-lock) *(automation)* — Automatically re-lock after a configurable delay
 - [Lock on Door Close](#lock-on-door-close) *(automation)* — Lock when a door sensor detects the door closed
 
 **Notifications**
+
 - [Slot Usage Notifier](#slot-usage-notifier) *(automation)* — Send a notification when a code slot PIN is used
 
 **Setup Helpers**
+
 - [Condition Linker](#condition-linker) *(automation)* — Assign a condition entity to a slot via the UI
 
 ---

--- a/BLUEPRINTS.md
+++ b/BLUEPRINTS.md
@@ -1,0 +1,168 @@
+# Blueprints
+
+Lock Code Manager includes pre-built blueprints for common lock management patterns. Each blueprint can be imported directly into Home Assistant with one click.
+
+See the [wiki](https://github.com/raman325/lock_code_manager/wiki/Blueprints) for additional setup guides and examples.
+
+## Table of Contents
+
+**Access Control**
+- [Slot Usage Limiter](#slot-usage-limiter) — Disable a slot after a set number of uses
+- [Calendar Condition](#calendar-condition) — Control slot access based on calendar events
+- [Date Range Condition](#date-range-condition) — Control slot access based on start/end dates
+- [Calendar PIN Setter](#calendar-pin-setter) — Extract and set PINs from calendar events
+
+**Lock Automation**
+- [Auto Re-lock](#auto-re-lock) — Automatically re-lock after a configurable delay
+- [Lock on Door Close](#lock-on-door-close) — Lock when a door sensor detects the door closed
+
+**Notifications**
+- [Slot Usage Notifier](#slot-usage-notifier) — Send a notification when a code slot PIN is used
+
+**Setup Helpers**
+- [Condition Linker](#condition-linker) — Assign a condition entity to a slot via the UI
+
+---
+
+## Access Control
+
+### Slot Usage Limiter
+
+Decrements an `input_number` helper each time a code slot PIN is used. When the counter reaches 0, the slot is automatically disabled. Optionally resets the counter when the slot is re-enabled.
+
+- Set counter to **-1** for unlimited uses
+- Set counter to **0** to disable on next use
+- Requires a lock that supports code slot events
+
+[![Import Blueprint](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Framan325%2Flock_code_manager%2Fblob%2Fmain%2Fblueprints%2Fautomation%2Flock_code_manager%2Fslot_usage_limiter.yaml)
+
+| Input | Description | Default |
+|-------|-------------|---------|
+| Config entry | LCM config entry that manages your locks | Required |
+| Slot number | Code slot to monitor (1-9999) | Required |
+| Uses counter | `input_number` helper for tracking remaining uses | Required |
+| Initial uses | Number of uses to reset to when slot is re-enabled (0 = no reset) | 0 |
+
+### Calendar Condition
+
+Creates a template binary sensor that turns ON when a calendar event is active and an optional condition template evaluates to true. Assign the sensor as a condition entity on a code slot to control when the PIN is active.
+
+- Filter by event title, description, or location using Jinja2 templates
+- Supports any HA calendar integration (local, Google, CalDAV, etc.)
+
+[![Import Blueprint](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Framan325%2Flock_code_manager%2Fblob%2Fmain%2Fblueprints%2Ftemplate%2Flock_code_manager%2Fcalendar_condition.yaml)
+
+| Input | Description | Default |
+|-------|-------------|---------|
+| Config entry | LCM config entry | Required |
+| Calendar entity | Calendar to monitor | Required |
+| Condition template | Jinja2 template to filter events | `{{ true }}` |
+
+### Date Range Condition
+
+Creates a template binary sensor that turns ON when the current time is between two `input_datetime` helpers. Use for rental-style access windows with specific check-in/check-out times.
+
+- Create `input_datetime` helpers first (Settings > Helpers)
+- Enable both "Date" and "Time" on each helper for date+time ranges
+- All comparisons done in UTC for timezone safety
+
+[![Import Blueprint](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Framan325%2Flock_code_manager%2Fblob%2Fmain%2Fblueprints%2Ftemplate%2Flock_code_manager%2Fdate_range_condition.yaml)
+
+| Input | Description | Default |
+|-------|-------------|---------|
+| Start date/time | `input_datetime` helper for access window start | Required |
+| End date/time | `input_datetime` helper for access window end | Required |
+
+### Calendar PIN Setter
+
+Extracts a PIN from calendar event attributes using a Jinja2 template and sets it on a code slot. Optionally clears the PIN when the event ends. Useful for automated guest access via shared calendars.
+
+- Extract PINs from event title, description, or location
+- Optionally set the slot number dynamically from the event
+- Supports optional notifications when PINs are set/cleared
+
+[![Import Blueprint](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Framan325%2Flock_code_manager%2Fblob%2Fmain%2Fblueprints%2Fautomation%2Flock_code_manager%2Fcalendar_pin_setter.yaml)
+
+| Input | Description | Default |
+|-------|-------------|---------|
+| Config entry | LCM config entry | Required |
+| Calendar entity | Calendar to monitor for events | Required |
+| PIN template | Jinja2 template to extract PIN from event | Required |
+| Slot number | Code slot to set the PIN on | Required |
+| Clear on event end | Clear the PIN when the calendar event ends | `true` |
+
+---
+
+## Lock Automation
+
+### Auto Re-lock
+
+Automatically re-locks a lock after it has been unlocked for a configurable amount of time. Supports separate day and night delays based on the sun entity's state (sunrise/sunset).
+
+- If the lock is manually locked before the timer expires, the timer is cancelled
+- Set night delay to 0 to use the same delay for both day and night
+- Uses `mode: restart` so a new unlock resets the timer
+
+[![Import Blueprint](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Framan325%2Flock_code_manager%2Fblob%2Fmain%2Fblueprints%2Fautomation%2Flock_code_manager%2Fauto_relock.yaml)
+
+| Input | Description | Default |
+|-------|-------------|---------|
+| Lock | Lock entity to auto-relock | Required |
+| Day delay | Minutes to wait before re-locking during the day | 5 |
+| Night delay | Minutes to wait at night (0 = use day delay) | 0 |
+
+### Lock on Door Close
+
+Automatically locks a lock when a door sensor detects the door has closed while the lock is unlocked. Useful for ensuring the door is always locked when closed.
+
+- Only locks if the lock is currently unlocked when the door closes
+- Optional delay to allow the door to fully close before locking
+- Uses `mode: single` to prevent duplicate lock commands
+
+[![Import Blueprint](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Framan325%2Flock_code_manager%2Fblob%2Fmain%2Fblueprints%2Fautomation%2Flock_code_manager%2Fdoor_lock_on_close.yaml)
+
+| Input | Description | Default |
+|-------|-------------|---------|
+| Lock | Lock entity to control | Required |
+| Door sensor | Binary sensor (door class) for open/closed state | Required |
+| Lock delay | Seconds to wait after door closes before locking | 5 |
+
+---
+
+## Notifications
+
+### Slot Usage Notifier
+
+Sends a notification when a code slot PIN is used on a lock. Works with any Home Assistant notification service (mobile app, email, Slack, etc.) and supports customizable message templates.
+
+- Requires a lock that supports code slot events
+- Message template can include slot name, number, lock name, and timestamp
+- Uses `mode: queued` to handle rapid successive uses
+
+[![Import Blueprint](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Framan325%2Flock_code_manager%2Fblob%2Fmain%2Fblueprints%2Fautomation%2Flock_code_manager%2Fslot_usage_notifier.yaml)
+
+| Input | Description | Default |
+|-------|-------------|---------|
+| Event entity | Code slot event entity (fires on PIN use) | Required |
+| Notification service | HA notify service (e.g., `notify.mobile_app_phone`) | Required |
+| Message template | Notification message with template variables | See default |
+| Notification title | Title for the notification | `Lock Code Used` |
+
+---
+
+## Setup Helpers
+
+### Condition Linker
+
+A one-shot automation that assigns a condition entity to a code slot via the `lock_code_manager.set_slot_condition` service. Run it once from the Automations page, then delete or keep for reference.
+
+- Uses a synthetic event trigger that never fires automatically
+- Manually run from the Automations page (three-dot menu > Run)
+
+[![Import Blueprint](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Framan325%2Flock_code_manager%2Fblob%2Fmain%2Fblueprints%2Fautomation%2Flock_code_manager%2Fcondition_linker.yaml)
+
+| Input | Description | Default |
+|-------|-------------|---------|
+| Config entry | LCM config entry | Required |
+| Slot number | Code slot to assign the condition to (1-9999) | Required |
+| Condition entity | Entity to use as the condition | Required |

--- a/README.md
+++ b/README.md
@@ -75,10 +75,12 @@ Pre-built automations and templates for common lock management patterns. See **[
 <summary>Available blueprints</summary>
 
 **Template blueprints** *(create entities)*
+
 - **Calendar Condition** — Binary sensor for calendar-based slot access
 - **Date Range Condition** — Binary sensor for start/end date access windows
 
 **Automation blueprints** *(trigger on events)*
+
 - **Slot Usage Limiter** — Disable a slot after a set number of uses
 - **Calendar PIN Setter** — Extract and set PINs from calendar events
 - **Auto Re-lock** — Re-lock after a configurable delay with day/night support

--- a/README.md
+++ b/README.md
@@ -74,13 +74,16 @@ Pre-built automations and templates for common lock management patterns. See **[
 <details>
 <summary>Available blueprints</summary>
 
+**Template blueprints** *(create entities)*
+- **Calendar Condition** — Binary sensor for calendar-based slot access
+- **Date Range Condition** — Binary sensor for start/end date access windows
+
+**Automation blueprints** *(trigger on events)*
 - **Slot Usage Limiter** — Disable a slot after a set number of uses
-- **Calendar Condition** — Control slot access based on calendar events
-- **Date Range Condition** — Control slot access based on start/end dates
 - **Calendar PIN Setter** — Extract and set PINs from calendar events
-- **Auto Re-lock** — Automatically re-lock after a configurable delay
+- **Auto Re-lock** — Re-lock after a configurable delay with day/night support
 - **Lock on Door Close** — Lock when a door sensor detects the door closed
-- **Slot Usage Notifier** — Send a notification when a code slot PIN is used
+- **Slot Usage Notifier** — Notify when a code slot PIN is used
 - **Condition Linker** — Assign a condition entity to a slot via the UI
 
 </details>

--- a/README.md
+++ b/README.md
@@ -69,20 +69,21 @@ The best way to install this integration is via HACS.
 
 ## Blueprints
 
-Pre-built automations for common patterns:
+Pre-built automations and templates for common lock management patterns. See **[BLUEPRINTS.md](BLUEPRINTS.md)** for full details, input tables, and import buttons.
+
+<details>
+<summary>Available blueprints</summary>
 
 - **Slot Usage Limiter** — Disable a slot after a set number of uses
-  [![Import Blueprint](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Framan325%2Flock_code_manager%2Fblob%2Fmain%2Fblueprints%2Fautomation%2Flock_code_manager%2Fslot_usage_limiter.yaml)
-- **Calendar PIN Setter** — Extract and set PINs from calendar event attributes
-  [![Import Blueprint](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Framan325%2Flock_code_manager%2Fblob%2Fmain%2Fblueprints%2Fautomation%2Flock_code_manager%2Fcalendar_pin_setter.yaml)
 - **Calendar Condition** — Control slot access based on calendar events
-  [![Import Blueprint](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Framan325%2Flock_code_manager%2Fblob%2Fmain%2Fblueprints%2Ftemplate%2Flock_code_manager%2Fcalendar_condition.yaml)
-- **Date Range Condition** — Control slot access based on start/end date and time helpers
-  [![Import Blueprint](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Framan325%2Flock_code_manager%2Fblob%2Fmain%2Fblueprints%2Ftemplate%2Flock_code_manager%2Fdate_range_condition.yaml)
+- **Date Range Condition** — Control slot access based on start/end dates
+- **Calendar PIN Setter** — Extract and set PINs from calendar events
+- **Auto Re-lock** — Automatically re-lock after a configurable delay
+- **Lock on Door Close** — Lock when a door sensor detects the door closed
+- **Slot Usage Notifier** — Send a notification when a code slot PIN is used
 - **Condition Linker** — Assign a condition entity to a slot via the UI
-  [![Import Blueprint](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Framan325%2Flock_code_manager%2Fblob%2Fmain%2Fblueprints%2Fautomation%2Flock_code_manager%2Fcondition_linker.yaml)
 
-See the [wiki](https://github.com/raman325/lock_code_manager/wiki/Blueprints) for detailed setup and configuration.
+</details>
 
 ## Learn More
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ input tables, and import buttons.
 - **Slot Usage Limiter** — Disable a slot after a set number of uses
 - **Calendar PIN Setter** — Extract and set PINs from calendar events
 - **Auto Re-lock** — Re-lock after a delay with day/night support
-- **Lock on Door Close** — Lock when a door sensor detects close
+- **Lock on Door Close** — Lock when a door sensor detects closure
 - **Slot Usage Notifier** — Notify when a code slot PIN is used
 - **Condition Linker** — Assign a condition entity to a slot via UI
 

--- a/README.md
+++ b/README.md
@@ -69,26 +69,23 @@ The best way to install this integration is via HACS.
 
 ## Blueprints
 
-Pre-built automations and templates for common lock management patterns. See **[BLUEPRINTS.md](BLUEPRINTS.md)** for full details, input tables, and import buttons.
+Pre-built automations and templates for common lock management
+patterns. See [BLUEPRINTS.md](BLUEPRINTS.md) for full details,
+input tables, and import buttons.
 
-<details>
-<summary>Available blueprints</summary>
-
-**Template blueprints** *(create entities)*
+### Template blueprints
 
 - **Calendar Condition** — Binary sensor for calendar-based slot access
-- **Date Range Condition** — Binary sensor for start/end date access windows
+- **Date Range Condition** — Binary sensor for start/end date access
 
-**Automation blueprints** *(trigger on events)*
+### Automation blueprints
 
 - **Slot Usage Limiter** — Disable a slot after a set number of uses
 - **Calendar PIN Setter** — Extract and set PINs from calendar events
-- **Auto Re-lock** — Re-lock after a configurable delay with day/night support
-- **Lock on Door Close** — Lock when a door sensor detects the door closed
+- **Auto Re-lock** — Re-lock after a delay with day/night support
+- **Lock on Door Close** — Lock when a door sensor detects close
 - **Slot Usage Notifier** — Notify when a code slot PIN is used
-- **Condition Linker** — Assign a condition entity to a slot via the UI
-
-</details>
+- **Condition Linker** — Assign a condition entity to a slot via UI
 
 ## Learn More
 

--- a/blueprints/automation/lock_code_manager/auto_relock.yaml
+++ b/blueprints/automation/lock_code_manager/auto_relock.yaml
@@ -32,6 +32,11 @@ blueprint:
 
     4. Optionally set a night delay (in minutes). Set to 0 to use the day
        delay for both. Default: 0 (disabled).
+
+
+    **Note:** Night detection uses the `sun.sun` entity (Home Assistant
+    Sun integration). If the Sun integration is not enabled, the night
+    delay will never apply.
   domain: automation
   # yamllint disable-line rule:line-length
   source_url: https://github.com/raman325/lock_code_manager/blob/main/blueprints/automation/lock_code_manager/auto_relock.yaml

--- a/blueprints/automation/lock_code_manager/auto_relock.yaml
+++ b/blueprints/automation/lock_code_manager/auto_relock.yaml
@@ -83,8 +83,16 @@ actions:
            and is_state('sun.sun', 'below_horizon') }}
       delay_minutes: >-
         {{ night_delay_input if use_night else day_delay_input }}
-  - delay:
+  - wait_for_trigger:
+      - trigger: state
+        entity_id: !input lock_entity
+        to: locked
+    timeout:
       minutes: "{{ delay_minutes | int }}"
+    continue_on_timeout: true
+  - condition: state
+    entity_id: !input lock_entity
+    state: unlocked
   - action: lock.lock
     target:
       entity_id: !input lock_entity

--- a/blueprints/automation/lock_code_manager/auto_relock.yaml
+++ b/blueprints/automation/lock_code_manager/auto_relock.yaml
@@ -1,0 +1,90 @@
+---
+blueprint:
+  name: "Lock Code Manager: Auto Re-lock"
+  description: >
+    Automatically re-locks a lock after it has been unlocked for a
+    configurable amount of time. Supports separate day and night delays
+    based on the sun entity's state.
+
+
+    **How it works**
+
+    When the lock is unlocked, a timer starts. If the lock is not manually
+    locked before the timer expires, the automation locks it automatically.
+    If the lock is locked before the timer expires (manually or by another
+    automation), the timer is cancelled.
+
+
+    **Day/night support**
+
+    Optionally configure a shorter delay for nighttime (between sunset and
+    sunrise). If night delay is set to 0, the day delay is used for both
+    day and night.
+
+
+    **Setup**
+
+    1. Import this blueprint and create an automation from it.
+
+    2. Select the lock entity to auto-relock.
+
+    3. Set the day delay (in minutes). Default: 5 minutes.
+
+    4. Optionally set a night delay (in minutes). Set to 0 to use the day
+       delay for both. Default: 0 (disabled).
+  domain: automation
+  # yamllint disable-line rule:line-length
+  source_url: https://github.com/raman325/lock_code_manager/blob/main/blueprints/automation/lock_code_manager/auto_relock.yaml
+  input:
+    lock_entity:
+      name: Lock
+      description: The lock entity to auto-relock.
+      selector:
+        entity:
+          domain: lock
+    day_delay:
+      name: Day delay (minutes)
+      description: >
+        How long to wait (in minutes) before auto-relocking during the day.
+      default: 5
+      selector:
+        number:
+          min: 1
+          max: 60
+          unit_of_measurement: minutes
+          mode: box
+    night_delay:
+      name: Night delay (minutes)
+      description: >
+        How long to wait (in minutes) before auto-relocking at night
+        (between sunset and sunrise). Set to 0 to use the day delay
+        for both day and night.
+      default: 0
+      selector:
+        number:
+          min: 0
+          max: 60
+          unit_of_measurement: minutes
+          mode: box
+
+mode: restart
+
+triggers:
+  - trigger: state
+    entity_id: !input lock_entity
+    to: unlocked
+
+actions:
+  - variables:
+      night_delay_input: !input night_delay
+      day_delay_input: !input day_delay
+      use_night: >-
+        {{ night_delay_input | int(0) > 0
+           and is_state('sun.sun', 'below_horizon') }}
+      delay_minutes: >-
+        {{ night_delay_input if use_night else day_delay_input }}
+  - delay:
+      minutes: "{{ delay_minutes | int }}"
+  - action: lock.lock
+    target:
+      entity_id: !input lock_entity

--- a/blueprints/automation/lock_code_manager/door_lock_on_close.yaml
+++ b/blueprints/automation/lock_code_manager/door_lock_on_close.yaml
@@ -80,6 +80,9 @@ actions:
     then:
       - delay:
           seconds: "{{ delay_seconds | int }}"
+  - condition: state
+    entity_id: !input lock_entity
+    state: unlocked
   - action: lock.lock
     target:
       entity_id: !input lock_entity

--- a/blueprints/automation/lock_code_manager/door_lock_on_close.yaml
+++ b/blueprints/automation/lock_code_manager/door_lock_on_close.yaml
@@ -1,0 +1,85 @@
+---
+blueprint:
+  name: "Lock Code Manager: Lock on Door Close"
+  description: >
+    Automatically locks a lock when a door sensor detects the door has
+    closed while the lock is unlocked. Optionally adds a short delay
+    before locking to allow the door to fully close.
+
+
+    **How it works**
+
+    When the door sensor changes to closed (off), the automation checks
+    if the lock is currently unlocked. If so, it waits for the optional
+    delay and then locks the door. If the lock is already locked when
+    the door closes, nothing happens.
+
+
+    **Setup**
+
+    1. Import this blueprint and create an automation from it.
+
+    2. Select the lock entity to control.
+
+    3. Select the door sensor (binary_sensor) that detects open/closed
+       state.
+
+    4. Optionally set a delay (in seconds) before locking. Default: 5
+       seconds. Set to 0 to lock immediately.
+  domain: automation
+  # yamllint disable-line rule:line-length
+  source_url: https://github.com/raman325/lock_code_manager/blob/main/blueprints/automation/lock_code_manager/door_lock_on_close.yaml
+  input:
+    lock_entity:
+      name: Lock
+      description: The lock entity to control.
+      selector:
+        entity:
+          domain: lock
+    door_sensor:
+      name: Door sensor
+      description: >
+        A binary sensor that detects whether the door is open or closed.
+        The sensor should be "on" when the door is open and "off" when
+        closed.
+      selector:
+        entity:
+          domain: binary_sensor
+          device_class: door
+    lock_delay:
+      name: Lock delay (seconds)
+      description: >
+        How long to wait (in seconds) after the door closes before
+        locking. Set to 0 to lock immediately.
+      default: 5
+      selector:
+        number:
+          min: 0
+          max: 60
+          unit_of_measurement: seconds
+          mode: box
+
+mode: single
+
+triggers:
+  - trigger: state
+    entity_id: !input door_sensor
+    to: "off"
+
+conditions:
+  - condition: state
+    entity_id: !input lock_entity
+    state: unlocked
+
+actions:
+  - variables:
+      delay_seconds: !input lock_delay
+  - if:
+      - condition: template
+        value_template: "{{ delay_seconds | int(0) > 0 }}"
+    then:
+      - delay:
+          seconds: "{{ delay_seconds | int }}"
+  - action: lock.lock
+    target:
+      entity_id: !input lock_entity

--- a/blueprints/automation/lock_code_manager/slot_usage_notifier.yaml
+++ b/blueprints/automation/lock_code_manager/slot_usage_notifier.yaml
@@ -2,39 +2,30 @@
 blueprint:
   name: "Lock Code Manager: Slot Usage Notifier"
   description: >
-    Sends a notification when a Lock Code Manager code slot PIN is used
-    on a lock. Supports any HA notification service (mobile app, email,
-    Slack, etc.) and customizable message templates.
+    Runs one or more actions when a Lock Code Manager code slot PIN
+    is used on a lock. Use this to send notifications, trigger scripts,
+    or run any other Home Assistant action.
 
 
     **How it works**
 
-    When a code slot event fires (PIN used on lock), the automation sends
-    a notification via the selected notification service. The message
-    template can include details about which slot was used, the slot name,
-    and when it happened.
+    When a code slot event fires (PIN used on lock), the automation
+    runs the configured actions. You can use the action editor to
+    configure any HA action — notifications, scripts, scenes, etc.
 
 
     **Available template variables**
 
-    Your message template can use these variables:
+    Your actions can reference these variables in templates:
 
     - `slot_num` — the code slot number that was used
 
-    - `slot_name` — the friendly name of the code slot (from the event
-      entity's friendly name)
+    - `slot_name` — the friendly name of the code slot (from the
+      event entity's friendly name)
 
     - `lock_name` — the friendly name of the lock
 
     - `timestamp` — the time the event occurred
-
-
-    **Example message templates**
-
-    - Default: `{{ slot_name }} (slot {{ slot_num }}) was used on
-      {{ lock_name }} at {{ timestamp }}`
-
-    - Short: `Slot {{ slot_num }} used on {{ lock_name }}`
 
 
     **Requirements**
@@ -49,9 +40,7 @@ blueprint:
 
     2. Select the code slot event entity to monitor.
 
-    3. Select the notification service to use (e.g., `notify.mobile_app_phone`).
-
-    4. Optionally customize the message template.
+    3. Configure the actions to run when the PIN is used.
   domain: automation
   # yamllint disable-line rule:line-length
   source_url: https://github.com/raman325/lock_code_manager/blob/main/blueprints/automation/lock_code_manager/slot_usage_notifier.yaml
@@ -59,34 +48,20 @@ blueprint:
     event_entity:
       name: Code slot event entity
       description: >
-        The Lock Code Manager event entity that fires when a PIN is used.
-        These are named like "Code slot X PIN used".
+        The Lock Code Manager event entity that fires when a PIN
+        is used. These are named like "Code slot X PIN used".
       selector:
         entity:
           domain: event
-    notify_service:
-      name: Notification service
+    notify_actions:
+      name: Actions
       description: >
-        The notification service to use (e.g., `notify.mobile_app_phone`,
-        `notify.email`, `notify.slack`).
+        The actions to run when a PIN is used. You can configure
+        any HA action here — notifications, scripts, etc. Use
+        template variables like `{{ slot_name }}` and
+        `{{ lock_name }}` in your action data.
       selector:
-        text:
-    message_template:
-      name: Message template
-      description: >
-        The notification message template. Available variables:
-        `slot_name`, `slot_num`, `lock_name`, `timestamp`.
-      default: >-
-        {{ slot_name }} (slot {{ slot_num }}) was used on {{ lock_name }}
-        at {{ timestamp }}
-      selector:
-        template:
-    notification_title:
-      name: Notification title
-      description: The title for the notification.
-      default: Lock Code Used
-      selector:
-        text:
+        action:
 
 mode: queued
 max: 10
@@ -100,7 +75,9 @@ triggers:
 
 variables:
   event_entity_id: !input event_entity
-  slot_name: "{{ state_attr(event_entity_id, 'friendly_name') | default('Unknown slot') }}"
+  slot_name: >-
+    {{ state_attr(event_entity_id, 'friendly_name')
+       | default('Unknown slot') }}
   slot_num: >-
     {{ state_attr(event_entity_id, 'friendly_name')
        | default('')
@@ -112,8 +89,4 @@ variables:
        | default('Unknown lock') }}
   timestamp: "{{ now().strftime('%H:%M:%S') }}"
 
-actions:
-  - action: "{{ notify_service }}"
-    data:
-      title: !input notification_title
-      message: !input message_template
+actions: !input notify_actions

--- a/blueprints/automation/lock_code_manager/slot_usage_notifier.yaml
+++ b/blueprints/automation/lock_code_manager/slot_usage_notifier.yaml
@@ -76,16 +76,15 @@ triggers:
 variables:
   event_entity_id: !input event_entity
   slot_name: >-
-    {{ state_attr(event_entity_id, 'friendly_name')
+    {{ trigger.to_state.attributes.code_slot_name
        | default('Unknown slot') }}
   slot_num: >-
-    {{ state_attr(event_entity_id, 'friendly_name')
-       | default('')
-       | regex_findall('\\d+')
-       | first
+    {{ trigger.to_state.attributes.code_slot
        | default('?') }}
   lock_name: >-
-    {{ device_attr(device_id(event_entity_id), 'name')
+    {% set lock_eid = trigger.to_state.attributes.entity_id
+       | default('') %}
+    {{ state_attr(lock_eid, 'friendly_name')
        | default('Unknown lock') }}
   timestamp: "{{ now().strftime('%H:%M:%S') }}"
 

--- a/blueprints/automation/lock_code_manager/slot_usage_notifier.yaml
+++ b/blueprints/automation/lock_code_manager/slot_usage_notifier.yaml
@@ -1,0 +1,119 @@
+---
+blueprint:
+  name: "Lock Code Manager: Slot Usage Notifier"
+  description: >
+    Sends a notification when a Lock Code Manager code slot PIN is used
+    on a lock. Supports any HA notification service (mobile app, email,
+    Slack, etc.) and customizable message templates.
+
+
+    **How it works**
+
+    When a code slot event fires (PIN used on lock), the automation sends
+    a notification via the selected notification service. The message
+    template can include details about which slot was used, the slot name,
+    and when it happened.
+
+
+    **Available template variables**
+
+    Your message template can use these variables:
+
+    - `slot_num` — the code slot number that was used
+
+    - `slot_name` — the friendly name of the code slot (from the event
+      entity's friendly name)
+
+    - `lock_name` — the friendly name of the lock
+
+    - `timestamp` — the time the event occurred
+
+
+    **Example message templates**
+
+    - Default: `{{ slot_name }} (slot {{ slot_num }}) was used on
+      {{ lock_name }} at {{ timestamp }}`
+
+    - Short: `Slot {{ slot_num }} used on {{ lock_name }}`
+
+
+    **Requirements**
+
+    This blueprint requires at least one lock that supports code slot
+    events (i.e. produces `*_code_slot_*_pin_used` events).
+
+
+    **Setup**
+
+    1. Import this blueprint and create an automation from it.
+
+    2. Select the code slot event entity to monitor.
+
+    3. Select the notification service to use (e.g., `notify.mobile_app_phone`).
+
+    4. Optionally customize the message template.
+  domain: automation
+  # yamllint disable-line rule:line-length
+  source_url: https://github.com/raman325/lock_code_manager/blob/main/blueprints/automation/lock_code_manager/slot_usage_notifier.yaml
+  input:
+    event_entity:
+      name: Code slot event entity
+      description: >
+        The Lock Code Manager event entity that fires when a PIN is used.
+        These are named like "Code slot X PIN used".
+      selector:
+        entity:
+          domain: event
+    notify_service:
+      name: Notification service
+      description: >
+        The notification service to use (e.g., `notify.mobile_app_phone`,
+        `notify.email`, `notify.slack`).
+      selector:
+        text:
+    message_template:
+      name: Message template
+      description: >
+        The notification message template. Available variables:
+        `slot_name`, `slot_num`, `lock_name`, `timestamp`.
+      default: >-
+        {{ slot_name }} (slot {{ slot_num }}) was used on {{ lock_name }}
+        at {{ timestamp }}
+      selector:
+        template:
+    notification_title:
+      name: Notification title
+      description: The title for the notification.
+      default: Lock Code Used
+      selector:
+        text:
+
+mode: queued
+max: 10
+
+triggers:
+  - trigger: state
+    entity_id: !input event_entity
+    not_to:
+      - unknown
+      - unavailable
+
+variables:
+  event_entity_id: !input event_entity
+  slot_name: "{{ state_attr(event_entity_id, 'friendly_name') | default('Unknown slot') }}"
+  slot_num: >-
+    {{ state_attr(event_entity_id, 'friendly_name')
+       | default('')
+       | regex_findall('\\d+')
+       | first
+       | default('?') }}
+  lock_name: >-
+    {{ device_attr(device_id(event_entity_id), 'name')
+       | default('Unknown lock') }}
+  timestamp: "{{ now().strftime('%H:%M:%S') }}"
+
+actions:
+  - action: "{{ notify_service }}"
+    data:
+      title: !input notification_title
+      message: !input message_template

--- a/blueprints/automation/lock_code_manager/slot_usage_notifier.yaml
+++ b/blueprints/automation/lock_code_manager/slot_usage_notifier.yaml
@@ -53,6 +53,7 @@ blueprint:
       selector:
         entity:
           domain: event
+          integration: lock_code_manager
     notify_actions:
       name: Actions
       description: >
@@ -86,6 +87,6 @@ variables:
        | default('') %}
     {{ state_attr(lock_eid, 'friendly_name')
        | default('Unknown lock') }}
-  timestamp: "{{ now().strftime('%H:%M:%S') }}"
+  timestamp: "{{ now().strftime('%Y-%m-%d %H:%M:%S') }}"
 
 actions: !input notify_actions


### PR DESCRIPTION
## Proposed change

Three new blueprints for common lock management patterns, plus a new BLUEPRINTS.md with organized documentation.

**New blueprints:**

- **Auto Re-lock** — Automatically re-locks after configurable delay when unlocked. Supports separate day/night delays based on sun entity state (sunrise/sunset). Uses `mode: restart` so a new unlock resets the timer.

- **Lock on Door Close** — Locks when a door binary sensor detects the door closed while the lock is unlocked. Optional delay before locking. Uses `mode: single` to prevent duplicate lock commands.

- **Slot Usage Notifier** — Sends a notification via any HA notify service when a code slot PIN is used. Customizable message template with slot name, number, lock name, and timestamp. Uses `mode: queued` for rapid successive uses.

**Documentation:**

- New `BLUEPRINTS.md` with full documentation for all 8 blueprints, organized by category (Access Control, Lock Automation, Notifications, Setup Helpers) with table of contents, input tables, and import buttons.
- README simplified to link to BLUEPRINTS.md with a collapsed list of available blueprints.

## Type of change

- [x] New feature (which adds functionality)

## Additional information

- These blueprints address feature gaps identified in a comparison with keymaster (auto-relock, door sensor integration, notifications)