### PR TITLE
Consolidate slot models: merge SlotEntityIds+SlotEntityData, relocate single-consumer types

### DIFF
--- a/custom_components/lock_code_manager/models.py
+++ b/custom_components/lock_code_manager/models.py
@@ -48,48 +48,17 @@ class LockCodeManagerConfigEntryData:
 type LockCodeManagerConfigEntry = ConfigEntry[LockCodeManagerConfigEntryData]
 
 
-@dataclass(frozen=True)
-class SlotState:
-    """Snapshot of entity states for a slot on a specific lock."""
-
-    active_state: str
-    pin_state: str
-    name_state: str | None
-    code_state: str
-    coordinator_code: str | SlotCode | None
-
-
 @dataclass
-class SlotEntityIds:
-    """Entity IDs for a single slot's LCM entities."""
+class SlotEntities:
+    """Entity IDs for a single slot's LCM entities.
+
+    All entity ID fields are optional so callers that only need a subset
+    can populate what they have. ``config_entry_id`` is included for
+    callers iterating across entries who need to track origin.
+    """
 
     slot_num: int
     config_entry_id: str | None = None
-    name: str | None = None
-    pin: str | None = None
-    active: str | None = None
-    enabled: str | None = None
-
-    def all_ids(self) -> list[str]:
-        """Return all non-None entity IDs."""
-        return [eid for eid in (self.name, self.pin, self.active, self.enabled) if eid]
-
-
-@dataclass
-class SlotMetadata:
-    """Metadata for a single slot from LCM entities."""
-
-    name: str | None = None
-    configured_pin: str | None = None
-    active: bool | None = None
-    enabled: bool | None = None
-
-
-@dataclass
-class SlotEntityData:
-    """Entity IDs and data for a single slot."""
-
-    slot_num: int
     name_entity_id: str | None = None
     pin_entity_id: str | None = None
     enabled_entity_id: str | None = None
@@ -98,7 +67,7 @@ class SlotEntityData:
     event_entity_id: str | None = None
 
     def all_entity_ids(self) -> list[str]:
-        """Return all non-None entity IDs for state tracking."""
+        """Return all non-None entity IDs (excluding config_entry_id)."""
         return [
             eid
             for eid in (
@@ -111,3 +80,13 @@ class SlotEntityData:
             )
             if eid
         ]
+
+
+@dataclass
+class SlotMetadata:
+    """Metadata for a single slot from LCM entities."""
+
+    name: str | None = None
+    configured_pin: str | None = None
+    active: bool | None = None
+    enabled: bool | None = None

--- a/custom_components/lock_code_manager/models.py
+++ b/custom_components/lock_code_manager/models.py
@@ -46,37 +46,3 @@ class LockCodeManagerConfigEntryData:
 
 
 type LockCodeManagerConfigEntry = ConfigEntry[LockCodeManagerConfigEntryData]
-
-
-@dataclass
-class SlotEntities:
-    """Entity IDs for a single slot's LCM entities.
-
-    All entity ID fields are optional so callers that only need a subset
-    can populate what they have. ``config_entry_id`` is included for
-    callers iterating across entries who need to track origin.
-    """
-
-    slot_num: int
-    config_entry_id: str | None = None
-    name_entity_id: str | None = None
-    pin_entity_id: str | None = None
-    enabled_entity_id: str | None = None
-    active_entity_id: str | None = None
-    number_of_uses_entity_id: str | None = None
-    event_entity_id: str | None = None
-
-    def all_entity_ids(self) -> list[str]:
-        """Return all non-None entity IDs (excluding config_entry_id)."""
-        return [
-            eid
-            for eid in (
-                self.name_entity_id,
-                self.pin_entity_id,
-                self.enabled_entity_id,
-                self.active_entity_id,
-                self.number_of_uses_entity_id,
-                self.event_entity_id,
-            )
-            if eid
-        ]

--- a/custom_components/lock_code_manager/models.py
+++ b/custom_components/lock_code_manager/models.py
@@ -80,13 +80,3 @@ class SlotEntities:
             )
             if eid
         ]
-
-
-@dataclass
-class SlotMetadata:
-    """Metadata for a single slot from LCM entities."""
-
-    name: str | None = None
-    configured_pin: str | None = None
-    active: bool | None = None
-    enabled: bool | None = None

--- a/custom_components/lock_code_manager/sync.py
+++ b/custom_components/lock_code_manager/sync.py
@@ -13,6 +13,7 @@ Extracted from binary_sensor.py to separate domain logic from entity state displ
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import dataclass
 from datetime import datetime
 import logging
 from typing import TYPE_CHECKING, Any
@@ -52,7 +53,7 @@ from .const import (
     TICK_INTERVAL,
 )
 from .exceptions import CodeRejectedError, LockDisconnected
-from .models import SlotCode, SlotState
+from .models import SlotCode
 from .util import async_disable_slot
 
 if TYPE_CHECKING:
@@ -60,7 +61,26 @@ if TYPE_CHECKING:
     from .models import LockCodeManagerConfigEntry
     from .providers import BaseLock
 
+
 _LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class SlotState:
+    """Snapshot of entity states for a slot on a specific lock.
+
+    Used by SlotSyncManager to compare desired (entity) vs actual
+    (coordinator) state. Includes raw HA state strings (rather than
+    parsed values) because sync logic needs to distinguish between
+    "off" and "unavailable" — both look like the same parsed bool but
+    mean different things for retry decisions.
+    """
+
+    active_state: str
+    pin_state: str
+    name_state: str | None
+    code_state: str
+    coordinator_code: str | SlotCode | None
 
 
 class SlotSyncManager:

--- a/custom_components/lock_code_manager/websocket.py
+++ b/custom_components/lock_code_manager/websocket.py
@@ -102,7 +102,7 @@ from .helpers import (
     async_set_slot_condition,
     async_set_usercode,
 )
-from .models import SlotCode, SlotEntityData, SlotEntityIds, SlotMetadata
+from .models import SlotCode, SlotEntities, SlotMetadata
 from .providers import BaseLock
 
 _LOGGER = logging.getLogger(__name__)
@@ -420,18 +420,20 @@ def _get_managed_slots(hass: HomeAssistant, lock_entity_id: str) -> set[Any]:
 
 def _get_slot_entity_ids(
     hass: HomeAssistant, lock_entity_id: str
-) -> dict[int, SlotEntityIds]:
+) -> dict[int, SlotEntities]:
     """
     Get entity IDs for all slots managed by LCM for a lock.
 
-    Returns a dict mapping slot number to SlotEntityIds containing the entity IDs
-    for name, PIN, active, and enabled entities.
+    Returns a dict mapping slot number to SlotEntities containing the entity IDs
+    for name, PIN, active, and enabled entities. ``number_of_uses_entity_id`` and
+    ``event_entity_id`` are left unset because this function is used for
+    state-tracking subscriptions which only care about the four primary entities.
 
     Note: If multiple config entries manage the same lock with overlapping slot
     numbers (which shouldn't happen in normal use), the last entry wins. This is
     expected behavior since slot conflicts are validated during config flow.
     """
-    slot_entities: dict[int, SlotEntityIds] = {}
+    slot_entities: dict[int, SlotEntities] = {}
     ent_reg = er.async_get(hass)
 
     for entry in hass.config_entries.async_entries(DOMAIN):
@@ -448,15 +450,19 @@ def _get_slot_entity_ids(
             active_uid = f"{entry.entry_id}|{slot_num}|{ATTR_ACTIVE}"
             enabled_uid = f"{entry.entry_id}|{slot_num}|{CONF_ENABLED}"
 
-            slot_entities[slot_int] = SlotEntityIds(
+            slot_entities[slot_int] = SlotEntities(
                 slot_num=slot_int,
                 config_entry_id=entry.entry_id,
-                name=ent_reg.async_get_entity_id(TEXT_DOMAIN, DOMAIN, name_uid),
-                pin=ent_reg.async_get_entity_id(TEXT_DOMAIN, DOMAIN, pin_uid),
-                active=ent_reg.async_get_entity_id(
+                name_entity_id=ent_reg.async_get_entity_id(
+                    TEXT_DOMAIN, DOMAIN, name_uid
+                ),
+                pin_entity_id=ent_reg.async_get_entity_id(TEXT_DOMAIN, DOMAIN, pin_uid),
+                active_entity_id=ent_reg.async_get_entity_id(
                     BINARY_SENSOR_DOMAIN, DOMAIN, active_uid
                 ),
-                enabled=ent_reg.async_get_entity_id(SWITCH_DOMAIN, DOMAIN, enabled_uid),
+                enabled_entity_id=ent_reg.async_get_entity_id(
+                    SWITCH_DOMAIN, DOMAIN, enabled_uid
+                ),
             )
 
     return slot_entities
@@ -477,10 +483,10 @@ def _get_slot_metadata(
     slot_entities = _get_slot_entity_ids(hass, lock_entity_id)
     return {
         slot_num: SlotMetadata(
-            name=_get_text_state(hass, ids.name),
-            configured_pin=_get_text_state(hass, ids.pin),
-            active=_get_bool_state(hass, ids.active),
-            enabled=_get_bool_state(hass, ids.enabled),
+            name=_get_text_state(hass, ids.name_entity_id),
+            configured_pin=_get_text_state(hass, ids.pin_entity_id),
+            active=_get_bool_state(hass, ids.active_entity_id),
+            enabled=_get_bool_state(hass, ids.enabled_entity_id),
         )
         for slot_num, ids in slot_entities.items()
     }
@@ -496,7 +502,7 @@ def _get_slot_state_entity_ids(hass: HomeAssistant, lock_entity_id: str) -> list
     slot_entities = _get_slot_entity_ids(hass, lock_entity_id)
     entity_ids: list[str] = []
     for ids in slot_entities.values():
-        entity_ids.extend(ids.all_ids())
+        entity_ids.extend(ids.all_entity_ids())
     return entity_ids
 
 
@@ -659,7 +665,7 @@ async def subscribe_lock_codes(
 
 def _get_slot_entity_data(
     hass: HomeAssistant, config_entry: ConfigEntry, slot_num: int
-) -> SlotEntityData:
+) -> SlotEntities:
     """Get entity IDs for a specific slot."""
     ent_reg = er.async_get(hass)
     entry_id = config_entry.entry_id
@@ -668,7 +674,7 @@ def _get_slot_entity_data(
         unique_id = f"{entry_id}|{slot_num}|{key}"
         return ent_reg.async_get_entity_id(domain, DOMAIN, unique_id)
 
-    return SlotEntityData(
+    return SlotEntities(
         slot_num=slot_num,
         name_entity_id=_get_entity_id(TEXT_DOMAIN, CONF_NAME),
         pin_entity_id=_get_entity_id(TEXT_DOMAIN, CONF_PIN),
@@ -888,7 +894,7 @@ def _serialize_slot_card_data(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
     slot_num: int,
-    slot_entities: SlotEntityData,
+    slot_entities: SlotEntities,
     in_sync_map: dict[str, str],
     *,
     reveal: bool,
@@ -1022,7 +1028,7 @@ async def subscribe_code_slot(
     # Re-resolve entity IDs on each update to handle entities created after
     # subscription (for example, during initial config setup when entities may
     # not exist yet). These are lightweight entity registry lookups.
-    def _resolve_entity_ids() -> tuple[SlotEntityData, dict[str, str], str | None]:
+    def _resolve_entity_ids() -> tuple[SlotEntities, dict[str, str], str | None]:
         """Resolve current entity IDs for this slot from the entity registry."""
         return (
             _get_slot_entity_data(hass, config_entry, slot_num),
@@ -1099,7 +1105,7 @@ async def subscribe_code_slot(
 
     @callback
     def _refresh_state_tracking(
-        current_entities: SlotEntityData,
+        current_entities: SlotEntities,
         current_in_sync: dict[str, str],
         current_condition: str | None = None,
     ) -> None:

--- a/custom_components/lock_code_manager/websocket.py
+++ b/custom_components/lock_code_manager/websocket.py
@@ -103,7 +103,7 @@ from .helpers import (
     async_set_slot_condition,
     async_set_usercode,
 )
-from .models import SlotCode, SlotEntities
+from .models import SlotCode
 from .providers import BaseLock
 
 _LOGGER = logging.getLogger(__name__)
@@ -419,6 +419,55 @@ def _get_managed_slots(hass: HomeAssistant, lock_entity_id: str) -> set[Any]:
     return managed_slots
 
 
+@dataclass
+class SlotEntities:
+    """Entity IDs for a single slot's LCM entities.
+
+    All entity ID fields are optional so callers that only need a subset
+    can populate what they have. ``config_entry_id`` is included for
+    callers iterating across entries who need to track origin.
+    """
+
+    slot_num: int
+    config_entry_id: str | None = None
+    name_entity_id: str | None = None
+    pin_entity_id: str | None = None
+    enabled_entity_id: str | None = None
+    active_entity_id: str | None = None
+    number_of_uses_entity_id: str | None = None
+    event_entity_id: str | None = None
+
+    def all_entity_ids(self) -> list[str]:
+        """Return all non-None entity IDs (excluding config_entry_id)."""
+        return [
+            eid
+            for eid in (
+                self.name_entity_id,
+                self.pin_entity_id,
+                self.enabled_entity_id,
+                self.active_entity_id,
+                self.number_of_uses_entity_id,
+                self.event_entity_id,
+            )
+            if eid
+        ]
+
+
+@dataclass
+class SlotMetadata:
+    """Parsed values for a single slot, derived from LCM entity states.
+
+    Used as the per-slot shape inside websocket subscription responses.
+    Fields are typed (bool / str) rather than raw HA states because
+    consumers want clean JSON-serializable values.
+    """
+
+    name: str | None = None
+    configured_pin: str | None = None
+    active: bool | None = None
+    enabled: bool | None = None
+
+
 def _get_slot_entity_ids(
     hass: HomeAssistant, lock_entity_id: str
 ) -> dict[int, SlotEntities]:
@@ -467,21 +516,6 @@ def _get_slot_entity_ids(
             )
 
     return slot_entities
-
-
-@dataclass
-class SlotMetadata:
-    """Parsed values for a single slot, derived from LCM entity states.
-
-    Used as the per-slot shape inside websocket subscription responses.
-    Fields are typed (bool / str) rather than raw HA states because
-    consumers want clean JSON-serializable values.
-    """
-
-    name: str | None = None
-    configured_pin: str | None = None
-    active: bool | None = None
-    enabled: bool | None = None
 
 
 def _get_slot_metadata(

--- a/custom_components/lock_code_manager/websocket.py
+++ b/custom_components/lock_code_manager/websocket.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Coroutine
+from dataclasses import dataclass
 from datetime import timedelta
 from functools import wraps
 import logging
@@ -102,7 +103,7 @@ from .helpers import (
     async_set_slot_condition,
     async_set_usercode,
 )
-from .models import SlotCode, SlotEntities, SlotMetadata
+from .models import SlotCode, SlotEntities
 from .providers import BaseLock
 
 _LOGGER = logging.getLogger(__name__)
@@ -466,6 +467,21 @@ def _get_slot_entity_ids(
             )
 
     return slot_entities
+
+
+@dataclass
+class SlotMetadata:
+    """Parsed values for a single slot, derived from LCM entity states.
+
+    Used as the per-slot shape inside websocket subscription responses.
+    Fields are typed (bool / str) rather than raw HA states because
+    consumers want clean JSON-serializable values.
+    """
+
+    name: str | None = None
+    configured_pin: str | None = None
+    active: bool | None = None
+    enabled: bool | None = None
 
 
 def _get_slot_metadata(

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -16,8 +16,8 @@ from homeassistant.helpers.issue_registry import (
 )
 
 from custom_components.lock_code_manager.const import DOMAIN
-from custom_components.lock_code_manager.models import SlotCode, SlotState
-from custom_components.lock_code_manager.sync import SlotSyncManager
+from custom_components.lock_code_manager.models import SlotCode
+from custom_components.lock_code_manager.sync import SlotState, SlotSyncManager
 
 from .common import SLOT_1_IN_SYNC_ENTITY
 from .conftest import async_trigger_sync_tick, get_in_sync_entity_obj

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -64,7 +64,7 @@ from custom_components.lock_code_manager.const import (
     DOMAIN,
 )
 from custom_components.lock_code_manager.exceptions import DuplicateCodeError
-from custom_components.lock_code_manager.models import SlotCode, SlotEntityData
+from custom_components.lock_code_manager.models import SlotCode, SlotEntities
 from custom_components.lock_code_manager.providers import BaseLock
 from custom_components.lock_code_manager.websocket import (
     _find_config_entry_by_title,
@@ -2528,8 +2528,8 @@ async def test_subscribe_code_slot_entity_tracking_refreshes_on_update(
         if call_count <= 1:
             return real_entity_data
         # Return entity data with the new entity added via name_entity_id
-        # (using a new SlotEntityData with an extra entity)
-        return SlotEntityData(
+        # (using a new SlotEntities with an extra entity)
+        return SlotEntities(
             slot_num=real_entity_data.slot_num,
             name_entity_id=new_entity_id,
             pin_entity_id=real_entity_data.pin_entity_id,
@@ -2754,7 +2754,7 @@ async def test_subscribe_code_slot_unsub_all_with_empty_state_ref(
     ws_client = await hass_ws_client(hass)
 
     # Mock entity data to return empty entity data so unsub_state_ref stays empty
-    empty_entity_data = SlotEntityData(slot_num=1)
+    empty_entity_data = SlotEntities(slot_num=1)
 
     with (
         patch(

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -64,9 +64,10 @@ from custom_components.lock_code_manager.const import (
     DOMAIN,
 )
 from custom_components.lock_code_manager.exceptions import DuplicateCodeError
-from custom_components.lock_code_manager.models import SlotCode, SlotEntities
+from custom_components.lock_code_manager.models import SlotCode
 from custom_components.lock_code_manager.providers import BaseLock
 from custom_components.lock_code_manager.websocket import (
+    SlotEntities,
     _find_config_entry_by_title,
     _get_bool_state,
     _get_condition_entity_data,


### PR DESCRIPTION
## Proposed change

Audit + cleanup of the data model types in `models.py`. Two outcomes:

1. **Merge two near-identical types** that had drifted apart
2. **Relocate single-consumer types** to live next to their actual consumers, so `models.py`'s "canonical home for cross-cutting types" claim is truthful

### What landed (4 commits, separately reviewable)

**Commit 1: Merge `SlotEntityIds` + `SlotEntityData` → `SlotEntities`**

Both lived in `models.py` for the same purpose — entity IDs for a single slot — but had drifted into two near-identical shapes:

| | `SlotEntityIds` | `SlotEntityData` |
|---|---|---|
| name field | `name` | `name_entity_id` |
| pin field | `pin` | `pin_entity_id` |
| active field | `active` | `active_entity_id` |
| enabled field | `enabled` | `enabled_entity_id` |
| number_of_uses | — | `number_of_uses_entity_id` |
| event | — | `event_entity_id` |
| extra | `config_entry_id` | — |
| method | `all_ids()` | `all_entity_ids()` |

Unified as `SlotEntities` with all 6 entity-ID fields plus `config_entry_id`, all optional. Picked the `_entity_id` suffix naming since it's clearer about what each field holds (the entity ID, not the entity's name/value).

**Commit 2: Move `SlotState` → `sync.py`** — sync-only, used exclusively by `SlotSyncManager`. (Got the import-block ordering wrong on the first try; fix in same commit.)

**Commit 3: Move `SlotMetadata` → `websocket.py`** — websocket-only, the per-slot shape inside subscription responses.

**Commit 4: Move `SlotEntities` → `websocket.py`** — same audit principle: only `websocket.py` consumes it.

### Result

`models.py` is now down to genuinely cross-cutting types only:

- `SlotCode` — enum used by `sync.py`, `data.py`, `coordinator.py`, providers, websocket, tests
- `LockCodeManagerConfigEntryData` — runtime data shape attached to every config entry
- `LockCodeManagerConfigEntry` — type alias

The "Canonical home for cross-cutting types" claim in the module docstring is now truthful instead of aspirational.

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Additional information

- 602 tests pass, all pre-commit hooks clean
- Each commit is independently reviewable; the merge (commit 1) is the largest and most semantically interesting