### PR TITLE
EntryConfig stage 2: writers + delete get_entry_data

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -58,52 +58,47 @@
   sensor entities to coordinator (survives entity recreation during config
   updates).
 - **EntryConfig migration** — Multi-stage refactor centralizing entry-config
-  reads through a typed `EntryConfig` dataclass to eliminate the str/int slot
-  key inconsistency that HA's JSON storage round-trip creates. **Stage 1
-  delivered in PR #1029**: introduced `EntryConfig` with `from_entry` /
-  `from_mapping` / `slot` / `has_slot` / `has_lock` / `empty`, cached it on
-  `runtime_data.config` (refreshed at the top of `async_update_listener` so
-  even entity-driven writes update the cache), and migrated readers in
-  `data.get_slot_data` / `get_managed_slots` / `find_entry_for_lock_slot`,
-  `coordinator.get_expected_pin`, and `websocket._get_condition_entity_id` /
-  `subscribe_code_slot` validator. The accessors absorb `int|str` slot_num
-  internally so call sites have no visible casts.
+  reads and writes through a typed `EntryConfig` dataclass to eliminate the
+  str/int slot key inconsistency that HA's JSON storage round-trip creates.
 
-  **Stage 2: writers** — Migrate sites that mutate `config_entry.data[CONF_SLOTS]`
-  directly off raw dict access. Affected sites:
+  **Stage 1 delivered in PR #1029**: introduced `EntryConfig` with
+  `from_entry` / `from_mapping` / `slot` / `has_slot` / `has_lock` / `empty`,
+  cached it on `runtime_data.config` (refreshed at the top of
+  `async_update_listener` so even entity-driven writes update the cache),
+  and migrated readers in `data.get_slot_data` / `get_managed_slots` /
+  `find_entry_for_lock_slot`, `coordinator.get_expected_pin`, and
+  `websocket._get_condition_entity_id` / `subscribe_code_slot` validator.
+  The accessors absorb `int|str` slot_num internally so call sites have no
+  visible casts.
 
-  - `entity._update_config_entry` (`entity.py:105`) — `data[CONF_SLOTS][self
-    .slot_num][self.key] = value`. Needs an `EntryConfig.with_slot_field_set
-    (slot_num, key, value)` immutable helper that returns a new `EntryConfig`,
-    plus a `to_dict()` for handing back to `async_update_entry`.
-  - `helpers.py:146` `slot_key = slot_num if slot_num in slots else str(slot_num)`
-  - `helpers.py:191` and `:209` (same defensive pattern around
-    `data[CONF_SLOTS][slot_key][CONF_ENTITY_ID]` set/delete)
-  - `config_flow.py:508/544` write paths — these construct fresh slot dicts
-    so they're already controlled, mostly want type-tightening.
+  **Stage 2 delivered (this PR)**: added immutable update API
+  (`with_slot_field_set`, `with_slot_field_removed`, `to_dict`) and migrated
+  every writer off raw `data[CONF_SLOTS][...]` mutation —
+  `entity._update_config_entry`, `helpers.async_set_slot_condition`,
+  `helpers.async_clear_slot_condition`, `helpers.get_slot_config` (drops
+  the defensive `slot if slot in slots else str(slot)` pattern). Also
+  deleted `get_entry_data` entirely after a survey showed 100% of its
+  callers were doing `CONF_LOCKS` or `CONF_SLOTS` lookups — all migrated
+  to `EntryConfig` (`__init__.py`, `helpers.py`, `config_flow.py`,
+  `websocket.py`).
 
-  After Stage 2, `runtime_data.config.slots` is the only authoritative view
-  and writers go through it.
-
-  **Stage 3: listener int-normalization** (was [PR #1028][pr-1028] review
-  item #3) — Once writers are migrated, the listener's `curr_slots` /
-  `new_slots` locals can normalize to int keys without breaking downstream
-  consumers. Closes the latent
+  **Stage 3 still pending: listener int-normalization** (was
+  [PR #1028][pr-1028] review item #3). With readers and writers all
+  consuming `EntryConfig` (which is always int-keyed internally), the
+  listener can finally normalize its `curr_slots` / `new_slots` locals
+  to int keys without breaking downstream. Closes the latent
   `slots_unchanged` `KeyError` risk and lets `EntryConfigDiff` drop its
   source-key-type preservation gymnastics (all dict outputs can be
   `Mapping[int, ...]`, the int-normalization-for-comparison-only special
   case in `compute_entry_config_diff` simplifies to plain set ops).
 
-  **Stage 4: API cleanup** — After the migration is end-to-end:
+  **Stage 4 still pending: API cleanup**:
 
   - `compute_entry_config_diff(old, new)` becomes a method
     `EntryConfig.diff(self, other) -> EntryConfigDiff`. Module-level helper
     can be removed.
   - `_async_setup_new_locks(hass, entry, locks_to_add, new_slots, ...)` takes
     `EntryConfig` instead of separate `locks_to_add` + `new_slots` args.
-  - `get_entry_data(entry, key, default)` callers that don't need the
-    options-over-data fallback can switch to `runtime_data.config.locks` /
-    `.slots`. Helper can eventually be removed.
   - `get_slot_data(entry, slot_num)` thin-wrapper can be removed; callers
     use `get_entry_config(entry).slot(slot_num)` directly.
 

--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -79,7 +79,7 @@ from .const import (
     STRATEGY_PATH,
     Platform,
 )
-from .data import EntryConfig, compute_entry_config_diff, get_entry_data
+from .data import EntryConfig, compute_entry_config_diff, get_entry_config
 from .helpers import (
     async_clear_slot_condition,
     async_clear_usercode,
@@ -435,7 +435,7 @@ async def async_setup_entry(
     try:
         entity_id = next(
             entity_id
-            for entity_id in get_entry_data(config_entry, CONF_LOCKS, [])
+            for entity_id in get_entry_config(config_entry).locks
             if not ent_reg.async_get(entity_id)
         )
     except StopIteration:
@@ -468,7 +468,7 @@ async def async_setup_entry(
     has_number_of_uses = any(
         CONF_NUMBER_OF_USES in slot_config
         for entry in hass.config_entries.async_entries(DOMAIN)
-        for slot_config in get_entry_data(entry, CONF_SLOTS, {}).values()
+        for slot_config in get_entry_config(entry).slots.values()
     )
     if has_number_of_uses:
         async_create_issue(
@@ -581,10 +581,12 @@ async def async_unload_entry(
     if unload_ok:
         await async_unload_lock(hass, config_entry)
 
-        # Clean up repair issues for this config entry. Use get_entry_data to
-        # check both data and options since data migrates to options during setup.
+        # Clean up repair issues for this config entry. EntryConfig handles
+        # the data-vs-options precedence (matters during the data→options
+        # migration that happens early in setup).
         entry_id = config_entry.entry_id
-        for slot_num in get_entry_data(config_entry, CONF_SLOTS, {}):
+        config = get_entry_config(config_entry)
+        for slot_num in config.slots:
             async_delete_issue(hass, DOMAIN, f"slot_disabled_{entry_id}_{slot_num}")
             async_delete_issue(hass, DOMAIN, f"pin_required_{entry_id}_{slot_num}")
         # Only delete lock_offline if no other LCM entry manages this lock
@@ -595,10 +597,9 @@ async def async_unload_entry(
             )
             if e.entry_id != entry_id
         ]
-        for lock_entity_id in get_entry_data(config_entry, CONF_LOCKS, []):
+        for lock_entity_id in config.locks:
             still_managed = any(
-                lock_entity_id in get_entry_data(e, CONF_LOCKS, [])
-                for e in other_entries
+                get_entry_config(e).has_lock(lock_entity_id) for e in other_entries
             )
             if not still_managed:
                 async_delete_issue(hass, DOMAIN, f"lock_offline_{lock_entity_id}")

--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -651,11 +651,11 @@ class LockCodeManagerOptionsFlow(_ExistingCodesFlowMixin, config_entries.Options
                 if not errors:
                     return await self._maybe_confirm_then_persist(user_input)
 
-        current_config = get_entry_config(self.config_entry)
-        defaults = {
-            CONF_LOCKS: list(current_config.locks),
-            CONF_SLOTS: dict(current_config.slots),
-        }
+        # Use to_dict() rather than .locks / .slots directly — to_dict
+        # returns plain mutable dict/list, while EntryConfig.slots is a
+        # deeply read-only MappingProxyType which the form selectors
+        # can't JSON-serialize.
+        defaults = get_entry_config(self.config_entry).to_dict()
 
         return self.async_show_form(
             step_id="init",

--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -36,7 +36,7 @@ from .const import (
     DOMAIN,
     EXCLUDED_CONDITION_PLATFORMS,
 )
-from .data import compute_entry_config_diff, get_entry_data
+from .data import compute_entry_config_diff, get_entry_config
 from .exceptions import LockCodeManagerError, LockCodeManagerProviderError
 from .models import SlotCode
 from .providers import INTEGRATIONS_CLASS_MAP
@@ -102,11 +102,9 @@ def _check_common_slots(
             (lock, common_slots, entry.title)
             for lock in locks
             for entry in hass.config_entries.async_entries(DOMAIN)
-            if lock in get_entry_data(entry, CONF_LOCKS, {})
+            if (config := get_entry_config(entry)).has_lock(lock)
             and (
-                common_slots := sorted(
-                    set(get_entry_data(entry, CONF_SLOTS, {})) & set(slots_list)
-                )
+                common_slots := sorted(set(config.slots) & {int(s) for s in slots_list})
             )
             and not (config_entry and config_entry == entry)
         )
@@ -582,7 +580,7 @@ class LockCodeManagerFlowHandler(
             additional_errors, additional_placeholders = _check_common_slots(
                 self.hass,
                 user_input[CONF_LOCKS],
-                get_entry_data(config_entry, CONF_SLOTS, {}).keys(),
+                get_entry_config(config_entry).slots.keys(),
                 config_entry,
             )
             errors.update(additional_errors)
@@ -653,19 +651,23 @@ class LockCodeManagerOptionsFlow(_ExistingCodesFlowMixin, config_entries.Options
                 if not errors:
                     return await self._maybe_confirm_then_persist(user_input)
 
-        def _get_default(key: str) -> Any:
-            """Get default value."""
-            return user_input.get(key, get_entry_data(self.config_entry, key, {}))
+        current_config = get_entry_config(self.config_entry)
+        defaults = {
+            CONF_LOCKS: list(current_config.locks),
+            CONF_SLOTS: dict(current_config.slots),
+        }
 
         return self.async_show_form(
             step_id="init",
             data_schema=vol.Schema(
                 {
                     vol.Required(
-                        CONF_LOCKS, default=_get_default(CONF_LOCKS)
+                        CONF_LOCKS,
+                        default=user_input.get(CONF_LOCKS, defaults[CONF_LOCKS]),
                     ): LOCK_ENTITY_SELECTOR,
                     vol.Required(
-                        CONF_SLOTS, default=_get_default(CONF_SLOTS)
+                        CONF_SLOTS,
+                        default=user_input.get(CONF_SLOTS, defaults[CONF_SLOTS]),
                     ): SLOTS_YAML_SELECTOR,
                 }
             ),
@@ -685,11 +687,9 @@ class LockCodeManagerOptionsFlow(_ExistingCodesFlowMixin, config_entries.Options
         """
         # Use the same diff helper as the update listener so the "is this
         # pair new?" definition stays in one place
-        old_data = {
-            CONF_LOCKS: get_entry_data(self.config_entry, CONF_LOCKS, []),
-            CONF_SLOTS: get_entry_data(self.config_entry, CONF_SLOTS, {}),
-        }
-        diff = compute_entry_config_diff(old_data, user_input)
+        diff = compute_entry_config_diff(
+            get_entry_config(self.config_entry).to_dict(), user_input
+        )
         if not diff.pairs_added:
             return self.async_create_entry(title="", data=user_input)
 

--- a/custom_components/lock_code_manager/data.py
+++ b/custom_components/lock_code_manager/data.py
@@ -55,9 +55,9 @@ class EntryConfig:
     def from_entry(cls, entry: ConfigEntry) -> EntryConfig:
         """Build EntryConfig from a config entry, options-preferred.
 
-        Matches the precedence used by :func:`get_entry_data`: during
-        options-flow updates the new config is in ``options`` while
-        ``data`` still holds the old config.
+        Uses options-preferred precedence: during options-flow updates
+        the new config is in ``options`` while ``data`` still holds the
+        old config.
         """
         return cls.from_mapping(
             {
@@ -109,6 +109,64 @@ class EntryConfig:
         """
         return self.slots.get(int(slot_num), {})
 
+    def with_slot_field_set(
+        self, slot_num: int | str, key: str, value: Any
+    ) -> EntryConfig:
+        """Return a new EntryConfig with one slot's field set to ``value``.
+
+        Creates the slot if it doesn't already exist. Used by writer
+        paths (entity field updates, condition entity set service) to
+        produce the new config to hand to ``async_update_entry``, paired
+        with :meth:`to_dict`.
+        """
+        sn = int(slot_num)
+        new_slots: dict[int, dict[str, Any]] = {
+            k: dict(v) for k, v in self.slots.items()
+        }
+        new_slots.setdefault(sn, {})[key] = value
+        return EntryConfig(
+            locks=self.locks,
+            slots=MappingProxyType(
+                {k: MappingProxyType(v) for k, v in new_slots.items()}
+            ),
+        )
+
+    def with_slot_field_removed(self, slot_num: int | str, key: str) -> EntryConfig:
+        """Return a new EntryConfig with one slot's field removed.
+
+        No-op (returns ``self``) if the slot or key is already absent.
+        """
+        sn = int(slot_num)
+        if sn not in self.slots or key not in self.slots[sn]:
+            return self
+        new_slots: dict[int, dict[str, Any]] = {
+            k: dict(v) for k, v in self.slots.items()
+        }
+        new_slots[sn].pop(key, None)
+        return EntryConfig(
+            locks=self.locks,
+            slots=MappingProxyType(
+                {k: MappingProxyType(v) for k, v in new_slots.items()}
+            ),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a plain mutable dict suitable for ``async_update_entry``.
+
+        Only includes the keys EntryConfig knows about (CONF_LOCKS and
+        CONF_SLOTS). Inner slot dicts are plain ``dict`` (not
+        ``MappingProxyType``) so HA's storage layer can serialize them.
+
+        Callers preserving other top-level keys in ``entry.data`` /
+        ``entry.options`` should merge: ``{**dict(entry.data),
+        **new_config.to_dict()}``. In practice LCM entries only carry
+        these two keys.
+        """
+        return {
+            CONF_LOCKS: list(self.locks),
+            CONF_SLOTS: {k: dict(v) for k, v in self.slots.items()},
+        }
+
 
 def get_entry_config(entry: ConfigEntry) -> EntryConfig:
     """Return the EntryConfig view of ``entry``.
@@ -124,16 +182,6 @@ def get_entry_config(entry: ConfigEntry) -> EntryConfig:
     if isinstance(cached, EntryConfig):
         return cached
     return EntryConfig.from_entry(entry)
-
-
-def get_entry_data(config_entry: ConfigEntry, key: str, default: Any) -> Any:
-    """
-    Get data from config entry.
-
-    Prefers options over data because during options flow updates, the new
-    configuration is in options while data still contains the old configuration.
-    """
-    return config_entry.options.get(key, config_entry.data.get(key, default))
 
 
 def get_slot_data(config_entry, slot_num: int | str) -> Mapping[str, Any]:

--- a/custom_components/lock_code_manager/entity.py
+++ b/custom_components/lock_code_manager/entity.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import copy
 import logging
 from typing import Any, final
 
@@ -23,10 +22,9 @@ from homeassistant.helpers.event import TrackStates, async_track_state_change_fi
 from .const import (
     ATTR_CODE_SLOT,
     ATTR_TO,
-    CONF_SLOTS,
     DOMAIN,
 )
-from .data import build_slot_unique_id, get_slot_data
+from .data import build_slot_unique_id, get_entry_config, get_slot_data
 from .models import LockCodeManagerConfigEntry
 from .providers import BaseLock
 
@@ -101,9 +99,12 @@ class BaseLockCodeManagerEntity(Entity):
             self.key,
             value,
         )
-        data = copy.deepcopy(dict(self.config_entry.data))
-        data[CONF_SLOTS][self.slot_num][self.key] = value
-        self.hass.config_entries.async_update_entry(self.config_entry, data=data)
+        new_config = get_entry_config(self.config_entry).with_slot_field_set(
+            self.slot_num, self.key, value
+        )
+        self.hass.config_entries.async_update_entry(
+            self.config_entry, data=new_config.to_dict()
+        )
         self.async_write_ha_state()
 
     async def _internal_async_remove(self) -> None:

--- a/custom_components/lock_code_manager/helpers.py
+++ b/custom_components/lock_code_manager/helpers.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import copy
+from collections.abc import Mapping
 import logging
 from typing import Any
 
@@ -22,8 +22,8 @@ from homeassistant.helpers import (
     entity_registry as er,
 )
 
-from .const import CONF_LOCKS, CONF_SLOTS, DOMAIN, EXCLUDED_CONDITION_PLATFORMS
-from .data import get_entry_data
+from .const import CONF_LOCKS, DOMAIN, EXCLUDED_CONDITION_PLATFORMS
+from .data import get_entry_config
 from .providers import INTEGRATIONS_CLASS_MAP, BaseLock
 
 _LOGGER = logging.getLogger(__name__)
@@ -140,13 +140,12 @@ async def async_clear_usercode(
     await lock.async_internal_clear_usercode(code_slot)
 
 
-def get_slot_config(config_entry: ConfigEntry, slot_num: int) -> dict[str, Any]:
-    """Get slot config dict, raising if not found."""
-    slots = get_entry_data(config_entry, CONF_SLOTS, {})
-    slot_key = slot_num if slot_num in slots else str(slot_num)
-    if slot_key not in slots:
+def get_slot_config(config_entry: ConfigEntry, slot_num: int) -> Mapping[str, Any]:
+    """Get slot config, raising if not found."""
+    config = get_entry_config(config_entry)
+    if not config.has_slot(slot_num):
         raise ServiceValidationError(f"Slot {slot_num} not found in config entry")
-    return slots[slot_key]
+    return config.slot(slot_num)
 
 
 def get_loaded_config_entry(hass: HomeAssistant, config_entry_id: str) -> ConfigEntry:
@@ -183,15 +182,10 @@ async def async_set_slot_condition(
             "Unsupported-Condition-Entity-Integrations"
         )
 
-    # Update config entry data using effective config (handles data vs options)
-    data = {
-        CONF_LOCKS: copy.deepcopy(get_entry_data(config_entry, CONF_LOCKS, [])),
-        CONF_SLOTS: copy.deepcopy(get_entry_data(config_entry, CONF_SLOTS, {})),
-    }
-    slot_key = slot if slot in data[CONF_SLOTS] else str(slot)
-    data[CONF_SLOTS][slot_key][CONF_ENTITY_ID] = entity_id
-
-    hass.config_entries.async_update_entry(config_entry, options=data)
+    new_config = get_entry_config(config_entry).with_slot_field_set(
+        slot, CONF_ENTITY_ID, entity_id
+    )
+    hass.config_entries.async_update_entry(config_entry, options=new_config.to_dict())
 
 
 async def async_clear_slot_condition(
@@ -201,12 +195,7 @@ async def async_clear_slot_condition(
     config_entry = get_loaded_config_entry(hass, config_entry_id)
     get_slot_config(config_entry, slot)
 
-    # Update config entry data using effective config (handles data vs options)
-    data = {
-        CONF_LOCKS: copy.deepcopy(get_entry_data(config_entry, CONF_LOCKS, [])),
-        CONF_SLOTS: copy.deepcopy(get_entry_data(config_entry, CONF_SLOTS, {})),
-    }
-    slot_key = slot if slot in data[CONF_SLOTS] else str(slot)
-    data[CONF_SLOTS][slot_key].pop(CONF_ENTITY_ID, None)
-
-    hass.config_entries.async_update_entry(config_entry, options=data)
+    new_config = get_entry_config(config_entry).with_slot_field_removed(
+        slot, CONF_ENTITY_ID
+    )
+    hass.config_entries.async_update_entry(config_entry, options=new_config.to_dict())

--- a/custom_components/lock_code_manager/websocket.py
+++ b/custom_components/lock_code_manager/websocket.py
@@ -95,7 +95,7 @@ from .const import (
     DOMAIN,
     EVENT_PIN_USED,
 )
-from .data import get_entry_config, get_entry_data
+from .data import get_entry_config
 from .helpers import (
     async_clear_slot_condition,
     async_clear_usercode,
@@ -303,7 +303,7 @@ async def get_config_entry_data(
 
     """
     all_locks = hass.data.get(DOMAIN, {}).get(CONF_LOCKS, {})
-    entry_lock_ids = get_entry_data(config_entry, CONF_LOCKS, [])
+    entry_config = get_entry_config(config_entry)
 
     connection.send_result(
         msg["id"],
@@ -321,11 +321,10 @@ async def get_config_entry_data(
                     CONF_NAME: _get_lock_friendly_name(hass, lock),
                 }
                 for lock_id, lock in all_locks.items()
-                if lock_id in entry_lock_ids
+                if entry_config.has_lock(lock_id)
             ],
             CONF_SLOTS: {
-                k: v.get(CONF_ENTITY_ID)
-                for k, v in get_entry_data(config_entry, CONF_SLOTS, {}).items()
+                k: v.get(CONF_ENTITY_ID) for k, v in entry_config.slots.items()
             },
         },
     )
@@ -411,9 +410,10 @@ def _get_managed_slots(hass: HomeAssistant, lock_entity_id: str) -> set[Any]:
     """Return slot identifiers managed by LCM for a given lock."""
     managed_slots: set[Any] = set()
     for entry in hass.config_entries.async_entries(DOMAIN):
-        if lock_entity_id not in get_entry_data(entry, CONF_LOCKS, []):
+        config = get_entry_config(entry)
+        if not config.has_lock(lock_entity_id):
             continue
-        for slot_num in get_entry_data(entry, CONF_SLOTS, {}):
+        for slot_num in config.slots:
             managed_slots.update(_slot_variants(slot_num))
     return managed_slots
 
@@ -435,11 +435,12 @@ def _get_slot_entity_ids(
     ent_reg = er.async_get(hass)
 
     for entry in hass.config_entries.async_entries(DOMAIN):
-        if lock_entity_id not in get_entry_data(entry, CONF_LOCKS, []):
+        config = get_entry_config(entry)
+        if not config.has_lock(lock_entity_id):
             continue
 
-        for slot_num in get_entry_data(entry, CONF_SLOTS, {}):
-            slot_int = int(slot_num)
+        for slot_int in config.slots:
+            slot_num = slot_int
 
             # Build unique IDs for each entity type
             name_uid = f"{entry.entry_id}|{slot_num}|{CONF_NAME}"
@@ -688,7 +689,7 @@ def _get_slot_in_sync_entity_ids(
     """
     ent_reg = er.async_get(hass)
     entry_id = config_entry.entry_id
-    lock_entity_ids = get_entry_data(config_entry, CONF_LOCKS, [])
+    lock_entity_ids = get_entry_config(config_entry).locks
 
     in_sync_map: dict[str, str] = {}
     for lock_entity_id in lock_entity_ids:
@@ -910,7 +911,7 @@ def _serialize_slot_card_data(
 
     # Build per-lock status
     all_locks = hass.data.get(DOMAIN, {}).get(CONF_LOCKS, {})
-    entry_lock_ids = get_entry_data(config_entry, CONF_LOCKS, [])
+    entry_lock_ids = get_entry_config(config_entry).locks
 
     locks_data: list[dict[str, Any]] = [
         _build_lock_status(
@@ -1128,7 +1129,7 @@ async def subscribe_code_slot(
     # Track coordinator updates for all locks
     unsub_coordinators: list[Any] = []
     all_locks = hass.data.get(DOMAIN, {}).get(CONF_LOCKS, {})
-    entry_lock_ids = get_entry_data(config_entry, CONF_LOCKS, [])
+    entry_lock_ids = get_entry_config(config_entry).locks
 
     for lock_entity_id in entry_lock_ids:
         lock = all_locks.get(lock_entity_id)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -228,7 +228,7 @@ def test_entry_config_from_mapping_preserves_int_slot_keys() -> None:
 
 
 def test_entry_config_from_entry_options_preferred() -> None:
-    """from_entry prefers options over data, matching get_entry_data."""
+    """from_entry prefers options over data (the options-flow precedence)."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={CONF_LOCKS: ["lock.old"], CONF_SLOTS: {"1": _slot("old")}},
@@ -326,3 +326,123 @@ def test_get_entry_config_falls_back_when_runtime_data_lacks_config() -> None:
     result = get_entry_config(entry)
 
     assert result.locks == ("lock.fresh",)
+
+
+# --- Immutable update helper tests ---
+
+
+def test_with_slot_field_set_creates_slot_when_missing() -> None:
+    """with_slot_field_set creates the slot if it wasn't already present."""
+    config = EntryConfig.from_mapping(
+        {CONF_LOCKS: ["lock.a"], CONF_SLOTS: {1: _slot()}}
+    )
+
+    updated = config.with_slot_field_set(2, "pin", "5678")
+
+    assert set(updated.slots.keys()) == {1, 2}
+    assert dict(updated.slots[2]) == {"pin": "5678"}
+
+
+def test_with_slot_field_set_updates_existing_field() -> None:
+    """with_slot_field_set replaces an existing field on an existing slot."""
+    config = EntryConfig.from_mapping({CONF_SLOTS: {1: _slot(pin="abc")}})
+
+    updated = config.with_slot_field_set(1, "pin", "xyz")
+
+    assert updated.slots[1]["pin"] == "xyz"
+    assert updated.slots[1]["enabled"] is True  # other fields preserved
+
+
+def test_with_slot_field_set_does_not_mutate_original() -> None:
+    """with_slot_field_set returns a new EntryConfig — original is untouched."""
+    config = EntryConfig.from_mapping({CONF_SLOTS: {1: _slot(pin="abc")}})
+
+    updated = config.with_slot_field_set(1, "pin", "xyz")
+
+    assert config.slots[1]["pin"] == "abc"  # unchanged
+    assert updated is not config
+    assert updated.slots[1]["pin"] == "xyz"
+
+
+def test_with_slot_field_set_accepts_str_slot_num() -> None:
+    """Normalizes the slot_num argument the same way has_slot does."""
+    config = EntryConfig.from_mapping({CONF_SLOTS: {1: _slot()}})
+
+    updated = config.with_slot_field_set("1", "pin", "new")
+
+    assert updated.slots[1]["pin"] == "new"
+
+
+def test_with_slot_field_set_output_is_deeply_immutable() -> None:
+    """The returned EntryConfig is frozen with read-only mappings, same as the input."""
+    config = EntryConfig.empty()
+    updated = config.with_slot_field_set(1, "pin", "1234")
+
+    with pytest.raises(TypeError):
+        updated.slots[1]["pin"] = "9999"  # type: ignore[index]
+
+
+def test_with_slot_field_removed_removes_key() -> None:
+    """with_slot_field_removed drops the named key from the slot config."""
+    config = EntryConfig.from_mapping(
+        {CONF_SLOTS: {1: {"pin": "1234", "enabled": True, "entity_id": "binary.a"}}}
+    )
+
+    updated = config.with_slot_field_removed(1, "entity_id")
+
+    assert "entity_id" not in updated.slots[1]
+    assert updated.slots[1]["pin"] == "1234"  # other fields preserved
+
+
+def test_with_slot_field_removed_is_noop_when_absent() -> None:
+    """Returns self (same instance) when there's nothing to remove."""
+    config = EntryConfig.from_mapping({CONF_SLOTS: {1: _slot()}})
+
+    # Slot exists but key doesn't
+    assert config.with_slot_field_removed(1, "entity_id") is config
+    # Slot doesn't exist at all
+    assert config.with_slot_field_removed(99, "pin") is config
+
+
+def test_to_dict_round_trips_through_from_mapping() -> None:
+    """to_dict → from_mapping reconstructs an equivalent EntryConfig.
+
+    Guards the write path used by entity._update_config_entry and the
+    helpers write functions: they build a new EntryConfig, call
+    to_dict(), hand it to async_update_entry, and expect the eventual
+    listener re-read to produce the same logical config.
+    """
+    original = EntryConfig.from_mapping(
+        {
+            CONF_LOCKS: ["lock.a", "lock.b"],
+            CONF_SLOTS: {1: _slot("1234"), 2: _slot("5678")},
+        }
+    )
+
+    round_tripped = EntryConfig.from_mapping(original.to_dict())
+
+    assert round_tripped.locks == original.locks
+    assert dict(round_tripped.slots) == dict(original.slots)
+
+
+def test_to_dict_produces_plain_mutable_dicts() -> None:
+    """to_dict output is plain dict (not MappingProxyType).
+
+    HA's async_update_entry expects a plain dict it can serialize; the
+    read-only wrappers EntryConfig uses internally would break that.
+    """
+    config = EntryConfig.from_mapping(
+        {CONF_LOCKS: ["lock.a"], CONF_SLOTS: {1: _slot()}}
+    )
+
+    result = config.to_dict()
+
+    assert isinstance(result, dict)
+    assert isinstance(result[CONF_SLOTS], dict)
+    assert isinstance(result[CONF_SLOTS][1], dict)
+    # Mutability — the returned dicts are the caller's to modify
+    result[CONF_SLOTS][1]["pin"] = "9999"
+    result[CONF_LOCKS].append("lock.b")
+    # Original EntryConfig is untouched by that mutation
+    assert config.slots[1]["pin"] == "1234"
+    assert config.locks == ("lock.a",)


### PR DESCRIPTION
## Proposed change

**Stage 2** of the EntryConfig migration ([TODO.md](https://github.com/raman325/lock_code_manager/blob/main/TODO.md)). Migrates every writer off raw `data[CONF_SLOTS][...]` mutation onto immutable `EntryConfig` update helpers, and **deletes `get_entry_data` entirely** after a survey showed 100% of its callers were just doing `CONF_LOCKS` / `CONF_SLOTS` lookups.

### What landed

**1. Immutable update API on `EntryConfig`:**

```python
config.with_slot_field_set(slot_num, key, value)    -> EntryConfig
config.with_slot_field_removed(slot_num, key)       -> EntryConfig  # returns self if nothing to remove
config.to_dict()                                     -> dict[str, Any]
```

All three accept `int | str` slot_num and normalize internally, matching the reader-side accessors landed in #1029.

**2. Writer migrations:**

| Site | Before | After |
|------|--------|-------|
| `entity._update_config_entry` | `copy.deepcopy(...)` + index mutation | single `get_entry_config(...).with_slot_field_set(...).to_dict()` pipeline |
| `helpers.async_set_slot_condition` | defensive `slot if slot in d else str(slot)` + index assign | `with_slot_field_set` |
| `helpers.async_clear_slot_condition` | same defensive pattern + `.pop()` | `with_slot_field_removed` |
| `helpers.get_slot_config` | same defensive pattern (read) | `EntryConfig.has_slot` / `.slot` (absorbs type variance) |

**3. Deleted `get_entry_data` + migrated all 24 callers** across `__init__.py`, `helpers.py`, `config_flow.py`, `websocket.py` to either `get_entry_config(entry).locks` / `.slots` or `EntryConfig` predicates. Every single call was for `CONF_LOCKS` or `CONF_SLOTS` — there were no other keys to look up — so the helper was purely redundant with `EntryConfig`.

### What did NOT land (deferred)

Per the staged plan in TODO.md:

- **Stage 3: listener int-normalization** — now safe because all readers AND writers consume `EntryConfig`, but the listener locals still preserve source key types. Closes the latent `slots_unchanged` `KeyError` when done.
- **Stage 4 cleanups** — `compute_entry_config_diff` → `EntryConfig.diff` method, `_async_setup_new_locks` taking `EntryConfig`, `get_slot_data` thin-wrapper removal.

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Additional information

- 599 tests pass, 100% coverage on `data.py`, 99% on `entity.py`, 98% on `helpers.py`
- 9 new tests in [`tests/test_data.py`](https://github.com/raman325/lock_code_manager/blob/refactor/entry-config-writers/tests/test_data.py) covering the three new immutable-update methods and their round-trip behavior