### PR TITLE
Tier 1 housekeeping: int normalization + dedupe providers + drop sync method tier

### DIFF
--- a/custom_components/lock_code_manager/coordinator.py
+++ b/custom_components/lock_code_manager/coordinator.py
@@ -174,7 +174,15 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator[dict[int, str | SlotCo
         )
 
     async def async_get_usercodes(self) -> dict[int, str | SlotCode]:
-        """Update usercodes."""
+        """Update usercodes.
+
+        Normalizes slot keys to ``int`` here at the coordinator boundary so
+        every downstream consumer of ``coordinator.data`` can rely on int
+        keys regardless of provider implementation. All in-tree providers
+        already return int, but the cast is the contract that makes the
+        guarantee enforceable (and protects against future providers or
+        edge cases like Virtual's str-keyed JSON storage).
+        """
         try:
             data = await self._lock.async_internal_get_usercodes()
         except LockCodeManagerError as err:
@@ -185,7 +193,7 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator[dict[int, str | SlotCo
             raise UpdateFailed from err
 
         self._reset_backoff()
-        return data
+        return {int(k): v for k, v in data.items()}
 
     async def _async_drift_check(self, now: datetime) -> None:
         """

--- a/custom_components/lock_code_manager/coordinator.py
+++ b/custom_components/lock_code_manager/coordinator.py
@@ -93,13 +93,29 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator[dict[int, str | SlotCo
         """Return whether LCM expects a PIN on this slot (enabled with PIN)."""
         return self.get_expected_pin(slot_num) is not None
 
+    @staticmethod
+    def _normalize_keys(
+        data: dict[Any, str | SlotCode],
+    ) -> dict[int, str | SlotCode]:
+        """Coerce slot keys to ``int``.
+
+        The single chokepoint that enforces the ``coordinator.data`` int-key
+        invariant. Applied at every write site (poll, push, drift-check) so
+        downstream consumers (websocket serializer, listeners) can rely on
+        plain int membership/sorting without defensive str/int gymnastics.
+
+        Raises ``ValueError``/``TypeError`` if a key cannot be cast — that's
+        a programming error worth surfacing rather than poisoning the cache.
+        """
+        return {int(k): v for k, v in data.items()}
+
     @callback
     def push_update(self, updates: dict[int, str | SlotCode]) -> None:
         """Push one or more slot updates and notify listening entities."""
         if not updates:
             return
 
-        new_data = {**self.data, **updates}
+        new_data = {**self.data, **self._normalize_keys(updates)}
         # Skip update if data hasn't actually changed to avoid redundant logging
         # and unnecessary listener notifications
         if new_data == self.data:
@@ -176,12 +192,10 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator[dict[int, str | SlotCo
     async def async_get_usercodes(self) -> dict[int, str | SlotCode]:
         """Update usercodes.
 
-        Normalizes slot keys to ``int`` here at the coordinator boundary so
-        every downstream consumer of ``coordinator.data`` can rely on int
-        keys regardless of provider implementation. All in-tree providers
-        already return int, but the cast is the contract that makes the
-        guarantee enforceable (and protects against future providers or
-        edge cases like Virtual's str-keyed JSON storage).
+        Routes the provider response through ``_normalize_keys`` — the
+        chokepoint that guarantees ``coordinator.data`` is always int-keyed,
+        regardless of which provider produced it. See ``_normalize_keys``
+        for rationale.
         """
         try:
             data = await self._lock.async_internal_get_usercodes()
@@ -193,7 +207,7 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator[dict[int, str | SlotCo
             raise UpdateFailed from err
 
         self._reset_backoff()
-        return {int(k): v for k, v in data.items()}
+        return self._normalize_keys(data)
 
     async def _async_drift_check(self, now: datetime) -> None:
         """
@@ -220,7 +234,9 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator[dict[int, str | SlotCo
             self._lock.lock.entity_id,
         )
         try:
-            new_data = await self._lock.async_internal_hard_refresh_codes()
+            new_data = self._normalize_keys(
+                await self._lock.async_internal_hard_refresh_codes()
+            )
         except LockCodeManagerError as err:
             self._apply_backoff()
             _LOGGER.warning(
@@ -233,7 +249,10 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator[dict[int, str | SlotCo
         # Push subscription retry is handled by BaseLock's OneShotRetry
         # and the config entry state listener — no need to retry here.
 
-        # Compare with current data and notify if changed
+        # Compare with current data and notify if changed.
+        # Both sides are int-keyed (poll path normalized, this path normalized
+        # above) so the equality check won't spuriously trigger on key-type
+        # mismatch.
         if new_data != self.data:
             _LOGGER.debug(
                 "Drift detected for %s, updating coordinator data",

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -19,7 +19,7 @@ from homeassistant.components.text import DOMAIN as TEXT_DOMAIN
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import ATTR_DEVICE_ID, ATTR_ENTITY_ID, ATTR_STATE, CONF_NAME
 from homeassistant.core import Event, HomeAssistant, State, callback
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
@@ -856,7 +856,12 @@ class BaseLock:
                 blocking=blocking,
                 return_response=return_response,
             )
-        except Exception as err:
+        except HomeAssistantError as err:
+            # Narrow catch: only HA-raised service errors map to LockDisconnected.
+            # ServiceValidationError is a subclass of HomeAssistantError so it's
+            # covered. Letting CancelledError, TypeError, and other programming
+            # bugs propagate avoids false "lock offline" issue creation, drift
+            # backoff, and push-resub loops on shutdown or call-site mistakes.
             LOGGER.error(
                 "Error calling %s.%s service call: %s", domain, service, str(err)
             )

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -10,7 +10,6 @@ import asyncio
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from datetime import timedelta
-import functools
 import logging
 import time
 from typing import Any, Literal, NoReturn, final
@@ -183,17 +182,6 @@ class BaseLock:
         manager's standard CodeRejectedError handling.
         """
         self._rejected_code_slots.add(code_slot)
-
-    @final
-    async def _async_executor_call(
-        self, func: Callable[..., Any], *args: Any, **kwargs: Any
-    ) -> Any:
-        """Run a sync method in the executor."""
-        if kwargs:
-            return await self.hass.async_add_executor_job(
-                functools.partial(func, *args, **kwargs)
-            )
-        return await self.hass.async_add_executor_job(func, *args)
 
     @final
     async def _execute_rate_limited(
@@ -546,29 +534,23 @@ class BaseLock:
             else:
                 self.subscribe_push_updates()
 
-    def setup(self) -> None:
-        """Set up lock by provider."""
-        pass
-
     async def async_setup(self, config_entry: ConfigEntry) -> None:
-        """
-        Set up lock by provider.
+        """Set up lock by provider.
 
-        Overridden by providers that need custom one time async setup logic.
+        Default is a no-op; providers override to do one-time async setup.
         """
-        await self.hass.async_add_executor_job(self.setup)
 
     @final
     async def async_wait_for_setup(self) -> None:
         """Wait until async_setup has completed."""
         await self._setup_complete.wait()
 
-    def unload(self, remove_permanently: bool) -> None:
-        """Unload lock."""
-        pass
-
     async def async_unload(self, remove_permanently: bool) -> None:
-        """Unload lock."""
+        """Unload lock.
+
+        Providers override to add their own teardown; the base handles
+        config-entry-state listener cleanup and push subscription teardown.
+        """
         if self._config_entry_state_unsub:
             self._config_entry_state_unsub()
             self._config_entry_state_unsub = None
@@ -577,19 +559,9 @@ class BaseLock:
         if self.supports_push:
             self.unsubscribe_push_updates()
 
-        await self.hass.async_add_executor_job(self.unload, remove_permanently)
-
-    def is_integration_connected(self) -> bool:
-        """Return whether the integration's client/driver/broker is connected."""
-        raise NotImplementedError()
-
-    def is_device_available(self) -> bool:
-        """Return whether the physical device is available for commands."""
-        return True
-
     async def async_is_device_available(self) -> bool:
         """Return whether the physical device is available for commands."""
-        return await self._async_executor_call(self.is_device_available)
+        return True
 
     @final
     def _setup_config_entry_state_listener(self) -> None:
@@ -627,7 +599,11 @@ class BaseLock:
 
     async def async_is_integration_connected(self) -> bool:
         """Return whether the integration's client/driver/broker is connected."""
-        return await self._async_executor_call(self.is_integration_connected)
+        self._raise_not_implemented(
+            "async_is_integration_connected",
+            "Override this method to report whether the underlying "
+            "integration is connected.",
+        )
 
     @final
     async def async_internal_is_integration_connected(self) -> bool:
@@ -657,30 +633,16 @@ class BaseLock:
         elif self._last_connection_up is True and not is_up:
             self.unsubscribe_push_updates()
 
-    def hard_refresh_codes(self) -> dict[int, str | SlotCode]:
-        """
-        Perform hard refresh and return all codes.
+    async def async_hard_refresh_codes(self) -> dict[int, str | SlotCode]:
+        """Perform hard refresh and return all codes.
 
-        Needed for integrations where usercodes are cached and may get out of sync with
-        the lock. Returns codes in the same format as get_usercodes().
-
-        Raises:
-            LockDisconnected: If the lock cannot be communicated with.
-
+        Needed for integrations where usercodes are cached and may get out of sync
+        with the lock. Returns codes in the same format as async_get_usercodes().
         """
         self._raise_not_implemented(
-            "hard_refresh_codes",
+            "async_hard_refresh_codes",
             "Override this method to re-fetch codes from the lock device.",
         )
-
-    async def async_hard_refresh_codes(self) -> dict[int, str | SlotCode]:
-        """
-        Perform hard refresh and return all codes.
-
-        Needed for integrations where usercodes are cached and may get out of sync with
-        the lock. Returns codes in the same format as async_get_usercodes().
-        """
-        return await self._async_executor_call(self.hard_refresh_codes)
 
     @final
     async def async_internal_hard_refresh_codes(self) -> dict[int, str | SlotCode]:
@@ -694,15 +656,14 @@ class BaseLock:
             "refresh", self.async_hard_refresh_codes
         )
 
-    def set_usercode(
+    async def async_set_usercode(
         self, code_slot: int, usercode: str, name: str | None = None
     ) -> bool:
-        """
-        Set a usercode on a code slot.
+        """Set a usercode on a code slot.
 
-        Returns True if the value was changed, False if already set to this value.
-        If the provider cannot determine whether a change occurred, return True
-        to ensure the coordinator refreshes and verifies the state.
+        Returns True if the value was changed, False if already set to this
+        value. If the provider cannot determine whether a change occurred,
+        return True so the coordinator refreshes and verifies the state.
 
         Optimistic Updates
         ------------------
@@ -710,34 +671,21 @@ class BaseLock:
         asynchronously (e.g., Z-Wave JS push notifications), the base class
         coordinator refresh may read stale data, causing sync loops.
 
-        In these cases, call ``self.coordinator.push_update({code_slot: usercode})``
-        after a successful set operation to update coordinator data immediately.
+        In these cases, call
+        ``self.coordinator.push_update({code_slot: usercode})`` after a
+        successful set operation to update coordinator data immediately.
         This prevents the sync sensor from seeing a mismatch and retrying.
 
         Providers with synchronous caches (like Virtual) don't need this as
-        get_usercodes() returns the updated value immediately.
+        async_get_usercodes() returns the updated value immediately.
 
         Raises:
             LockDisconnected: If the lock cannot be communicated with.
 
         """
         self._raise_not_implemented(
-            "set_usercode",
+            "async_set_usercode",
             "Override this method to set a usercode on the lock.",
-        )
-
-    async def async_set_usercode(
-        self, code_slot: int, usercode: str, name: str | None = None
-    ) -> bool:
-        """
-        Set a usercode on a code slot.
-
-        Returns True if the value was changed, False if already set to this value.
-        If the provider cannot determine whether a change occurred, return True
-        to ensure the coordinator refreshes and verifies the state.
-        """
-        return await self._async_executor_call(
-            self.set_usercode, code_slot, usercode, name=name
         )
 
     @final
@@ -790,13 +738,12 @@ class BaseLock:
         if changed and self.coordinator and not self.supports_push:
             await self.coordinator.async_request_refresh()
 
-    def clear_usercode(self, code_slot: int) -> bool:
-        """
-        Clear a usercode on a code slot.
+    async def async_clear_usercode(self, code_slot: int) -> bool:
+        """Clear a usercode on a code slot.
 
         Returns True if the value was changed, False if already cleared.
-        If the provider cannot determine whether a change occurred, return True
-        to ensure the coordinator refreshes and verifies the state.
+        If the provider cannot determine whether a change occurred, return
+        True so the coordinator refreshes and verifies the state.
 
         Optimistic Updates
         ------------------
@@ -805,30 +752,21 @@ class BaseLock:
         coordinator refresh may read stale data, causing sync loops.
 
         In these cases, call ``self.coordinator.push_update({code_slot: ""})``
-        after a successful clear operation to update coordinator data immediately.
-        This prevents the sync sensor from seeing a mismatch and retrying.
+        after a successful clear operation to update coordinator data
+        immediately. This prevents the sync sensor from seeing a mismatch
+        and retrying.
 
         Providers with synchronous caches (like Virtual) don't need this as
-        get_usercodes() returns the updated value immediately.
+        async_get_usercodes() returns the updated value immediately.
 
         Raises:
             LockDisconnected: If the lock cannot be communicated with.
 
         """
         self._raise_not_implemented(
-            "clear_usercode",
+            "async_clear_usercode",
             "Override this method to clear a usercode from the lock.",
         )
-
-    async def async_clear_usercode(self, code_slot: int) -> bool:
-        """
-        Clear a usercode on a code slot.
-
-        Returns True if the value was changed, False if already cleared.
-        If the provider cannot determine whether a change occurred, return True
-        to ensure the coordinator refreshes and verifies the state.
-        """
-        return await self._async_executor_call(self.clear_usercode, code_slot)
 
     @final
     async def async_internal_clear_usercode(
@@ -854,44 +792,23 @@ class BaseLock:
         if changed and self.coordinator and not self.supports_push:
             await self.coordinator.async_request_refresh()
 
-    def get_usercodes(self) -> dict[int, str | SlotCode]:
-        """
-        Get dictionary of code slots and usercodes.
+    async def async_get_usercodes(self) -> dict[int, str | SlotCode]:
+        """Get dictionary of code slots and usercodes.
 
         Called by data coordinator to get data for code slot sensors.
 
-        Key is code slot, value is usercode, e.g.:
-        {
-            1: '1234',
-            'B': '5678',
-        }
+        Key is code slot (int), value is usercode, e.g.::
+
+            {1: '1234', 2: '5678'}
 
         Raises:
             LockDisconnected: If the lock cannot be communicated with.
 
         """
         self._raise_not_implemented(
-            "get_usercodes",
+            "async_get_usercodes",
             "Override this method to retrieve usercodes from the lock.",
         )
-
-    async def async_get_usercodes(self) -> dict[int, str | SlotCode]:
-        """
-        Get dictionary of code slots and usercodes.
-
-        Called by data coordinator to get data for code slot sensors.
-
-        Key is code slot, value is usercode, e.g.:
-        {
-            1: '1234',
-            'B': '5678',
-        }
-
-        Raises:
-            LockDisconnected: If the lock cannot be communicated with.
-
-        """
-        return await self._async_executor_call(self.get_usercodes)
 
     @final
     async def async_internal_get_usercodes(self) -> dict[int, str | SlotCode]:

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -598,12 +598,17 @@ class BaseLock:
         )
 
     async def async_is_integration_connected(self) -> bool:
-        """Return whether the integration's client/driver/broker is connected."""
-        self._raise_not_implemented(
-            "async_is_integration_connected",
-            "Override this method to report whether the underlying "
-            "integration is connected.",
-        )
+        """Return whether the integration's client/driver/broker is connected.
+
+        Default: ``True`` iff the lock's parent config entry is loaded.
+        Providers override when "the integration is connected" means
+        something more specific than "config entry loaded" — e.g. Z-Wave
+        JS checks the websocket client state separately from the entry
+        state.
+        """
+        if not self.lock_config_entry:
+            return False
+        return self.lock_config_entry.state == ConfigEntryState.LOADED
 
     @final
     async def async_internal_is_integration_connected(self) -> bool:
@@ -826,35 +831,30 @@ class BaseLock:
         return await self._execute_rate_limited("get", self.async_get_usercodes)
 
     @final
-    def call_service(
-        self,
-        domain: str,
-        service: str,
-        service_data: dict[str, Any] | None = None,
-        blocking: bool = True,
-    ):
-        """Call a hass service and log a failure on an error."""
-        try:
-            self.hass.services.call(
-                domain, service, service_data=service_data, blocking=blocking
-            )
-        except Exception as err:
-            LOGGER.error(
-                "Error calling %s.%s service call: %s", domain, service, str(err)
-            )
-
-    @final
     async def async_call_service(
         self,
         domain: str,
         service: str,
         service_data: dict[str, Any] | None = None,
+        target: dict[str, Any] | None = None,
         blocking: bool = True,
-    ):
-        """Call a hass service and re-raise failures as LockDisconnected."""
+        return_response: bool = False,
+    ) -> dict[str, Any] | None:
+        """Call a hass service and re-raise failures as LockDisconnected.
+
+        When ``return_response=True``, returns the service response (as a
+        dict) so callers don't have to write their own service-call wrapper
+        just to access response data. ``target`` mirrors HA's standard
+        target dict for platform-aware services.
+        """
         try:
-            await self.hass.services.async_call(
-                domain, service, service_data=service_data, blocking=blocking
+            return await self.hass.services.async_call(
+                domain,
+                service,
+                service_data=service_data,
+                target=target,
+                blocking=blocking,
+                return_response=return_response,
             )
         except Exception as err:
             LOGGER.error(

--- a/custom_components/lock_code_manager/providers/_util.py
+++ b/custom_components/lock_code_manager/providers/_util.py
@@ -1,0 +1,33 @@
+"""Shared helpers for provider implementations.
+
+Provider-internal utilities that don't belong in the integration-wide
+``util.py``. Currently: slot-tagging used by providers whose lock APIs
+identify codes by user-name rather than by slot number (Schlage, Akuvox).
+"""
+
+from __future__ import annotations
+
+import re
+
+# Format: ``[LCM:<slot>] <friendly name>`` — providers prepend this tag
+# so we can recover which slot a code belongs to from the lock's stored
+# user name.
+_SLOT_TAG_RE = re.compile(r"^\[LCM:(\d+)\]\s*(.*)")
+
+
+def make_tagged_name(slot_num: int, name: str | None = None) -> str:
+    """Return a code name tagged with the Lock Code Manager slot number."""
+    base = name or f"Code Slot {slot_num}"
+    return f"[LCM:{slot_num}] {base}"
+
+
+def parse_tag(name: str) -> tuple[int | None, str]:
+    """Parse a Lock Code Manager slot tag from a code name.
+
+    Returns ``(slot_num, friendly_name)`` when a tag is present, or
+    ``(None, original_name)`` when no tag is found.
+    """
+    match = _SLOT_TAG_RE.match(name)
+    if match:
+        return int(match.group(1)), match.group(2)
+    return None, name

--- a/custom_components/lock_code_manager/providers/akuvox.py
+++ b/custom_components/lock_code_manager/providers/akuvox.py
@@ -16,23 +16,19 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import timedelta
-import re
 from typing import Any
 
-from homeassistant.config_entries import ConfigEntry, ConfigEntryState
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.exceptions import HomeAssistantError
 
 from ..data import get_managed_slots
 from ..exceptions import LockCodeManagerProviderError, LockDisconnected
 from ..models import SlotCode
 from ._base import BaseLock
+from ._util import make_tagged_name as _make_tagged_name, parse_tag as _parse_tag
 from .const import LOGGER
 
 AKUVOX_DOMAIN = "local_akuvox"
-
-# Regex to parse the Lock Code Manager slot tag from user names.
-# Format: [LCM:XX] Friendly Name
-_SLOT_TAG_RE = re.compile(r"^\[LCM:(\d+)\]\s*(.*)")
 
 # Default schedule/relay values for Lock Code Manager-managed users.
 # These are required by the Akuvox add_user service but are not
@@ -54,24 +50,6 @@ def _is_local_user(user: dict[str, Any]) -> bool:
         return str(source_type) == _LOCAL_SOURCE_TYPE
     # source_type absent -- fall back to user_type (X916 pattern)
     return str(user.get("user_type", "")) == _LOCAL_USER_TYPE
-
-
-def _make_tagged_name(slot_num: int, name: str | None = None) -> str:
-    """Create a tagged user name with Lock Code Manager slot number."""
-    base = name or f"Code Slot {slot_num}"
-    return f"[LCM:{slot_num}] {base}"
-
-
-def _parse_tag(name: str) -> tuple[int | None, str]:
-    """Parse a Lock Code Manager slot tag from a user name.
-
-    Returns ``(slot_num, friendly_name)`` when a tag is present, or
-    ``(None, original_name)`` when no tag is found.
-    """
-    match = _SLOT_TAG_RE.match(name)
-    if match:
-        return int(match.group(1)), match.group(2)
-    return None, name
 
 
 @dataclass(repr=False, eq=False)
@@ -105,12 +83,6 @@ class AkuvoxLock(BaseLock):
     # Connection
     # ------------------------------------------------------------------
 
-    async def async_is_integration_connected(self) -> bool:
-        """Return whether the local_akuvox integration is loaded."""
-        if not self.lock_config_entry:
-            return False
-        return self.lock_config_entry.state == ConfigEntryState.LOADED
-
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
@@ -122,19 +94,13 @@ class AkuvoxLock(BaseLock):
         private_pin, card_code, schedule_relay, lift_floor_num, etc.
         """
         entity_id = self.lock.entity_id
-        try:
-            response = await self.hass.services.async_call(
-                AKUVOX_DOMAIN,
-                "list_users",
-                service_data={},
-                target={"entity_id": entity_id},
-                blocking=True,
-                return_response=True,
-            )
-        except HomeAssistantError as err:
-            raise LockDisconnected(
-                f"Failed to list users on {entity_id}: {err}"
-            ) from err
+        response = await self.async_call_service(
+            AKUVOX_DOMAIN,
+            "list_users",
+            service_data={},
+            target={"entity_id": entity_id},
+            return_response=True,
+        )
 
         if not isinstance(response, dict):
             raise LockCodeManagerProviderError(

--- a/custom_components/lock_code_manager/providers/matter.py
+++ b/custom_components/lock_code_manager/providers/matter.py
@@ -15,7 +15,7 @@ from typing import Any
 
 from matter_server.common.models import EventType
 
-from homeassistant.config_entries import ConfigEntry, ConfigEntryState
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 
@@ -161,12 +161,6 @@ class MatterLock(BaseLock):
             self.lock.entity_id,
             lock_info,
         )
-
-    async def async_is_integration_connected(self) -> bool:
-        """Return whether the Matter integration is loaded."""
-        if not self.lock_config_entry:
-            return False
-        return self.lock_config_entry.state == ConfigEntryState.LOADED
 
     async def async_is_device_available(self) -> bool:
         """Return whether the Matter lock device is available for commands."""

--- a/custom_components/lock_code_manager/providers/schlage.py
+++ b/custom_components/lock_code_manager/providers/schlage.py
@@ -19,40 +19,18 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import timedelta
-import re
 
-from homeassistant.config_entries import ConfigEntry, ConfigEntryState
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 
 from ..data import get_managed_slots
 from ..exceptions import LockCodeManagerProviderError, LockDisconnected
 from ..models import SlotCode
 from ._base import BaseLock
+from ._util import make_tagged_name as _make_tagged_name, parse_tag as _parse_tag
 from .const import LOGGER
 
 SCHLAGE_DOMAIN = "schlage"
-
-# Regex to parse the Lock Code Manager slot tag from code names.
-# Format: [LCM:XX] Friendly Name
-_SLOT_TAG_RE = re.compile(r"^\[LCM:(\d+)\]\s*(.*)")
-
-
-def _make_tagged_name(slot_num: int, name: str | None = None) -> str:
-    """Create a tagged code name with Lock Code Manager slot number."""
-    base = name or f"Code Slot {slot_num}"
-    return f"[LCM:{slot_num}] {base}"
-
-
-def _parse_tag(name: str) -> tuple[int | None, str]:
-    """Parse a Lock Code Manager slot tag from a code name.
-
-    Returns ``(slot_num, friendly_name)`` when a tag is present, or
-    ``(None, original_name)`` when no tag is found.
-    """
-    match = _SLOT_TAG_RE.match(name)
-    if match:
-        return int(match.group(1)), match.group(2)
-    return None, name
 
 
 @dataclass(repr=False, eq=False)
@@ -93,18 +71,12 @@ class SchlageLock(BaseLock):
         Returns a dict mapping access-code IDs to ``{"name": ..., "code": ...}``.
         """
         entity_id = self.lock.entity_id
-        try:
-            response = await self.hass.services.async_call(
-                SCHLAGE_DOMAIN,
-                "get_codes",
-                service_data={"entity_id": entity_id},
-                blocking=True,
-                return_response=True,
-            )
-        except (ServiceValidationError, HomeAssistantError) as err:
-            raise LockDisconnected(
-                f"Schlage get_codes failed for {entity_id}: {err}"
-            ) from err
+        response = await self.async_call_service(
+            SCHLAGE_DOMAIN,
+            "get_codes",
+            service_data={"entity_id": entity_id},
+            return_response=True,
+        )
 
         if not isinstance(response, dict):
             raise LockCodeManagerProviderError(
@@ -150,12 +122,6 @@ class SchlageLock(BaseLock):
             raise LockDisconnected(
                 f"Schlage delete_code failed for {entity_id}: {err}"
             ) from err
-
-    async def async_is_integration_connected(self) -> bool:
-        """Return whether the Schlage integration is loaded."""
-        if not self.lock_config_entry:
-            return False
-        return self.lock_config_entry.state == ConfigEntryState.LOADED
 
     async def async_is_device_available(self) -> bool:
         """Return whether the Schlage lock device is available for commands."""

--- a/custom_components/lock_code_manager/websocket.py
+++ b/custom_components/lock_code_manager/websocket.py
@@ -96,7 +96,7 @@ from .const import (
     DOMAIN,
     EVENT_PIN_USED,
 )
-from .data import get_entry_config
+from .data import get_entry_config, get_managed_slots
 from .helpers import (
     async_clear_slot_condition,
     async_clear_usercode,
@@ -386,16 +386,6 @@ def _serialize_slot(
     return result
 
 
-def _get_managed_slots(hass: HomeAssistant, lock_entity_id: str) -> set[int]:
-    """Return slot numbers managed by LCM for a given lock."""
-    return {
-        slot_num
-        for entry in hass.config_entries.async_entries(DOMAIN)
-        if (config := get_entry_config(entry)).has_lock(lock_entity_id)
-        for slot_num in config.slots
-    }
-
-
 @dataclass
 class SlotEntities:
     """Entity IDs for a single slot's LCM entities.
@@ -549,7 +539,7 @@ def _serialize_lock_coordinator(
     """Serialize coordinator data for a lock."""
     coordinator = lock.coordinator
     data = coordinator.data if coordinator is not None else {}
-    managed_slots = _get_managed_slots(hass, lock.lock.entity_id)
+    managed_slots = get_managed_slots(hass, lock.lock.entity_id)
     slot_metadata = _get_slot_metadata(hass, lock.lock.entity_id)
     slot_entity_ids = _get_slot_entity_ids(hass, lock.lock.entity_id)
 

--- a/custom_components/lock_code_manager/websocket.py
+++ b/custom_components/lock_code_manager/websocket.py
@@ -331,14 +331,6 @@ async def get_config_entry_data(
     )
 
 
-def _slot_sort_key(slot: Any) -> tuple[int, str]:
-    """Return a stable sort key for slot numbers that may be non-numeric."""
-    try:
-        return (0, f"{int(slot):010d}")
-    except (TypeError, ValueError):
-        return (1, str(slot))
-
-
 def _serialize_slot(
     slot: Any,
     code: str | SlotCode | None,
@@ -394,29 +386,14 @@ def _serialize_slot(
     return result
 
 
-def _slot_variants(slot: Any) -> set[Any]:
-    """Return comparable variants of a slot identifier (string/int)."""
-    variants: set[Any] = {slot}
-    try:
-        slot_int = int(slot)
-    except (TypeError, ValueError):
-        variants.add(str(slot))
-    else:
-        variants.add(slot_int)
-        variants.add(str(slot_int))
-    return variants
-
-
-def _get_managed_slots(hass: HomeAssistant, lock_entity_id: str) -> set[Any]:
-    """Return slot identifiers managed by LCM for a given lock."""
-    managed_slots: set[Any] = set()
-    for entry in hass.config_entries.async_entries(DOMAIN):
-        config = get_entry_config(entry)
-        if not config.has_lock(lock_entity_id):
-            continue
-        for slot_num in config.slots:
-            managed_slots.update(_slot_variants(slot_num))
-    return managed_slots
+def _get_managed_slots(hass: HomeAssistant, lock_entity_id: str) -> set[int]:
+    """Return slot numbers managed by LCM for a given lock."""
+    return {
+        slot_num
+        for entry in hass.config_entries.async_entries(DOMAIN)
+        if (config := get_entry_config(entry)).has_lock(lock_entity_id)
+        for slot_num in config.slots
+    }
 
 
 @dataclass
@@ -576,31 +553,24 @@ def _serialize_lock_coordinator(
     slot_metadata = _get_slot_metadata(hass, lock.lock.entity_id)
     slot_entity_ids = _get_slot_entity_ids(hass, lock.lock.entity_id)
 
-    def _get_metadata(slot: Any) -> SlotMetadata | None:
-        if str(slot).isdigit():
-            return slot_metadata.get(int(slot))
-        return None
-
-    def _get_config_entry_id(slot: Any) -> str | None:
-        if str(slot).isdigit():
-            slot_ids = slot_entity_ids.get(int(slot))
-            return slot_ids.config_entry_id if slot_ids else None
-        return None
-
     slots = []
-    for slot, code in sorted(data.items(), key=lambda item: _slot_sort_key(item[0])):
-        meta = _get_metadata(slot)
+    # `data` is int-keyed (coordinator normalizes); managed_slots is also
+    # int-keyed (built from EntryConfig.slots). All slot lookups below are
+    # plain int operations — no str/int variant gymnastics needed.
+    for slot, code in sorted(data.items()):
+        meta = slot_metadata.get(slot)
+        slot_ids = slot_entity_ids.get(slot)
         slots.append(
             _serialize_slot(
                 slot,
                 code,
                 reveal=reveal,
                 name=meta.name if meta else None,
-                managed=slot in managed_slots or str(slot) in managed_slots,
+                managed=slot in managed_slots,
                 configured_code=meta.configured_pin if meta else None,
                 active=meta.active if meta else None,
                 enabled=meta.enabled if meta else None,
-                config_entry_id=_get_config_entry_id(slot),
+                config_entry_id=slot_ids.config_entry_id if slot_ids else None,
             )
         )
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -70,39 +70,25 @@ class MockLCMLock(BaseLock):
         """Return integration domain."""
         return "test"
 
-    @callback
-    def setup(self) -> None:
-        """Set up lock."""
-
-    @callback
-    def unload(self, remove_permanently: bool) -> None:
-        """Unload lock."""
-
     def set_connected(self, connected: bool) -> None:
         """Set connection state for testing."""
         self._connected = connected
 
-    def is_integration_connected(self) -> bool:
+    async def async_is_integration_connected(self) -> bool:
         """Return whether the integration's client/driver/broker is connected."""
         return self._connected
 
-    def hard_refresh_codes(self) -> dict[int, str | SlotCode]:
-        """
-        Perform hard refresh all codes.
-
-        Needed for integrations where usercodes are cached and may get out of sync
-        with the lock.
-        """
+    async def async_hard_refresh_codes(self) -> dict[int, str | SlotCode]:
+        """Perform hard refresh of all codes."""
         self.service_calls["hard_refresh_codes"].append(())
-        return self.get_usercodes()
+        return await self.async_get_usercodes()
 
-    def set_usercode(
+    async def async_set_usercode(
         self, code_slot: int, usercode: str, name: str | None = None
     ) -> bool:
-        """
-        Set a usercode on a code slot.
+        """Set a usercode on a code slot.
 
-        Returns True if the value was changed, False if already set to this value.
+        Returns True if the value was changed, False if already set.
         """
         if self.codes.get(code_slot) == usercode:
             return False
@@ -110,9 +96,8 @@ class MockLCMLock(BaseLock):
         self.service_calls["set_usercode"].append((code_slot, usercode, name))
         return True
 
-    def clear_usercode(self, code_slot: int) -> bool:
-        """
-        Clear a usercode on a code slot.
+    async def async_clear_usercode(self, code_slot: int) -> bool:
+        """Clear a usercode on a code slot.
 
         Returns True if the value was changed, False if already cleared.
         """
@@ -122,18 +107,8 @@ class MockLCMLock(BaseLock):
         self.service_calls["clear_usercode"].append((code_slot,))
         return True
 
-    def get_usercodes(self) -> dict[int, str | SlotCode]:
-        """
-        Get dictionary of code slots and usercodes.
-
-        Called by data coordinator to get data for code slot sensors.
-
-        Key is code slot, value is usercode, e.g.:
-        {
-            1: '1234',
-            'B': '5678',
-        }
-        """
+    async def async_get_usercodes(self) -> dict[int, str | SlotCode]:
+        """Return dictionary of code slots and usercodes."""
         snapshot = self.codes.copy()
         self.service_calls["get_usercodes"].append(snapshot)
         return snapshot

--- a/tests/providers/test_akuvox.py
+++ b/tests/providers/test_akuvox.py
@@ -620,7 +620,11 @@ class TestListUsersErrors:
             hass, AKUVOX_DOMAIN, "list_users", AsyncMock(return_value="not a dict")
         )
 
-        with pytest.raises(LockDisconnected, match="Failed to list users"):
+        # The base async_call_service wrapper re-raises any failure as
+        # LockDisconnected with the standard "Service call X.Y failed" prefix.
+        with pytest.raises(
+            LockDisconnected, match="Service call local_akuvox.list_users failed"
+        ):
             await akuvox_lock.async_get_usercodes()
 
     async def test_list_users_malformed_entity_response(

--- a/tests/providers/test_base.py
+++ b/tests/providers/test_base.py
@@ -9,6 +9,7 @@ import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from homeassistant.core import HomeAssistant, State, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from custom_components.lock_code_manager.const import (
@@ -359,23 +360,44 @@ async def test_async_call_service_raises_lock_disconnected_on_error(
     mock_lock_config_entry,
     lock_code_manager_config_entry,
 ):
-    """Test that async_call_service raises LockDisconnected when service call fails."""
+    """Test that async_call_service wraps HA service errors as LockDisconnected."""
     lock_provider = lock_code_manager_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
 
-    # Register a service that raises an error
     async def failing_service(call):
-        raise ValueError("Service failed")
+        raise HomeAssistantError("Service failed")
 
     hass.services.async_register("test_domain", "failing_service", failing_service)
 
-    # Calling a failing service should raise LockDisconnected
     with pytest.raises(
         LockDisconnected, match="Service call test_domain.failing_service failed"
     ):
         await lock_provider.async_call_service("test_domain", "failing_service", {})
 
-    # Clean up
     hass.services.async_remove("test_domain", "failing_service")
+
+
+async def test_async_call_service_propagates_non_ha_exceptions(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """Non-HomeAssistantError exceptions must propagate, not become LockDisconnected.
+
+    Wrapping programming errors (TypeError) or shutdown signals
+    (asyncio.CancelledError) as LockDisconnected would trigger false
+    "lock offline" issues, drift backoff, and push-resub loops.
+    """
+    lock_provider = lock_code_manager_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
+
+    async def buggy_service(call):
+        raise TypeError("programmer made a mistake")
+
+    hass.services.async_register("test_domain", "buggy_service", buggy_service)
+
+    with pytest.raises(TypeError, match="programmer made a mistake"):
+        await lock_provider.async_call_service("test_domain", "buggy_service", {})
+
+    hass.services.async_remove("test_domain", "buggy_service")
 
 
 async def test_set_usercode_refreshes_coordinator_on_change(

--- a/tests/providers/test_base.py
+++ b/tests/providers/test_base.py
@@ -723,7 +723,6 @@ async def test_is_device_available_default_returns_true(hass: HomeAssistant):
     )
 
     # Default implementation returns True
-    assert lock.is_device_available() is True
     assert await lock.async_is_device_available() is True
 
 

--- a/tests/providers/test_base.py
+++ b/tests/providers/test_base.py
@@ -90,19 +90,23 @@ async def test_base(hass: HomeAssistant):
     assert lock.usercode_scan_interval == timedelta(minutes=1)
     with pytest.raises(NotImplementedError):
         assert lock.domain
-    with pytest.raises(NotImplementedError):
-        await lock.async_internal_is_integration_connected()
-    # Note: hard_refresh, set, and clear operations now check connection first,
-    # so they raise NotImplementedError from is_integration_connected() instead of
-    # the expected error from the unimplemented method
-    with pytest.raises(NotImplementedError):
-        await lock.async_internal_hard_refresh_codes()
-    with pytest.raises(NotImplementedError):
-        await lock.async_internal_clear_usercode(1)
-    with pytest.raises(NotImplementedError):
-        await lock.async_internal_set_usercode(1, "1234")
-    with pytest.raises(NotImplementedError):
-        await lock.async_internal_get_usercodes()
+    # async_is_integration_connected has a sensible default — it returns
+    # False here because the test config entry isn't in the LOADED state.
+    assert await lock.async_internal_is_integration_connected() is False
+    # hard_refresh / set / clear / get all check connection first via
+    # _execute_rate_limited; since the default connection check returned
+    # False above, they raise LockDisconnected before reaching the abstract
+    # method that would raise NotImplementedError. Patch the connection
+    # check to True so we actually exercise the abstract methods.
+    with patch.object(BaseLock, "async_is_integration_connected", return_value=True):
+        with pytest.raises(NotImplementedError):
+            await lock.async_internal_hard_refresh_codes()
+        with pytest.raises(NotImplementedError):
+            await lock.async_internal_clear_usercode(1)
+        with pytest.raises(NotImplementedError):
+            await lock.async_internal_set_usercode(1, "1234")
+        with pytest.raises(NotImplementedError):
+            await lock.async_internal_get_usercodes()
 
 
 async def test_config_entry_state_change_resubscribes(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -45,25 +45,25 @@ class MockLockWithHardRefresh(BaseLock):
         """Return configurable hard refresh interval."""
         return self._hard_refresh_interval
 
-    def is_integration_connected(self) -> bool:
+    async def async_is_integration_connected(self) -> bool:
         """Return whether the integration's client/driver/broker is connected."""
         return self._is_connected
 
-    def hard_refresh_codes(self) -> dict[int, str | None]:
+    async def async_hard_refresh_codes(self) -> dict[int, str | None]:
         """Perform hard refresh and return all codes."""
-        return self.get_usercodes()
+        return await self.async_get_usercodes()
 
-    def get_usercodes(self) -> dict[int, str | None]:
-        """Get dictionary of code slots and usercodes."""
+    async def async_get_usercodes(self) -> dict[int, str | None]:
+        """Return dictionary of code slots and usercodes."""
         return {}
 
-    def set_usercode(
+    async def async_set_usercode(
         self, code_slot: int, usercode: str, name: str | None = None
     ) -> bool:
         """Set a usercode on a code slot."""
         return True
 
-    def clear_usercode(self, code_slot: int) -> bool:
+    async def async_clear_usercode(self, code_slot: int) -> bool:
         """Clear a usercode on a code slot."""
         return True
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -539,8 +539,9 @@ async def test_drift_check_calls_hard_refresh(
 
     coordinator = LockUsercodeUpdateCoordinator(hass, lock, config_entry)
 
-    # Mock the hard refresh method
-    mock_hard_refresh = AsyncMock()
+    # Mock the hard refresh method. Return a real dict so the coordinator's
+    # int-key normalization (applied to drift-check results) can iterate it.
+    mock_hard_refresh = AsyncMock(return_value={1: "1234"})
 
     with patch.object(lock, "async_internal_hard_refresh_codes", mock_hard_refresh):
         await coordinator._async_drift_check(dt_util.utcnow())

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,6 +1,7 @@
 """Test the exceptions module."""
 
 from dataclasses import dataclass
+import inspect
 
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -138,7 +139,7 @@ async def test_base_lock_raises_provider_not_implemented(
         # async methods return coroutines that raise on await; sync raise
         # immediately when called — this with block captures both shapes.
         result = call(lock)
-        if hasattr(result, "__await__"):
+        if inspect.isawaitable(result):
             await result
 
     assert "MinimalMockLock" in str(exc_info.value)

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -30,7 +30,7 @@ class MinimalMockLock(BaseLock):
         """Return integration domain."""
         return "test"
 
-    def is_integration_connected(self) -> bool:
+    async def async_is_integration_connected(self) -> bool:
         """Return whether the integration's client/driver/broker is connected."""
         return True
 
@@ -108,10 +108,13 @@ def test_provider_not_implemented_error_inherits_correctly():
 @pytest.mark.parametrize(
     ("method_name", "call"),
     [
-        ("get_usercodes", lambda lock: lock.get_usercodes()),
-        ("set_usercode", lambda lock: lock.set_usercode(1, "1234")),
-        ("clear_usercode", lambda lock: lock.clear_usercode(1)),
-        ("hard_refresh_codes", lambda lock: lock.hard_refresh_codes()),
+        ("async_get_usercodes", lambda lock: lock.async_get_usercodes()),
+        ("async_set_usercode", lambda lock: lock.async_set_usercode(1, "1234")),
+        ("async_clear_usercode", lambda lock: lock.async_clear_usercode(1)),
+        ("async_hard_refresh_codes", lambda lock: lock.async_hard_refresh_codes()),
+        # setup_push_subscription / teardown_push_subscription are still sync
+        # — they're called synchronously in the push lifecycle code paths and
+        # raise NotImplementedError directly when not overridden.
         (
             "setup_push_subscription",
             lambda lock: lock.setup_push_subscription(),
@@ -125,14 +128,18 @@ def test_provider_not_implemented_error_inherits_correctly():
 async def test_base_lock_raises_provider_not_implemented(
     hass: HomeAssistant, method_name: str, call
 ):
-    """Test that BaseLock raises ProviderNotImplementedError for unimplemented methods."""
+    """Test BaseLock raises ProviderNotImplementedError for unimplemented methods."""
     config_entry = MockConfigEntry(domain=DOMAIN)
     config_entry.add_to_hass(hass)
 
     lock = create_minimal_lock(hass, config_entry)
 
     with pytest.raises(ProviderNotImplementedError) as exc_info:
-        call(lock)
+        # async methods return coroutines that raise on await; sync raise
+        # immediately when called — this with block captures both shapes.
+        result = call(lock)
+        if hasattr(result, "__await__"):
+            await result
 
     assert "MinimalMockLock" in str(exc_info.value)
     assert method_name in str(exc_info.value)


### PR DESCRIPTION
## Proposed change

Three independent cleanup items from the [complexity audit](https://github.com/raman325/lock_code_manager/pull/1033#issuecomment-) bundled into one PR. All low-risk, all reduce LOC, all clear the way for a followup conversation about the bigger SlotSyncManager question.

### Item 1: Coordinator normalizes int slot keys ([commit](https://github.com/raman325/lock_code_manager/commit/8250150))

Adds `{int(k): v for k, v in data.items()}` cast in `coordinator.async_get_usercodes` so `coordinator.data` is guaranteed int-keyed regardless of provider implementation. Finishes the EntryConfig migration's last unfinished boundary.

The defensive str/int gymnastics in `websocket.py` become dead code:
- Deleted `_slot_variants` and `_slot_sort_key`
- Simplified `_get_managed_slots` to `set[int]`
- Simplified `_serialize_lock_coordinator`: drops helper closures, drops `or str(slot) in managed_slots`, drops `str(slot).isdigit()` guards

### Item 3: Drop sync method tier from BaseLock ([commit](https://github.com/raman325/lock_code_manager/commit/f909967))

Every in-tree provider implements `async_*` methods directly; the sync stubs (`set_usercode`, `clear_usercode`, etc.) and the `_async_executor_call` bridge that wrapped them were dead pass-through code. ~120 LOC removed from `_base.py`.

Test mocks (`tests/common.py`, `tests/test_coordinator.py`, `tests/test_exceptions.py`) updated to implement `async_*` methods.

**Clean break, no deprecation cycle** (per maintainer direction — out-of-tree providers, if any, must be updated to async-only).

### Item 4: Lift duplicated provider methods ([commit](https://github.com/raman325/lock_code_manager/commit/5a1a92c))

Three sub-items rolled together (all "dedupe provider boilerplate"):

**(a)** `async_is_integration_connected` default in `BaseLock` — body was byte-identical in matter/schlage/akuvox. zwave_js and virtual keep their custom impls.

**(b)** `make_tagged_name` / `parse_tag` moved to new `providers/_util.py` — were byte-equal in schlage and akuvox.

**(c)** `BaseLock.async_call_service` supports `return_response` and `target` — schlage and akuvox previously had inline `hass.services.async_call(..., return_response=True)` blocks with their own try/except wrappers.

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Additional information

- 602 tests pass, all pre-commit hooks clean
- Net diff: removes ~250 LOC of dead/duplicated code
- Out-of-scope (deferred to its own design discussion): the `SlotSyncManager` per-(lock, slot) → coordinator-per-lock refactor — flagged in the audit as the largest potential cleanup, requires planning