### PR TITLE
Fix notifier blueprint description and timestamp accuracy

### DIFF
--- a/blueprints/automation/lock_code_manager/slot_usage_notifier.yaml
+++ b/blueprints/automation/lock_code_manager/slot_usage_notifier.yaml
@@ -83,9 +83,7 @@ variables:
     {{ trigger.to_state.attributes.code_slot
        | default('?') }}
   lock_name: >-
-    {% set lock_eid = trigger.to_state.attributes.entity_id
-       | default('') %}
-    {{ state_attr(lock_eid, 'friendly_name')
+    {{ state_attr(trigger.to_state.state, 'friendly_name')
        | default('Unknown lock') }}
   timestamp: >-
     {{ trigger.to_state.last_updated | as_local

--- a/blueprints/automation/lock_code_manager/slot_usage_notifier.yaml
+++ b/blueprints/automation/lock_code_manager/slot_usage_notifier.yaml
@@ -20,12 +20,12 @@ blueprint:
 
     - `slot_num` — the code slot number that was used
 
-    - `slot_name` — the friendly name of the code slot (from the
-      event entity's friendly name)
+    - `slot_name` — the user-configured name of the code slot
 
-    - `lock_name` — the friendly name of the lock
+    - `lock_name` — the friendly name of the lock where the PIN
+      was used
 
-    - `timestamp` — the time the event occurred
+    - `timestamp` — the date and time the event occurred
 
 
     **Requirements**
@@ -87,6 +87,8 @@ variables:
        | default('') %}
     {{ state_attr(lock_eid, 'friendly_name')
        | default('Unknown lock') }}
-  timestamp: "{{ now().strftime('%Y-%m-%d %H:%M:%S') }}"
+  timestamp: >-
+    {{ trigger.to_state.last_changed | as_local
+       | as_timestamp | timestamp_custom('%Y-%m-%d %H:%M:%S') }}
 
 actions: !input notify_actions

--- a/blueprints/automation/lock_code_manager/slot_usage_notifier.yaml
+++ b/blueprints/automation/lock_code_manager/slot_usage_notifier.yaml
@@ -88,7 +88,7 @@ variables:
     {{ state_attr(lock_eid, 'friendly_name')
        | default('Unknown lock') }}
   timestamp: >-
-    {{ trigger.to_state.last_changed | as_local
+    {{ trigger.to_state.last_updated | as_local
        | as_timestamp | timestamp_custom('%Y-%m-%d %H:%M:%S') }}
 
 actions: !input notify_actions


### PR DESCRIPTION
## Proposed change

Fixes from code review on #1023:

- Fix `slot_name` variable description: says "user-configured name" instead of "event entity's friendly name" (the value comes from `trigger.to_state.attributes.code_slot_name`, not the entity's display name)
- Use `trigger.to_state.last_changed` for `timestamp` instead of `now()` — with `mode: queued`, the action may execute later than the actual event, so `now()` would report the wrong time

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR is related to issue: #1023