### PR TITLE
Audit pass: trim historical docstrings, prune noise comments, add value-add comments

### DIFF
--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -489,6 +489,9 @@ async def async_setup_entry(
     if hass.state == CoreState.running:
         _setup_entry_after_start(hass, config_entry)
     else:
+        # async_listen_once self-unsubscribes when it fires, so calling
+        # unsub() again would error. Track whether it fired so unload only
+        # tears down the listener if HA never started before unload.
         started = [False]
 
         @callback
@@ -540,13 +543,7 @@ async def async_unload_lock(
 async def async_unload_entry(
     hass: HomeAssistant, config_entry: LockCodeManagerConfigEntry
 ) -> bool:
-    """Handle removal of an entry.
-
-    Routes through the same lock-removed and slot-removed callbacks that
-    async_update_listener uses, so that entities are notified symmetrically
-    on unload just as they are during a config update that removes all
-    slots and locks.
-    """
+    """Unload an entry, firing slot- and lock-removed callbacks before tearing down platforms."""
     hass_data = hass.data[DOMAIN]
     runtime_data = config_entry.runtime_data
     callbacks = runtime_data.callbacks
@@ -581,9 +578,7 @@ async def async_unload_entry(
     if unload_ok:
         await async_unload_lock(hass, config_entry)
 
-        # Clean up repair issues for this config entry. EntryConfig handles
-        # the data-vs-options precedence (matters during the data→options
-        # migration that happens early in setup).
+        # Clean up repair issues for this config entry.
         entry_id = config_entry.entry_id
         config = get_entry_config(config_entry)
         for slot_num in config.slots:
@@ -795,9 +790,6 @@ async def async_update_listener(
         )
     await asyncio.gather(*setup_tasks.values())
 
-    # Identify changes that need to be made. The `-` operator on
-    # EntryConfig is sugar for EntryConfigDiff(old=..., new=...) — both
-    # configs are int-keyed by construction so no normalization needed.
     diff = old_config - new_config
     slots_to_add = diff.slots_added
     slots_to_remove = diff.slots_removed

--- a/custom_components/lock_code_manager/binary_sensor.py
+++ b/custom_components/lock_code_manager/binary_sensor.py
@@ -1,13 +1,4 @@
-"""Binary sensor entities for lock_code_manager.
-
-LockCodeManagerActiveEntity: PIN active status (enabled + conditions met).
-LockCodeManagerCodeSlotInSyncEntity: Per-lock sync status — thin observer
-    that delegates all sync logic to SlotSyncManager.
-
-Sync logic (state comparison, set/clear operations, circuit breaking) is
-implemented in SlotSyncManager (sync.py) to separate domain logic from
-entity state display.
-"""
+"""Binary sensor entities for lock_code_manager."""
 
 from __future__ import annotations
 
@@ -239,11 +230,7 @@ class LockCodeManagerCodeSlotInSyncEntity(
     CoordinatorEntity[LockUsercodeUpdateCoordinator],
     BinarySensorEntity,
 ):
-    """PIN synced binary sensor entity for lock code manager.
-
-    Thin observer that delegates all sync logic to SlotSyncManager.
-    Reads manager.in_sync for display state.
-    """
+    """PIN synced binary sensor entity for lock code manager."""
 
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 

--- a/custom_components/lock_code_manager/callbacks.py
+++ b/custom_components/lock_code_manager/callbacks.py
@@ -1,9 +1,7 @@
-"""
-Typed callback registry for entity lifecycle management.
+"""Typed callback registry for entity lifecycle management.
 
-This module replaces the HA dispatcher mechanism with a type-safe callback
-registry pattern. Platforms register callbacks for entity creation, and entities
-register callbacks for their own removal.
+Platforms register entity-creation callbacks; entities register
+their own removal callbacks.
 """
 
 from __future__ import annotations
@@ -65,12 +63,7 @@ UnregisterFunc = Callable[[], None]
 
 @dataclass
 class EntityCallbackRegistry:
-    """
-    Registry of entity lifecycle callbacks.
-
-    This replaces the HA dispatcher pattern with explicit, typed callbacks.
-    Platforms register their entity creation callbacks here, and entities
-    register their removal callbacks.
+    """Registry of entity lifecycle callbacks.
 
     Entity Types:
         Standard: Entities created once per slot (e.g., enabled switch, name/PIN

--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -119,14 +119,7 @@ def _check_common_slots(
 
 
 class _LockQuerySkipped(LockCodeManagerError):
-    """Raised when a lock should be skipped before any provider call.
-
-    Used internally by ``_async_build_lock_instance`` to signal one of the
-    three expected setup-time skip conditions (missing entity, unsupported
-    platform, missing config entry). Subclasses ``LockCodeManagerError`` (not
-    ``LockCodeManagerProviderError``) because it doesn't originate from a
-    provider — the lock provider is never even constructed.
-    """
+    """Raised when a lock should be skipped before any provider call."""
 
 
 def _async_build_lock_instance(
@@ -139,10 +132,7 @@ def _async_build_lock_instance(
 
     Performs setup-time checks (entity in registry, supported platform,
     parent config entry exists) and instantiates the provider class.
-
-    Raises ``_LockQuerySkipped`` if any setup-time check fails. The provider
-    constructor itself is not wrapped — failures there propagate as
-    unexpected exceptions and are caught one level up.
+    Raises ``_LockQuerySkipped`` if any setup-time check fails.
     """
     lock_entry = ent_reg.async_get(lock_entity_id)
     if not lock_entry:
@@ -179,19 +169,11 @@ async def _async_get_all_codes(
 ) -> tuple[dict[str, dict[int, str | SlotCode]], dict[str, Any]]:
     """Query locks for all usercodes.
 
-    Returns a tuple of:
-    - Dict keyed by lock entity ID, each value being a dict of slot number to
-      code value (including SlotCode.EMPTY for empty slots). Callers must
-      filter as needed.
-    - Dict keyed by lock entity ID to temporary lock provider instances, for
-      reuse in clearing slots.
-
-    Locks are skipped (with logging) for these failure modes:
-    - Setup-time skip (entity missing, unsupported platform, etc.) → DEBUG
-    - Provider failure (e.g. ``LockDisconnected``) → WARNING with details
-    - Bare ``LockCodeManagerError`` from a provider that hasn't migrated
-      to ``LockCodeManagerProviderError`` → WARNING with details
-    - Unexpected exception → WARNING with traceback
+    Returns ``(codes_by_lock, lock_instances_by_lock)`` where ``codes_by_lock``
+    maps each lock entity ID to its slot/code dict (``SlotCode.EMPTY`` for
+    empty slots) and ``lock_instances_by_lock`` retains the provider
+    instances so the caller can reuse them when clearing slots. Locks that
+    fail to query are skipped with logging.
     """
     result: dict[str, dict[int, str | SlotCode]] = {}
     lock_instances: dict[str, Any] = {}
@@ -217,12 +199,8 @@ async def _async_get_all_codes(
             )
             continue
         except LockCodeManagerError as err:
-            # Defensive: a provider raised the bare base class. Treat as
-            # a real failure (not a setup-time skip — those use
-            # _LockQuerySkipped) but warn without traceback so it stays
-            # actionable. All in-tree providers raise
-            # LockCodeManagerProviderError; this catches third-party or
-            # not-yet-migrated providers.
+            # Defensive fallback for third-party providers that raise the
+            # bare base class instead of LockCodeManagerProviderError.
             _LOGGER.warning(
                 "Failed to get usercodes from %s: %s",
                 lock_entity_id,
@@ -230,6 +208,10 @@ async def _async_get_all_codes(
             )
             continue
         except Exception:  # noqa: BLE001
+            # Last-resort catch: this runs in the user-facing config flow.
+            # Any provider exception (including programmer error in a
+            # third-party provider) must degrade to "no codes shown" rather
+            # than aborting the flow.
             _LOGGER.warning(
                 "Failed to get usercodes from %s; this lock's codes will not be shown",
                 lock_entity_id,
@@ -248,14 +230,7 @@ def _scope_codes_to_pairs(
     lock_instances: dict[str, Any],
     pairs: Iterable[tuple[str, int]],
 ) -> tuple[dict[str, dict[int, str | SlotCode]], dict[str, Any]]:
-    """Filter raw query results to only the ``(lock, slot)`` pairs given.
-
-    Used by the options flow so the mixin's clearing logic cannot touch
-    already-managed ``(lock, slot)`` pairs even though they appear in the
-    raw query result. The mixin's ``_clear_existing_slot`` only iterates
-    pairs present in ``_all_codes``, so scoping there constrains the blast
-    radius without the mixin needing to know about pairs.
-    """
+    """Filter raw query results to only the ``(lock, slot)`` pairs given."""
     scoped_codes: dict[str, dict[int, str | SlotCode]] = {}
     for lock, slot in pairs:
         if (code := all_codes.get(lock, {}).get(slot)) is not None:
@@ -265,15 +240,7 @@ def _scope_codes_to_pairs(
 
 
 class _ExistingCodesFlowMixin:
-    """Mixin providing existing-codes detection, confirm UI, and clearing.
-
-    Inheriting flow must call ``_init_existing_codes_state()`` from its
-    ``__init__``. Before showing the confirm step, populate ``_all_codes``
-    and ``_lock_instances`` (typically from ``_async_get_all_codes``),
-    set ``_slots_to_clear`` (typically via ``_slots_with_existing_codes``),
-    and assign ``_next_step`` to the coroutine to run after the user
-    confirms clearing.
-    """
+    """Mixin providing existing-codes detection, confirm UI, and clearing for config/options flows."""
 
     _all_codes: dict[str, dict[int, str | SlotCode]]
     _lock_instances: dict[str, Any]
@@ -334,17 +301,7 @@ class _ExistingCodesFlowMixin:
     async def _clear_then_create_entry(
         self, *, title: str, data: dict[str, Any]
     ) -> dict[str, Any]:
-        """Clear pending slots, then create the entry.
-
-        Used by both the config flow and the options flow as the persist
-        target after the user confirms clearing. Bind ``title``/``data``
-        via ``functools.partial`` when assigning ``_next_step``, or call
-        directly when no confirmation step is required.
-
-        Clearing happens BEFORE ``async_create_entry()`` because
-        ``async_create_entry()`` only builds a FlowResult dict — the entry
-        isn't persisted until after this step returns.
-        """
+        """Clear pending slots, then create the entry."""
         await self._clear_all_pending_slots()
         return self.async_create_entry(  # type: ignore[attr-defined]
             title=title, data=data
@@ -685,10 +642,6 @@ class LockCodeManagerOptionsFlow(_ExistingCodesFlowMixin, config_entries.Options
         current configuration. If any newly-added pair has a non-empty
         code on its lock, show the confirmation step before persisting.
         """
-        # Same diff API as the update listener — the `-` operator on
-        # EntryConfig returns an EntryConfigDiff. user_input has int slot
-        # keys (voluptuous coerced) and current entry data is normalized
-        # by EntryConfig.from_mapping, so the diff is consistent.
         diff = get_entry_config(self.config_entry) - EntryConfig.from_mapping(
             user_input
         )

--- a/custom_components/lock_code_manager/coordinator.py
+++ b/custom_components/lock_code_manager/coordinator.py
@@ -97,16 +97,7 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator[dict[int, str | SlotCo
     def _normalize_keys(
         data: dict[Any, str | SlotCode],
     ) -> dict[int, str | SlotCode]:
-        """Coerce slot keys to ``int``.
-
-        The single chokepoint that enforces the ``coordinator.data`` int-key
-        invariant. Applied at every write site (poll, push, drift-check) so
-        downstream consumers (websocket serializer, listeners) can rely on
-        plain int membership/sorting without defensive str/int gymnastics.
-
-        Raises ``ValueError``/``TypeError`` if a key cannot be cast — that's
-        a programming error worth surfacing rather than poisoning the cache.
-        """
+        """Coerce slot keys to ``int``. Raises ValueError/TypeError if a key cannot be cast."""
         return {int(k): v for k, v in data.items()}
 
     @callback
@@ -190,18 +181,15 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator[dict[int, str | SlotCo
         )
 
     async def async_get_usercodes(self) -> dict[int, str | SlotCode]:
-        """Update usercodes.
-
-        Routes the provider response through ``_normalize_keys`` — the
-        chokepoint that guarantees ``coordinator.data`` is always int-keyed,
-        regardless of which provider produced it. See ``_normalize_keys``
-        for rationale.
-        """
+        """Fetch usercodes from the provider, normalize slot keys to int, and apply backoff handling."""
         try:
             data = await self._lock.async_internal_get_usercodes()
         except LockCodeManagerError as err:
             self._apply_backoff()
-            # We can silently fail if we've never been able to retrieve data
+            # During cold start (no successful poll yet) we must not raise
+            # UpdateFailed — it would mark entities unavailable forever
+            # instead of letting them appear and recover when the lock
+            # connects.
             if not self.last_update_success:
                 return {}
             raise UpdateFailed from err
@@ -249,10 +237,6 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator[dict[int, str | SlotCo
         # Push subscription retry is handled by BaseLock's OneShotRetry
         # and the config entry state listener — no need to retry here.
 
-        # Compare with current data and notify if changed.
-        # Both sides are int-keyed (poll path normalized, this path normalized
-        # above) so the equality check won't spuriously trigger on key-type
-        # mismatch.
         if new_data != self.data:
             _LOGGER.debug(
                 "Drift detected for %s, updating coordinator data",

--- a/custom_components/lock_code_manager/coordinator.py
+++ b/custom_components/lock_code_manager/coordinator.py
@@ -186,10 +186,10 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator[dict[int, str | SlotCo
             data = await self._lock.async_internal_get_usercodes()
         except LockCodeManagerError as err:
             self._apply_backoff()
-            # During cold start (no successful poll yet) we must not raise
-            # UpdateFailed — it would mark entities unavailable forever
-            # instead of letting them appear and recover when the lock
-            # connects.
+            # During cold start (before the first successful poll), do not
+            # raise UpdateFailed. That would fail the initial refresh and
+            # keep coordinator-backed entities unavailable until a
+            # successful poll completes.
             if not self.last_update_success:
                 return {}
             raise UpdateFailed from err

--- a/custom_components/lock_code_manager/data.py
+++ b/custom_components/lock_code_manager/data.py
@@ -19,23 +19,16 @@ _EMPTY_SLOTS: Mapping[int, Mapping[str, Any]] = MappingProxyType({})
 class EntryConfig:
     """Typed, normalized view of an LCM entry's configuration.
 
-    Single chokepoint for reading entry config: the on-disk representation
-    has ``str`` slot keys (JSON storage) while voluptuous-validated user
-    input has ``int`` keys. ``EntryConfig`` normalizes to ``int`` keys
-    once at construction so every downstream consumer can treat slot
-    numbers uniformly. The defensive ``slot if slot in d else str(slot)``
-    patterns scattered across the codebase exist precisely because there
-    was no such chokepoint before.
+    Slot keys are normalized to ``int`` at construction (the on-disk
+    JSON representation uses ``str``; voluptuous-validated user input
+    uses ``int``). ``slots`` is a deeply read-only mapping
+    (``MappingProxyType`` at both levels) so instances can be cached
+    without defensive copies.
 
-    ``slots`` is a deeply read-only mapping (``MappingProxyType`` at both
-    levels) so callers can keep an ``EntryConfig`` as cached state without
-    defensive copies.
-
-    Lifecycle: an instance is cached on
-    ``LockCodeManagerConfigEntryData.config`` and refreshed by the update
-    listener whenever the entry is mutated. Most callers should access it
-    via ``entry.runtime_data.config`` directly. Iteration helpers that
-    walk ``hass.config_entries.async_entries(DOMAIN)`` use
+    An instance is cached on ``LockCodeManagerConfigEntryData.config``
+    and refreshed by the update listener. Most callers should access it
+    via ``entry.runtime_data.config``. Iteration helpers that walk
+    ``hass.config_entries.async_entries(DOMAIN)`` use
     :func:`get_entry_config` to handle the unloaded-entry case.
     """
 
@@ -260,21 +253,9 @@ class EntryConfigDiff:
       uses to detect existing-codes hazards on newly-added pairs (catches
       both "new slot on existing lock" and "new lock with existing slot").
 
-    All slot keys (in ``slots_added`` / ``slots_removed`` /
-    ``slots_unchanged`` / ``pairs_added`` / ``pairs_removed``) are
-    guaranteed ``int`` — :class:`EntryConfig` already normalizes its
-    storage so the diff inherits that.
-
-    **Immutability**: the dataclass is frozen, and all containers are
-    deeply immutable (``MappingProxyType`` for dicts, ``frozenset`` for
-    sets, ``tuple`` for lists) so callers can use this safely as cached
-    state without defensive copies.
+    All slot keys are ``int``, inherited from :class:`EntryConfig`.
     """
 
-    # Source configs — readable after construction (useful for logging,
-    # debugging, and tests). Default to EntryConfig.empty() so callers
-    # can omit either side for the "all added" / "all removed" cases:
-    # ``EntryConfigDiff(new=cfg)`` reads as "diff from nothing to cfg".
     old: EntryConfig = field(default_factory=EntryConfig.empty)
     new: EntryConfig = field(default_factory=EntryConfig.empty)
 
@@ -302,13 +283,8 @@ class EntryConfigDiff:
             (lock, slot) for lock in self.new.locks for slot in new_keys
         }
 
-        # Frozen dataclass blocks normal assignment; bypass via
-        # object.__setattr__ for the computed fields. Standard idiom for
-        # frozen dataclasses with __post_init__-computed state.
-        # Inner slot configs are wrapped (not just referenced) so the
-        # diff is genuinely deeply immutable — matches the pattern in
-        # EntryConfig.from_mapping. dict(v) snapshots the source so
-        # caller-side mutation can't leak into the diff view.
+        # dict(v) + MappingProxyType wrapping snapshots inner slot configs
+        # so caller-side mutation can't leak into the diff view.
         set_field = object.__setattr__
         set_field(
             self,

--- a/custom_components/lock_code_manager/exceptions.py
+++ b/custom_components/lock_code_manager/exceptions.py
@@ -22,11 +22,8 @@ class LockCodeManagerProviderError(LockCodeManagerError):
     ``DuplicateCodeError``), or the provider declining to implement an
     operation (``ProviderNotImplementedError``).
 
-    LCM-internal exceptions (e.g. ``EntityNotFoundError``, the
-    ``_LockQuerySkipped`` sentinel in the config flow) stay at the
-    ``LockCodeManagerError`` level. Catching this class lets callers say
-    "did this error come from the lock provider?" without enumerating
-    every provider error type.
+    Catching this class lets callers ask "did this error come from the
+    lock provider?" without enumerating every provider error type.
     """
 
 
@@ -87,14 +84,7 @@ class LockDisconnected(LockCodeManagerProviderError):
 
 
 class ProviderNotImplementedError(LockCodeManagerProviderError, NotImplementedError):
-    """
-    Raised when a provider method is not implemented.
-
-    This exception should be raised by BaseLock methods that must be overridden
-    by provider subclasses. It combines LockCodeManagerProviderError (so the
-    coordinator can catch it uniformly with other provider failures) with
-    NotImplementedError (for standard Python semantics).
-    """
+    """Raised when a provider method that subclasses must override is called."""
 
     def __init__(self, provider: BaseLock, method_name: str, guidance: str = ""):
         """Initialize the error."""

--- a/custom_components/lock_code_manager/providers/__init__.py
+++ b/custom_components/lock_code_manager/providers/__init__.py
@@ -1,8 +1,4 @@
-"""
-Integrations module.
-
-There should be one file per integration, named after the integration.
-"""
+"""Lock provider implementations."""
 
 from __future__ import annotations
 

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -175,12 +175,7 @@ class BaseLock:
     @final
     @callback
     def mark_code_rejected(self, code_slot: int) -> None:
-        """Mark a slot as having its code rejected by the lock.
-
-        The next sync tick will raise DuplicateCodeError for this slot
-        in async_internal_set_usercode, routing it through the sync
-        manager's standard CodeRejectedError handling.
-        """
+        """Mark a slot as having its code rejected so the next set attempt raises DuplicateCodeError."""
         self._rejected_code_slots.add(code_slot)
 
     @final
@@ -382,16 +377,15 @@ class BaseLock:
     @final
     @callback
     def subscribe_push_updates(self) -> None:
-        """Subscribe to push-based value updates with automatic retry.
+        """Subscribe to push-based value updates, scheduling a one-shot retry on transient failure.
 
-        Calls the provider's setup_push_subscription(). Any exception other than
-        ProviderNotImplementedError is treated as a potentially transient failure:
-        it is logged at debug level and a one-shot retry is scheduled. Permanent
-        errors (ProviderNotImplementedError) propagate immediately.
+        ProviderNotImplementedError propagates.
         """
-        # Block retry-driven calls after unsubscribe to prevent in-flight retries
-        # from resubscribing after teardown. Explicit calls (from setup or state
-        # listener) clear the flag and cancel any stale pending retry.
+        # Block retry-driven calls after unsubscribe to prevent in-flight
+        # retries from resubscribing after teardown. We check `active` (not
+        # `pending`) because a pending retry was already cancelled by
+        # unsubscribe_push_updates, but an in-flight callback that already
+        # started running can't be cancelled and would otherwise resubscribe.
         if self._push_disabled:
             if self._push_retry and self._push_retry.active:
                 return
@@ -410,7 +404,6 @@ class BaseLock:
             )
             self._ensure_push_retry().schedule()
         else:
-            # Subscription succeeded — cancel any pending retry
             if self._push_retry is not None:
                 self._push_retry.cancel()
 
@@ -445,11 +438,7 @@ class BaseLock:
     @final
     @callback
     def unsubscribe_push_updates(self) -> None:
-        """Unsubscribe from push-based value updates.
-
-        Sets _push_disabled to prevent in-flight retries from resubscribing,
-        cancels any pending retry, and calls teardown_push_subscription().
-        """
+        """Unsubscribe from push-based value updates and cancel any pending retry."""
         self._push_disabled = True
         if self._push_retry is not None:
             self._push_retry.cancel()
@@ -473,9 +462,8 @@ class BaseLock:
         """
         Set up lock and coordinator, signaling completion to waiters.
 
-        Provider-specific async_setup() runs first so providers can initialize
-        any state the coordinator needs during its first refresh. Then the base
-        setup creates the coordinator and subscribes to push updates.
+        Provider ``async_setup()`` runs first so providers can initialize
+        any state the coordinator needs during its first refresh.
         """
         try:
             await self.async_setup(config_entry)
@@ -546,11 +534,7 @@ class BaseLock:
         await self._setup_complete.wait()
 
     async def async_unload(self, remove_permanently: bool) -> None:
-        """Unload lock.
-
-        Providers override to add their own teardown; the base handles
-        config-entry-state listener cleanup and push subscription teardown.
-        """
+        """Tear down config-entry-state listener and push subscription."""
         if self._config_entry_state_unsub:
             self._config_entry_state_unsub()
             self._config_entry_state_unsub = None
@@ -598,13 +582,9 @@ class BaseLock:
         )
 
     async def async_is_integration_connected(self) -> bool:
-        """Return whether the integration's client/driver/broker is connected.
+        """Return True iff the lock's parent config entry is loaded.
 
-        Default: ``True`` iff the lock's parent config entry is loaded.
-        Providers override when "the integration is connected" means
-        something more specific than "config entry loaded" — e.g. Z-Wave
-        JS checks the websocket client state separately from the entry
-        state.
+        Providers override for integration-specific connection signals.
         """
         if not self.lock_config_entry:
             return False
@@ -625,7 +605,9 @@ class BaseLock:
         lock_entry = self.lock_config_entry
         if not self.supports_push or not lock_entry:
             return
-        # Only react to connection transitions when the config entry is loaded.
+        # Skip during SETUP_IN_PROGRESS: the setup path handles the initial
+        # subscription, and a parallel subscribe here would race with
+        # coordinator creation in _async_setup_internal.
         if lock_entry.state != ConfigEntryState.LOADED:
             return
         if self._last_connection_up is False and is_up:
@@ -639,11 +621,7 @@ class BaseLock:
             self.unsubscribe_push_updates()
 
     async def async_hard_refresh_codes(self) -> dict[int, str | SlotCode]:
-        """Perform hard refresh and return all codes.
-
-        Needed for integrations where usercodes are cached and may get out of sync
-        with the lock. Returns codes in the same format as async_get_usercodes().
-        """
+        """Re-fetch all codes from the lock and return them in the same shape as async_get_usercodes()."""
         self._raise_not_implemented(
             "async_hard_refresh_codes",
             "Override this method to re-fetch codes from the lock device.",
@@ -651,12 +629,7 @@ class BaseLock:
 
     @final
     async def async_internal_hard_refresh_codes(self) -> dict[int, str | SlotCode]:
-        """
-        Perform hard refresh and return all codes.
-
-        Needed for integrations where usercodes are cached and may get out of sync with
-        the lock. Returns codes in the same format as async_internal_get_usercodes().
-        """
+        """Rate-limited wrapper around async_hard_refresh_codes()."""
         return await self._execute_rate_limited(
             "refresh", self.async_hard_refresh_codes
         )
@@ -669,24 +642,6 @@ class BaseLock:
         Returns True if the value was changed, False if already set to this
         value. If the provider cannot determine whether a change occurred,
         return True so the coordinator refreshes and verifies the state.
-
-        Optimistic Updates
-        ------------------
-        For providers where the underlying integration's value cache updates
-        asynchronously (e.g., Z-Wave JS push notifications), the base class
-        coordinator refresh may read stale data, causing sync loops.
-
-        In these cases, call
-        ``self.coordinator.push_update({code_slot: usercode})`` after a
-        successful set operation to update coordinator data immediately.
-        This prevents the sync sensor from seeing a mismatch and retrying.
-
-        Providers with synchronous caches (like Virtual) don't need this as
-        async_get_usercodes() returns the updated value immediately.
-
-        Raises:
-            LockDisconnected: If the lock cannot be communicated with.
-
         """
         self._raise_not_implemented(
             "async_set_usercode",
@@ -749,24 +704,6 @@ class BaseLock:
         Returns True if the value was changed, False if already cleared.
         If the provider cannot determine whether a change occurred, return
         True so the coordinator refreshes and verifies the state.
-
-        Optimistic Updates
-        ------------------
-        For providers where the underlying integration's value cache updates
-        asynchronously (e.g., Z-Wave JS push notifications), the base class
-        coordinator refresh may read stale data, causing sync loops.
-
-        In these cases, call ``self.coordinator.push_update({code_slot: ""})``
-        after a successful clear operation to update coordinator data
-        immediately. This prevents the sync sensor from seeing a mismatch
-        and retrying.
-
-        Providers with synchronous caches (like Virtual) don't need this as
-        async_get_usercodes() returns the updated value immediately.
-
-        Raises:
-            LockDisconnected: If the lock cannot be communicated with.
-
         """
         self._raise_not_implemented(
             "async_clear_usercode",
@@ -789,27 +726,12 @@ class BaseLock:
         changed = await self._execute_rate_limited(
             "clear", self.async_clear_usercode, code_slot
         )
-        # Refresh coordinator to update entity states from cache (only if changed).
-        # Skip for push-based providers — they update the coordinator optimistically
-        # via push_update() in their set/clear methods, and refreshing from cache
-        # could overwrite the optimistic update with stale data when the underlying
-        # driver defers cache updates until device confirmation.
+        # Push-based providers handle this via push_update(); see async_internal_set_usercode.
         if changed and self.coordinator and not self.supports_push:
             await self.coordinator.async_request_refresh()
 
     async def async_get_usercodes(self) -> dict[int, str | SlotCode]:
-        """Get dictionary of code slots and usercodes.
-
-        Called by data coordinator to get data for code slot sensors.
-
-        Key is code slot (int), value is usercode, e.g.::
-
-            {1: '1234', 2: '5678'}
-
-        Raises:
-            LockDisconnected: If the lock cannot be communicated with.
-
-        """
+        """Return a dict of {slot_num: usercode_or_SlotCode_sentinel} for the data coordinator."""
         self._raise_not_implemented(
             "async_get_usercodes",
             "Override this method to retrieve usercodes from the lock.",
@@ -817,21 +739,9 @@ class BaseLock:
 
     @final
     async def async_internal_get_usercodes(self) -> dict[int, str | SlotCode]:
-        """
-        Get dictionary of code slots and usercodes.
+        """Rate-limited wrapper around async_get_usercodes().
 
-        Called by data coordinator to get data for code slot sensors.
-        Slot keys are always ``int`` — the coordinator's ``_normalize_keys``
-        chokepoint enforces this on the way out, but providers should
-        return int-keyed dicts directly. Values are either a usercode
-        string or a ``SlotCode`` sentinel (``EMPTY``/``UNKNOWN``).
-
-        Example::
-
-            {
-                1: '1234',
-                2: SlotCode.EMPTY,
-            }
+        Slot keys are int; values are usercode strings or SlotCode sentinels.
         """
         return await self._execute_rate_limited("get", self.async_get_usercodes)
 
@@ -862,11 +772,9 @@ class BaseLock:
                 return_response=return_response,
             )
         except HomeAssistantError as err:
-            # Narrow catch: only HA-raised service errors map to LockDisconnected.
-            # ServiceValidationError is a subclass of HomeAssistantError so it's
-            # covered. Letting CancelledError, TypeError, and other programming
-            # bugs propagate avoids false "lock offline" issue creation, drift
-            # backoff, and push-resub loops on shutdown or call-site mistakes.
+            # ServiceValidationError is a subclass of HomeAssistantError so
+            # it's covered here. CancelledError and programming bugs (TypeError,
+            # KeyError) deliberately propagate.
             LOGGER.error(
                 "Error calling %s.%s service call: %s", domain, service, str(err)
             )

--- a/custom_components/lock_code_manager/providers/akuvox.py
+++ b/custom_components/lock_code_manager/providers/akuvox.py
@@ -8,8 +8,7 @@ device are automatically tagged and assigned to the next available slot
 number.
 
 All operations go through the Home Assistant ``local_akuvox`` integration
-services (``list_users``, ``add_user``, ``modify_user``, ``delete_user``)
-rather than importing pylocal-akuvox directly.
+services (``list_users``, ``add_user``, ``modify_user``, ``delete_user``).
 """
 
 from __future__ import annotations
@@ -78,14 +77,6 @@ class AkuvoxLock(BaseLock):
     def usercode_scan_interval(self) -> timedelta:
         """Return scan interval for usercodes."""
         return timedelta(minutes=2)
-
-    # ------------------------------------------------------------------
-    # Connection
-    # ------------------------------------------------------------------
-
-    # ------------------------------------------------------------------
-    # Internal helpers
-    # ------------------------------------------------------------------
 
     async def _async_list_users(self) -> list[dict[str, Any]]:
         """Call ``local_akuvox.list_users`` and return the user list.
@@ -179,17 +170,9 @@ class AkuvoxLock(BaseLock):
                 f"Failed to delete user {device_user_id} on {entity_id}: {err}"
             ) from err
 
-    # ------------------------------------------------------------------
-    # Managed slot helpers
-    # ------------------------------------------------------------------
-
     def _get_managed_slots(self) -> set[int]:
         """Return managed slot numbers for this lock."""
         return get_managed_slots(self.hass, self.lock.entity_id)
-
-    # ------------------------------------------------------------------
-    # Setup and refresh
-    # ------------------------------------------------------------------
 
     async def async_setup(self, config_entry: ConfigEntry) -> None:
         """Set up lock by tagging any pre-existing unmanaged users."""
@@ -200,10 +183,6 @@ class AkuvoxLock(BaseLock):
         """Re-tag unmanaged users, then return all codes."""
         await self._async_tag_unmanaged_users()
         return await self.async_get_usercodes()
-
-    # ------------------------------------------------------------------
-    # Auto-tagging
-    # ------------------------------------------------------------------
 
     async def _async_tag_unmanaged_users(self) -> None:
         """Discover untagged local users and tag them with a slot number.
@@ -268,10 +247,6 @@ class AkuvoxLock(BaseLock):
                 slot_num,
                 tagged_name,
             )
-
-    # ------------------------------------------------------------------
-    # Code slot operations
-    # ------------------------------------------------------------------
 
     async def async_get_usercodes(self) -> dict[int, str | SlotCode]:
         """Get dictionary of code slots and usercodes.

--- a/custom_components/lock_code_manager/providers/matter.py
+++ b/custom_components/lock_code_manager/providers/matter.py
@@ -110,23 +110,14 @@ class MatterLock(BaseLock):
         service: str,
         service_data: dict[str, Any],
     ) -> dict[str, Any]:
-        """Call a Matter service and return the per-entity response data.
+        """Call a Matter service and return the per-entity dict.
 
-        Intentionally does NOT route through ``BaseLock.async_call_service``.
-        That helper does exactly one thing: wrap raw service-call failures
-        (``HomeAssistantError`` family) as ``LockDisconnected``. Matter
-        needs two additional jobs the base helper deliberately doesn't do:
-
-        1. Unwrap the ``{entity_id: {...}}``-shaped response the Matter
-           service returns and hand back the inner per-entity dict.
-        2. Validate that response shape and raise
-           ``LockCodeManagerProviderError`` (a different error class) when
-           the lock returns no/non-dict data — a "malformed response" path
-           the base helper has no opinion on at all.
-
-        Future refactors should preserve this bypass rather than "unifying"
-        it back into the base helper.
+        Raises LockDisconnected on service failure or
+        LockCodeManagerProviderError on malformed response.
         """
+        # Bypasses BaseLock.async_call_service because Matter responses are
+        # wrapped per entity_id and need structural validation that raises
+        # LockCodeManagerProviderError (not LockDisconnected) on bad shape.
         entity_id = self.lock.entity_id
         try:
             result = await self.hass.services.async_call(

--- a/custom_components/lock_code_manager/providers/schlage.py
+++ b/custom_components/lock_code_manager/providers/schlage.py
@@ -8,7 +8,7 @@ available slot number.
 
 All lock operations go through the Home Assistant Schlage integration
 services (``schlage.get_codes``, ``schlage.add_code``,
-``schlage.delete_code``) rather than importing pyschlage directly.
+``schlage.delete_code``).
 
 PINs are write-only from the Schlage API perspective: the ``get_codes``
 service returns masked PINs (``****``), so occupied slots report

--- a/custom_components/lock_code_manager/providers/virtual.py
+++ b/custom_components/lock_code_manager/providers/virtual.py
@@ -60,12 +60,7 @@ class VirtualLock(BaseLock):
         return True
 
     async def async_hard_refresh_codes(self) -> dict[int, str | SlotCode]:
-        """
-        Perform hard refresh and return all codes.
-
-        Needed for integrations where usercodes are cached and may get out of sync with
-        the lock. Returns codes in the same format as async_get_usercodes().
-        """
+        """Reload from store and return all codes."""
         self._data = data if (data := await self._store.async_load()) else {}
         return await self.async_get_usercodes()
 

--- a/custom_components/lock_code_manager/providers/zwave_js.py
+++ b/custom_components/lock_code_manager/providers/zwave_js.py
@@ -119,12 +119,7 @@ class ZWaveJSLock(BaseLock):
 
     @property
     def supports_push(self) -> bool:
-        """
-        Return whether this lock supports push-based updates.
-
-        Z-Wave JS emits value update events when the cache changes, so we
-        subscribe to those instead of polling.
-        """
+        """Return whether this lock supports push-based updates."""
         return True
 
     @property
@@ -167,11 +162,7 @@ class ZWaveJSLock(BaseLock):
             return None
 
     def _slot_expects_pin(self, code_slot: int) -> bool:
-        """Check if LCM expects a PIN on this slot (enabled with PIN configured).
-
-        Used to ignore stale userIdStatus=AVAILABLE events from locks that
-        report old status after a code was successfully set.
-        """
+        """Return True if this slot is enabled and has a PIN configured."""
         if not self.coordinator:
             return False
         return self.coordinator.slot_expects_pin(code_slot)
@@ -213,11 +204,14 @@ class ZWaveJSLock(BaseLock):
         else:
             value = str(new_value)
             slot_in_use = self.code_slot_in_use(code_slot)
+            # Asymmetric in_use checks: masked codes count as UNKNOWN even
+            # when in_use is None (some firmwares mask before reporting
+            # status), but all-zeros only counts as EMPTY when in_use is
+            # explicitly False (zeros from a partially-loaded cache must
+            # not be misread as cleared).
             if value == "*" * len(value) and slot_in_use is not False:
-                # Masked code: treat as UNKNOWN whether in_use is True or None
                 resolved = SlotCode.UNKNOWN
             elif value.strip("0") == "" and slot_in_use is False:
-                # All-zeros with slot explicitly not in use means cleared
                 resolved = SlotCode.EMPTY
             else:
                 resolved = value
@@ -326,6 +320,9 @@ class ZWaveJSLock(BaseLock):
         # Mark the slot as rejected so the sync manager raises DuplicateCodeError
         # on the next tick, routing through the standard CodeRejectedError flow
         # (tracker reset, circuit breaker awareness, notification).
+        # Some Z-Wave lock firmwares report this notification with userId=0
+        # instead of the offending slot; treat 0 as referring to the slot
+        # we're currently setting.
         if (
             evt.data[ATTR_EVENT]
             == AccessControlNotificationEvent.NEW_USER_CODE_NOT_ADDED_DUE_TO_DUPLICATE_CODE
@@ -391,13 +388,7 @@ class ZWaveJSLock(BaseLock):
             return False
 
     async def async_hard_refresh_codes(self) -> dict[int, str | SlotCode]:
-        """
-        Perform hard refresh and return all codes.
-
-        Uses Z-Wave JS's refresh_cc_values which handles checksum optimization
-        internally - it will skip re-fetching codes if the checksum hasn't changed.
-        Returns codes in the same format as async_get_usercodes().
-        """
+        """Refresh the User Code CC cache from the device and return all codes."""
         await self._async_refresh_usercode_cache()
         return await self.async_get_usercodes()
 
@@ -409,11 +400,12 @@ class ZWaveJSLock(BaseLock):
 
         Returns True if the value was changed, False if already set to this value.
         """
-        # Check if the code is already set to this value (avoid unnecessary network call)
+        # Cache lookup short-circuits no-op writes. Bare-except is intentional:
+        # a stale or missing cache entry must not block the set operation.
         try:
             if (current := get_usercode(self.node, code_slot)).get("in_use"):
                 current_code = str(current.get("usercode", ""))
-                # If masked (all asterisks), skip duplicate check since we cannot compare
+                # Skip the duplicate check if the current code is masked.
                 if current_code != "*" * len(current_code) and usercode == current_code:
                     _LOGGER.debug(
                         "Lock %s slot %s already has this PIN, skipping set",
@@ -421,8 +413,7 @@ class ZWaveJSLock(BaseLock):
                         code_slot,
                     )
                     return False
-        except Exception:
-            # If we can't check the cache, proceed with the set
+        except Exception:  # noqa: BLE001
             pass
 
         self._set_in_progress_code_slot = code_slot
@@ -456,7 +447,8 @@ class ZWaveJSLock(BaseLock):
 
         Returns True if the value was changed, False if already cleared.
         """
-        # Check if the slot is already cleared (avoid unnecessary network call)
+        # Cache lookup short-circuits no-op clears. Bare-except is intentional:
+        # see async_set_usercode for rationale.
         try:
             current = get_usercode(self.node, code_slot)
             if not current.get("in_use"):
@@ -466,8 +458,7 @@ class ZWaveJSLock(BaseLock):
                     code_slot,
                 )
                 return False
-        except Exception:
-            # If we can't check the cache, proceed with the clear
+        except Exception:  # noqa: BLE001
             pass
 
         service_data = {

--- a/custom_components/lock_code_manager/sync.py
+++ b/custom_components/lock_code_manager/sync.py
@@ -479,8 +479,10 @@ class SlotSyncManager:
             if slot_state.active_state not in (STATE_ON, STATE_OFF):
                 self._invalid_state_count += 1
 
+                # Exact `== MAX+1` (not `>=`) is intentional: we log the
+                # warning exactly once. Subsequent invalid-state ticks fall
+                # through to neither branch and stay silent to avoid spam.
                 if self._invalid_state_count == MAX_SYNC_ATTEMPTS + 1:
-                    # Log warning once after threshold, then stay silent
                     _LOGGER.warning(
                         "%s: Active entity has invalid state '%s' for %s consecutive checks. "
                         "Entity may be unavailable or misconfigured. Check that the active "

--- a/custom_components/lock_code_manager/websocket.py
+++ b/custom_components/lock_code_manager/websocket.py
@@ -283,26 +283,7 @@ async def get_config_entry_data(
     msg: dict[str, Any],
     config_entry: ConfigEntry,
 ) -> None:
-    """
-    Return complete config entry data for Lock Code Manager.
-
-    This is the primary data-fetching command for the frontend. It returns all
-    static configuration and entity registry data needed to render the dashboard.
-
-    Frontend usage:
-    - generate-view.ts: Fetches slot numbers for section generation, lock entity
-      IDs for badges, and lock names for sorting/display
-    - slot-section-strategy.ts: Fetches entities for legacy slot card generation
-    - dashboard-strategy.ts: Fetches data for dashboard view generation
-    - view-strategy.ts: Fetches config entry and entities for view rendering
-
-    Sends:
-        config_entry: The config entry JSON fragment (entry_id, title, etc.)
-        entities: List of entity registry entries for this config entry
-        locks: List of lock objects with entity_id and friendly name
-        slots: Mapping of slot numbers to calendar entity IDs (or null)
-
-    """
+    """Return the config entry fragment, entity registry entries, lock list, and slot calendar mapping."""
     all_locks = hass.data.get(DOMAIN, {}).get(CONF_LOCKS, {})
     entry_config = get_entry_config(config_entry)
 
@@ -343,16 +324,7 @@ def _serialize_slot(
     enabled: bool | None = None,
     config_entry_id: str | None = None,
 ) -> dict[str, Any]:
-    """
-    Serialize a single slot, optionally masking the code.
-
-    - code/code_length: What's actually on the lock (actual state)
-    - configured_code/configured_code_length: What LCM has configured (desired state)
-      Always included for managed slots, even if code is active on lock.
-    - active: True if enabled + conditions met, False if inactive, None if unknown
-    - enabled: True if enabled switch is ON, False if OFF, None if unknown
-    - config_entry_id: ID of the LCM config entry managing this slot (for navigation)
-    """
+    """Serialize a slot dict, masking the code unless ``reveal`` is True."""
     result: dict[str, Any] = {ATTR_SLOT: slot}
     if name:
         result[CONF_NAME] = name
@@ -388,12 +360,7 @@ def _serialize_slot(
 
 @dataclass
 class SlotEntities:
-    """Entity IDs for a single slot's LCM entities.
-
-    All entity ID fields are optional so callers that only need a subset
-    can populate what they have. ``config_entry_id`` is included for
-    callers iterating across entries who need to track origin.
-    """
+    """Entity IDs for a single slot's LCM entities."""
 
     slot_num: int
     config_entry_id: str | None = None
@@ -422,12 +389,7 @@ class SlotEntities:
 
 @dataclass
 class SlotMetadata:
-    """Parsed values for a single slot, derived from LCM entity states.
-
-    Used as the per-slot shape inside websocket subscription responses.
-    Fields are typed (bool / str) rather than raw HA states because
-    consumers want clean JSON-serializable values.
-    """
+    """Parsed values for a single slot, derived from LCM entity states."""
 
     name: str | None = None
     configured_pin: str | None = None
@@ -438,18 +400,7 @@ class SlotMetadata:
 def _get_slot_entity_ids(
     hass: HomeAssistant, lock_entity_id: str
 ) -> dict[int, SlotEntities]:
-    """
-    Get entity IDs for all slots managed by LCM for a lock.
-
-    Returns a dict mapping slot number to SlotEntities containing the entity IDs
-    for name, PIN, active, and enabled entities. ``number_of_uses_entity_id`` and
-    ``event_entity_id`` are left unset because this function is used for
-    state-tracking subscriptions which only care about the four primary entities.
-
-    Note: If multiple config entries manage the same lock with overlapping slot
-    numbers (which shouldn't happen in normal use), the last entry wins. This is
-    expected behavior since slot conflicts are validated during config flow.
-    """
+    """Return a dict of slot number to SlotEntities for the four primary per-slot entities."""
     slot_entities: dict[int, SlotEntities] = {}
     ent_reg = er.async_get(hass)
 
@@ -488,15 +439,7 @@ def _get_slot_entity_ids(
 def _get_slot_metadata(
     hass: HomeAssistant, lock_entity_id: str
 ) -> dict[int, SlotMetadata]:
-    """
-    Get all slot metadata from LCM entities for a lock in one pass.
-
-    Returns a dict mapping slot number to SlotMetadata containing:
-    - name: From text entity
-    - configured_pin: From text entity
-    - active: From binary sensor (True=on, False=off, None=unknown)
-    - enabled: From switch (True=on, False=off, None=unknown)
-    """
+    """Return a dict of slot number to SlotMetadata for all slots LCM manages on a lock."""
     slot_entities = _get_slot_entity_ids(hass, lock_entity_id)
     return {
         slot_num: SlotMetadata(
@@ -544,9 +487,6 @@ def _serialize_lock_coordinator(
     slot_entity_ids = _get_slot_entity_ids(hass, lock.lock.entity_id)
 
     slots = []
-    # `data` is int-keyed (coordinator normalizes); managed_slots is also
-    # int-keyed (built from EntryConfig.slots). All slot lookups below are
-    # plain int operations — no str/int variant gymnastics needed.
     for slot, code in sorted(data.items()):
         meta = slot_metadata.get(slot)
         slot_ids = slot_entity_ids.get(slot)
@@ -647,10 +587,6 @@ async def subscribe_lock_codes(
             _send_update()
 
     # Track coordinator updates (lock code changes).
-    # Note: if coordinator is None AND the initial entity set is empty, nothing
-    # drives re-resolution of entities. This is acceptable because coordinators
-    # are always present for real lock providers; None only occurs in degenerate
-    # test scenarios where no actual lock hardware is involved.
     unsub_coordinator = (
         coordinator.async_add_listener(_send_update) if coordinator else lambda: None
     )

--- a/tests/providers/test_base.py
+++ b/tests/providers/test_base.py
@@ -208,13 +208,8 @@ async def test_rate_limiting_set_usercode(
     lock_code_manager_config_entry,
 ):
     """Test that operations are rate limited with minimum delay between calls."""
-    # Arrange: shorter delay for faster assertions
     lock_provider = lock_code_manager_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
-
-    # Set a smaller delay for testing
     lock_provider._min_operation_delay = TEST_OPERATION_DELAY
-
-    # Reset the last operation time to ensure clean test
     lock_provider._last_operation_time = 0.0
 
     # First operation should execute immediately
@@ -243,12 +238,8 @@ async def test_rate_limiting_mixed_operations(
     lock_code_manager_config_entry,
 ):
     """Test that rate limiting applies across different operation types."""
-    # Arrange: shorter delay for faster assertions
     lock_provider = lock_code_manager_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
-
-    # Set a smaller delay for testing
     lock_provider._min_operation_delay = TEST_OPERATION_DELAY
-    # Reset the last operation time to ensure clean test isolation
     lock_provider._last_operation_time = 0.0
 
     # First operation: set usercode
@@ -269,13 +260,8 @@ async def test_rate_limiting_get_usercodes(
     lock_code_manager_config_entry,
 ):
     """Test that get operations are also rate limited."""
-    # Arrange: shorter delay for faster assertions
     lock_provider = lock_code_manager_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
-
-    # Set a smaller delay for testing
     lock_provider._min_operation_delay = TEST_OPERATION_DELAY
-
-    # Reset the last operation time to ensure clean test
     lock_provider._last_operation_time = 0.0
 
     # First get should be fast
@@ -297,12 +283,8 @@ async def test_operations_are_serialized(
     lock_code_manager_config_entry,
 ):
     """Test that multiple parallel operations are serialized by the lock."""
-    # Arrange: shorter delay for faster assertions
     lock_provider = lock_code_manager_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
-
-    # Set a smaller delay for testing
     lock_provider._min_operation_delay = TEST_OPERATION_DELAY
-    # Reset the last operation time to ensure clean test isolation
     lock_provider._last_operation_time = 0.0
 
     # Start multiple operations in parallel

--- a/tests/providers/test_zwave_js.py
+++ b/tests/providers/test_zwave_js.py
@@ -435,19 +435,7 @@ async def test_set_usercode_optimistic_update_prevents_stale_read(
     zwave_js_lock: ZWaveJSLock,
     zwave_integration: MockConfigEntry,
 ) -> None:
-    """
-    Test that optimistic update prevents sync loops from stale cache reads.
-
-    This test verifies the fix for the reported issue where out-of-sync slots
-    cause constant lock activity. The scenario:
-    1. LCM sets a code on the lock
-    2. Z-Wave command succeeds (lock acknowledges)
-    3. Without optimistic update: coordinator.data still has old value
-    4. Binary sensor sees mismatch → triggers another sync → loop
-
-    With the fix, push_update immediately sets coordinator.data to the new value,
-    so the binary sensor sees the expected value and doesn't retry.
-    """
+    """Test that optimistic update prevents sync loops from stale cache reads."""
     lcm_entry = MockConfigEntry(domain=DOMAIN, data={CONF_LOCKS: [], CONF_SLOTS: {}})
     lcm_entry.add_to_hass(hass)
     await zwave_js_lock.async_setup_internal(lcm_entry)

--- a/tests/providers/test_zwave_js.py
+++ b/tests/providers/test_zwave_js.py
@@ -344,6 +344,37 @@ async def test_set_usercode_proceeds_when_masked(
     await zwave_js_lock.async_unload(False)
 
 
+async def test_set_usercode_proceeds_on_cache_failure(
+    hass: HomeAssistant,
+    zwave_js_lock: ZWaveJSLock,
+    zwave_integration: MockConfigEntry,
+) -> None:
+    """Test that set_usercode proceeds when the cache lookup raises.
+
+    A stale or missing cache entry must not block the set operation —
+    the bare-except in the cache short-circuit guards against this.
+    """
+    lcm_entry = MockConfigEntry(domain=DOMAIN, data={CONF_LOCKS: [], CONF_SLOTS: {}})
+    lcm_entry.add_to_hass(hass)
+    await zwave_js_lock.async_setup_internal(lcm_entry)
+
+    with (
+        patch(
+            "custom_components.lock_code_manager.providers.zwave_js.get_usercode",
+            side_effect=ValueError("cache miss"),
+        ),
+        patch.object(
+            zwave_js_lock, "async_call_service", new_callable=AsyncMock
+        ) as mock_service,
+    ):
+        result = await zwave_js_lock.async_set_usercode(4, "5678", "Test User")
+
+        assert result is True
+        mock_service.assert_called_once()
+
+    await zwave_js_lock.async_unload(False)
+
+
 async def test_clear_usercode_calls_service(
     hass: HomeAssistant,
     zwave_js_lock: ZWaveJSLock,
@@ -390,6 +421,36 @@ async def test_clear_usercode_skips_when_already_cleared(
 
         assert result is False
         mock_service.assert_not_called()
+
+    await zwave_js_lock.async_unload(False)
+
+
+async def test_clear_usercode_proceeds_on_cache_failure(
+    hass: HomeAssistant,
+    zwave_js_lock: ZWaveJSLock,
+    zwave_integration: MockConfigEntry,
+) -> None:
+    """Test that clear_usercode proceeds when the cache lookup raises.
+
+    Mirrors test_set_usercode_proceeds_on_cache_failure for the clear path.
+    """
+    lcm_entry = MockConfigEntry(domain=DOMAIN, data={CONF_LOCKS: [], CONF_SLOTS: {}})
+    lcm_entry.add_to_hass(hass)
+    await zwave_js_lock.async_setup_internal(lcm_entry)
+
+    with (
+        patch(
+            "custom_components.lock_code_manager.providers.zwave_js.get_usercode",
+            side_effect=ValueError("cache miss"),
+        ),
+        patch.object(
+            zwave_js_lock, "async_call_service", new_callable=AsyncMock
+        ) as mock_service,
+    ):
+        result = await zwave_js_lock.async_clear_usercode(2)
+
+        assert result is True
+        mock_service.assert_called_once()
 
     await zwave_js_lock.async_unload(False)
 

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -333,7 +333,6 @@ async def test_startup_out_of_sync_slots_sync_once(
     With coordinator-triggered syncs, out-of-sync slots are detected and synced
     automatically during startup via coordinator update callbacks.
     """
-    # Arrange two slots that need syncing on startup
     config = {
         CONF_LOCKS: [LOCK_1_ENTITY_ID],
         CONF_SLOTS: {
@@ -1123,11 +1122,9 @@ async def test_sync_manager_handles_string_slot_num(
     mock_lock_config_entry,
     lock_code_manager_config_entry,
 ):
-    """Regression test: slot_num from config entry is a string, coordinator keys are int."""
+    """Test sync manager normalizes string slot keys to int before coordinator lookup."""
     in_sync_entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
     manager = in_sync_entity_obj._sync_manager
 
-    # Config entry stores slot numbers as strings (JSON keys), but
-    # coordinator.data uses int keys. The sync manager must cast to int.
     assert isinstance(manager._slot_num, int)
     assert manager._slot_num in manager._coordinator.data

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -713,7 +713,7 @@ def _create_push_coordinator(
 async def test_backoff_failure_counter_increments(hass: HomeAssistant) -> None:
     """Test that consecutive failure counter increments on each failure."""
     coordinator, lock = _create_poll_coordinator(hass)
-    # Simulate that we previously had a successful update so UpdateFailed is raised
+    # last_update_success=True is required for UpdateFailed to be raised on next failure.
     coordinator.last_update_success = True
 
     mock_get = AsyncMock(side_effect=LockDisconnected("Lock offline"))

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -128,13 +128,7 @@ async def test_event_entity_unavailable_when_no_supported_locks(
     hass: HomeAssistant,
     mock_lock_config_entry,
 ):
-    """
-    Test that event entity is unavailable when no locks support code slot events.
-
-    Note: When the entity is unavailable, extra_state_attributes (including
-    unsupported_locks) won't be visible in the state.
-    """
-    # Create config with mock lock that doesn't support events
+    """Test that event entity is unavailable when no locks support code slot events."""
     with patch(
         "custom_components.lock_code_manager.helpers.INTEGRATIONS_CLASS_MAP",
         {"test": MockLCMLockNoEvents},
@@ -148,8 +142,8 @@ async def test_event_entity_unavailable_when_no_supported_locks(
 
         state = hass.states.get(SLOT_1_EVENT_ENTITY)
         assert state
-
-        # Entity should be unavailable when no locks support code slot events
+        # While unavailable, extra_state_attributes (e.g. unsupported_locks)
+        # are not exposed on the state.
         assert state.state == STATE_UNAVAILABLE
 
         await hass.config_entries.async_unload(config_entry.entry_id)
@@ -161,20 +155,16 @@ async def test_event_without_lock_entity_id_logs_warning(
     lock_code_manager_config_entry,
     caplog,
 ):
-    """
-    Test that event without lock entity ID logs a warning.
-
-    Note: We call _handle_event directly because the event filter accesses
-    ATTR_ENTITY_ID directly (would raise KeyError before reaching handler).
-    This tests the defensive code in _handle_event.
-    """
+    """Test that event without lock entity ID logs a warning."""
     ent_reg = er.async_get(hass)
     entry = ent_reg.async_get(SLOT_1_EVENT_ENTITY)
     assert entry
     entity = hass.data["entity_components"]["event"].get_entity(entry.entity_id)
     assert entity
 
-    # Call _handle_event directly with event missing ATTR_ENTITY_ID
+    # Bypass the event filter (which would raise KeyError on missing
+    # ATTR_ENTITY_ID before reaching the handler) so we exercise the
+    # defensive path in _handle_event itself.
     entity._handle_event(Event("test_event", {"slot_num": 1}))
 
     assert "Received event without lock entity ID" in caplog.text

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -10,10 +10,6 @@ from custom_components.lock_code_manager.helpers import get_locks_from_targets
 
 from .common import LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID
 
-# =============================================================================
-# get_locks_from_targets Tests
-# =============================================================================
-
 
 async def test_get_locks_from_targets_with_entity_ids(
     hass: HomeAssistant,
@@ -72,7 +68,6 @@ async def test_get_locks_from_targets_with_area_id(
     lock_code_manager_config_entry,
 ):
     """Test get_locks_from_targets resolves area IDs to locks."""
-    # Assign lock.test_1 to an area
     area_reg = ar.async_get(hass)
     area = area_reg.async_get_or_create("test_area")
     ent_reg = er.async_get(hass)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -676,11 +676,7 @@ async def test_unload_fires_lock_removed_callbacks(
     mock_lock_config_entry,
     lock_code_manager_config_entry,
 ):
-    """Test that unloading an entry fires lock-removed callbacks for each lock.
-
-    Before the symmetric-unload refactor, async_unload_entry bypassed
-    the update listener path, so lock-removed callbacks never fired.
-    """
+    """Test that unloading an entry fires lock-removed callbacks for each lock."""
     runtime_data = lock_code_manager_config_entry.runtime_data
     callbacks = runtime_data.callbacks
 
@@ -792,9 +788,7 @@ async def test_number_of_uses_repair_flow_strips_data(
 
     assert result["type"] == "create_entry"
 
-    # Verify number_of_uses was stripped from the config entry. The
-    # listener normalizes slot keys to int when it writes back to data,
-    # so look up by int rather than the str key the test originally wrote.
+    # Listener normalizes slot keys to int before persisting; look up by int.
     assert CONF_NUMBER_OF_USES not in config_entry.data[CONF_SLOTS][2]
     # Slot 1 should be unchanged
     assert CONF_NUMBER_OF_USES not in config_entry.data[CONF_SLOTS][1]

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -26,13 +26,7 @@ async def test_sensor_entity(
     hass: HomeAssistant,
     mock_lock_config_entry,
 ):
-    """
-    Test sensor entity shows lock code values.
-
-    Uses a config without calendar to test pure sensor functionality.
-    All slots are active, so codes remain synced and sensors show expected values.
-    """
-    # Config without calendar - both slots active
+    """Test sensor entity shows lock code values."""
     config = {
         CONF_LOCKS: [LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID],
         CONF_SLOTS: {

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -90,7 +90,6 @@ from .common import (
 
 _LOGGER = logging.getLogger(__name__)
 
-# Test entity IDs
 CALENDAR_TEST_ENTITY_ID = f"{CALENDAR_DOMAIN}.test_cal"
 BINARY_SENSOR_TEST_ENTITY_ID = "binary_sensor.test_motion"
 SWITCH_TEST_ENTITY_ID = "switch.test_switch"
@@ -1321,7 +1320,7 @@ async def test_subscribe_code_slot_response_shape(
     assert event["type"] == "event"
     data = event["event"]
 
-    # Assert all expected top-level keys are present (matching SlotCardData interface)
+    # Matches SlotCardData interface in frontend types.
     expected_keys = {
         ATTR_SLOT_NUM,
         ATTR_CONFIG_ENTRY_ID,
@@ -1338,7 +1337,7 @@ async def test_subscribe_code_slot_response_shape(
         f"Missing keys: {expected_keys - data.keys()}"
     )
 
-    # Assert entities dictionary has expected keys (matching SlotCardEntities interface)
+    # Matches SlotCardEntities interface in frontend types.
     entities = data[CONF_ENTITIES]
     expected_entity_keys = {
         ATTR_ACTIVE,
@@ -1349,7 +1348,7 @@ async def test_subscribe_code_slot_response_shape(
     }
     assert expected_entity_keys == set(entities.keys())
 
-    # Assert each lock has expected keys (matching SlotCardLockStatus interface)
+    # Matches SlotCardLockStatus interface in frontend types.
     assert len(data[CONF_LOCKS]) > 0
     for lock_data in data[CONF_LOCKS]:
         assert ATTR_ENTITY_ID in lock_data
@@ -1357,7 +1356,7 @@ async def test_subscribe_code_slot_response_shape(
         assert ATTR_IN_SYNC in lock_data
         assert ATTR_CODE in lock_data
 
-    # Assert correct types (matching TypeScript types)
+    # Type assertions mirror the TypeScript types in frontend types.
     assert isinstance(data[ATTR_SLOT_NUM], int)
     assert isinstance(data[CONF_NAME], str)
     assert isinstance(data[CONF_ENABLED], bool) or data[CONF_ENABLED] is None
@@ -1389,12 +1388,12 @@ async def test_subscribe_lock_codes_response_shape(
     assert event["type"] == "event"
     data = event["event"]
 
-    # Assert top-level keys match LockCoordinatorData interface
+    # Matches LockCoordinatorData interface in frontend types.
     assert isinstance(data[ATTR_LOCK_ENTITY_ID], str)
     assert isinstance(data[ATTR_LOCK_NAME], str)
     assert isinstance(data[CONF_SLOTS], list)
 
-    # Assert each slot matches LockCoordinatorSlotData interface
+    # Matches LockCoordinatorSlotData interface in frontend types.
     assert len(data[CONF_SLOTS]) > 0
     for slot in data[CONF_SLOTS]:
         assert isinstance(slot[ATTR_SLOT], int)


### PR DESCRIPTION
## Proposed change

Two complementary sweeps across the integration applying a strict comment/docstring rubric:

### Pass 1 — strip historical narratives from docstrings

Docstrings now describe the *current contract only*. Removed:

- Refactor narratives ("we used to...", "this was extracted because...", "before the X migration...")
- Google-style Args/Returns/Raises blocks (project preference is prose)
- Design-rationale paragraphs that belong in ARCHITECTURE.md, not on a method contract
- Banner separator comments (\`# === Section ===\`) inside class bodies that drift when methods move
- "# Arrange / # Assert / # Reset for isolation" prefixes in tests that paraphrase the assignment immediately below

### Pass 2 — add value-add comments where the *why* is non-obvious

Inverse pass adding comments where the absence would actually trip a maintainer:

- \`__init__.py\` — \`async_listen_once\` self-unsub footgun (calling \`unsub()\` twice errors when the listener already self-removed)
- \`sync.py\` — exact \`== MAX+1\` log-once boundary (not \`>=\`)
- \`_base.py\` — push retry race: check \`active\` not \`pending\` because a pending retry was already cancelled by unsubscribe
- \`_base.py\` — SETUP_IN_PROGRESS skip in \`_handle_connection_transition\` avoids race with coordinator creation
- \`coordinator.py\` — cold-start no-raise prevents entities from being marked permanently unavailable
- \`zwave_js.py\` — slot-0 quirk in duplicate-code notifications (some firmwares report \`userId=0\` instead of the offending slot)
- \`zwave_js.py\` — asymmetric \`in_use\` checks for masked codes (UNKNOWN even when status is None) vs all-zeros codes (EMPTY only when status is explicitly False)
- \`config_flow.py\` — last-resort flow-context catch must not abort the user-facing flow

### Self-incriminating fixes (caught my own recent work)

The audit flagged several of my own recent docstrings that did exactly what the rubric forbids:
- \`coordinator.py\` \`_normalize_keys\` — was a 12-line refactor narrative; now one line
- \`websocket.py\` "no str/int variant gymnastics" comment from PR #1034 — referenced deleted helpers; deleted
- \`matter.py\` \`_async_call_service\` (rewrote it twice last hour) — *still* contained "Future refactors should preserve this bypass rather than 'unifying' it" — exactly the future-warning narrative the rubric bans. Now the rationale lives in a brief inline comment.
- \`tests/test_binary_sensor.py:1126\` — "Regression test:" docstring; now describes what it tests
- Property docstring at \`zwave_js.py supports_push\` initially over-trimmed to "Return True; Z-Wave JS push subscription is supported"; corrected per feedback ("property docstring should describe purpose, not the hardcoded return value")

### Methodology

- Dispatched 4 parallel comment-analyzer subagents scoped by area (core / providers / platforms+websocket / tests) for the first pass
- Ran a single inverse-pass subagent for missing comments
- Applied only high-confidence findings; deferred borderline items

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Test plan

- [x] Pre-commit hooks pass cleanly (ruff, ruff-format, pydocstyle, flake8, mypy)
- [x] Full pytest suite green (603 passed)
- [x] No production behavior changed — comment/docstring-only edits

## Additional information

Net diff: **−392 LOC across 25 files**. The bulk of the deletion is in \`_base.py\` (-114) and \`websocket.py\` / \`config_flow.py\` (combined -135) where multi-paragraph design-narrative docstrings collapsed to one-liners.