### PR TITLE
Reduce duplication: shared diff helper, persist consolidation, scoped-codes builder

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -52,19 +52,6 @@
 
 ## Code Quality
 
-- **Config flow + update listener: shared diff helper** — The options flow's
-  added-`(lock, slot)`-pair calculation in
-  `LockCodeManagerOptionsFlow._maybe_confirm_then_persist` and the
-  `slots_to_add/remove` + `locks_to_add/remove` calculation in
-  `__init__.py:async_update_listener` compute related views of the same
-  old-vs-new diff. Extract a single `compute_entry_config_diff(old, new)`
-  helper in `data.py` returning a frozen dataclass with all three views
-  (slot dict diff, lock list diff, cartesian pair diff). Single source of
-  truth for slot-key int/str normalization. While there: collapse the two
-  near-identical `_create_entry_and_clear_slots` /
-  `_persist_options_and_clear_slots` methods into one mixin helper, and
-  extract the `scoped_codes` builder in `_maybe_confirm_then_persist` into
-  a named helper for readability.
 - **Dual storage pattern** — Simplify `data` + `options` config entry pattern.
   Document when to use each.
 - **Coordinator-owned sync managers** — Move sync manager lifecycle from binary

--- a/TODO.md
+++ b/TODO.md
@@ -57,8 +57,93 @@
 - **Coordinator-owned sync managers** — Move sync manager lifecycle from binary
   sensor entities to coordinator (survives entity recreation during config
   updates).
-- **Dataclass conversion** — Convert config entry data and internal dicts to typed
-  dataclasses with `from_dict`/`from_entry` class methods.
+- **EntryConfig: typed boundary container** — Introduce a frozen `EntryConfig`
+  dataclass in `data.py` as the single chokepoint for reading entry config.
+  Solves the long-standing str/int slot key inconsistency that HA's JSON
+  storage round-trip creates (visible today as defensive `slot_key = slot
+  if slot in d else str(slot)` patterns scattered across the codebase).
+
+  **Core shape:**
+
+  ```python
+  @dataclass(frozen=True, slots=True)
+  class EntryConfig:
+      locks: tuple[str, ...]
+      slots: Mapping[int, Mapping[str, Any]]  # always int keys
+
+      @classmethod
+      def from_entry(cls, entry: ConfigEntry) -> EntryConfig: ...
+      @classmethod
+      def from_mapping(cls, m: Mapping) -> EntryConfig: ...
+      def diff(self, other: EntryConfig) -> EntryConfigDiff: ...
+      def has_lock(self, lock_entity_id: str) -> bool: ...
+      def has_slot(self, slot_num: int) -> bool: ...
+      def with_slot_updated(self, slot_num: int, key: str, value: Any) -> EntryConfig: ...
+  ```
+
+  **Type boundary cleanup that lands with this:**
+
+  - Migrate readers off raw `entry.data[CONF_SLOTS]` / `entry.options[CONF_SLOTS]`
+    indexing onto `EntryConfig.from_entry(entry).slots`. Sites today:
+    `coordinator.py:89` (`get_expected_pin`), `entity.py:82/105`,
+    `helpers.py:146/191/209`, `websocket.py:194/1018`, providers `virtual.py`
+    `:80/93/121`, `__init__.py` listener locals, `config_flow.py:508/544`
+    write paths.
+  - `get_slot_data(entry, slot_num)` becomes `EntryConfig.from_entry(entry)
+    .slots.get(slot_num, {})` — one helper to delete.
+  - `get_entry_data(entry, key, default)` becomes `EntryConfig.from_entry(entry)
+    .locks` / `.slots` attribute access. Helper can be removed once all
+    callers are migrated.
+  - `get_managed_slots(hass, lock_entity_id)` keeps its signature but its body
+    iterates entries and calls `EntryConfig.from_entry(entry)` instead of
+    raw indexing.
+  - `find_entry_for_lock_slot(hass, lock_entity_id, code_slot)` similarly.
+  - `compute_entry_config_diff(old, new)` becomes a method
+    `EntryConfig.diff(self, other) -> EntryConfigDiff`. Module-level helper
+    can be removed (or kept as a thin shim during transition).
+  - `_async_setup_new_locks(hass, entry, locks_to_add, new_slots, ...)`
+    can take `EntryConfig` instead of separate `locks_to_add` + `new_slots`
+    args.
+
+  **Defensive patterns to delete after migration:**
+
+  - `helpers.py:146` `slot_key = slot_num if slot_num in slots else str(slot_num)`
+  - `helpers.py:191` and `:209` (same pattern)
+  - `websocket.py:194` `slots_data.get(slot_num) or slots_data.get(str(slot_num))`
+  - `websocket.py:1018` `if slot_num not in slots and str(slot_num) not in slots`
+  - `coordinator.py:89` `.get(str(slot_num), {})` becomes `.get(slot_num, {})`
+  - The `for code_slot in get_entry_data(entry, CONF_SLOTS, {})` patterns where
+    the int(code_slot) cast is needed (find_entry_for_lock_slot, get_managed_slots)
+
+  **Ancillary improvements worth bundling:**
+
+  - **TypedDict for slot config** — define `class SlotConfig(TypedDict)` with
+    fields `pin: NotRequired[str]`, `enabled: bool`, `name: NotRequired[str]`,
+    `entity_id: NotRequired[str]`, `number_of_uses: NotRequired[int]`. Replaces
+    `dict[str, Any]` typing for slot inner dicts; gives pyright real signal on
+    slot reads/writes.
+  - **Listener int normalization (was PR #1028 review item #3)** — once the
+    str-hardcoded readers are migrated, the listener can normalize its locals
+    (`curr_slots`, `new_slots`) to int keys without breaking downstream
+    consumers. Closes the latent `slots_unchanged` `KeyError` risk.
+  - **EntryConfigDiff source-key-type complexity goes away** — currently
+    preserves the source's str-or-int key type to avoid breaking the listener.
+    With normalized inputs guaranteed, all dict outputs can be `Mapping[int, ...]`
+    and the int-normalization-for-comparison-only special case in
+    `compute_entry_config_diff` simplifies to plain set ops.
+  - **Drop `get_entry_data`'s options-over-data fallback in callers that don't
+    need it** — once `EntryConfig.from_entry()` encapsulates the priority logic,
+    callers stop carrying that detail.
+  - **HA storage round-trip stays as-is** — JSON layer continues to serialize
+    int keys to str on disk; we don't fight it. Normalization is purely on
+    READ via `from_entry()`. This keeps the migration additive (no changes to
+    on-disk format, no migration version bump needed).
+
+  **Migration approach:** introduce `EntryConfig` and migrate one module at
+  a time (coordinator → entities → helpers → websocket → providers →
+  listener). Each step deletes its local defensive str-handling. Single PR
+  for the introduction + first migration target; follow-up PRs for the rest
+  to keep reviews focused.
 - **Websocket optimization** — Add optional `include_entities`/`include_locks`
   flags to `get_config_entry_data` command.
 - **Entity registry change detection** — Warn if LCM entity IDs change (reload

--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -78,7 +78,7 @@ from .const import (
     STRATEGY_PATH,
     Platform,
 )
-from .data import get_entry_data
+from .data import compute_entry_config_diff, get_entry_data
 from .helpers import (
     async_clear_slot_condition,
     async_clear_usercode,
@@ -757,7 +757,6 @@ async def async_update_listener(
 
     curr_slots: dict[int, Any] = {**config_entry.data.get(CONF_SLOTS, {})}
     new_slots: dict[int, Any] = {**config_entry.options.get(CONF_SLOTS, {})}
-    curr_locks: list[str] = [*config_entry.data.get(CONF_LOCKS, [])]
     new_locks: list[str] = [*config_entry.options.get(CONF_LOCKS, [])]
 
     # Strip number_of_uses from slots that didn't previously have it
@@ -780,15 +779,13 @@ async def async_update_listener(
         )
     await asyncio.gather(*setup_tasks.values())
 
-    # Identify changes that need to be made
-    slots_to_add: dict[int, Any] = {
-        k: v for k, v in new_slots.items() if k not in curr_slots
-    }
-    slots_to_remove: dict[int, Any] = {
-        k: v for k, v in curr_slots.items() if k not in new_slots
-    }
-    locks_to_add: list[str] = [lock for lock in new_locks if lock not in curr_locks]
-    locks_to_remove: list[str] = [lock for lock in curr_locks if lock not in new_locks]
+    # Identify changes that need to be made (single source of truth for the
+    # data-vs-options diff; same helper is used by the options-flow scan)
+    diff = compute_entry_config_diff(config_entry.data, config_entry.options)
+    slots_to_add = diff.slots_added
+    slots_to_remove = diff.slots_removed
+    locks_to_add = diff.locks_added
+    locks_to_remove = diff.locks_removed
 
     callbacks = runtime_data.callbacks
 
@@ -878,7 +875,7 @@ async def async_update_listener(
 
     # For all slots that are in both the old and new config, check if any of the
     # configuration options have changed
-    for slot_num in set(curr_slots).intersection(new_slots):
+    for slot_num in diff.slots_unchanged:
         await _async_reconcile_slot_entities(
             config_entry,
             slot_num,
@@ -897,5 +894,5 @@ async def async_update_listener(
 
     # Notify Lovelace dashboards to re-render when structure changes
     # (slots or locks added/removed), so strategy-generated cards update
-    if slots_to_add or slots_to_remove or locks_to_add or locks_to_remove:
+    if diff.has_changes:
         _async_notify_lovelace_dashboards(hass)

--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Sequence
 import logging
 from pathlib import Path
 from typing import Any
@@ -609,7 +610,7 @@ async def async_unload_entry(
 async def _async_setup_new_locks(
     hass: HomeAssistant,
     config_entry: LockCodeManagerConfigEntry,
-    locks_to_add: list[str],
+    locks_to_add: Sequence[str],
     new_slots: dict[int, Any],
     callbacks: Any,
     ent_reg: er.EntityRegistry,

--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable, Iterable
+from functools import partial
 import logging
 import pkgutil
 from typing import Any
@@ -35,7 +36,7 @@ from .const import (
     DOMAIN,
     EXCLUDED_CONDITION_PLATFORMS,
 )
-from .data import get_entry_data
+from .data import compute_entry_config_diff, get_entry_data
 from .exceptions import LockCodeManagerError, LockCodeManagerProviderError
 from .models import SlotCode
 from .providers import INTEGRATIONS_CLASS_MAP
@@ -244,6 +245,27 @@ async def _async_get_all_codes(
     return result, lock_instances
 
 
+def _scope_codes_to_pairs(
+    all_codes: dict[str, dict[int, str | SlotCode]],
+    lock_instances: dict[str, Any],
+    pairs: Iterable[tuple[str, int]],
+) -> tuple[dict[str, dict[int, str | SlotCode]], dict[str, Any]]:
+    """Filter raw query results to only the ``(lock, slot)`` pairs given.
+
+    Used by the options flow so the mixin's clearing logic cannot touch
+    already-managed ``(lock, slot)`` pairs even though they appear in the
+    raw query result. The mixin's ``_clear_existing_slot`` only iterates
+    pairs present in ``_all_codes``, so scoping there constrains the blast
+    radius without the mixin needing to know about pairs.
+    """
+    scoped_codes: dict[str, dict[int, str | SlotCode]] = {}
+    for lock, slot in pairs:
+        if (code := all_codes.get(lock, {}).get(slot)) is not None:
+            scoped_codes.setdefault(lock, {})[slot] = code
+    scoped_instances = {lock: lock_instances[lock] for lock in scoped_codes}
+    return scoped_codes, scoped_instances
+
+
 class _ExistingCodesFlowMixin:
     """Mixin providing existing-codes detection, confirm UI, and clearing.
 
@@ -310,6 +332,25 @@ class _ExistingCodesFlowMixin:
         self._slots_to_clear = []
         self._all_codes = {}
         self._lock_instances = {}
+
+    async def _clear_then_create_entry(
+        self, *, title: str, data: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Clear pending slots, then create the entry.
+
+        Used by both the config flow and the options flow as the persist
+        target after the user confirms clearing. Bind ``title``/``data``
+        via ``functools.partial`` when assigning ``_next_step``, or call
+        directly when no confirmation step is required.
+
+        Clearing happens BEFORE ``async_create_entry()`` because
+        ``async_create_entry()`` only builds a FlowResult dict — the entry
+        isn't persisted until after this step returns.
+        """
+        await self._clear_all_pending_slots()
+        return self.async_create_entry(  # type: ignore[attr-defined]
+            title=title, data=data
+        )
 
     async def async_step_existing_codes_confirm(
         self, user_input: dict[str, Any] | None = None
@@ -389,17 +430,6 @@ class LockCodeManagerFlowHandler(
             last_step=False,
         )
 
-    async def _create_entry_and_clear_slots(self) -> dict[str, Any]:
-        """Clear existing codes (already user-authorized), then create entry.
-
-        The user explicitly confirmed clearing in the existing_codes_confirm
-        step, so we do it before creating the entry. async_create_entry()
-        only builds a FlowResult dict — the entry isn't persisted until
-        after this step returns.
-        """
-        await self._clear_all_pending_slots()
-        return self.async_create_entry(title=self.title, data=self.data)
-
     async def async_step_choose_path(
         self, user_input: dict[str, Any] | None = None
     ) -> dict[str, Any]:
@@ -477,7 +507,9 @@ class LockCodeManagerFlowHandler(
                 slot_num = int(self.slots_to_configure.pop(0))
                 self.data[CONF_SLOTS][slot_num] = CODE_SLOT_SCHEMA(user_input)
                 if not self.slots_to_configure:
-                    return await self._create_entry_and_clear_slots()
+                    return await self._clear_then_create_entry(
+                        title=self.title, data=self.data
+                    )
                 current_slot = self.slots_to_configure[0]
                 description_placeholders["slot_num"] = current_slot
 
@@ -512,7 +544,11 @@ class LockCodeManagerFlowHandler(
                     self.data[CONF_SLOTS] = slots
                     self._slots_to_clear = self._slots_with_existing_codes(slots.keys())
                     if self._slots_to_clear:
-                        self._next_step = self._create_entry_and_clear_slots
+                        self._next_step = partial(
+                            self._clear_then_create_entry,
+                            title=self.title,
+                            data=self.data,
+                        )
                         return await self.async_step_existing_codes_confirm()
                     return self.async_create_entry(title=self.title, data=self.data)
 
@@ -588,7 +624,6 @@ class LockCodeManagerOptionsFlow(_ExistingCodesFlowMixin, config_entries.Options
     def __init__(self) -> None:
         """Initialize options flow."""
         self._init_existing_codes_state()
-        self._pending_options: dict[str, Any] = {}
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
@@ -648,45 +683,36 @@ class LockCodeManagerOptionsFlow(_ExistingCodesFlowMixin, config_entries.Options
         current configuration. If any newly-added pair has a non-empty
         code on its lock, show the confirmation step before persisting.
         """
-        old_locks: Iterable[str] = get_entry_data(self.config_entry, CONF_LOCKS, [])
-        old_slots: Iterable[int] = get_entry_data(self.config_entry, CONF_SLOTS, {})
-        old_pairs = {(lock, int(slot)) for lock in old_locks for slot in old_slots}
-
-        new_locks = user_input[CONF_LOCKS]
-        new_slots = user_input[CONF_SLOTS]
-        new_pairs = {(lock, int(slot)) for lock in new_locks for slot in new_slots}
-
-        added_pairs = new_pairs - old_pairs
-        if not added_pairs:
+        # Use the same diff helper as the update listener so the "is this
+        # pair new?" definition stays in one place
+        old_data = {
+            CONF_LOCKS: get_entry_data(self.config_entry, CONF_LOCKS, []),
+            CONF_SLOTS: get_entry_data(self.config_entry, CONF_SLOTS, {}),
+        }
+        diff = compute_entry_config_diff(old_data, user_input)
+        if not diff.pairs_added:
             return self.async_create_entry(title="", data=user_input)
 
         # Query only the locks involved in newly-added pairs
-        locks_to_query = sorted({lock for lock, _ in added_pairs})
+        locks_to_query = sorted({lock for lock, _ in diff.pairs_added})
         ent_reg = er.async_get(self.hass)
         dev_reg = dr.async_get(self.hass)
         all_codes, lock_instances = await _async_get_all_codes(
             self.hass, dev_reg, ent_reg, locks_to_query
         )
 
-        # Scope _all_codes to ONLY the added pairs so the mixin's
-        # clearing logic doesn't touch already-managed (lock, slot) pairs
-        scoped_codes: dict[str, dict[int, str | SlotCode]] = {}
-        for lock, slot in added_pairs:
-            if (code := all_codes.get(lock, {}).get(slot)) is not None:
-                scoped_codes.setdefault(lock, {})[slot] = code
-        self._all_codes = scoped_codes
-        self._lock_instances = {lock: lock_instances[lock] for lock in scoped_codes}
+        # Scope to ONLY the added pairs so the mixin's clearing logic
+        # cannot touch already-managed (lock, slot) pairs
+        self._all_codes, self._lock_instances = _scope_codes_to_pairs(
+            all_codes, lock_instances, diff.pairs_added
+        )
 
-        added_slot_nums = {slot for _, slot in added_pairs}
+        added_slot_nums = {slot for _, slot in diff.pairs_added}
         self._slots_to_clear = self._slots_with_existing_codes(added_slot_nums)
         if not self._slots_to_clear:
             return self.async_create_entry(title="", data=user_input)
 
-        self._pending_options = user_input
-        self._next_step = self._persist_options_and_clear_slots
+        self._next_step = partial(
+            self._clear_then_create_entry, title="", data=user_input
+        )
         return await self.async_step_existing_codes_confirm()
-
-    async def _persist_options_and_clear_slots(self) -> dict[str, Any]:
-        """Clear confirmed slots, then persist the pending options."""
-        await self._clear_all_pending_slots()
-        return self.async_create_entry(title="", data=self._pending_options)

--- a/custom_components/lock_code_manager/data.py
+++ b/custom_components/lock_code_manager/data.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass
+from types import MappingProxyType
 from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
@@ -74,20 +75,25 @@ class EntryConfigDiff:
       uses to detect existing-codes hazards on newly-added pairs (catches
       both "new slot on existing lock" and "new lock with existing slot").
 
-    **Slot key types**: the slot-dict outputs (``slots_added``,
-    ``slots_removed``, ``slots_unchanged``) preserve the *new* mapping's
-    key type (``str`` if loaded from JSON storage, ``int`` if from
-    voluptuous validation). The cartesian pair sets always use ``int``
-    slot keys so they compare correctly even when ``old`` and ``new``
-    have different key types (a common situation: stored ``data`` is
-    ``str``-keyed, fresh user input from voluptuous is ``int``-keyed).
+    **Slot key types**: ``slots_added`` and ``slots_unchanged`` preserve
+    the *new* mapping's key type. ``slots_removed`` preserves the *old*
+    mapping's key type (its keys come from the old mapping). The
+    cartesian pair sets always use ``int`` slot keys so they compare
+    correctly even when ``old`` and ``new`` have different key types (a
+    common situation: stored ``data`` is ``str``-keyed, fresh user input
+    from voluptuous is ``int``-keyed).
+
+    **Immutability**: the dataclass is frozen, and all containers are
+    deeply immutable (``MappingProxyType`` for dicts, ``frozenset`` for
+    sets, ``tuple`` for lists) so callers can use this safely as cached
+    state without defensive copies.
     """
 
-    slots_added: dict[Any, Any]
-    slots_removed: dict[Any, Any]
-    slots_unchanged: set[Any]
-    locks_added: list[str]
-    locks_removed: list[str]
+    slots_added: Mapping[Any, Any]
+    slots_removed: Mapping[Any, Any]
+    slots_unchanged: frozenset[Any]
+    locks_added: tuple[str, ...]
+    locks_removed: tuple[str, ...]
     pairs_added: frozenset[tuple[str, int]]
     pairs_removed: frozenset[tuple[str, int]]
 
@@ -134,18 +140,20 @@ def compute_entry_config_diff(
     }
 
     return EntryConfigDiff(
-        slots_added={
-            k: v for k, v in raw_new_slots.items() if int(k) not in old_int_keys
-        },
-        slots_removed={
-            k: v for k, v in raw_old_slots.items() if int(k) not in new_int_keys
-        },
+        slots_added=MappingProxyType(
+            {k: v for k, v in raw_new_slots.items() if int(k) not in old_int_keys}
+        ),
+        slots_removed=MappingProxyType(
+            {k: v for k, v in raw_old_slots.items() if int(k) not in new_int_keys}
+        ),
         # Preserve the new mapping's key type — the listener's reconcile
         # loop indexes back into raw_new_slots / raw_old_slots and needs
         # the original key type to find the slot config dict.
-        slots_unchanged={k for k in raw_new_slots if int(k) in unchanged_int_keys},
-        locks_added=[lock for lock in new_locks if lock not in old_lock_set],
-        locks_removed=[lock for lock in old_locks if lock not in new_lock_set],
+        slots_unchanged=frozenset(
+            k for k in raw_new_slots if int(k) in unchanged_int_keys
+        ),
+        locks_added=tuple(lock for lock in new_locks if lock not in old_lock_set),
+        locks_removed=tuple(lock for lock in old_locks if lock not in new_lock_set),
         pairs_added=frozenset(new_pairs - old_pairs),
         pairs_removed=frozenset(old_pairs - new_pairs),
     )

--- a/custom_components/lock_code_manager/data.py
+++ b/custom_components/lock_code_manager/data.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+from dataclasses import dataclass
 from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
@@ -51,6 +53,101 @@ def find_entry_for_lock_slot(
             and code_slot in (int(s) for s in get_entry_data(entry, CONF_SLOTS, {}))
         ),
         None,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class EntryConfigDiff:
+    """Diff between two LCM entry configurations.
+
+    Produced by :func:`compute_entry_config_diff`. Provides three views of
+    the same diff so callers can ask the question that fits their need:
+
+    - **By axis** (slot dict + lock list): used by the update listener,
+      which adds/removes slot entities and lock providers along independent
+      axes.
+    - **By unchanged set**: ``slots_unchanged`` enumerates slot keys
+      present in both configs, used by the listener to reconcile per-slot
+      configuration changes.
+    - **By cartesian pair**: ``pairs_added`` / ``pairs_removed`` give
+      ``(lock, slot)`` tuples that are new or gone, which the options flow
+      uses to detect existing-codes hazards on newly-added pairs (catches
+      both "new slot on existing lock" and "new lock with existing slot").
+
+    **Slot key types**: the slot-dict outputs (``slots_added``,
+    ``slots_removed``, ``slots_unchanged``) preserve the *new* mapping's
+    key type (``str`` if loaded from JSON storage, ``int`` if from
+    voluptuous validation). The cartesian pair sets always use ``int``
+    slot keys so they compare correctly even when ``old`` and ``new``
+    have different key types (a common situation: stored ``data`` is
+    ``str``-keyed, fresh user input from voluptuous is ``int``-keyed).
+    """
+
+    slots_added: dict[Any, Any]
+    slots_removed: dict[Any, Any]
+    slots_unchanged: set[Any]
+    locks_added: list[str]
+    locks_removed: list[str]
+    pairs_added: frozenset[tuple[str, int]]
+    pairs_removed: frozenset[tuple[str, int]]
+
+    @property
+    def has_changes(self) -> bool:
+        """True if any slot or lock was added or removed."""
+        return bool(
+            self.slots_added
+            or self.slots_removed
+            or self.locks_added
+            or self.locks_removed
+        )
+
+
+def compute_entry_config_diff(
+    old: Mapping[str, Any], new: Mapping[str, Any]
+) -> EntryConfigDiff:
+    """Compute the diff between two LCM entry config mappings.
+
+    Each input is a mapping with ``CONF_LOCKS`` (list[str]) and
+    ``CONF_SLOTS`` (dict[int|str, dict]) keys. Slot keys are normalized
+    to ``int`` *internally* for set comparisons (so ``str``-keyed stored
+    data and ``int``-keyed voluptuous output compare correctly), but the
+    slot-dict outputs preserve the source key type of ``new``. This
+    matches the existing convention in the listener and entity layer
+    where ``slot_num`` may be ``str`` or ``int`` depending on origin.
+    """
+    raw_old_slots = old.get(CONF_SLOTS, {})
+    raw_new_slots = new.get(CONF_SLOTS, {})
+    # int-normalized key sets for comparisons only
+    old_int_keys = {int(k) for k in raw_old_slots}
+    new_int_keys = {int(k) for k in raw_new_slots}
+    unchanged_int_keys = old_int_keys & new_int_keys
+
+    old_locks: list[str] = list(old.get(CONF_LOCKS, []))
+    new_locks: list[str] = list(new.get(CONF_LOCKS, []))
+    old_lock_set = set(old_locks)
+    new_lock_set = set(new_locks)
+    old_pairs: set[tuple[str, int]] = {
+        (lock, slot) for lock in old_locks for slot in old_int_keys
+    }
+    new_pairs: set[tuple[str, int]] = {
+        (lock, slot) for lock in new_locks for slot in new_int_keys
+    }
+
+    return EntryConfigDiff(
+        slots_added={
+            k: v for k, v in raw_new_slots.items() if int(k) not in old_int_keys
+        },
+        slots_removed={
+            k: v for k, v in raw_old_slots.items() if int(k) not in new_int_keys
+        },
+        # Preserve the new mapping's key type — the listener's reconcile
+        # loop indexes back into raw_new_slots / raw_old_slots and needs
+        # the original key type to find the slot config dict.
+        slots_unchanged={k for k in raw_new_slots if int(k) in unchanged_int_keys},
+        locks_added=[lock for lock in new_locks if lock not in old_lock_set],
+        locks_removed=[lock for lock in old_locks if lock not in new_lock_set],
+        pairs_added=frozenset(new_pairs - old_pairs),
+        pairs_removed=frozenset(old_pairs - new_pairs),
     )
 
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -20,11 +20,11 @@ def test_diff_empty_inputs() -> None:
     """No old, no new -> empty diff, no changes."""
     diff = compute_entry_config_diff({}, {})
 
-    assert diff.slots_added == {}
-    assert diff.slots_removed == {}
-    assert diff.slots_unchanged == set()
-    assert diff.locks_added == []
-    assert diff.locks_removed == []
+    assert dict(diff.slots_added) == {}
+    assert dict(diff.slots_removed) == {}
+    assert diff.slots_unchanged == frozenset()
+    assert diff.locks_added == ()
+    assert diff.locks_removed == ()
     assert diff.pairs_added == frozenset()
     assert diff.pairs_removed == frozenset()
     assert not diff.has_changes
@@ -36,8 +36,8 @@ def test_diff_added_slots_and_locks() -> None:
 
     diff = compute_entry_config_diff({}, new)
 
-    assert diff.slots_added == {1: _slot(), 2: _slot()}
-    assert diff.locks_added == ["lock.a"]
+    assert dict(diff.slots_added) == {1: _slot(), 2: _slot()}
+    assert diff.locks_added == ("lock.a",)
     assert diff.pairs_added == frozenset({("lock.a", 1), ("lock.a", 2)})
     assert diff.has_changes
 
@@ -48,8 +48,8 @@ def test_diff_removed_slots_and_locks() -> None:
 
     diff = compute_entry_config_diff(old, {})
 
-    assert diff.slots_removed == {1: _slot()}
-    assert diff.locks_removed == ["lock.a"]
+    assert dict(diff.slots_removed) == {1: _slot()}
+    assert diff.locks_removed == ("lock.a",)
     assert diff.pairs_removed == frozenset({("lock.a", 1)})
     assert diff.has_changes
 
@@ -61,7 +61,7 @@ def test_diff_no_changes() -> None:
     diff = compute_entry_config_diff(config, config)
 
     assert not diff.has_changes
-    assert diff.slots_unchanged == {1}
+    assert diff.slots_unchanged == frozenset({1})
     assert diff.pairs_added == frozenset()
     assert diff.pairs_removed == frozenset()
 
@@ -79,15 +79,15 @@ def test_diff_str_keys_match_int_keys() -> None:
 
     diff = compute_entry_config_diff(old, new)
 
-    assert diff.slots_added == {}
-    assert diff.slots_removed == {}
+    assert dict(diff.slots_added) == {}
+    assert dict(diff.slots_removed) == {}
     assert diff.pairs_added == frozenset()
     assert diff.pairs_removed == frozenset()
     assert not diff.has_changes
 
 
-def test_diff_slot_dicts_preserve_new_key_type() -> None:
-    """slots_added/unchanged use the *new* mapping's key type.
+def test_diff_slot_dicts_preserve_source_key_types() -> None:
+    """slots_{added,unchanged} take new's key type; slots_removed takes old's.
 
     The listener indexes back into raw_new_slots/raw_old_slots with these
     keys to look up the slot config dict, so changing the key type would
@@ -95,16 +95,17 @@ def test_diff_slot_dicts_preserve_new_key_type() -> None:
     """
     # Both sides use str keys (typical of the listener case where both
     # `data` and `options` come from JSON storage round-trips)
-    old = {CONF_SLOTS: {"1": _slot()}}
+    old = {CONF_SLOTS: {"1": _slot(), "3": _slot()}}
     new = {CONF_SLOTS: {"1": _slot("9999"), "2": _slot()}}
 
     diff = compute_entry_config_diff(old, new)
 
-    # New mapping has str keys -> outputs preserve str
+    # slots_added/unchanged take new's key type (str here)
     assert "2" in diff.slots_added
     assert "1" in diff.slots_unchanged
-    # Pair tuples normalize to int regardless
-    assert diff.pairs_added == frozenset()  # no locks given
+    # slots_removed takes old's key type (also str here, but importantly
+    # it is the OLD mapping's keys regardless)
+    assert "3" in diff.slots_removed
 
 
 def test_diff_pair_added_for_new_lock_with_existing_slot() -> None:
@@ -119,8 +120,8 @@ def test_diff_pair_added_for_new_lock_with_existing_slot() -> None:
 
     diff = compute_entry_config_diff(old, new)
 
-    assert diff.locks_added == ["lock.b"]
-    assert diff.slots_added == {}
+    assert diff.locks_added == ("lock.b",)
+    assert dict(diff.slots_added) == {}
     # (lock.b, 1) is new even though slot 1 isn't
     assert diff.pairs_added == frozenset({("lock.b", 1)})
 
@@ -132,15 +133,36 @@ def test_diff_pair_added_for_new_slot_on_existing_lock() -> None:
 
     diff = compute_entry_config_diff(old, new)
 
-    assert diff.slots_added == {2: _slot()}
+    assert dict(diff.slots_added) == {2: _slot()}
     assert diff.pairs_added == frozenset({("lock.a", 2), ("lock.b", 2)})
 
 
-def test_diff_is_immutable() -> None:
-    """EntryConfigDiff is a frozen dataclass — supports use as cached state."""
-    diff = compute_entry_config_diff({}, {})
+def test_diff_is_deeply_immutable() -> None:
+    """EntryConfigDiff fields are immutable containers — safe as cached state.
 
+    The dataclass is frozen (attribute reassignment blocked) AND the
+    contained dicts/sets/lists are immutable variants
+    (``MappingProxyType`` / ``frozenset`` / ``tuple``), so callers
+    cannot mutate the diff after the fact.
+    """
+    diff = compute_entry_config_diff(
+        {CONF_LOCKS: ["lock.a"], CONF_SLOTS: {1: _slot()}}, {}
+    )
+
+    # Attribute reassignment blocked
     with pytest.raises(FrozenInstanceError):
-        diff.slots_added = {1: _slot()}  # type: ignore[misc]
+        diff.slots_added = {99: _slot()}  # type: ignore[misc]
+
+    # Contained dicts are read-only
+    with pytest.raises(TypeError):
+        diff.slots_removed[99] = _slot()  # type: ignore[index]
+
+    # Contained sets cannot grow
+    assert not hasattr(diff.slots_unchanged, "add")
+    assert not hasattr(diff.pairs_added, "add")
+
+    # Contained lists are tuples (no mutation methods)
+    assert not hasattr(diff.locks_added, "append")
+    assert not hasattr(diff.locks_removed, "append")
 
     assert isinstance(diff, EntryConfigDiff)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,0 +1,146 @@
+"""Tests for data helpers (compute_entry_config_diff, etc)."""
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from custom_components.lock_code_manager.const import CONF_LOCKS, CONF_SLOTS
+from custom_components.lock_code_manager.data import (
+    EntryConfigDiff,
+    compute_entry_config_diff,
+)
+
+
+def _slot(pin: str = "1234") -> dict:
+    """Trivial slot config dict for tests."""
+    return {"pin": pin, "enabled": True}
+
+
+def test_diff_empty_inputs() -> None:
+    """No old, no new -> empty diff, no changes."""
+    diff = compute_entry_config_diff({}, {})
+
+    assert diff.slots_added == {}
+    assert diff.slots_removed == {}
+    assert diff.slots_unchanged == set()
+    assert diff.locks_added == []
+    assert diff.locks_removed == []
+    assert diff.pairs_added == frozenset()
+    assert diff.pairs_removed == frozenset()
+    assert not diff.has_changes
+
+
+def test_diff_added_slots_and_locks() -> None:
+    """Brand-new entry: everything is added."""
+    new = {CONF_LOCKS: ["lock.a"], CONF_SLOTS: {1: _slot(), 2: _slot()}}
+
+    diff = compute_entry_config_diff({}, new)
+
+    assert diff.slots_added == {1: _slot(), 2: _slot()}
+    assert diff.locks_added == ["lock.a"]
+    assert diff.pairs_added == frozenset({("lock.a", 1), ("lock.a", 2)})
+    assert diff.has_changes
+
+
+def test_diff_removed_slots_and_locks() -> None:
+    """All slots/locks removed."""
+    old = {CONF_LOCKS: ["lock.a"], CONF_SLOTS: {1: _slot()}}
+
+    diff = compute_entry_config_diff(old, {})
+
+    assert diff.slots_removed == {1: _slot()}
+    assert diff.locks_removed == ["lock.a"]
+    assert diff.pairs_removed == frozenset({("lock.a", 1)})
+    assert diff.has_changes
+
+
+def test_diff_no_changes() -> None:
+    """Same locks and slots -> no diff, no has_changes."""
+    config = {CONF_LOCKS: ["lock.a"], CONF_SLOTS: {1: _slot()}}
+
+    diff = compute_entry_config_diff(config, config)
+
+    assert not diff.has_changes
+    assert diff.slots_unchanged == {1}
+    assert diff.pairs_added == frozenset()
+    assert diff.pairs_removed == frozenset()
+
+
+def test_diff_str_keys_match_int_keys() -> None:
+    """Stored data has str slot keys; voluptuous output has int.
+
+    The helper must treat ``"1"`` and ``1`` as the same slot for both
+    set comparisons and pair tuples — otherwise the options flow would
+    flag every existing slot as "newly added" the first time the user
+    edits options.
+    """
+    old = {CONF_LOCKS: ["lock.a"], CONF_SLOTS: {"1": _slot(), "2": _slot()}}
+    new = {CONF_LOCKS: ["lock.a"], CONF_SLOTS: {1: _slot(), 2: _slot()}}
+
+    diff = compute_entry_config_diff(old, new)
+
+    assert diff.slots_added == {}
+    assert diff.slots_removed == {}
+    assert diff.pairs_added == frozenset()
+    assert diff.pairs_removed == frozenset()
+    assert not diff.has_changes
+
+
+def test_diff_slot_dicts_preserve_new_key_type() -> None:
+    """slots_added/unchanged use the *new* mapping's key type.
+
+    The listener indexes back into raw_new_slots/raw_old_slots with these
+    keys to look up the slot config dict, so changing the key type would
+    break those lookups.
+    """
+    # Both sides use str keys (typical of the listener case where both
+    # `data` and `options` come from JSON storage round-trips)
+    old = {CONF_SLOTS: {"1": _slot()}}
+    new = {CONF_SLOTS: {"1": _slot("9999"), "2": _slot()}}
+
+    diff = compute_entry_config_diff(old, new)
+
+    # New mapping has str keys -> outputs preserve str
+    assert "2" in diff.slots_added
+    assert "1" in diff.slots_unchanged
+    # Pair tuples normalize to int regardless
+    assert diff.pairs_added == frozenset()  # no locks given
+
+
+def test_diff_pair_added_for_new_lock_with_existing_slot() -> None:
+    """A new lock with a slot already managed elsewhere is a NEW pair.
+
+    This is the key options-flow case: user has lock.a managing slot 1,
+    then adds lock.b — (lock.b, 1) is a brand-new pair to scan, even
+    though slot 1 is "unchanged" in the slot dict view.
+    """
+    old = {CONF_LOCKS: ["lock.a"], CONF_SLOTS: {1: _slot()}}
+    new = {CONF_LOCKS: ["lock.a", "lock.b"], CONF_SLOTS: {1: _slot()}}
+
+    diff = compute_entry_config_diff(old, new)
+
+    assert diff.locks_added == ["lock.b"]
+    assert diff.slots_added == {}
+    # (lock.b, 1) is new even though slot 1 isn't
+    assert diff.pairs_added == frozenset({("lock.b", 1)})
+
+
+def test_diff_pair_added_for_new_slot_on_existing_lock() -> None:
+    """Adding a slot creates a new pair on every existing lock."""
+    old = {CONF_LOCKS: ["lock.a", "lock.b"], CONF_SLOTS: {1: _slot()}}
+    new = {CONF_LOCKS: ["lock.a", "lock.b"], CONF_SLOTS: {1: _slot(), 2: _slot()}}
+
+    diff = compute_entry_config_diff(old, new)
+
+    assert diff.slots_added == {2: _slot()}
+    assert diff.pairs_added == frozenset({("lock.a", 2), ("lock.b", 2)})
+
+
+def test_diff_is_immutable() -> None:
+    """EntryConfigDiff is a frozen dataclass — supports use as cached state."""
+    diff = compute_entry_config_diff({}, {})
+
+    with pytest.raises(FrozenInstanceError):
+        diff.slots_added = {1: _slot()}  # type: ignore[misc]
+
+    assert isinstance(diff, EntryConfigDiff)


### PR DESCRIPTION
## Proposed change

Three related refactors to reduce duplication between the config flow, options flow, and update listener.

### 1. Shared diff helper in [`data.py`](https://github.com/raman325/lock_code_manager/blob/main/custom_components/lock_code_manager/data.py)

`compute_entry_config_diff(old, new)` returns a frozen `EntryConfigDiff` dataclass with three views of the same diff:

- **Axis** (\`slots_added\` / \`slots_removed\` / \`locks_added\` / \`locks_removed\`) — used by [\`async_update_listener\`](https://github.com/raman325/lock_code_manager/blob/main/custom_components/lock_code_manager/__init__.py)
- **Unchanged set** (\`slots_unchanged\`) — used by the listener for the per-slot reconcile loop
- **Cartesian pair** (\`pairs_added\` / \`pairs_removed\`) — used by [\`LockCodeManagerOptionsFlow._maybe_confirm_then_persist\`](https://github.com/raman325/lock_code_manager/blob/main/custom_components/lock_code_manager/config_flow.py) to detect existing-codes hazards on newly-added (lock, slot) pairs (catches both \"new slot on existing lock\" and \"new lock with existing slot\")

Plus a \`has_changes\` property for the listener's \"did anything structurally change?\" check.

**Slot key types**: int-normalize for set comparisons (so str-keyed JSON storage matches int-keyed voluptuous output) but preserve the new mapping's key type in the slot-dict outputs. This matches the existing convention where \`slot_num\` may be str or int depending on origin — the listener indexes back into the source mappings using these keys, and changing the key type would break \`get_slot_data\` lookups.

### 2. Mixin: `_clear_then_create_entry(title, data)`

Replaces both \`_create_entry_and_clear_slots\` (config flow) and \`_persist_options_and_clear_slots\` (options flow) with a single parameterized method on \`_ExistingCodesFlowMixin\`. Each flow uses \`functools.partial\` to bind title/data when assigning \`_next_step\`, or calls directly when no confirmation step is required.

Drops the \`LockCodeManagerOptionsFlow._pending_options\` state — the captured \`user_input\` lives in the partial's closure now.

### 3. Module helper: `_scope_codes_to_pairs(...)`

Extracts the 5-line block that filtered \`_all_codes\` / \`_lock_instances\` to only the newly-added (lock, slot) pairs. Now \`_maybe_confirm_then_persist\` reads top-to-bottom as: *compute diff → query → scope → check → confirm or persist*.

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Additional information

- 580 tests pass, 100% coverage on \`config_flow.py\`, new helper fully covered
- 9 new tests in [\`tests/test_data.py\`](https://github.com/raman325/lock_code_manager/blob/refactor/reduce-flow-duplication/tests/test_data.py) covering the diff helper, including the str/int key-mixing case and the \"new lock with existing slot\" case
- Update listener and options flow behavior unchanged (verified by existing zwave_js, sensor, and init tests that exercise the data-vs-options round-trip)