### PR TITLE
EntryConfig stage 3: listener int-normalization

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -82,15 +82,14 @@
   to `EntryConfig` (`__init__.py`, `helpers.py`, `config_flow.py`,
   `websocket.py`).
 
-  **Stage 3 still pending: listener int-normalization** (was
-  [PR #1028][pr-1028] review item #3). With readers and writers all
-  consuming `EntryConfig` (which is always int-keyed internally), the
-  listener can finally normalize its `curr_slots` / `new_slots` locals
-  to int keys without breaking downstream. Closes the latent
-  `slots_unchanged` `KeyError` risk and lets `EntryConfigDiff` drop its
-  source-key-type preservation gymnastics (all dict outputs can be
-  `Mapping[int, ...]`, the int-normalization-for-comparison-only special
-  case in `compute_entry_config_diff` simplifies to plain set ops).
+  **Stage 3 delivered (this PR)**: listener now uses `EntryConfig` views
+  for its locals (`curr_slots = old_config.slots`, etc.) — int-keyed
+  throughout, closing the latent `slots_unchanged` `KeyError`
+  ([PR #1028][pr-1028] review item #3 plus the post-merge Copilot
+  comments on #1030). `EntryConfigDiff` slot outputs are now typed
+  `Mapping[int, Mapping[str, Any]]` and `frozenset[int]` —
+  source-key-type preservation gymnastics gone. The listener writes
+  back via `new_config.to_dict()` so persisted data stays JSON-safe.
 
   **Stage 4 still pending: API cleanup**:
 

--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 import logging
 from pathlib import Path
 from typing import Any
@@ -614,7 +614,7 @@ async def _async_setup_new_locks(
     hass: HomeAssistant,
     config_entry: LockCodeManagerConfigEntry,
     locks_to_add: Sequence[str],
-    new_slots: dict[int, Any],
+    new_slots: Mapping[int, Any],
     callbacks: Any,
     ent_reg: er.EntityRegistry,
 ) -> None:
@@ -692,8 +692,8 @@ async def _async_setup_new_locks(
 async def _async_reconcile_slot_entities(
     config_entry: LockCodeManagerConfigEntry,
     slot_num: int,
-    old_config: dict[str, Any],
-    new_config: dict[str, Any],
+    old_config: Mapping[str, Any],
+    new_config: Mapping[str, Any],
     callbacks: Any,
     ent_reg: er.EntityRegistry,
 ) -> None:
@@ -767,9 +767,15 @@ async def async_update_listener(
 
     setup_tasks = runtime_data.setup_tasks
 
-    curr_slots: dict[int, Any] = {**config_entry.data.get(CONF_SLOTS, {})}
-    new_slots: dict[int, Any] = {**config_entry.options.get(CONF_SLOTS, {})}
-    new_locks: list[str] = [*config_entry.options.get(CONF_LOCKS, [])]
+    # Build EntryConfig views of data (old) and options (new) so all
+    # downstream slot lookups use int keys regardless of how the storage
+    # round-tripped them. Callers that need a plain dict (e.g. to hand
+    # back to async_update_entry at the end of this function) call
+    # to_dict() at the write site.
+    old_config = EntryConfig.from_mapping(config_entry.data)
+    new_config = EntryConfig.from_mapping(config_entry.options)
+    curr_slots = old_config.slots
+    new_slots = new_config.slots
 
     # Strip number_of_uses from slots that didn't previously have it
     # (deprecated — only existing values are preserved). Skip on initial
@@ -792,8 +798,9 @@ async def async_update_listener(
     await asyncio.gather(*setup_tasks.values())
 
     # Identify changes that need to be made (single source of truth for the
-    # data-vs-options diff; same helper is used by the options-flow scan)
-    diff = compute_entry_config_diff(config_entry.data, config_entry.options)
+    # data-vs-options diff; same helper is used by the options-flow scan).
+    # Both inputs go through EntryConfig.to_dict() so they're int-keyed.
+    diff = compute_entry_config_diff(old_config.to_dict(), new_config.to_dict())
     slots_to_add = diff.slots_added
     slots_to_remove = diff.slots_removed
     locks_to_add = diff.locks_added
@@ -897,12 +904,16 @@ async def async_update_listener(
             ent_reg,
         )
 
-    # Existing entities will listen to updates and act on it
-    new_data = {CONF_LOCKS: new_locks, CONF_SLOTS: new_slots}
+    # Existing entities will listen to updates and act on it.
+    # Use to_dict() so the stored data has plain dicts (not the read-only
+    # MappingProxyType wrappers EntryConfig uses internally) — HA's
+    # storage layer can't serialize MappingProxyType.
     _LOGGER.info(
         "%s (%s): Done creating and/or updating entities", entry_id, entry_title
     )
-    hass.config_entries.async_update_entry(config_entry, data=new_data, options={})
+    hass.config_entries.async_update_entry(
+        config_entry, data=new_config.to_dict(), options={}
+    )
     # The async_update_entry above re-triggers this listener, which
     # refreshes runtime_data.config at the top before the early-return.
 

--- a/custom_components/lock_code_manager/data.py
+++ b/custom_components/lock_code_manager/data.py
@@ -232,7 +232,7 @@ class EntryConfigDiff:
     - **By axis** (slot dict + lock list): used by the update listener,
       which adds/removes slot entities and lock providers along independent
       axes.
-    - **By unchanged set**: ``slots_unchanged`` enumerates slot keys
+    - **By unchanged set**: ``slots_unchanged`` enumerates slot numbers
       present in both configs, used by the listener to reconcile per-slot
       configuration changes.
     - **By cartesian pair**: ``pairs_added`` / ``pairs_removed`` give
@@ -240,13 +240,11 @@ class EntryConfigDiff:
       uses to detect existing-codes hazards on newly-added pairs (catches
       both "new slot on existing lock" and "new lock with existing slot").
 
-    **Slot key types**: ``slots_added`` and ``slots_unchanged`` preserve
-    the *new* mapping's key type. ``slots_removed`` preserves the *old*
-    mapping's key type (its keys come from the old mapping). The
-    cartesian pair sets always use ``int`` slot keys so they compare
-    correctly even when ``old`` and ``new`` have different key types (a
-    common situation: stored ``data`` is ``str``-keyed, fresh user input
-    from voluptuous is ``int``-keyed).
+    All slot keys (in ``slots_added`` / ``slots_removed`` / ``slots_unchanged``
+    / ``pairs_added`` / ``pairs_removed``) are guaranteed ``int``. Inputs
+    with ``str`` keys (e.g. raw entry data after a JSON round-trip) are
+    normalized internally — typical callers go through
+    :meth:`EntryConfig.to_dict` which already produces ``int`` keys.
 
     **Immutability**: the dataclass is frozen, and all containers are
     deeply immutable (``MappingProxyType`` for dicts, ``frozenset`` for
@@ -254,9 +252,9 @@ class EntryConfigDiff:
     state without defensive copies.
     """
 
-    slots_added: Mapping[Any, Any]
-    slots_removed: Mapping[Any, Any]
-    slots_unchanged: frozenset[Any]
+    slots_added: Mapping[int, Mapping[str, Any]]
+    slots_removed: Mapping[int, Mapping[str, Any]]
+    slots_unchanged: frozenset[int]
     locks_added: tuple[str, ...]
     locks_removed: tuple[str, ...]
     pairs_added: frozenset[tuple[str, int]]
@@ -280,43 +278,43 @@ def compute_entry_config_diff(
 
     Each input is a mapping with ``CONF_LOCKS`` (list[str]) and
     ``CONF_SLOTS`` (dict[int|str, dict]) keys. Slot keys are normalized
-    to ``int`` *internally* for set comparisons (so ``str``-keyed stored
-    data and ``int``-keyed voluptuous output compare correctly), but the
-    slot-dict outputs preserve the source key type of ``new``. This
-    matches the existing convention in the listener and entity layer
-    where ``slot_num`` may be ``str`` or ``int`` depending on origin.
+    to ``int`` so ``str``-keyed stored data and ``int``-keyed voluptuous
+    output compare correctly. All output dicts are int-keyed regardless
+    of source.
     """
-    raw_old_slots = old.get(CONF_SLOTS, {})
-    raw_new_slots = new.get(CONF_SLOTS, {})
-    # int-normalized key sets for comparisons only
-    old_int_keys = {int(k) for k in raw_old_slots}
-    new_int_keys = {int(k) for k in raw_new_slots}
-    unchanged_int_keys = old_int_keys & new_int_keys
+    raw_old_slots: Mapping[Any, Any] = old.get(CONF_SLOTS, {})
+    raw_new_slots: Mapping[Any, Any] = new.get(CONF_SLOTS, {})
+    # Normalize source dicts up front. After this everything is int-keyed
+    # — the listener's `curr_slots[slot_num]` lookups against
+    # `diff.slots_unchanged` are safe regardless of the source key type.
+    old_slots: dict[int, Mapping[str, Any]] = {
+        int(k): v for k, v in raw_old_slots.items()
+    }
+    new_slots: dict[int, Mapping[str, Any]] = {
+        int(k): v for k, v in raw_new_slots.items()
+    }
+    old_keys = old_slots.keys()
+    new_keys = new_slots.keys()
 
     old_locks: list[str] = list(old.get(CONF_LOCKS, []))
     new_locks: list[str] = list(new.get(CONF_LOCKS, []))
     old_lock_set = set(old_locks)
     new_lock_set = set(new_locks)
     old_pairs: set[tuple[str, int]] = {
-        (lock, slot) for lock in old_locks for slot in old_int_keys
+        (lock, slot) for lock in old_locks for slot in old_keys
     }
     new_pairs: set[tuple[str, int]] = {
-        (lock, slot) for lock in new_locks for slot in new_int_keys
+        (lock, slot) for lock in new_locks for slot in new_keys
     }
 
     return EntryConfigDiff(
         slots_added=MappingProxyType(
-            {k: v for k, v in raw_new_slots.items() if int(k) not in old_int_keys}
+            {k: v for k, v in new_slots.items() if k not in old_slots}
         ),
         slots_removed=MappingProxyType(
-            {k: v for k, v in raw_old_slots.items() if int(k) not in new_int_keys}
+            {k: v for k, v in old_slots.items() if k not in new_slots}
         ),
-        # Preserve the new mapping's key type — the listener's reconcile
-        # loop indexes back into raw_new_slots / raw_old_slots and needs
-        # the original key type to find the slot config dict.
-        slots_unchanged=frozenset(
-            k for k in raw_new_slots if int(k) in unchanged_int_keys
-        ),
+        slots_unchanged=frozenset(old_keys & new_keys),
         locks_added=tuple(lock for lock in new_locks if lock not in old_lock_set),
         locks_removed=tuple(lock for lock in old_locks if lock not in new_lock_set),
         pairs_added=frozenset(new_pairs - old_pairs),

--- a/custom_components/lock_code_manager/data.py
+++ b/custom_components/lock_code_manager/data.py
@@ -308,11 +308,23 @@ def compute_entry_config_diff(
     }
 
     return EntryConfigDiff(
+        # Inner slot configs are wrapped (not just held by reference) so
+        # the diff is genuinely deeply immutable — matches the pattern
+        # in EntryConfig.from_mapping. dict(v) snapshots the source so a
+        # later mutation in the caller doesn't leak into the diff view.
         slots_added=MappingProxyType(
-            {k: v for k, v in new_slots.items() if k not in old_slots}
+            {
+                k: MappingProxyType(dict(v))
+                for k, v in new_slots.items()
+                if k not in old_slots
+            }
         ),
         slots_removed=MappingProxyType(
-            {k: v for k, v in old_slots.items() if k not in new_slots}
+            {
+                k: MappingProxyType(dict(v))
+                for k, v in old_slots.items()
+                if k not in new_slots
+            }
         ),
         slots_unchanged=frozenset(old_keys & new_keys),
         locks_added=tuple(lock for lock in new_locks if lock not in old_lock_set),

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -153,17 +153,30 @@ def test_diff_is_deeply_immutable() -> None:
     (``MappingProxyType`` / ``frozenset`` / ``tuple``), so callers
     cannot mutate the diff after the fact.
     """
+    # Build a diff with both an added slot AND a removed slot so we can
+    # exercise inner-mutation guards on both
     diff = compute_entry_config_diff(
-        {CONF_LOCKS: ["lock.a"], CONF_SLOTS: {1: _slot()}}, {}
+        {CONF_LOCKS: ["lock.a"], CONF_SLOTS: {1: _slot()}},
+        {CONF_LOCKS: ["lock.a"], CONF_SLOTS: {2: _slot()}},
     )
 
     # Attribute reassignment blocked
     with pytest.raises(FrozenInstanceError):
         diff.slots_added = {99: _slot()}  # type: ignore[misc]
 
-    # Contained dicts are read-only
+    # Outer dicts are read-only
     with pytest.raises(TypeError):
         diff.slots_removed[99] = _slot()  # type: ignore[index]
+    with pytest.raises(TypeError):
+        diff.slots_added[99] = _slot()  # type: ignore[index]
+
+    # INNER per-slot dicts are also read-only (deep immutability).
+    # Without this, callers could do diff.slots_added[2]["pin"] = "X"
+    # and mutate cached state — defeating the whole point of frozen.
+    with pytest.raises(TypeError):
+        diff.slots_added[2]["pin"] = "9999"  # type: ignore[index]
+    with pytest.raises(TypeError):
+        diff.slots_removed[1]["pin"] = "9999"  # type: ignore[index]
 
     # Contained sets cannot grow
     assert not hasattr(diff.slots_unchanged, "add")
@@ -174,6 +187,25 @@ def test_diff_is_deeply_immutable() -> None:
     assert not hasattr(diff.locks_removed, "append")
 
     assert isinstance(diff, EntryConfigDiff)
+
+
+def test_diff_snapshots_inner_slot_dicts() -> None:
+    """Mutating the source slot config after diff() doesn't leak into the diff.
+
+    The defensive ``dict(v)`` copy in compute_entry_config_diff means
+    the diff captures a snapshot of slot configs at construction time —
+    later mutations to the original mapping don't change the diff view.
+    """
+    inner_slot = {"pin": "1234", "enabled": True}
+    new = {CONF_SLOTS: {1: inner_slot}}
+
+    diff = compute_entry_config_diff({}, new)
+
+    # Mutate the original inner slot dict after the diff is built
+    inner_slot["pin"] = "9999"
+
+    # Diff snapshot is unaffected
+    assert diff.slots_added[1]["pin"] == "1234"
 
 
 # --- EntryConfig tests ---

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -94,26 +94,26 @@ def test_diff_str_keys_match_int_keys() -> None:
     assert not diff.has_changes
 
 
-def test_diff_slot_dicts_preserve_source_key_types() -> None:
-    """slots_{added,unchanged} take new's key type; slots_removed takes old's.
+def test_diff_slot_dicts_always_int_keyed() -> None:
+    """All slot-dict outputs are int-keyed regardless of input key type.
 
-    The listener indexes back into raw_new_slots/raw_old_slots with these
-    keys to look up the slot config dict, so changing the key type would
-    break those lookups.
+    Stage 3 of the EntryConfig migration: callers normalize via
+    EntryConfig.to_dict() before passing to compute_entry_config_diff,
+    so the helper guarantees int-keyed outputs and downstream code
+    (notably the listener's reconcile loop) doesn't have to translate.
     """
-    # Both sides use str keys (typical of the listener case where both
-    # `data` and `options` come from JSON storage round-trips)
+    # Mixed: old has str keys (raw JSON-loaded data), new has int (voluptuous)
     old = {CONF_SLOTS: {"1": _slot(), "3": _slot()}}
-    new = {CONF_SLOTS: {"1": _slot("9999"), "2": _slot()}}
+    new = {CONF_SLOTS: {1: _slot("9999"), 2: _slot()}}
 
     diff = compute_entry_config_diff(old, new)
 
-    # slots_added/unchanged take new's key type (str here)
-    assert "2" in diff.slots_added
-    assert "1" in diff.slots_unchanged
-    # slots_removed takes old's key type (also str here, but importantly
-    # it is the OLD mapping's keys regardless)
-    assert "3" in diff.slots_removed
+    assert 2 in diff.slots_added
+    assert "2" not in diff.slots_added
+    assert 1 in diff.slots_unchanged
+    assert "1" not in diff.slots_unchanged
+    assert 3 in diff.slots_removed
+    assert "3" not in diff.slots_removed
 
 
 def test_diff_pair_added_for_new_lock_with_existing_slot() -> None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -792,10 +792,12 @@ async def test_number_of_uses_repair_flow_strips_data(
 
     assert result["type"] == "create_entry"
 
-    # Verify number_of_uses was stripped from the config entry
-    assert CONF_NUMBER_OF_USES not in config_entry.data[CONF_SLOTS]["2"]
+    # Verify number_of_uses was stripped from the config entry. The
+    # listener normalizes slot keys to int when it writes back to data,
+    # so look up by int rather than the str key the test originally wrote.
+    assert CONF_NUMBER_OF_USES not in config_entry.data[CONF_SLOTS][2]
     # Slot 1 should be unchanged
-    assert CONF_NUMBER_OF_USES not in config_entry.data[CONF_SLOTS]["1"]
+    assert CONF_NUMBER_OF_USES not in config_entry.data[CONF_SLOTS][1]
 
     await hass.config_entries.async_unload(config_entry.entry_id)
 


### PR DESCRIPTION
## Proposed change

**Stage 3** of the EntryConfig migration ([TODO.md](https://github.com/raman325/lock_code_manager/blob/main/TODO.md)). Closes the latent `slots_unchanged` `KeyError` flagged in [#1028 review item #3](https://github.com/raman325/lock_code_manager/pull/1028) and re-raised by Copilot in 3 post-merge comments on #1030 ([1](https://github.com/raman325/lock_code_manager/pull/1030#discussion_r-data-py-168), [2](https://github.com/raman325/lock_code_manager/pull/1030#discussion_r-helpers-py-188), [3](https://github.com/raman325/lock_code_manager/pull/1030#discussion_r-helpers-py-201)) — all describing the same bug:

> `EntryConfig.to_dict()` always emits `CONF_SLOTS` with int keys. When callers pass that into `config_entry.options`, `async_update_listener` later indexes `curr_slots[slot_num]` using keys from *options* (via `diff.slots_unchanged`). If `entry.data` was loaded from JSON (str keys), this becomes a reproducible `KeyError`.

### What landed

**Listener uses `EntryConfig` views for its locals** — never sees raw entry data:

```python
# Before: str-keyed if loaded from JSON, int-keyed if just written by us
curr_slots: dict[int, Any] = {**config_entry.data.get(CONF_SLOTS, {})}
new_slots: dict[int, Any] = {**config_entry.options.get(CONF_SLOTS, {})}

# After: always int-keyed via EntryConfig
old_config = EntryConfig.from_mapping(config_entry.data)
new_config = EntryConfig.from_mapping(config_entry.options)
curr_slots = old_config.slots
new_slots = new_config.slots
```

The reconcile loop's `curr_slots[slot_num]` is therefore always an int lookup in an int-keyed dict.

**Listener writes back via `to_dict()`** so persisted data stays JSON-safe (HA's storage layer can't serialize `MappingProxyType`).

**`EntryConfigDiff` simplification** — slot outputs are now strictly typed:

- `slots_added` / `slots_removed`: `Mapping[int, Mapping[str, Any]]` (was `Mapping[Any, Any]` with source-key-type preservation)
- `slots_unchanged`: `frozenset[int]` (was `frozenset[Any]`)
- `compute_entry_config_diff` drops the int-normalization-for-comparison-only special case — both inputs are normalized up front, then the diff is plain set/dict operations

**Inner-function signature widening** to accept the `MappingProxyType` views:
- `_async_setup_new_locks`: `new_slots: Mapping[int, Any]` (was `dict`)
- `_async_reconcile_slot_entities`: `old/new_config: Mapping[str, Any]` (was `dict`)

**One test updated**: `test_number_of_uses_repair_flow_strips_data` indexed `CONF_SLOTS["2"]` expecting str keys (the old listener write-back behavior). Now indexes `[2]` (int), matching the new behavior.

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Additional information

- 599 tests pass, all pre-commit hooks pass
- Stage 4 (API cleanup: `compute_entry_config_diff` → `EntryConfig.diff` method, `_async_setup_new_locks` taking `EntryConfig`, `get_slot_data` thin-wrapper removal) still pending per TODO