### PR TITLE
Add LockCodeManagerProviderError parent for provider-raised exceptions

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -52,17 +52,6 @@
 
 ## Code Quality
 
-- **Provider exception hierarchy** — Introduce `LockCodeManagerProviderError`
-  as a parent for exceptions raised by lock providers (`LockDisconnected`,
-  `CodeRejectedError`/`DuplicateCodeError`, `ProviderNotImplementedError`).
-  `EntityNotFoundError` stays at the `LockCodeManagerError` base since it's
-  about LCM's internal entity-registry view, not the lock itself. The
-  internal `_LockQuerySkipped` sentinel in `config_flow.py` also stays at
-  the base. Once the parent exists, `_async_get_all_codes` can collapse its
-  two-try workaround into a single try with three `except` arms
-  (skip / provider-failure / unexpected). Touches every provider and every
-  catch site in coordinator/sync/repair — file as its own PR for focused
-  review of the classification.
 - **Config flow + update listener: shared diff helper** — The options flow's
   added-`(lock, slot)`-pair calculation in
   `LockCodeManagerOptionsFlow._maybe_confirm_then_persist` and the

--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -36,7 +36,7 @@ from .const import (
     EXCLUDED_CONDITION_PLATFORMS,
 )
 from .data import get_entry_data
-from .exceptions import LockCodeManagerError
+from .exceptions import LockCodeManagerError, LockCodeManagerProviderError
 from .models import SlotCode
 from .providers import INTEGRATIONS_CLASS_MAP
 
@@ -124,11 +124,9 @@ class _LockQuerySkipped(LockCodeManagerError):
 
     Used internally by ``_async_build_lock_instance`` to signal one of the
     three expected setup-time skip conditions (missing entity, unsupported
-    platform, missing config entry). Subclasses ``LockCodeManagerError`` so
-    it belongs to the project's exception family, but is caught separately
-    from provider-raised ``LockCodeManagerError`` (e.g. ``LockDisconnected``)
-    so setup-time skips log at DEBUG and real provider failures log at
-    WARNING.
+    platform, missing config entry). Subclasses ``LockCodeManagerError`` (not
+    ``LockCodeManagerProviderError``) because it doesn't originate from a
+    provider — the lock provider is never even constructed.
     """
 
 
@@ -203,14 +201,12 @@ async def _async_get_all_codes(
             lock_instance = _async_build_lock_instance(
                 hass, dev_reg, ent_reg, lock_entity_id
             )
+            usercodes = await lock_instance.async_internal_get_usercodes()
         except _LockQuerySkipped:
             # Already logged by _async_build_lock_instance with the
             # appropriate level for the specific skip reason
             continue
-
-        try:
-            usercodes = await lock_instance.async_internal_get_usercodes()
-        except LockCodeManagerError as err:
+        except LockCodeManagerProviderError as err:
             # Real provider failure (e.g. LockDisconnected) — surface it
             # so users can see why a lock's codes weren't checked
             _LOGGER.warning(

--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -187,9 +187,11 @@ async def _async_get_all_codes(
     - Dict keyed by lock entity ID to temporary lock provider instances, for
       reuse in clearing slots.
 
-    Locks are skipped (with logging) for three failure modes:
+    Locks are skipped (with logging) for these failure modes:
     - Setup-time skip (entity missing, unsupported platform, etc.) → DEBUG
     - Provider failure (e.g. ``LockDisconnected``) → WARNING with details
+    - Bare ``LockCodeManagerError`` from a provider that hasn't migrated
+      to ``LockCodeManagerProviderError`` → WARNING with details
     - Unexpected exception → WARNING with traceback
     """
     result: dict[str, dict[int, str | SlotCode]] = {}
@@ -209,6 +211,19 @@ async def _async_get_all_codes(
         except LockCodeManagerProviderError as err:
             # Real provider failure (e.g. LockDisconnected) — surface it
             # so users can see why a lock's codes weren't checked
+            _LOGGER.warning(
+                "Failed to get usercodes from %s: %s",
+                lock_entity_id,
+                err,
+            )
+            continue
+        except LockCodeManagerError as err:
+            # Defensive: a provider raised the bare base class. Treat as
+            # a real failure (not a setup-time skip — those use
+            # _LockQuerySkipped) but warn without traceback so it stays
+            # actionable. All in-tree providers raise
+            # LockCodeManagerProviderError; this catches third-party or
+            # not-yet-migrated providers.
             _LOGGER.warning(
                 "Failed to get usercodes from %s: %s",
                 lock_entity_id,

--- a/custom_components/lock_code_manager/exceptions.py
+++ b/custom_components/lock_code_manager/exceptions.py
@@ -14,6 +14,22 @@ class LockCodeManagerError(HomeAssistantError):
     """Base class for lock_code_manager exceptions."""
 
 
+class LockCodeManagerProviderError(LockCodeManagerError):
+    """Base class for exceptions raised by lock providers.
+
+    Subclasses cover real provider-side failures: communication problems
+    (``LockDisconnected``), the lock rejecting a code (``CodeRejectedError``,
+    ``DuplicateCodeError``), or the provider declining to implement an
+    operation (``ProviderNotImplementedError``).
+
+    LCM-internal exceptions (e.g. ``EntityNotFoundError``, the
+    ``_LockQuerySkipped`` sentinel in the config flow) stay at the
+    ``LockCodeManagerError`` level. Catching this class lets callers say
+    "did this error come from the lock provider?" without enumerating
+    every provider error type.
+    """
+
+
 class EntityNotFoundError(LockCodeManagerError):
     """Raise when en entity is not found."""
 
@@ -25,7 +41,7 @@ class EntityNotFoundError(LockCodeManagerError):
         super().__init__(f"Entity not found for lock {lock} slot {slot_num} key {key}")
 
 
-class CodeRejectedError(LockCodeManagerError):
+class CodeRejectedError(LockCodeManagerProviderError):
     """Raised when the lock will not accept a PIN on a slot."""
 
     def __init__(self, code_slot: int, lock_entity_id: str, reason: str | None = None):
@@ -66,17 +82,18 @@ class DuplicateCodeError(CodeRejectedError):
         )
 
 
-class LockDisconnected(LockCodeManagerError):
+class LockDisconnected(LockCodeManagerProviderError):
     """Raised when lock can't be communicated with."""
 
 
-class ProviderNotImplementedError(LockCodeManagerError, NotImplementedError):
+class ProviderNotImplementedError(LockCodeManagerProviderError, NotImplementedError):
     """
     Raised when a provider method is not implemented.
 
     This exception should be raised by BaseLock methods that must be overridden
-    by provider subclasses. It combines LockCodeManagerError (so the coordinator
-    can catch it uniformly) with NotImplementedError (for standard Python semantics).
+    by provider subclasses. It combines LockCodeManagerProviderError (so the
+    coordinator can catch it uniformly with other provider failures) with
+    NotImplementedError (for standard Python semantics).
     """
 
     def __init__(self, provider: BaseLock, method_name: str, guidance: str = ""):

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -141,13 +141,16 @@ class BaseLock:
 
     Exception Handling
     ------------------
-    Provider implementations should raise LockCodeManagerError (or subclasses like
-    LockDisconnected) for lock communication failures. The coordinator catches
-    LockCodeManagerError and handles it appropriately (e.g., retrying, logging).
+    Provider implementations should raise LockCodeManagerProviderError (or one of
+    its subclasses: LockDisconnected, CodeRejectedError/DuplicateCodeError,
+    ProviderNotImplementedError) for any failure originating from the lock or
+    its integration. The coordinator catches LockCodeManagerError (the broader
+    parent) and handles it appropriately (e.g., retrying, logging).
 
-    Do NOT raise generic exceptions or HomeAssistantError directly - always use
-    LCM-derived exceptions so the coordinator can distinguish lock failures from
-    other errors.
+    Do NOT raise generic exceptions, HomeAssistantError, or the bare
+    LockCodeManagerError directly — always use LockCodeManagerProviderError
+    or a subclass so callers can distinguish provider failures from
+    LCM-internal exceptions.
     """
 
     hass: HomeAssistant = field(repr=False)

--- a/custom_components/lock_code_manager/providers/akuvox.py
+++ b/custom_components/lock_code_manager/providers/akuvox.py
@@ -23,7 +23,7 @@ from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.exceptions import HomeAssistantError
 
 from ..data import get_managed_slots
-from ..exceptions import LockCodeManagerError, LockDisconnected
+from ..exceptions import LockCodeManagerProviderError, LockDisconnected
 from ..models import SlotCode
 from ._base import BaseLock
 from .const import LOGGER
@@ -137,7 +137,7 @@ class AkuvoxLock(BaseLock):
             ) from err
 
         if not isinstance(response, dict):
-            raise LockCodeManagerError(
+            raise LockCodeManagerProviderError(
                 f"Malformed list_users response from {entity_id}: "
                 f"expected dict, got {type(response).__name__}"
             )
@@ -145,7 +145,7 @@ class AkuvoxLock(BaseLock):
         # Platform entity services wrap the response per entity_id.
         entity_response = response.get(entity_id, response)
         if not isinstance(entity_response, dict):
-            raise LockCodeManagerError(
+            raise LockCodeManagerProviderError(
                 f"Malformed list_users entity response from {entity_id}: "
                 f"expected dict, got {type(entity_response).__name__}"
             )

--- a/custom_components/lock_code_manager/providers/matter.py
+++ b/custom_components/lock_code_manager/providers/matter.py
@@ -20,7 +20,11 @@ from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 
 from ..data import get_managed_slots
-from ..exceptions import DuplicateCodeError, LockCodeManagerError, LockDisconnected
+from ..exceptions import (
+    DuplicateCodeError,
+    LockCodeManagerProviderError,
+    LockDisconnected,
+)
 from ..models import SlotCode
 from ._base import BaseLock
 from .const import LOGGER
@@ -126,13 +130,13 @@ class MatterLock(BaseLock):
                 f"{entity_id}: {err}"
             ) from err
         if not isinstance(result, dict) or entity_id not in result:
-            raise LockCodeManagerError(
+            raise LockCodeManagerProviderError(
                 f"Matter service {MATTER_DOMAIN}.{service} returned no data for "
                 f"{entity_id}"
             )
         entity_data = result[entity_id]
         if not isinstance(entity_data, dict):
-            raise LockCodeManagerError(
+            raise LockCodeManagerProviderError(
                 f"Matter service {MATTER_DOMAIN}.{service} returned non-dict data "
                 f"for {entity_id}: {type(entity_data).__name__}"
             )
@@ -145,11 +149,11 @@ class MatterLock(BaseLock):
             {"entity_id": self.lock.entity_id},
         )
         if not lock_info.get("supports_user_management"):
-            raise LockCodeManagerError(
+            raise LockCodeManagerProviderError(
                 f"Matter lock {self.lock.entity_id} does not support user management"
             )
         if "pin" not in (lock_info.get("supported_credential_types") or []):
-            raise LockCodeManagerError(
+            raise LockCodeManagerProviderError(
                 f"Matter lock {self.lock.entity_id} does not support PIN credentials"
             )
         LOGGER.debug(
@@ -171,7 +175,7 @@ class MatterLock(BaseLock):
                 "get_lock_info",
                 {"entity_id": self.lock.entity_id},
             )
-        except (LockDisconnected, LockCodeManagerError) as err:
+        except LockCodeManagerProviderError as err:
             LOGGER.debug(
                 "Lock %s: availability check failed: %s",
                 self.lock.entity_id,
@@ -367,7 +371,7 @@ class MatterLock(BaseLock):
         )
         users = lock_data.get("users")
         if not isinstance(users, list):
-            raise LockCodeManagerError(
+            raise LockCodeManagerProviderError(
                 f"Matter get_lock_users response for {self.lock.entity_id} "
                 f"has unexpected 'users' value: {users!r}"
             )
@@ -444,7 +448,7 @@ class MatterLock(BaseLock):
                         "user_name": name,
                     },
                 )
-            except (LockDisconnected, LockCodeManagerError):
+            except LockCodeManagerProviderError:
                 LOGGER.warning(
                     "Lock %s: credential set on slot %s but failed to set "
                     "user name '%s'",

--- a/custom_components/lock_code_manager/providers/schlage.py
+++ b/custom_components/lock_code_manager/providers/schlage.py
@@ -25,7 +25,7 @@ from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 
 from ..data import get_managed_slots
-from ..exceptions import LockCodeManagerError, LockDisconnected
+from ..exceptions import LockCodeManagerProviderError, LockDisconnected
 from ..models import SlotCode
 from ._base import BaseLock
 from .const import LOGGER
@@ -107,7 +107,7 @@ class SchlageLock(BaseLock):
             ) from err
 
         if not isinstance(response, dict):
-            raise LockCodeManagerError(
+            raise LockCodeManagerProviderError(
                 f"Schlage get_codes returned malformed response for {entity_id}: "
                 f"expected dict, got {type(response).__name__}"
             )
@@ -115,7 +115,7 @@ class SchlageLock(BaseLock):
         # Platform entity services wrap the response per entity_id.
         entity_response = response.get(entity_id, response)
         if not isinstance(entity_response, dict):
-            raise LockCodeManagerError(
+            raise LockCodeManagerProviderError(
                 f"Schlage get_codes returned malformed entity response for "
                 f"{entity_id}: expected dict, got {type(entity_response).__name__}"
             )
@@ -161,7 +161,7 @@ class SchlageLock(BaseLock):
         """Return whether the Schlage lock device is available for commands."""
         try:
             await self._async_get_codes()
-        except (LockDisconnected, LockCodeManagerError) as err:
+        except LockCodeManagerProviderError as err:
             LOGGER.debug(
                 "Lock %s: availability check failed: %s",
                 self.lock.entity_id,

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -22,7 +22,7 @@ from custom_components.lock_code_manager.const import (
     CONF_START_SLOT,
     DOMAIN,
 )
-from custom_components.lock_code_manager.exceptions import LockCodeManagerError
+from custom_components.lock_code_manager.exceptions import LockDisconnected
 from custom_components.lock_code_manager.models import SlotCode
 
 from .common import BASE_CONFIG, LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID
@@ -590,15 +590,16 @@ async def test_async_get_all_codes_exception(hass: HomeAssistant):
 async def test_async_get_all_codes_provider_failure_logs_warning(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ):
-    """Provider raising LockCodeManagerError logs WARNING (not DEBUG).
+    """Provider raising LockCodeManagerProviderError logs WARNING (not DEBUG).
 
-    Distinguishes a real failure (e.g. LockDisconnected) from the expected
-    setup-time skip cases (missing entity / unsupported platform / missing
-    config entry) so users see actionable signal when a lock is unreachable.
+    Distinguishes a real failure (LockDisconnected, a provider error) from
+    the expected setup-time skip cases (missing entity / unsupported
+    platform / missing config entry) so users see actionable signal when a
+    lock is unreachable.
     """
     mock_instance = MagicMock()
     mock_instance.async_internal_get_usercodes = AsyncMock(
-        side_effect=LockCodeManagerError("lock disconnected")
+        side_effect=LockDisconnected("lock offline")
     )
     mock_lock_cls = MagicMock(return_value=mock_instance)
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -22,7 +22,10 @@ from custom_components.lock_code_manager.const import (
     CONF_START_SLOT,
     DOMAIN,
 )
-from custom_components.lock_code_manager.exceptions import LockDisconnected
+from custom_components.lock_code_manager.exceptions import (
+    LockCodeManagerError,
+    LockDisconnected,
+)
 from custom_components.lock_code_manager.models import SlotCode
 
 from .common import BASE_CONFIG, LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID
@@ -632,6 +635,55 @@ async def test_async_get_all_codes_provider_failure_logs_warning(
         record.levelname == "WARNING" and LOCK_1_ENTITY_ID in record.message
         for record in caplog.records
     )
+
+
+async def test_async_get_all_codes_bare_base_error_logs_warning(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+):
+    """Defensive: a provider raising the bare base LockCodeManagerError still warns.
+
+    All in-tree providers raise LockCodeManagerProviderError, but a third-party
+    or not-yet-migrated provider could raise the bare base. We catch and warn
+    rather than letting it fall through to the generic Exception arm (which
+    would log a confusing traceback for what is really a known failure mode).
+    """
+    mock_instance = MagicMock()
+    mock_instance.async_internal_get_usercodes = AsyncMock(
+        side_effect=LockCodeManagerError("bare base")
+    )
+    mock_lock_cls = MagicMock(return_value=mock_instance)
+
+    ent_reg = er.async_get(hass)
+    ent_reg.async_get_or_create(
+        "lock", "zwave_js", "test_lock_1", suggested_object_id="test_1"
+    )
+    dev_reg = dr.async_get(hass)
+
+    with (
+        patch(
+            "custom_components.lock_code_manager.config_flow.INTEGRATIONS_CLASS_MAP",
+            {"zwave_js": mock_lock_cls},
+        ),
+        patch.object(
+            hass.config_entries,
+            "async_get_entry",
+            return_value=MockConfigEntry(domain="zwave_js"),
+        ),
+        caplog.at_level("WARNING"),
+    ):
+        result, instances = await _async_get_all_codes(
+            hass, dev_reg, ent_reg, [LOCK_1_ENTITY_ID]
+        )
+
+    assert result == {}
+    assert instances == {}
+    # Should be a clean WARNING (no traceback), since this is a known
+    # failure mode — not the generic Exception arm
+    warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+    assert any(
+        LOCK_1_ENTITY_ID in r.message and "bare base" in r.message for r in warnings
+    )
+    assert all(r.exc_info is None for r in warnings)
 
 
 async def test_async_get_all_codes_returns_all_codes(hass: HomeAssistant):

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -14,6 +14,7 @@ from custom_components.lock_code_manager.exceptions import (
     DuplicateCodeError,
     EntityNotFoundError,
     LockCodeManagerError,
+    LockCodeManagerProviderError,
     LockDisconnected,
     ProviderNotImplementedError,
 )
@@ -99,6 +100,7 @@ def test_provider_not_implemented_error_inherits_correctly():
 
     err = ProviderNotImplementedError(FakeProvider(), "test")
 
+    assert isinstance(err, LockCodeManagerProviderError)
     assert isinstance(err, LockCodeManagerError)
     assert isinstance(err, NotImplementedError)
 
@@ -147,11 +149,28 @@ def test_lock_code_manager_error_is_base():
     assert str(err) == "test error"
 
 
-def test_lock_disconnected_inherits_from_base():
-    """Test LockDisconnected inherits from LockCodeManagerError."""
+def test_lock_disconnected_inherits_from_provider_error():
+    """LockDisconnected is a provider error and a LockCodeManagerError."""
     err = LockDisconnected("lock offline")
+    assert isinstance(err, LockCodeManagerProviderError)
     assert isinstance(err, LockCodeManagerError)
     assert "lock offline" in str(err)
+
+
+def test_entity_not_found_is_not_a_provider_error(hass: HomeAssistant):
+    """EntityNotFoundError is LCM-internal, NOT a provider error.
+
+    This split lets callers catch only real provider failures via
+    ``except LockCodeManagerProviderError`` without also swallowing
+    LCM-internal entity-registry misses.
+    """
+    config_entry = MockConfigEntry(domain=DOMAIN)
+    config_entry.add_to_hass(hass)
+
+    lock = create_minimal_lock(hass, config_entry)
+    err = EntityNotFoundError(lock, 1, "pin")
+    assert isinstance(err, LockCodeManagerError)
+    assert not isinstance(err, LockCodeManagerProviderError)
 
 
 async def test_entity_not_found_error(hass: HomeAssistant):
@@ -193,9 +212,10 @@ def test_code_rejected_error_custom_reason():
     assert "appears to reject" not in str(err)
 
 
-def test_code_rejected_error_inherits_from_base():
-    """Test CodeRejectedError inherits from LockCodeManagerError."""
+def test_code_rejected_error_inherits_from_provider_error():
+    """CodeRejectedError is a provider error and a LockCodeManagerError."""
     err = CodeRejectedError(code_slot=1, lock_entity_id="lock.test")
+    assert isinstance(err, LockCodeManagerProviderError)
     assert isinstance(err, LockCodeManagerError)
 
 
@@ -242,4 +262,5 @@ def test_duplicate_code_error_inherits_from_code_rejected():
         lock_entity_id="lock.test",
     )
     assert isinstance(err, CodeRejectedError)
+    assert isinstance(err, LockCodeManagerProviderError)
     assert isinstance(err, LockCodeManagerError)


### PR DESCRIPTION
## Proposed change

Introduces an intermediate exception class `LockCodeManagerProviderError` so callers can distinguish "the lock provider raised this" from other `LockCodeManagerError` subclasses without enumerating every type.

### New hierarchy

```
HomeAssistantError
└── LockCodeManagerError
    ├── _LockQuerySkipped              (config-flow internal sentinel)
    ├── EntityNotFoundError            (LCM internal — registry miss)
    └── LockCodeManagerProviderError   (NEW)
        ├── LockDisconnected
        ├── CodeRejectedError
        │   └── DuplicateCodeError
        └── ProviderNotImplementedError (also NotImplementedError)
```

`EntityNotFoundError` stays at the LCM-base level because it's about LCM's view of the entity registry, not lock behavior. The four provider-raised errors all originate from the `BaseLock` subclass talking to its hardware/service layer, so they share the new parent.

### Why

Concretely, this lets `_async_get_all_codes` (added in #983) collapse its two-try workaround into a single try with three semantically distinct except arms:

- `_LockQuerySkipped` → DEBUG (expected setup-time skip)
- `LockCodeManagerProviderError` → WARNING with error message
- `Exception` → WARNING with traceback

The two try blocks existed because we couldn't say "catch only real provider failures, not setup-time skips" — both raised `LockCodeManagerError`. With the new parent, that distinction is in the type system.

### Compatibility

Existing catch sites all continue to work because the hierarchy widens, never narrows:

- [`coordinator.py`](https://github.com/raman325/lock_code_manager/blob/main/custom_components/lock_code_manager/coordinator.py): catches `LockCodeManagerError` (still catches everything)
- [`sync.py`](https://github.com/raman325/lock_code_manager/blob/main/custom_components/lock_code_manager/sync.py): catches `CodeRejectedError`, `LockDisconnected` directly (still works — those types are unchanged)
- [`providers/_base.py`](https://github.com/raman325/lock_code_manager/blob/main/custom_components/lock_code_manager/providers/_base.py): catches `ProviderNotImplementedError` directly (still works)

No catch site needed updating.

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Additional information

- 570 tests pass, 100% coverage on `config_flow.py`, 97% on `exceptions.py`
- Updated inheritance assertions for `LockDisconnected`, `CodeRejectedError`, `DuplicateCodeError`, `ProviderNotImplementedError`
- Added explicit test that `EntityNotFoundError` is **not** a `LockCodeManagerProviderError` (locks in the classification)