### PR TITLE
Introduce EntryConfig: typed boundary for entry config reads

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,6 +179,15 @@ scripts/setup
 
 Creates Python 3.13 venv, installs dependencies with uv, sets up pre-commit hooks, and installs Node dependencies.
 
+**pre-commit on Python 3.14 (macOS)**: `scripts/setup` installs pre-commit
+as a uv tool pinned to Python 3.13 (`uv tool install --python 3.13
+pre-commit`). If your `pre-commit` was previously installed via Homebrew
+and Homebrew's Python is 3.14, it will fail on macOS with
+`Symbol not found: _XML_SetAllocTrackerActivationThreshold` — Python 3.14's
+bundled `pyexpat` is built against a newer `libexpat` than the one
+`/usr/lib/libexpat.1.dylib` provides. Run `brew uninstall pre-commit` so
+the uv-managed binary at `~/.local/bin/pre-commit` is the one in `PATH`.
+
 ### Testing
 
 **Python tests:**

--- a/TODO.md
+++ b/TODO.md
@@ -57,93 +57,76 @@
 - **Coordinator-owned sync managers** — Move sync manager lifecycle from binary
   sensor entities to coordinator (survives entity recreation during config
   updates).
-- **EntryConfig: typed boundary container** — Introduce a frozen `EntryConfig`
-  dataclass in `data.py` as the single chokepoint for reading entry config.
-  Solves the long-standing str/int slot key inconsistency that HA's JSON
-  storage round-trip creates (visible today as defensive `slot_key = slot
-  if slot in d else str(slot)` patterns scattered across the codebase).
+- **EntryConfig migration** — Multi-stage refactor centralizing entry-config
+  reads through a typed `EntryConfig` dataclass to eliminate the str/int slot
+  key inconsistency that HA's JSON storage round-trip creates. **Stage 1
+  delivered in PR #1029**: introduced `EntryConfig` with `from_entry` /
+  `from_mapping` / `slot` / `has_slot` / `has_lock` / `empty`, cached it on
+  `runtime_data.config` (refreshed at the top of `async_update_listener` so
+  even entity-driven writes update the cache), and migrated readers in
+  `data.get_slot_data` / `get_managed_slots` / `find_entry_for_lock_slot`,
+  `coordinator.get_expected_pin`, and `websocket._get_condition_entity_id` /
+  `subscribe_code_slot` validator. The accessors absorb `int|str` slot_num
+  internally so call sites have no visible casts.
 
-  **Core shape:**
+  **Stage 2: writers** — Migrate sites that mutate `config_entry.data[CONF_SLOTS]`
+  directly off raw dict access. Affected sites:
 
-  ```python
-  @dataclass(frozen=True, slots=True)
-  class EntryConfig:
-      locks: tuple[str, ...]
-      slots: Mapping[int, Mapping[str, Any]]  # always int keys
+  - `entity._update_config_entry` (`entity.py:105`) — `data[CONF_SLOTS][self
+    .slot_num][self.key] = value`. Needs an `EntryConfig.with_slot_field_set
+    (slot_num, key, value)` immutable helper that returns a new `EntryConfig`,
+    plus a `to_dict()` for handing back to `async_update_entry`.
+  - `helpers.py:146` `slot_key = slot_num if slot_num in slots else str(slot_num)`
+  - `helpers.py:191` and `:209` (same defensive pattern around
+    `data[CONF_SLOTS][slot_key][CONF_ENTITY_ID]` set/delete)
+  - `config_flow.py:508/544` write paths — these construct fresh slot dicts
+    so they're already controlled, mostly want type-tightening.
 
-      @classmethod
-      def from_entry(cls, entry: ConfigEntry) -> EntryConfig: ...
-      @classmethod
-      def from_mapping(cls, m: Mapping) -> EntryConfig: ...
-      def diff(self, other: EntryConfig) -> EntryConfigDiff: ...
-      def has_lock(self, lock_entity_id: str) -> bool: ...
-      def has_slot(self, slot_num: int) -> bool: ...
-      def with_slot_updated(self, slot_num: int, key: str, value: Any) -> EntryConfig: ...
-  ```
+  After Stage 2, `runtime_data.config.slots` is the only authoritative view
+  and writers go through it.
 
-  **Type boundary cleanup that lands with this:**
+  **Stage 3: listener int-normalization** (was [PR #1028 review item #3](https://github.com/raman325/lock_code_manager/pull/1028)) — Once writers are
+  migrated, the listener's `curr_slots` / `new_slots` locals can normalize to
+  int keys without breaking downstream consumers. Closes the latent
+  `slots_unchanged` `KeyError` risk and lets `EntryConfigDiff` drop its
+  source-key-type preservation gymnastics (all dict outputs can be
+  `Mapping[int, ...]`, the int-normalization-for-comparison-only special
+  case in `compute_entry_config_diff` simplifies to plain set ops).
 
-  - Migrate readers off raw `entry.data[CONF_SLOTS]` / `entry.options[CONF_SLOTS]`
-    indexing onto `EntryConfig.from_entry(entry).slots`. Sites today:
-    `coordinator.py:89` (`get_expected_pin`), `entity.py:82/105`,
-    `helpers.py:146/191/209`, `websocket.py:194/1018`, providers `virtual.py`
-    `:80/93/121`, `__init__.py` listener locals, `config_flow.py:508/544`
-    write paths.
-  - `get_slot_data(entry, slot_num)` becomes `EntryConfig.from_entry(entry)
-    .slots.get(slot_num, {})` — one helper to delete.
-  - `get_entry_data(entry, key, default)` becomes `EntryConfig.from_entry(entry)
-    .locks` / `.slots` attribute access. Helper can be removed once all
-    callers are migrated.
-  - `get_managed_slots(hass, lock_entity_id)` keeps its signature but its body
-    iterates entries and calls `EntryConfig.from_entry(entry)` instead of
-    raw indexing.
-  - `find_entry_for_lock_slot(hass, lock_entity_id, code_slot)` similarly.
+  **Stage 4: API cleanup** — After the migration is end-to-end:
+
   - `compute_entry_config_diff(old, new)` becomes a method
     `EntryConfig.diff(self, other) -> EntryConfigDiff`. Module-level helper
-    can be removed (or kept as a thin shim during transition).
-  - `_async_setup_new_locks(hass, entry, locks_to_add, new_slots, ...)`
-    can take `EntryConfig` instead of separate `locks_to_add` + `new_slots`
-    args.
+    can be removed.
+  - `_async_setup_new_locks(hass, entry, locks_to_add, new_slots, ...)` takes
+    `EntryConfig` instead of separate `locks_to_add` + `new_slots` args.
+  - `get_entry_data(entry, key, default)` callers that don't need the
+    options-over-data fallback can switch to `runtime_data.config.locks` /
+    `.slots`. Helper can eventually be removed.
+  - `get_slot_data(entry, slot_num)` thin-wrapper can be removed; callers
+    use `get_entry_config(entry).slot(slot_num)` directly.
 
-  **Defensive patterns to delete after migration:**
+  **Out-of-scope boundaries** (related, not part of this migration):
 
-  - `helpers.py:146` `slot_key = slot_num if slot_num in slots else str(slot_num)`
-  - `helpers.py:191` and `:209` (same pattern)
-  - `websocket.py:194` `slots_data.get(slot_num) or slots_data.get(str(slot_num))`
-  - `websocket.py:1018` `if slot_num not in slots and str(slot_num) not in slots`
-  - `coordinator.py:89` `.get(str(slot_num), {})` becomes `.get(slot_num, {})`
-  - The `for code_slot in get_entry_data(entry, CONF_SLOTS, {})` patterns where
-    the int(code_slot) cast is needed (find_entry_for_lock_slot, get_managed_slots)
+  - **TypedDict for slot config** — `class SlotConfig(TypedDict)` with
+    `pin: NotRequired[str]`, `enabled: bool`, `name: NotRequired[str]`,
+    `entity_id: NotRequired[str]`, `number_of_uses: NotRequired[int]`.
+    Replaces `dict[str, Any]` for slot inner dicts; gives pyright real
+    signal on slot reads/writes. Would let `EntryConfig.slots` be typed
+    `Mapping[int, SlotConfig]`.
+  - **`coordinator.data` typing** — currently `dict[int, str | SlotCode]`.
+    Already int-keyed; `binary_sensor.py:281` and `entity.py:193` cast
+    defensively against `self.slot_num`'s type variance. Goes away when
+    listener is migrated and entities receive int slot_num.
+  - **Other internal dict boundaries** — `websocket.py:401/442/524/529`
+    cast into websocket-internal lookup dicts, `__init__.py:561` casts at
+    a callback boundary. These are separate from EntryConfig but solved
+    by the same broader "typed slot_num everywhere" theme.
 
-  **Ancillary improvements worth bundling:**
-
-  - **TypedDict for slot config** — define `class SlotConfig(TypedDict)` with
-    fields `pin: NotRequired[str]`, `enabled: bool`, `name: NotRequired[str]`,
-    `entity_id: NotRequired[str]`, `number_of_uses: NotRequired[int]`. Replaces
-    `dict[str, Any]` typing for slot inner dicts; gives pyright real signal on
-    slot reads/writes.
-  - **Listener int normalization (was PR #1028 review item #3)** — once the
-    str-hardcoded readers are migrated, the listener can normalize its locals
-    (`curr_slots`, `new_slots`) to int keys without breaking downstream
-    consumers. Closes the latent `slots_unchanged` `KeyError` risk.
-  - **EntryConfigDiff source-key-type complexity goes away** — currently
-    preserves the source's str-or-int key type to avoid breaking the listener.
-    With normalized inputs guaranteed, all dict outputs can be `Mapping[int, ...]`
-    and the int-normalization-for-comparison-only special case in
-    `compute_entry_config_diff` simplifies to plain set ops.
-  - **Drop `get_entry_data`'s options-over-data fallback in callers that don't
-    need it** — once `EntryConfig.from_entry()` encapsulates the priority logic,
-    callers stop carrying that detail.
-  - **HA storage round-trip stays as-is** — JSON layer continues to serialize
-    int keys to str on disk; we don't fight it. Normalization is purely on
-    READ via `from_entry()`. This keeps the migration additive (no changes to
-    on-disk format, no migration version bump needed).
-
-  **Migration approach:** introduce `EntryConfig` and migrate one module at
-  a time (coordinator → entities → helpers → websocket → providers →
-  listener). Each step deletes its local defensive str-handling. Single PR
-  for the introduction + first migration target; follow-up PRs for the rest
-  to keep reviews focused.
+  **HA storage round-trip stays as-is** — JSON layer continues to serialize
+  int keys to str on disk; we don't fight it. Normalization is purely on
+  READ via `from_entry()`. The migration is additive — no changes to
+  on-disk format, no migration version bump needed.
 - **Websocket optimization** — Add optional `include_entities`/`include_locks`
   flags to `get_config_entry_data` command.
 - **Entity registry change detection** — Warn if LCM entity IDs change (reload

--- a/TODO.md
+++ b/TODO.md
@@ -85,9 +85,10 @@
   After Stage 2, `runtime_data.config.slots` is the only authoritative view
   and writers go through it.
 
-  **Stage 3: listener int-normalization** (was [PR #1028 review item #3](https://github.com/raman325/lock_code_manager/pull/1028)) — Once writers are
-  migrated, the listener's `curr_slots` / `new_slots` locals can normalize to
-  int keys without breaking downstream consumers. Closes the latent
+  **Stage 3: listener int-normalization** (was [PR #1028][pr-1028] review
+  item #3) — Once writers are migrated, the listener's `curr_slots` /
+  `new_slots` locals can normalize to int keys without breaking downstream
+  consumers. Closes the latent
   `slots_unchanged` `KeyError` risk and lets `EntryConfigDiff` drop its
   source-key-type preservation gymnastics (all dict outputs can be
   `Mapping[int, ...]`, the int-normalization-for-comparison-only special
@@ -145,3 +146,5 @@
   changes.
 - Review TODOs after completing current work, when starting new features, during
   refactoring sessions, or on `/todos`.
+
+[pr-1028]: https://github.com/raman325/lock_code_manager/pull/1028

--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -79,7 +79,7 @@ from .const import (
     STRATEGY_PATH,
     Platform,
 )
-from .data import compute_entry_config_diff, get_entry_data
+from .data import EntryConfig, compute_entry_config_diff, get_entry_data
 from .helpers import (
     async_clear_slot_condition,
     async_clear_usercode,
@@ -448,7 +448,9 @@ async def async_setup_entry(
 
     hass.data.setdefault(DOMAIN, {CONF_LOCKS: {}, "resources": False})
     await _async_register_strategy_resource(hass)
-    config_entry.runtime_data = LockCodeManagerConfigEntryData()
+    config_entry.runtime_data = LockCodeManagerConfigEntryData(
+        config=EntryConfig.from_entry(config_entry),
+    )
 
     dev_reg = dr.async_get(hass)
     dev_reg.async_get_or_create(
@@ -742,12 +744,20 @@ async def async_update_listener(
     hass: HomeAssistant, config_entry: LockCodeManagerConfigEntry
 ) -> None:
     """Update listener."""
-    # No need to update if there are no options because that only happens at the end
-    # of this function
+    # Refresh the cached EntryConfig on EVERY update — including entity-driven
+    # writes that go straight to data with empty options (e.g. a slot's name or
+    # PIN being edited via its text entity). The early-return below skips the
+    # entity-creation pass for those cases, but downstream readers via
+    # runtime_data.config still need to see the current data.
+    runtime_data = config_entry.runtime_data
+    runtime_data.config = EntryConfig.from_entry(config_entry)
+
+    # No need to do entity creation/removal work if there are no options
+    # because that only happens at the end of this function (data + empty
+    # options = the post-listener state we just wrote ourselves).
     if not config_entry.options:
         return
 
-    runtime_data = config_entry.runtime_data
     ent_reg = er.async_get(hass)
 
     entry_id = config_entry.entry_id
@@ -892,6 +902,8 @@ async def async_update_listener(
         "%s (%s): Done creating and/or updating entities", entry_id, entry_title
     )
     hass.config_entries.async_update_entry(config_entry, data=new_data, options={})
+    # The async_update_entry above re-triggers this listener, which
+    # refreshes runtime_data.config at the top before the early-return.
 
     # Notify Lovelace dashboards to re-render when structure changes
     # (slots or locks added/removed), so strategy-generated cards update

--- a/custom_components/lock_code_manager/coordinator.py
+++ b/custom_components/lock_code_manager/coordinator.py
@@ -24,11 +24,10 @@ from .const import (
     BACKOFF_FAILURE_THRESHOLD,
     BACKOFF_INITIAL_SECONDS,
     BACKOFF_MAX_SECONDS,
-    CONF_SLOTS,
     DOMAIN,
     POLL_FAILURE_ALERT_THRESHOLD,
 )
-from .data import get_entry_data
+from .data import get_entry_config
 from .exceptions import LockCodeManagerError
 from .models import SlotCode
 
@@ -85,9 +84,7 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator[dict[int, str | SlotCo
 
     def get_expected_pin(self, slot_num: int) -> str | None:
         """Return configured PIN for a slot, or None if disabled/unconfigured."""
-        slot_data = get_entry_data(self._config_entry, CONF_SLOTS, {}).get(
-            str(slot_num), {}
-        )
+        slot_data = get_entry_config(self._config_entry).slots.get(int(slot_num), {})
         if not slot_data.get(CONF_ENABLED):
             return None
         return slot_data.get(CONF_PIN) or None

--- a/custom_components/lock_code_manager/coordinator.py
+++ b/custom_components/lock_code_manager/coordinator.py
@@ -84,7 +84,7 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator[dict[int, str | SlotCo
 
     def get_expected_pin(self, slot_num: int) -> str | None:
         """Return configured PIN for a slot, or None if disabled/unconfigured."""
-        slot_data = get_entry_config(self._config_entry).slots.get(int(slot_num), {})
+        slot_data = get_entry_config(self._config_entry).slot(slot_num)
         if not slot_data.get(CONF_ENABLED):
             return None
         return slot_data.get(CONF_PIN) or None

--- a/custom_components/lock_code_manager/data.py
+++ b/custom_components/lock_code_manager/data.py
@@ -12,6 +12,105 @@ from homeassistant.core import HomeAssistant
 
 from .const import CONF_LOCKS, CONF_SLOTS, DOMAIN
 
+_EMPTY_SLOTS: Mapping[int, Mapping[str, Any]] = MappingProxyType({})
+
+
+@dataclass(frozen=True, slots=True)
+class EntryConfig:
+    """Typed, normalized view of an LCM entry's configuration.
+
+    Single chokepoint for reading entry config: the on-disk representation
+    has ``str`` slot keys (JSON storage) while voluptuous-validated user
+    input has ``int`` keys. ``EntryConfig`` normalizes to ``int`` keys
+    once at construction so every downstream consumer can treat slot
+    numbers uniformly. The defensive ``slot if slot in d else str(slot)``
+    patterns scattered across the codebase exist precisely because there
+    was no such chokepoint before.
+
+    ``slots`` is a deeply read-only mapping (``MappingProxyType`` at both
+    levels) so callers can keep an ``EntryConfig`` as cached state without
+    defensive copies.
+
+    Lifecycle: an instance is cached on
+    ``LockCodeManagerConfigEntryData.config`` and refreshed by the update
+    listener whenever the entry is mutated. Most callers should access it
+    via ``entry.runtime_data.config`` directly. Iteration helpers that
+    walk ``hass.config_entries.async_entries(DOMAIN)`` use
+    :func:`get_entry_config` to handle the unloaded-entry case.
+    """
+
+    locks: tuple[str, ...]
+    slots: Mapping[int, Mapping[str, Any]]
+
+    @classmethod
+    def empty(cls) -> EntryConfig:
+        """Return a config representing an entry with no locks or slots.
+
+        Used as the initial value for ``runtime_data.config`` before the
+        entry's data has been read.
+        """
+        return cls(locks=(), slots=_EMPTY_SLOTS)
+
+    @classmethod
+    def from_entry(cls, entry: ConfigEntry) -> EntryConfig:
+        """Build EntryConfig from a config entry, options-preferred.
+
+        Matches the precedence used by :func:`get_entry_data`: during
+        options-flow updates the new config is in ``options`` while
+        ``data`` still holds the old config.
+        """
+        return cls.from_mapping(
+            {
+                CONF_LOCKS: entry.options.get(
+                    CONF_LOCKS, entry.data.get(CONF_LOCKS, [])
+                ),
+                CONF_SLOTS: entry.options.get(
+                    CONF_SLOTS, entry.data.get(CONF_SLOTS, {})
+                ),
+            }
+        )
+
+    @classmethod
+    def from_mapping(cls, mapping: Mapping[str, Any]) -> EntryConfig:
+        """Build EntryConfig from a raw config mapping (data, options, or input).
+
+        Slot keys are normalized to ``int`` regardless of source. Inner
+        slot config dicts are wrapped in ``MappingProxyType`` so the
+        whole structure is read-only.
+        """
+        raw_slots = mapping.get(CONF_SLOTS, {})
+        raw_locks = mapping.get(CONF_LOCKS, [])
+        return cls(
+            locks=tuple(raw_locks),
+            slots=MappingProxyType(
+                {int(k): MappingProxyType(dict(v)) for k, v in raw_slots.items()}
+            ),
+        )
+
+    def has_lock(self, lock_entity_id: str) -> bool:
+        """Return True if this entry manages the given lock."""
+        return lock_entity_id in self.locks
+
+    def has_slot(self, slot_num: int) -> bool:
+        """Return True if this entry manages the given slot number."""
+        return slot_num in self.slots
+
+
+def get_entry_config(entry: ConfigEntry) -> EntryConfig:
+    """Return the EntryConfig view of ``entry``.
+
+    Prefers the cached instance on ``entry.runtime_data.config`` (set by
+    the listener during setup and on every update) and falls back to
+    constructing fresh from the raw entry data. The fallback covers
+    iteration over ``hass.config_entries.async_entries(DOMAIN)`` which
+    may yield entries that haven't been loaded yet (or are mid-teardown)
+    and so don't have ``runtime_data`` populated.
+    """
+    cached = getattr(getattr(entry, "runtime_data", None), "config", None)
+    if isinstance(cached, EntryConfig):
+        return cached
+    return EntryConfig.from_entry(entry)
+
 
 def get_entry_data(config_entry: ConfigEntry, key: str, default: Any) -> Any:
     """
@@ -23,18 +122,24 @@ def get_entry_data(config_entry: ConfigEntry, key: str, default: Any) -> Any:
     return config_entry.options.get(key, config_entry.data.get(key, default))
 
 
-def get_slot_data(config_entry, slot_num: int) -> dict[str, Any]:
-    """Get data for slot."""
-    return get_entry_data(config_entry, CONF_SLOTS, {}).get(slot_num, {})
+def get_slot_data(config_entry, slot_num: int) -> Mapping[str, Any]:
+    """Get the slot config dict for ``slot_num`` (empty mapping if absent).
+
+    Goes via :class:`EntryConfig` so the returned mapping is found
+    regardless of whether the underlying storage uses ``str`` or ``int``
+    slot keys. Callers may pass either type for ``slot_num``.
+    """
+    return get_entry_config(config_entry).slots.get(int(slot_num), {})
 
 
 def get_managed_slots(hass: HomeAssistant, lock_entity_id: str) -> set[int]:
     """Return the set of slot numbers managed by any LCM config entry for a lock."""
     return {
-        int(code_slot)
+        slot_num
         for entry in hass.config_entries.async_entries(DOMAIN)
-        if lock_entity_id in get_entry_data(entry, CONF_LOCKS, [])
-        for code_slot in get_entry_data(entry, CONF_SLOTS, {})
+        for config in [get_entry_config(entry)]
+        if config.has_lock(lock_entity_id)
+        for slot_num in config.slots
     }
 
 
@@ -50,8 +155,8 @@ def find_entry_for_lock_slot(
         (
             entry
             for entry in hass.config_entries.async_entries(DOMAIN)
-            if lock_entity_id in get_entry_data(entry, CONF_LOCKS, [])
-            and code_slot in (int(s) for s in get_entry_data(entry, CONF_SLOTS, {}))
+            for config in [get_entry_config(entry)]
+            if config.has_lock(lock_entity_id) and config.has_slot(int(code_slot))
         ),
         None,
     )

--- a/custom_components/lock_code_manager/data.py
+++ b/custom_components/lock_code_manager/data.py
@@ -91,9 +91,23 @@ class EntryConfig:
         """Return True if this entry manages the given lock."""
         return lock_entity_id in self.locks
 
-    def has_slot(self, slot_num: int) -> bool:
-        """Return True if this entry manages the given slot number."""
-        return slot_num in self.slots
+    def has_slot(self, slot_num: int | str) -> bool:
+        """Return True if this entry manages the given slot number.
+
+        Accepts ``int`` or ``str`` to absorb the slot-key type variance
+        in the codebase (entities created during the listener may carry
+        either type as ``self.slot_num``). Internal storage is always
+        ``int``-keyed.
+        """
+        return int(slot_num) in self.slots
+
+    def slot(self, slot_num: int | str) -> Mapping[str, Any]:
+        """Return the slot config dict, or an empty mapping if absent.
+
+        Like :meth:`has_slot`, accepts ``int`` or ``str`` so callers
+        don't need to cast at every read site.
+        """
+        return self.slots.get(int(slot_num), {})
 
 
 def get_entry_config(entry: ConfigEntry) -> EntryConfig:
@@ -122,14 +136,13 @@ def get_entry_data(config_entry: ConfigEntry, key: str, default: Any) -> Any:
     return config_entry.options.get(key, config_entry.data.get(key, default))
 
 
-def get_slot_data(config_entry, slot_num: int) -> Mapping[str, Any]:
+def get_slot_data(config_entry, slot_num: int | str) -> Mapping[str, Any]:
     """Get the slot config dict for ``slot_num`` (empty mapping if absent).
 
-    Goes via :class:`EntryConfig` so the returned mapping is found
-    regardless of whether the underlying storage uses ``str`` or ``int``
-    slot keys. Callers may pass either type for ``slot_num``.
+    Thin wrapper around :meth:`EntryConfig.slot` for callers that don't
+    have an :class:`EntryConfig` in hand.
     """
-    return get_entry_config(config_entry).slots.get(int(slot_num), {})
+    return get_entry_config(config_entry).slot(slot_num)
 
 
 def get_managed_slots(hass: HomeAssistant, lock_entity_id: str) -> set[int]:
@@ -144,7 +157,7 @@ def get_managed_slots(hass: HomeAssistant, lock_entity_id: str) -> set[int]:
 
 
 def find_entry_for_lock_slot(
-    hass: HomeAssistant, lock_entity_id: str, code_slot: int
+    hass: HomeAssistant, lock_entity_id: str, code_slot: int | str
 ) -> ConfigEntry | None:
     """Find the config entry that manages a specific lock + slot combination.
 
@@ -156,7 +169,7 @@ def find_entry_for_lock_slot(
             entry
             for entry in hass.config_entries.async_entries(DOMAIN)
             for config in [get_entry_config(entry)]
-            if config.has_lock(lock_entity_id) and config.has_slot(int(code_slot))
+            if config.has_lock(lock_entity_id) and config.has_slot(code_slot)
         ),
         None,
     )

--- a/custom_components/lock_code_manager/data.py
+++ b/custom_components/lock_code_manager/data.py
@@ -150,8 +150,7 @@ def get_managed_slots(hass: HomeAssistant, lock_entity_id: str) -> set[int]:
     return {
         slot_num
         for entry in hass.config_entries.async_entries(DOMAIN)
-        for config in [get_entry_config(entry)]
-        if config.has_lock(lock_entity_id)
+        if (config := get_entry_config(entry)).has_lock(lock_entity_id)
         for slot_num in config.slots
     }
 
@@ -168,8 +167,8 @@ def find_entry_for_lock_slot(
         (
             entry
             for entry in hass.config_entries.async_entries(DOMAIN)
-            for config in [get_entry_config(entry)]
-            if config.has_lock(lock_entity_id) and config.has_slot(code_slot)
+            if (config := get_entry_config(entry)).has_lock(lock_entity_id)
+            and config.has_slot(code_slot)
         ),
         None,
     )

--- a/custom_components/lock_code_manager/models.py
+++ b/custom_components/lock_code_manager/models.py
@@ -15,6 +15,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 
 from .callbacks import EntityCallbackRegistry
+from .data import EntryConfig
 
 if TYPE_CHECKING:
     from .providers import BaseLock
@@ -38,6 +39,10 @@ class LockCodeManagerConfigEntryData:
     locks: dict[str, BaseLock] = field(default_factory=dict)
     setup_tasks: dict[str | Platform, asyncio.Task[Any]] = field(default_factory=dict)
     callbacks: EntityCallbackRegistry = field(default_factory=EntityCallbackRegistry)
+    # Cached typed view of the entry's current config; refreshed by the
+    # update listener on every change. Readers should prefer this over
+    # parsing config_entry.data/options directly. See data.EntryConfig.
+    config: EntryConfig = field(default_factory=EntryConfig.empty)
 
 
 type LockCodeManagerConfigEntry = ConfigEntry[LockCodeManagerConfigEntryData]

--- a/custom_components/lock_code_manager/websocket.py
+++ b/custom_components/lock_code_manager/websocket.py
@@ -95,7 +95,7 @@ from .const import (
     DOMAIN,
     EVENT_PIN_USED,
 )
-from .data import get_entry_data
+from .data import get_entry_config, get_entry_data
 from .helpers import (
     async_clear_slot_condition,
     async_clear_usercode,
@@ -190,11 +190,8 @@ def _get_slot_condition_entity_id(
     config_entry: ConfigEntry, slot_num: int
 ) -> str | None:
     """Get condition entity ID from slot config."""
-    slots_data = get_entry_data(config_entry, CONF_SLOTS, {})
-    slot_config = slots_data.get(slot_num) or slots_data.get(str(slot_num)) or {}
-    if isinstance(slot_config, dict):
-        return slot_config.get(CONF_ENTITY_ID)
-    return None
+    slot_config = get_entry_config(config_entry).slots.get(int(slot_num), {})
+    return slot_config.get(CONF_ENTITY_ID)
 
 
 def async_get_entry(
@@ -1013,9 +1010,8 @@ async def subscribe_code_slot(
     slot_num = msg[ATTR_SLOT]
     reveal = msg["reveal"]
 
-    # Validate slot exists in config (slot keys can be int or str)
-    slots = get_entry_data(config_entry, CONF_SLOTS, {})
-    if slot_num not in slots and str(slot_num) not in slots:
+    # Validate slot exists in config
+    if not get_entry_config(config_entry).has_slot(int(slot_num)):
         connection.send_error(
             msg["id"],
             websocket_api.const.ERR_NOT_FOUND,

--- a/custom_components/lock_code_manager/websocket.py
+++ b/custom_components/lock_code_manager/websocket.py
@@ -190,8 +190,7 @@ def _get_slot_condition_entity_id(
     config_entry: ConfigEntry, slot_num: int
 ) -> str | None:
     """Get condition entity ID from slot config."""
-    slot_config = get_entry_config(config_entry).slots.get(int(slot_num), {})
-    return slot_config.get(CONF_ENTITY_ID)
+    return get_entry_config(config_entry).slot(slot_num).get(CONF_ENTITY_ID)
 
 
 def async_get_entry(
@@ -1011,7 +1010,7 @@ async def subscribe_code_slot(
     reveal = msg["reveal"]
 
     # Validate slot exists in config
-    if not get_entry_config(config_entry).has_slot(int(slot_num)):
+    if not get_entry_config(config_entry).has_slot(slot_num):
         connection.send_error(
             msg["id"],
             websocket_api.const.ERR_NOT_FOUND,

--- a/scripts/setup
+++ b/scripts/setup
@@ -53,6 +53,17 @@ fi
 pip install --upgrade uv
 uv pip install -r requirements_dev.txt
 
+# Install pre-commit as a uv-managed tool pinned to Python 3.13.
+# Avoids relying on whatever pre-commit (and underlying Python) the
+# user has on PATH — a Homebrew install linked against Python 3.14
+# fails on macOS with "_XML_SetAllocTrackerActivationThreshold not
+# found" because 3.14's bundled pyexpat is built against a newer
+# libexpat than the one /usr/lib/libexpat.1.dylib provides.
+# uv puts the binary at ~/.local/bin/pre-commit which typically wins
+# over /opt/homebrew/bin in $PATH. If you have an existing Homebrew
+# install of pre-commit, run `brew uninstall pre-commit` to remove
+# the broken one.
+uv tool install --force --python 3.13 pre-commit
 
 pre-commit install
 yarn install

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,13 +1,21 @@
-"""Tests for data helpers (compute_entry_config_diff, etc)."""
+"""Tests for data helpers (compute_entry_config_diff, EntryConfig, etc)."""
 
 from dataclasses import FrozenInstanceError
+from types import SimpleNamespace
 
 import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.lock_code_manager.const import CONF_LOCKS, CONF_SLOTS
+from custom_components.lock_code_manager.const import (
+    CONF_LOCKS,
+    CONF_SLOTS,
+    DOMAIN,
+)
 from custom_components.lock_code_manager.data import (
+    EntryConfig,
     EntryConfigDiff,
     compute_entry_config_diff,
+    get_entry_config,
 )
 
 
@@ -166,3 +174,139 @@ def test_diff_is_deeply_immutable() -> None:
     assert not hasattr(diff.locks_removed, "append")
 
     assert isinstance(diff, EntryConfigDiff)
+
+
+# --- EntryConfig tests ---
+
+
+def test_entry_config_empty() -> None:
+    """EntryConfig.empty() returns a config with no locks or slots."""
+    config = EntryConfig.empty()
+    assert config.locks == ()
+    assert dict(config.slots) == {}
+    assert not config.has_lock("lock.anything")
+    assert not config.has_slot(1)
+
+
+def test_entry_config_from_mapping_normalizes_str_slot_keys_to_int() -> None:
+    """from_mapping normalizes str slot keys (JSON storage) to int.
+
+    The whole point of EntryConfig: every consumer sees int keys
+    regardless of how the config was loaded.
+    """
+    config = EntryConfig.from_mapping(
+        {CONF_LOCKS: ["lock.a"], CONF_SLOTS: {"1": _slot(), "2": _slot()}}
+    )
+    assert set(config.slots.keys()) == {1, 2}
+    assert all(isinstance(k, int) for k in config.slots.keys())
+    assert config.has_slot(1)
+    assert not config.has_slot("1")  # type: ignore[arg-type]  # str does not match
+
+
+def test_entry_config_from_mapping_preserves_int_slot_keys() -> None:
+    """Int keys (voluptuous output) pass through unchanged."""
+    config = EntryConfig.from_mapping(
+        {CONF_LOCKS: ["lock.a"], CONF_SLOTS: {1: _slot()}}
+    )
+    assert set(config.slots.keys()) == {1}
+
+
+def test_entry_config_from_entry_options_preferred() -> None:
+    """from_entry prefers options over data, matching get_entry_data."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_LOCKS: ["lock.old"], CONF_SLOTS: {"1": _slot("old")}},
+        options={CONF_LOCKS: ["lock.new"], CONF_SLOTS: {"2": _slot("new")}},
+    )
+    config = EntryConfig.from_entry(entry)
+    # Options wins entirely (not merged)
+    assert config.locks == ("lock.new",)
+    assert set(config.slots.keys()) == {2}
+
+
+def test_entry_config_from_entry_falls_back_to_data() -> None:
+    """When options is empty, from_entry reads from data."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_LOCKS: ["lock.a"], CONF_SLOTS: {"1": _slot()}},
+    )
+    config = EntryConfig.from_entry(entry)
+    assert config.locks == ("lock.a",)
+    assert set(config.slots.keys()) == {1}
+
+
+def test_entry_config_is_deeply_immutable() -> None:
+    """EntryConfig is frozen and contains read-only mappings."""
+    config = EntryConfig.from_mapping(
+        {CONF_LOCKS: ["lock.a"], CONF_SLOTS: {1: _slot()}}
+    )
+
+    with pytest.raises(FrozenInstanceError):
+        config.locks = ("lock.b",)  # type: ignore[misc]
+
+    # Outer slots mapping is read-only
+    with pytest.raises(TypeError):
+        config.slots[99] = _slot()  # type: ignore[index]
+
+    # Inner slot config dict is also read-only
+    with pytest.raises(TypeError):
+        config.slots[1]["pin"] = "9999"  # type: ignore[index]
+
+
+def test_get_entry_config_uses_runtime_data_when_present() -> None:
+    """get_entry_config returns the cached EntryConfig from runtime_data.
+
+    No fresh construction — same instance is returned, allowing the
+    listener's cache to act as a true singleton view of the entry.
+    """
+    cached = EntryConfig.from_mapping(
+        {CONF_LOCKS: ["lock.cached"], CONF_SLOTS: {1: _slot("cached")}}
+    )
+    fake_entry = SimpleNamespace(
+        runtime_data=SimpleNamespace(config=cached),
+        # data/options would normally be here too — proving they're not
+        # consulted when the cache is present:
+        data={CONF_LOCKS: ["lock.different"], CONF_SLOTS: {}},
+        options={},
+    )
+
+    result = get_entry_config(fake_entry)  # type: ignore[arg-type]
+
+    # Returns the cached instance — same object, not a fresh build
+    assert result is cached
+    assert result.locks == ("lock.cached",)
+
+
+def test_get_entry_config_falls_back_when_no_runtime_data() -> None:
+    """get_entry_config builds fresh from raw data if runtime_data is absent.
+
+    Covers iteration over hass.config_entries.async_entries(DOMAIN) which
+    may yield entries not yet loaded.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_LOCKS: ["lock.fresh"], CONF_SLOTS: {"1": _slot()}},
+    )
+    # MockConfigEntry has no runtime_data attribute by default
+
+    result = get_entry_config(entry)
+
+    assert result.locks == ("lock.fresh",)
+    assert set(result.slots.keys()) == {1}
+
+
+def test_get_entry_config_falls_back_when_runtime_data_lacks_config() -> None:
+    """If runtime_data exists but doesn't have a .config attr, fall back.
+
+    Defends against the brief window during async_setup_entry before
+    runtime_data.config is initialized.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_LOCKS: ["lock.fresh"], CONF_SLOTS: {"1": _slot()}},
+    )
+    entry.runtime_data = SimpleNamespace()  # no config attr
+
+    result = get_entry_config(entry)
+
+    assert result.locks == ("lock.fresh",)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -199,8 +199,24 @@ def test_entry_config_from_mapping_normalizes_str_slot_keys_to_int() -> None:
     )
     assert set(config.slots.keys()) == {1, 2}
     assert all(isinstance(k, int) for k in config.slots.keys())
+
+
+def test_entry_config_accessors_absorb_str_or_int_slot_num() -> None:
+    """has_slot / slot accept either type and normalize internally.
+
+    Lets callers stop carrying ``int(slot_num)`` casts at every read
+    site. The internal storage is still ``int``-keyed; the accessors
+    just absorb the type variance.
+    """
+    config = EntryConfig.from_mapping({CONF_SLOTS: {"1": _slot(pin="abc")}})
+
     assert config.has_slot(1)
-    assert not config.has_slot("1")  # type: ignore[arg-type]  # str does not match
+    assert config.has_slot("1")
+    assert config.slot(1) == {"pin": "abc", "enabled": True}
+    assert config.slot("1") == {"pin": "abc", "enabled": True}
+    # Missing slot returns empty mapping (not KeyError)
+    assert config.slot(99) == {}
+    assert config.slot("99") == {}
 
 
 def test_entry_config_from_mapping_preserves_int_slot_keys() -> None:


### PR DESCRIPTION
## Proposed change

**Stage 1** of the EntryConfig migration outlined in [TODO.md](https://github.com/raman325/lock_code_manager/blob/main/TODO.md). Adds a frozen `EntryConfig` dataclass as the single chokepoint for reading entry config — slot keys are normalized to ``int`` regardless of source (str-keyed JSON storage vs. int-keyed voluptuous output), eliminating one class of "slot if slot in d else str(slot)" defensive patterns scattered across the codebase.

### What landed

**1. EntryConfig in `data.py`** — frozen dataclass with `from_entry`, `from_mapping`, `has_lock`, `has_slot`, and an `empty()` factory. Inner mappings are deeply read-only (`MappingProxyType` at both levels) so callers can keep an instance as cached state.

**2. Cached on runtime_data** — `LockCodeManagerConfigEntryData` gains a `config: EntryConfig` field, initialized in `async_setup_entry` and refreshed at the **top** of `async_update_listener` (before the empty-options early-return). This means entity-driven writes that only touch `data` (e.g. text/switch entities updating slot config) also refresh the cache.

   Most readers use `entry.runtime_data.config` directly. Iteration helpers (`get_managed_slots`, `find_entry_for_lock_slot`) and code that may run before runtime_data is fully populated use the `get_entry_config()` helper, which falls back to `EntryConfig.from_entry()`.

**3. Migrated readers** — drops the str-fallback patterns from these sites:

| Site | Before | After |
|------|--------|-------|
| `data.get_slot_data` | `get_entry_data(...).get(slot_num, {})` | `get_entry_config(...).slots.get(int(slot_num), {})` |
| `data.get_managed_slots` | manual int-cast comprehension | iterates `EntryConfig.slots.keys()` directly |
| `data.find_entry_for_lock_slot` | `code_slot in (int(s) for s in ...)` | `config.has_slot(int(code_slot))` |
| `coordinator.get_expected_pin` | `.get(str(slot_num), {})` | `.slots.get(int(slot_num), {})` |
| `websocket._get_condition_entity_id` | `slots.get(slot_num) or slots.get(str(slot_num))` | direct int lookup |
| `websocket.subscribe_code_slot` validator | `slot_num not in slots and str(slot_num) not in slots` | `config.has_slot(int(slot_num))` |

### What did NOT change (deferred)

Per the staged plan in TODO.md:

- **Writers** (`entity._update_config_entry`, `helpers.py:191/209`, config-flow direct mutations) still use raw dict access. They write mixed-key-type dicts as before.
- **Listener local dicts** (`curr_slots`/`new_slots`) still preserve source key types. The listener int normalization called out in [PR #1028](https://github.com/raman325/lock_code_manager/pull/1028) review item #3 becomes safe once writers are migrated — that's the next PR.
- **`compute_entry_config_diff()`** unchanged. Could become `EntryConfig.diff()` once all callers consume `EntryConfig`.

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Additional information

- 589 tests pass (9 new in `tests/test_data.py` covering EntryConfig and `get_entry_config`)
- 100% coverage on `data.py` and `models.py`
- Followups tracked in [TODO.md](https://github.com/raman325/lock_code_manager/blob/main/TODO.md): writer migration, then listener int normalization