### PR TITLE
EntryConfig stage 4: API cleanup + operator sugar

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -57,71 +57,21 @@
 - **Coordinator-owned sync managers** — Move sync manager lifecycle from binary
   sensor entities to coordinator (survives entity recreation during config
   updates).
-- **EntryConfig migration** — Multi-stage refactor centralizing entry-config
-  reads and writes through a typed `EntryConfig` dataclass to eliminate the
-  str/int slot key inconsistency that HA's JSON storage round-trip creates.
-
-  **Stage 1 delivered in PR #1029**: introduced `EntryConfig` with
-  `from_entry` / `from_mapping` / `slot` / `has_slot` / `has_lock` / `empty`,
-  cached it on `runtime_data.config` (refreshed at the top of
-  `async_update_listener` so even entity-driven writes update the cache),
-  and migrated readers in `data.get_slot_data` / `get_managed_slots` /
-  `find_entry_for_lock_slot`, `coordinator.get_expected_pin`, and
-  `websocket._get_condition_entity_id` / `subscribe_code_slot` validator.
-  The accessors absorb `int|str` slot_num internally so call sites have no
-  visible casts.
-
-  **Stage 2 delivered (this PR)**: added immutable update API
-  (`with_slot_field_set`, `with_slot_field_removed`, `to_dict`) and migrated
-  every writer off raw `data[CONF_SLOTS][...]` mutation —
-  `entity._update_config_entry`, `helpers.async_set_slot_condition`,
-  `helpers.async_clear_slot_condition`, `helpers.get_slot_config` (drops
-  the defensive `slot if slot in slots else str(slot)` pattern). Also
-  deleted `get_entry_data` entirely after a survey showed 100% of its
-  callers were doing `CONF_LOCKS` or `CONF_SLOTS` lookups — all migrated
-  to `EntryConfig` (`__init__.py`, `helpers.py`, `config_flow.py`,
-  `websocket.py`).
-
-  **Stage 3 delivered (this PR)**: listener now uses `EntryConfig` views
-  for its locals (`curr_slots = old_config.slots`, etc.) — int-keyed
-  throughout, closing the latent `slots_unchanged` `KeyError`
-  ([PR #1028][pr-1028] review item #3 plus the post-merge Copilot
-  comments on #1030). `EntryConfigDiff` slot outputs are now typed
-  `Mapping[int, Mapping[str, Any]]` and `frozenset[int]` —
-  source-key-type preservation gymnastics gone. The listener writes
-  back via `new_config.to_dict()` so persisted data stays JSON-safe.
-
-  **Stage 4 still pending: API cleanup**:
-
-  - `compute_entry_config_diff(old, new)` becomes a method
-    `EntryConfig.diff(self, other) -> EntryConfigDiff`. Module-level helper
-    can be removed.
-  - `_async_setup_new_locks(hass, entry, locks_to_add, new_slots, ...)` takes
-    `EntryConfig` instead of separate `locks_to_add` + `new_slots` args.
-  - `get_slot_data(entry, slot_num)` thin-wrapper can be removed; callers
-    use `get_entry_config(entry).slot(slot_num)` directly.
-
-  **Out-of-scope boundaries** (related, not part of this migration):
-
-  - **TypedDict for slot config** — `class SlotConfig(TypedDict)` with
-    `pin: NotRequired[str]`, `enabled: bool`, `name: NotRequired[str]`,
-    `entity_id: NotRequired[str]`, `number_of_uses: NotRequired[int]`.
-    Replaces `dict[str, Any]` for slot inner dicts; gives pyright real
-    signal on slot reads/writes. Would let `EntryConfig.slots` be typed
-    `Mapping[int, SlotConfig]`.
-  - **`coordinator.data` typing** — currently `dict[int, str | SlotCode]`.
-    Already int-keyed; `binary_sensor.py:281` and `entity.py:193` cast
-    defensively against `self.slot_num`'s type variance. Goes away when
-    listener is migrated and entities receive int slot_num.
-  - **Other internal dict boundaries** — `websocket.py:401/442/524/529`
-    cast into websocket-internal lookup dicts, `__init__.py:561` casts at
-    a callback boundary. These are separate from EntryConfig but solved
-    by the same broader "typed slot_num everywhere" theme.
-
-  **HA storage round-trip stays as-is** — JSON layer continues to serialize
-  int keys to str on disk; we don't fight it. Normalization is purely on
-  READ via `from_entry()`. The migration is additive — no changes to
-  on-disk format, no migration version bump needed.
+- **TypedDict for slot config** — Define `class SlotConfig(TypedDict)` with
+  `pin: NotRequired[str]`, `enabled: bool`, `name: NotRequired[str]`,
+  `entity_id: NotRequired[str]`, `number_of_uses: NotRequired[int]` to
+  replace `dict[str, Any]` for slot inner dicts. Gives pyright real signal
+  on slot reads/writes. Would let `EntryConfig.slots` be typed
+  `Mapping[int, SlotConfig]`.
+- **`coordinator.data` typing** — Currently `dict[int, str | SlotCode]`,
+  already int-keyed. `binary_sensor.py:281` and `entity.py:193` cast
+  defensively against `self.slot_num`'s type variance — could be cleaned
+  up once entities consistently carry int slot_num end-to-end.
+- **Other internal dict boundaries** — `websocket.py:401/442/524/529`
+  cast into websocket-internal lookup dicts; `__init__.py:561` casts at
+  a callback boundary. Same broader "typed slot_num everywhere" theme as
+  the EntryConfig migration; resolved by the SlotConfig TypedDict work
+  above plus typed callback signatures.
 - **Websocket optimization** — Add optional `include_entities`/`include_locks`
   flags to `get_config_entry_data` command.
 - **Entity registry change detection** — Warn if LCM entity IDs change (reload
@@ -140,5 +90,3 @@
   changes.
 - Review TODOs after completing current work, when starting new features, during
   refactoring sessions, or on `/todos`.
-
-[pr-1028]: https://github.com/raman325/lock_code_manager/pull/1028

--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -79,7 +79,7 @@ from .const import (
     STRATEGY_PATH,
     Platform,
 )
-from .data import EntryConfig, compute_entry_config_diff, get_entry_config
+from .data import EntryConfig, get_entry_config
 from .helpers import (
     async_clear_slot_condition,
     async_clear_usercode,
@@ -614,7 +614,7 @@ async def _async_setup_new_locks(
     hass: HomeAssistant,
     config_entry: LockCodeManagerConfigEntry,
     locks_to_add: Sequence[str],
-    new_slots: Mapping[int, Any],
+    new_config: EntryConfig,
     callbacks: Any,
     ent_reg: er.EntityRegistry,
 ) -> None:
@@ -674,7 +674,7 @@ async def _async_setup_new_locks(
                 lock.lock.entity_id,
             )
 
-        for slot_num in new_slots:
+        for slot_num in new_config.slots:
             _LOGGER.debug(
                 "%s (%s): Adding lock %s slot %s sensor and event entity",
                 entry_id,
@@ -777,11 +777,9 @@ async def async_update_listener(
     curr_slots = old_config.slots
     new_slots = new_config.slots
 
-    # Strip number_of_uses from slots that didn't previously have it
-    # (deprecated — only existing values are preserved). Skip on initial
-    # setup (curr_slots empty) since the data just moved from data→options.
-    # Set up any platforms that the new slot configs need that haven't already been
-    # setup
+    # Set up any platforms that the new slot configs need that haven't
+    # already been set up. The number_of_uses deprecation cleanup lives
+    # in the repair flow (NumberOfUsesDeprecatedFlow), not here.
     for platform in {
         platform
         for slot_config in new_slots.values()
@@ -797,10 +795,10 @@ async def async_update_listener(
         )
     await asyncio.gather(*setup_tasks.values())
 
-    # Identify changes that need to be made (single source of truth for the
-    # data-vs-options diff; same helper is used by the options-flow scan).
-    # Both inputs go through EntryConfig.to_dict() so they're int-keyed.
-    diff = compute_entry_config_diff(old_config.to_dict(), new_config.to_dict())
+    # Identify changes that need to be made. The `-` operator on
+    # EntryConfig is sugar for EntryConfigDiff(old=..., new=...) — both
+    # configs are int-keyed by construction so no normalization needed.
+    diff = old_config - new_config
     slots_to_add = diff.slots_added
     slots_to_remove = diff.slots_removed
     locks_to_add = diff.locks_added
@@ -842,7 +840,7 @@ async def async_update_listener(
     # slot PIN sensors for the new locks
     if locks_to_add:
         await _async_setup_new_locks(
-            hass, config_entry, locks_to_add, new_slots, callbacks, ent_reg
+            hass, config_entry, locks_to_add, new_config, callbacks, ent_reg
         )
 
     # For each new slot, add standard entities and configuration entities. We also

--- a/custom_components/lock_code_manager/binary_sensor.py
+++ b/custom_components/lock_code_manager/binary_sensor.py
@@ -42,7 +42,7 @@ from .const import (
     EVENT_PIN_USED,
 )
 from .coordinator import LockUsercodeUpdateCoordinator
-from .data import get_slot_data
+from .data import get_entry_config
 from .entity import BaseLockCodeManagerCodeSlotPerLockEntity, BaseLockCodeManagerEntity
 from .models import LockCodeManagerConfigEntry
 from .providers import BaseLock
@@ -114,7 +114,9 @@ class LockCodeManagerActiveEntity(BaseLockCodeManagerEntity, BinarySensorEntity)
     @property
     def _condition_entity_id(self) -> str | None:
         """Return condition entity ID for this slot."""
-        return get_slot_data(self.config_entry, self.slot_num).get(CONF_ENTITY_ID)
+        return (
+            get_entry_config(self.config_entry).slot(self.slot_num).get(CONF_ENTITY_ID)
+        )
 
     @callback
     def _cleanup_condition_subscription(self) -> None:
@@ -134,7 +136,9 @@ class LockCodeManagerActiveEntity(BaseLockCodeManagerEntity, BinarySensorEntity)
         )
 
         states: dict[str, bool | None] = {}
-        for key, state in get_slot_data(self.config_entry, self.slot_num).items():
+        for key, state in (
+            get_entry_config(self.config_entry).slot(self.slot_num).items()
+        ):
             if key in (EVENT_PIN_USED, CONF_NAME, CONF_PIN, ATTR_IN_SYNC):
                 continue
 

--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -36,7 +36,7 @@ from .const import (
     DOMAIN,
     EXCLUDED_CONDITION_PLATFORMS,
 )
-from .data import compute_entry_config_diff, get_entry_config
+from .data import EntryConfig, get_entry_config
 from .exceptions import LockCodeManagerError, LockCodeManagerProviderError
 from .models import SlotCode
 from .providers import INTEGRATIONS_CLASS_MAP
@@ -685,10 +685,12 @@ class LockCodeManagerOptionsFlow(_ExistingCodesFlowMixin, config_entries.Options
         current configuration. If any newly-added pair has a non-empty
         code on its lock, show the confirmation step before persisting.
         """
-        # Use the same diff helper as the update listener so the "is this
-        # pair new?" definition stays in one place
-        diff = compute_entry_config_diff(
-            get_entry_config(self.config_entry).to_dict(), user_input
+        # Same diff API as the update listener — the `-` operator on
+        # EntryConfig returns an EntryConfigDiff. user_input has int slot
+        # keys (voluptuous coerced) and current entry data is normalized
+        # by EntryConfig.from_mapping, so the diff is consistent.
+        diff = get_entry_config(self.config_entry) - EntryConfig.from_mapping(
+            user_input
         )
         if not diff.pairs_added:
             return self.async_create_entry(title="", data=user_input)

--- a/custom_components/lock_code_manager/data.py
+++ b/custom_components/lock_code_manager/data.py
@@ -116,7 +116,14 @@ class EntryConfig:
         ``old_config - new_config`` — note this is a *delta* (both adds
         and removes), not strict set subtraction. The result includes
         what changed in either direction.
+
+        Returns ``NotImplemented`` for non-``EntryConfig`` operands so
+        Python's operator protocol falls back to ``__rsub__`` and
+        ultimately raises a clear ``TypeError`` rather than letting the
+        misuse fail deep inside ``EntryConfigDiff.__post_init__``.
         """
+        if not isinstance(other, EntryConfig):
+            return NotImplemented
         return EntryConfigDiff(old=self, new=other)
 
     def with_slot_field_set(
@@ -235,8 +242,9 @@ class EntryConfigDiff:
         # or via the operator sugar on EntryConfig:
         diff = current_config - proposed_config
 
-    Either side may be ``None`` (treated as :meth:`EntryConfig.empty`)
-    for the "all added" / "all removed" cases.
+    Either side may be omitted (defaults to :meth:`EntryConfig.empty`)
+    for the "all added" / "all removed" cases — for example,
+    ``EntryConfigDiff(new=cfg)`` reads as "diff from nothing to cfg".
 
     Provides three views of the same diff so callers can ask the
     question that fits their need:

--- a/custom_components/lock_code_manager/data.py
+++ b/custom_components/lock_code_manager/data.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from types import MappingProxyType
 from typing import Any
 
@@ -109,6 +109,16 @@ class EntryConfig:
         """
         return self.slots.get(int(slot_num), {})
 
+    def __sub__(self, other: EntryConfig) -> EntryConfigDiff:
+        """Return the diff from ``self`` (old) to ``other`` (new).
+
+        Sugar for ``EntryConfigDiff(old=self, new=other)``. Reads as
+        ``old_config - new_config`` — note this is a *delta* (both adds
+        and removes), not strict set subtraction. The result includes
+        what changed in either direction.
+        """
+        return EntryConfigDiff(old=self, new=other)
+
     def with_slot_field_set(
         self, slot_num: int | str, key: str, value: Any
     ) -> EntryConfig:
@@ -184,15 +194,6 @@ def get_entry_config(entry: ConfigEntry) -> EntryConfig:
     return EntryConfig.from_entry(entry)
 
 
-def get_slot_data(config_entry, slot_num: int | str) -> Mapping[str, Any]:
-    """Get the slot config dict for ``slot_num`` (empty mapping if absent).
-
-    Thin wrapper around :meth:`EntryConfig.slot` for callers that don't
-    have an :class:`EntryConfig` in hand.
-    """
-    return get_entry_config(config_entry).slot(slot_num)
-
-
 def get_managed_slots(hass: HomeAssistant, lock_entity_id: str) -> set[int]:
     """Return the set of slot numbers managed by any LCM config entry for a lock."""
     return {
@@ -226,8 +227,19 @@ def find_entry_for_lock_slot(
 class EntryConfigDiff:
     """Diff between two LCM entry configurations.
 
-    Produced by :func:`compute_entry_config_diff`. Provides three views of
-    the same diff so callers can ask the question that fits their need:
+    Constructed directly from the two configs being compared:
+
+    .. code-block:: python
+
+        diff = EntryConfigDiff(old=current_config, new=proposed_config)
+        # or via the operator sugar on EntryConfig:
+        diff = current_config - proposed_config
+
+    Either side may be ``None`` (treated as :meth:`EntryConfig.empty`)
+    for the "all added" / "all removed" cases.
+
+    Provides three views of the same diff so callers can ask the
+    question that fits their need:
 
     - **By axis** (slot dict + lock list): used by the update listener,
       which adds/removes slot entities and lock providers along independent
@@ -240,11 +252,10 @@ class EntryConfigDiff:
       uses to detect existing-codes hazards on newly-added pairs (catches
       both "new slot on existing lock" and "new lock with existing slot").
 
-    All slot keys (in ``slots_added`` / ``slots_removed`` / ``slots_unchanged``
-    / ``pairs_added`` / ``pairs_removed``) are guaranteed ``int``. Inputs
-    with ``str`` keys (e.g. raw entry data after a JSON round-trip) are
-    normalized internally — typical callers go through
-    :meth:`EntryConfig.to_dict` which already produces ``int`` keys.
+    All slot keys (in ``slots_added`` / ``slots_removed`` /
+    ``slots_unchanged`` / ``pairs_added`` / ``pairs_removed``) are
+    guaranteed ``int`` — :class:`EntryConfig` already normalizes its
+    storage so the diff inherits that.
 
     **Immutability**: the dataclass is frozen, and all containers are
     deeply immutable (``MappingProxyType`` for dicts, ``frozenset`` for
@@ -252,13 +263,80 @@ class EntryConfigDiff:
     state without defensive copies.
     """
 
-    slots_added: Mapping[int, Mapping[str, Any]]
-    slots_removed: Mapping[int, Mapping[str, Any]]
-    slots_unchanged: frozenset[int]
-    locks_added: tuple[str, ...]
-    locks_removed: tuple[str, ...]
-    pairs_added: frozenset[tuple[str, int]]
-    pairs_removed: frozenset[tuple[str, int]]
+    # Source configs — readable after construction (useful for logging,
+    # debugging, and tests). Default to EntryConfig.empty() so callers
+    # can omit either side for the "all added" / "all removed" cases:
+    # ``EntryConfigDiff(new=cfg)`` reads as "diff from nothing to cfg".
+    old: EntryConfig = field(default_factory=EntryConfig.empty)
+    new: EntryConfig = field(default_factory=EntryConfig.empty)
+
+    # Computed in __post_init__ from old/new
+    slots_added: Mapping[int, Mapping[str, Any]] = field(init=False)
+    slots_removed: Mapping[int, Mapping[str, Any]] = field(init=False)
+    slots_unchanged: frozenset[int] = field(init=False)
+    locks_added: tuple[str, ...] = field(init=False)
+    locks_removed: tuple[str, ...] = field(init=False)
+    pairs_added: frozenset[tuple[str, int]] = field(init=False)
+    pairs_removed: frozenset[tuple[str, int]] = field(init=False)
+
+    def __post_init__(self) -> None:
+        """Compute and freeze the diff fields."""
+        old_slots = self.old.slots
+        new_slots = self.new.slots
+        old_keys = old_slots.keys()
+        new_keys = new_slots.keys()
+        old_lock_set = set(self.old.locks)
+        new_lock_set = set(self.new.locks)
+        old_pairs: set[tuple[str, int]] = {
+            (lock, slot) for lock in self.old.locks for slot in old_keys
+        }
+        new_pairs: set[tuple[str, int]] = {
+            (lock, slot) for lock in self.new.locks for slot in new_keys
+        }
+
+        # Frozen dataclass blocks normal assignment; bypass via
+        # object.__setattr__ for the computed fields. Standard idiom for
+        # frozen dataclasses with __post_init__-computed state.
+        # Inner slot configs are wrapped (not just referenced) so the
+        # diff is genuinely deeply immutable — matches the pattern in
+        # EntryConfig.from_mapping. dict(v) snapshots the source so
+        # caller-side mutation can't leak into the diff view.
+        set_field = object.__setattr__
+        set_field(
+            self,
+            "slots_added",
+            MappingProxyType(
+                {
+                    k: MappingProxyType(dict(v))
+                    for k, v in new_slots.items()
+                    if k not in old_slots
+                }
+            ),
+        )
+        set_field(
+            self,
+            "slots_removed",
+            MappingProxyType(
+                {
+                    k: MappingProxyType(dict(v))
+                    for k, v in old_slots.items()
+                    if k not in new_slots
+                }
+            ),
+        )
+        set_field(self, "slots_unchanged", frozenset(old_keys & new_keys))
+        set_field(
+            self,
+            "locks_added",
+            tuple(lock for lock in self.new.locks if lock not in old_lock_set),
+        )
+        set_field(
+            self,
+            "locks_removed",
+            tuple(lock for lock in self.old.locks if lock not in new_lock_set),
+        )
+        set_field(self, "pairs_added", frozenset(new_pairs - old_pairs))
+        set_field(self, "pairs_removed", frozenset(old_pairs - new_pairs))
 
     @property
     def has_changes(self) -> bool:
@@ -269,69 +347,6 @@ class EntryConfigDiff:
             or self.locks_added
             or self.locks_removed
         )
-
-
-def compute_entry_config_diff(
-    old: Mapping[str, Any], new: Mapping[str, Any]
-) -> EntryConfigDiff:
-    """Compute the diff between two LCM entry config mappings.
-
-    Each input is a mapping with ``CONF_LOCKS`` (list[str]) and
-    ``CONF_SLOTS`` (dict[int|str, dict]) keys. Slot keys are normalized
-    to ``int`` so ``str``-keyed stored data and ``int``-keyed voluptuous
-    output compare correctly. All output dicts are int-keyed regardless
-    of source.
-    """
-    raw_old_slots: Mapping[Any, Any] = old.get(CONF_SLOTS, {})
-    raw_new_slots: Mapping[Any, Any] = new.get(CONF_SLOTS, {})
-    # Normalize source dicts up front. After this everything is int-keyed
-    # — the listener's `curr_slots[slot_num]` lookups against
-    # `diff.slots_unchanged` are safe regardless of the source key type.
-    old_slots: dict[int, Mapping[str, Any]] = {
-        int(k): v for k, v in raw_old_slots.items()
-    }
-    new_slots: dict[int, Mapping[str, Any]] = {
-        int(k): v for k, v in raw_new_slots.items()
-    }
-    old_keys = old_slots.keys()
-    new_keys = new_slots.keys()
-
-    old_locks: list[str] = list(old.get(CONF_LOCKS, []))
-    new_locks: list[str] = list(new.get(CONF_LOCKS, []))
-    old_lock_set = set(old_locks)
-    new_lock_set = set(new_locks)
-    old_pairs: set[tuple[str, int]] = {
-        (lock, slot) for lock in old_locks for slot in old_keys
-    }
-    new_pairs: set[tuple[str, int]] = {
-        (lock, slot) for lock in new_locks for slot in new_keys
-    }
-
-    return EntryConfigDiff(
-        # Inner slot configs are wrapped (not just held by reference) so
-        # the diff is genuinely deeply immutable — matches the pattern
-        # in EntryConfig.from_mapping. dict(v) snapshots the source so a
-        # later mutation in the caller doesn't leak into the diff view.
-        slots_added=MappingProxyType(
-            {
-                k: MappingProxyType(dict(v))
-                for k, v in new_slots.items()
-                if k not in old_slots
-            }
-        ),
-        slots_removed=MappingProxyType(
-            {
-                k: MappingProxyType(dict(v))
-                for k, v in old_slots.items()
-                if k not in new_slots
-            }
-        ),
-        slots_unchanged=frozenset(old_keys & new_keys),
-        locks_added=tuple(lock for lock in new_locks if lock not in old_lock_set),
-        locks_removed=tuple(lock for lock in old_locks if lock not in new_lock_set),
-        pairs_added=frozenset(new_pairs - old_pairs),
-        pairs_removed=frozenset(old_pairs - new_pairs),
-    )
 
 
 def build_slot_unique_id(

--- a/custom_components/lock_code_manager/entity.py
+++ b/custom_components/lock_code_manager/entity.py
@@ -24,7 +24,7 @@ from .const import (
     ATTR_TO,
     DOMAIN,
 )
-from .data import build_slot_unique_id, get_entry_config, get_slot_data
+from .data import build_slot_unique_id, get_entry_config
 from .models import LockCodeManagerConfigEntry
 from .providers import BaseLock
 
@@ -77,7 +77,7 @@ class BaseLockCodeManagerEntity(Entity):
     @property
     def _state(self) -> Any:
         """Return state of entity."""
-        return get_slot_data(self.config_entry, self.slot_num).get(self.key)
+        return get_entry_config(self.config_entry).slot(self.slot_num).get(self.key)
 
     @final
     def _get_uid(self, key: str) -> str:

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -164,6 +164,25 @@ def test_subtraction_operator_is_diff_sugar() -> None:
     assert via_operator.has_changes is via_constructor.has_changes
 
 
+def test_subtraction_with_non_entry_config_raises_type_error() -> None:
+    """``cfg - non_config`` returns NotImplemented -> Python raises TypeError.
+
+    Without the isinstance guard, the operator would succeed and the
+    error would surface deep inside EntryConfigDiff.__post_init__ as
+    a confusing AttributeError ("'str' has no attribute 'slots'").
+    Returning NotImplemented lets Python's operator protocol surface
+    the standard "unsupported operand type(s)" message instead.
+    """
+    cfg = _cfg({CONF_LOCKS: ["lock.a"], CONF_SLOTS: {1: _slot()}})
+
+    with pytest.raises(TypeError, match="unsupported operand"):
+        cfg - "not a config"  # type: ignore[operator]
+    with pytest.raises(TypeError, match="unsupported operand"):
+        cfg - {"locks": []}  # type: ignore[operator]
+    with pytest.raises(TypeError, match="unsupported operand"):
+        cfg - None  # type: ignore[operator]
+
+
 def test_diff_is_deeply_immutable() -> None:
     """EntryConfigDiff fields are immutable containers — safe as cached state.
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,4 +1,4 @@
-"""Tests for data helpers (compute_entry_config_diff, EntryConfig, etc)."""
+"""Tests for data helpers (EntryConfig, EntryConfigDiff, etc)."""
 
 from dataclasses import FrozenInstanceError
 from types import SimpleNamespace
@@ -14,7 +14,6 @@ from custom_components.lock_code_manager.const import (
 from custom_components.lock_code_manager.data import (
     EntryConfig,
     EntryConfigDiff,
-    compute_entry_config_diff,
     get_entry_config,
 )
 
@@ -24,9 +23,17 @@ def _slot(pin: str = "1234") -> dict:
     return {"pin": pin, "enabled": True}
 
 
+def _cfg(mapping: dict | None = None) -> EntryConfig:
+    """Build an EntryConfig from a raw mapping (test convenience)."""
+    return EntryConfig.from_mapping(mapping) if mapping else EntryConfig.empty()
+
+
+# --- EntryConfigDiff tests ---
+
+
 def test_diff_empty_inputs() -> None:
     """No old, no new -> empty diff, no changes."""
-    diff = compute_entry_config_diff({}, {})
+    diff = EntryConfigDiff()
 
     assert dict(diff.slots_added) == {}
     assert dict(diff.slots_removed) == {}
@@ -36,13 +43,16 @@ def test_diff_empty_inputs() -> None:
     assert diff.pairs_added == frozenset()
     assert diff.pairs_removed == frozenset()
     assert not diff.has_changes
+    # Source configs are accessible after construction (default to empty)
+    assert diff.old == EntryConfig.empty()
+    assert diff.new == EntryConfig.empty()
 
 
 def test_diff_added_slots_and_locks() -> None:
-    """Brand-new entry: everything is added."""
-    new = {CONF_LOCKS: ["lock.a"], CONF_SLOTS: {1: _slot(), 2: _slot()}}
+    """Brand-new entry: everything is added (omit `old` -> defaults to empty)."""
+    new = _cfg({CONF_LOCKS: ["lock.a"], CONF_SLOTS: {1: _slot(), 2: _slot()}})
 
-    diff = compute_entry_config_diff({}, new)
+    diff = EntryConfigDiff(new=new)
 
     assert dict(diff.slots_added) == {1: _slot(), 2: _slot()}
     assert diff.locks_added == ("lock.a",)
@@ -51,10 +61,10 @@ def test_diff_added_slots_and_locks() -> None:
 
 
 def test_diff_removed_slots_and_locks() -> None:
-    """All slots/locks removed."""
-    old = {CONF_LOCKS: ["lock.a"], CONF_SLOTS: {1: _slot()}}
+    """All slots/locks removed (omit `new` -> defaults to empty)."""
+    old = _cfg({CONF_LOCKS: ["lock.a"], CONF_SLOTS: {1: _slot()}})
 
-    diff = compute_entry_config_diff(old, {})
+    diff = EntryConfigDiff(old=old)
 
     assert dict(diff.slots_removed) == {1: _slot()}
     assert diff.locks_removed == ("lock.a",)
@@ -63,10 +73,10 @@ def test_diff_removed_slots_and_locks() -> None:
 
 
 def test_diff_no_changes() -> None:
-    """Same locks and slots -> no diff, no has_changes."""
-    config = {CONF_LOCKS: ["lock.a"], CONF_SLOTS: {1: _slot()}}
+    """Same config on both sides -> no diff, no has_changes."""
+    config = _cfg({CONF_LOCKS: ["lock.a"], CONF_SLOTS: {1: _slot()}})
 
-    diff = compute_entry_config_diff(config, config)
+    diff = EntryConfigDiff(old=config, new=config)
 
     assert not diff.has_changes
     assert diff.slots_unchanged == frozenset({1})
@@ -77,15 +87,16 @@ def test_diff_no_changes() -> None:
 def test_diff_str_keys_match_int_keys() -> None:
     """Stored data has str slot keys; voluptuous output has int.
 
-    The helper must treat ``"1"`` and ``1`` as the same slot for both
-    set comparisons and pair tuples — otherwise the options flow would
-    flag every existing slot as "newly added" the first time the user
-    edits options.
+    EntryConfig.from_mapping normalizes keys to int up front, so by the
+    time the diff is computed both sides are int-keyed and ``"1"`` /
+    ``1`` are treated as the same slot. Without this, the options flow
+    would flag every existing slot as "newly added" the first time the
+    user edits options.
     """
-    old = {CONF_LOCKS: ["lock.a"], CONF_SLOTS: {"1": _slot(), "2": _slot()}}
-    new = {CONF_LOCKS: ["lock.a"], CONF_SLOTS: {1: _slot(), 2: _slot()}}
+    old = _cfg({CONF_LOCKS: ["lock.a"], CONF_SLOTS: {"1": _slot(), "2": _slot()}})
+    new = _cfg({CONF_LOCKS: ["lock.a"], CONF_SLOTS: {1: _slot(), 2: _slot()}})
 
-    diff = compute_entry_config_diff(old, new)
+    diff = EntryConfigDiff(old=old, new=new)
 
     assert dict(diff.slots_added) == {}
     assert dict(diff.slots_removed) == {}
@@ -95,18 +106,11 @@ def test_diff_str_keys_match_int_keys() -> None:
 
 
 def test_diff_slot_dicts_always_int_keyed() -> None:
-    """All slot-dict outputs are int-keyed regardless of input key type.
+    """All slot-dict outputs are int-keyed regardless of input key type."""
+    old = _cfg({CONF_SLOTS: {"1": _slot(), "3": _slot()}})
+    new = _cfg({CONF_SLOTS: {1: _slot("9999"), 2: _slot()}})
 
-    Stage 3 of the EntryConfig migration: callers normalize via
-    EntryConfig.to_dict() before passing to compute_entry_config_diff,
-    so the helper guarantees int-keyed outputs and downstream code
-    (notably the listener's reconcile loop) doesn't have to translate.
-    """
-    # Mixed: old has str keys (raw JSON-loaded data), new has int (voluptuous)
-    old = {CONF_SLOTS: {"1": _slot(), "3": _slot()}}
-    new = {CONF_SLOTS: {1: _slot("9999"), 2: _slot()}}
-
-    diff = compute_entry_config_diff(old, new)
+    diff = EntryConfigDiff(old=old, new=new)
 
     assert 2 in diff.slots_added
     assert "2" not in diff.slots_added
@@ -123,10 +127,10 @@ def test_diff_pair_added_for_new_lock_with_existing_slot() -> None:
     then adds lock.b — (lock.b, 1) is a brand-new pair to scan, even
     though slot 1 is "unchanged" in the slot dict view.
     """
-    old = {CONF_LOCKS: ["lock.a"], CONF_SLOTS: {1: _slot()}}
-    new = {CONF_LOCKS: ["lock.a", "lock.b"], CONF_SLOTS: {1: _slot()}}
+    old = _cfg({CONF_LOCKS: ["lock.a"], CONF_SLOTS: {1: _slot()}})
+    new = _cfg({CONF_LOCKS: ["lock.a", "lock.b"], CONF_SLOTS: {1: _slot()}})
 
-    diff = compute_entry_config_diff(old, new)
+    diff = EntryConfigDiff(old=old, new=new)
 
     assert diff.locks_added == ("lock.b",)
     assert dict(diff.slots_added) == {}
@@ -136,13 +140,28 @@ def test_diff_pair_added_for_new_lock_with_existing_slot() -> None:
 
 def test_diff_pair_added_for_new_slot_on_existing_lock() -> None:
     """Adding a slot creates a new pair on every existing lock."""
-    old = {CONF_LOCKS: ["lock.a", "lock.b"], CONF_SLOTS: {1: _slot()}}
-    new = {CONF_LOCKS: ["lock.a", "lock.b"], CONF_SLOTS: {1: _slot(), 2: _slot()}}
+    old = _cfg({CONF_LOCKS: ["lock.a", "lock.b"], CONF_SLOTS: {1: _slot()}})
+    new = _cfg({CONF_LOCKS: ["lock.a", "lock.b"], CONF_SLOTS: {1: _slot(), 2: _slot()}})
 
-    diff = compute_entry_config_diff(old, new)
+    diff = EntryConfigDiff(old=old, new=new)
 
     assert dict(diff.slots_added) == {2: _slot()}
     assert diff.pairs_added == frozenset({("lock.a", 2), ("lock.b", 2)})
+
+
+def test_subtraction_operator_is_diff_sugar() -> None:
+    """``a - b`` on EntryConfig returns the same as EntryConfigDiff(old=a, new=b)."""
+    a = _cfg({CONF_LOCKS: ["lock.a"], CONF_SLOTS: {1: _slot()}})
+    b = _cfg({CONF_LOCKS: ["lock.a"], CONF_SLOTS: {1: _slot(), 2: _slot()}})
+
+    via_operator = a - b
+    via_constructor = EntryConfigDiff(old=a, new=b)
+
+    # Same diff content (the dataclasses are equal field-for-field;
+    # the source configs are also equal so __eq__ matches)
+    assert dict(via_operator.slots_added) == dict(via_constructor.slots_added)
+    assert via_operator.pairs_added == via_constructor.pairs_added
+    assert via_operator.has_changes is via_constructor.has_changes
 
 
 def test_diff_is_deeply_immutable() -> None:
@@ -155,9 +174,9 @@ def test_diff_is_deeply_immutable() -> None:
     """
     # Build a diff with both an added slot AND a removed slot so we can
     # exercise inner-mutation guards on both
-    diff = compute_entry_config_diff(
-        {CONF_LOCKS: ["lock.a"], CONF_SLOTS: {1: _slot()}},
-        {CONF_LOCKS: ["lock.a"], CONF_SLOTS: {2: _slot()}},
+    diff = EntryConfigDiff(
+        old=_cfg({CONF_LOCKS: ["lock.a"], CONF_SLOTS: {1: _slot()}}),
+        new=_cfg({CONF_LOCKS: ["lock.a"], CONF_SLOTS: {2: _slot()}}),
     )
 
     # Attribute reassignment blocked
@@ -190,16 +209,16 @@ def test_diff_is_deeply_immutable() -> None:
 
 
 def test_diff_snapshots_inner_slot_dicts() -> None:
-    """Mutating the source slot config after diff() doesn't leak into the diff.
+    """Mutating the source slot config after diff is built doesn't leak in.
 
-    The defensive ``dict(v)`` copy in compute_entry_config_diff means
-    the diff captures a snapshot of slot configs at construction time —
-    later mutations to the original mapping don't change the diff view.
+    The defensive ``dict(v)`` copy inside __post_init__ snapshots slot
+    configs at construction time — later mutations to the original
+    mapping don't change the diff view.
     """
     inner_slot = {"pin": "1234", "enabled": True}
-    new = {CONF_SLOTS: {1: inner_slot}}
+    new = _cfg({CONF_SLOTS: {1: inner_slot}})
 
-    diff = compute_entry_config_diff({}, new)
+    diff = EntryConfigDiff(new=new)
 
     # Mutate the original inner slot dict after the diff is built
     inner_slot["pin"] = "9999"


### PR DESCRIPTION
## Proposed change

Final stage of the EntryConfig migration. Consolidates the diff API, threads `EntryConfig` through the listener's helper signatures, removes the `get_slot_data` thin-wrapper, and fixes a stale comment.

### What landed

**1. `EntryConfigDiff` is now constructed directly from the two configs**

```python
diff = EntryConfigDiff(old=current_config, new=proposed_config)

# Or via operator sugar:
diff = current_config - proposed_config
```

Single construction path — `EntryConfigDiff` uses `field(init=False)` for all the computed views (`slots_added`, `slots_removed`, etc.); `__post_init__` populates them from `old`/`new` (which are stored as regular fields, accessible after construction for debugging/logging).

Both `old` and `new` default to `EntryConfig.empty()` so callers can omit either side for the "all added" / "all removed" cases:

```python
EntryConfigDiff(new=cfg)   # all added
EntryConfigDiff(old=cfg)   # all removed
EntryConfigDiff()          # empty diff
```

This eliminates the footgun where callers could build `EntryConfigDiff` with hand-rolled `slots_added=...` fields that didn't satisfy the diff invariants.

**2. Deleted standalone `compute_entry_config_diff`**

Migrated 2 production callers (`__init__.py` listener, `config_flow.py` options flow) to the new constructor / operator. Tests rewritten with a small `_cfg()` helper around `EntryConfig.from_mapping`.

**3. `_async_setup_new_locks(..., new_config: EntryConfig, ...)`**

Was `new_slots: Mapping[int, Any]`. The function reads `new_config.slots` internally; call site is one line shorter.

**4. Removed `get_slot_data` thin-wrapper**

Migrated 3 callers (`entity.py`, `binary_sensor.py` x2) to call `get_entry_config(...).slot(slot_num)` directly. Saves an indirection.

**5. Stale comment fix in `async_update_listener`**

The pre-platform-setup comment claimed it stripped `number_of_uses`, but the actual stripping lives in the repair flow (`NumberOfUsesDeprecatedFlow`). Comment now describes what the code actually does. (Flagged in #1031 review's "low confidence" details section.)

### TODO.md cleanup

The entire `EntryConfig migration` entry is now removed (migration complete). Out-of-scope items split into their own focused entries:
- TypedDict for SlotConfig
- coordinator.data typing
- Internal dict boundaries (websocket internals, callbacks)

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Additional information

- 601 tests pass, all pre-commit hooks clean
- New test `test_subtraction_operator_is_diff_sugar` verifies `a - b` produces the same diff as `EntryConfigDiff(old=a, new=b)`
- Net diff: -222/+208 (cleanup landed slightly more LOC than removed, but two helper functions and the redundant `compute_entry_config_diff` are gone)