### PR TITLE
Rename LockCodeManagerConfigEntryData → LockCodeManagerConfigEntryRuntimeData

### DIFF
--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -88,7 +88,7 @@ from .helpers import (
     async_set_usercode,
     get_locks_from_targets,
 )
-from .models import LockCodeManagerConfigEntry, LockCodeManagerConfigEntryData
+from .models import LockCodeManagerConfigEntry, LockCodeManagerConfigEntryRuntimeData
 from .providers import BaseLock
 from .websocket import async_setup as async_websocket_setup
 
@@ -448,7 +448,7 @@ async def async_setup_entry(
 
     hass.data.setdefault(DOMAIN, {CONF_LOCKS: {}, "resources": False})
     await _async_register_strategy_resource(hass)
-    config_entry.runtime_data = LockCodeManagerConfigEntryData(
+    config_entry.runtime_data = LockCodeManagerConfigEntryRuntimeData(
         config=EntryConfig.from_entry(config_entry),
     )
 

--- a/custom_components/lock_code_manager/data.py
+++ b/custom_components/lock_code_manager/data.py
@@ -25,7 +25,7 @@ class EntryConfig:
     (``MappingProxyType`` at both levels) so instances can be cached
     without defensive copies.
 
-    An instance is cached on ``LockCodeManagerConfigEntryData.config``
+    An instance is cached on ``LockCodeManagerConfigEntryRuntimeData.config``
     and refreshed by the update listener. Most callers should access it
     via ``entry.runtime_data.config``. Iteration helpers that walk
     ``hass.config_entries.async_entries(DOMAIN)`` use

--- a/custom_components/lock_code_manager/models.py
+++ b/custom_components/lock_code_manager/models.py
@@ -33,7 +33,7 @@ class SlotCode(StrEnum):
 
 
 @dataclass
-class LockCodeManagerConfigEntryData:
+class LockCodeManagerConfigEntryRuntimeData:
     """Runtime data for a Lock Code Manager config entry."""
 
     locks: dict[str, BaseLock] = field(default_factory=dict)
@@ -45,4 +45,4 @@ class LockCodeManagerConfigEntryData:
     config: EntryConfig = field(default_factory=EntryConfig.empty)
 
 
-type LockCodeManagerConfigEntry = ConfigEntry[LockCodeManagerConfigEntryData]
+type LockCodeManagerConfigEntry = ConfigEntry[LockCodeManagerConfigEntryRuntimeData]

--- a/tests/providers/test_zwave_js.py
+++ b/tests/providers/test_zwave_js.py
@@ -35,7 +35,7 @@ from custom_components.lock_code_manager.const import (
 )
 from custom_components.lock_code_manager.exceptions import DuplicateCodeError
 from custom_components.lock_code_manager.models import (
-    LockCodeManagerConfigEntryData,
+    LockCodeManagerConfigEntryRuntimeData,
     SlotCode,
 )
 from custom_components.lock_code_manager.providers.zwave_js import ZWaveJSLock
@@ -1883,7 +1883,7 @@ async def test_duplicate_code_notification_marks_rejected(
     )
 
     # Find the ZWaveJSLock instance created by LCM setup
-    runtime_data: LockCodeManagerConfigEntryData = lcm_entry.runtime_data
+    runtime_data: LockCodeManagerConfigEntryRuntimeData = lcm_entry.runtime_data
     lock_instance = runtime_data.locks[lock_entity.entity_id]
     lock_instance._set_in_progress_code_slot = 2
 
@@ -1916,7 +1916,7 @@ async def test_duplicate_code_notification_no_user_id_marks_rejected(
         mock_zwave_usercodes,
     )
 
-    runtime_data: LockCodeManagerConfigEntryData = lcm_entry.runtime_data
+    runtime_data: LockCodeManagerConfigEntryRuntimeData = lcm_entry.runtime_data
     lock_instance = runtime_data.locks[lock_entity.entity_id]
     lock_instance._set_in_progress_code_slot = 3
 
@@ -1989,7 +1989,7 @@ async def test_duplicate_code_notification_ignored_when_user_id_mismatches(
     switch_2 = _get_enabled_switch_entity_id(hass, lcm_entry.entry_id, 2)
     switch_3 = _get_enabled_switch_entity_id(hass, lcm_entry.entry_id, 3)
 
-    runtime_data: LockCodeManagerConfigEntryData = lcm_entry.runtime_data
+    runtime_data: LockCodeManagerConfigEntryRuntimeData = lcm_entry.runtime_data
     lock_instance = runtime_data.locks[lock_entity.entity_id]
 
     # LCM is setting slot 2, but notification says slot 3
@@ -2078,7 +2078,7 @@ async def test_internal_set_usercode_raises_duplicate_for_rejected_slot(
         mock_zwave_usercodes,
     )
 
-    runtime_data: LockCodeManagerConfigEntryData = lcm_entry.runtime_data
+    runtime_data: LockCodeManagerConfigEntryRuntimeData = lcm_entry.runtime_data
     lock_instance = runtime_data.locks[lock_entity.entity_id]
 
     # Mark slot 2 as rejected (simulating event 15)


### PR DESCRIPTION
## Proposed change

The class is the \`runtime_data\` attached to \`ConfigEntry\` (per HA's \`ConfigEntry.runtime_data\` convention), not the persisted entry \`data\`. The old name conflated the two — \"ConfigEntryData\" suggests the on-disk dict, but it actually holds in-memory state (locks, setup_tasks, callbacks, cached EntryConfig view).

Pure mechanical rename across 4 files:
- \`custom_components/lock_code_manager/models.py\` — class definition + \`LockCodeManagerConfigEntry\` type alias
- \`custom_components/lock_code_manager/__init__.py\` — import + instantiation in \`async_setup_entry\`
- \`custom_components/lock_code_manager/data.py\` — docstring reference in \`EntryConfig\`
- \`tests/providers/test_zwave_js.py\` — 5 type-annotation references

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Test plan

- [x] Pre-commit hooks pass cleanly
- [x] Full pytest suite green (605 passed)
- [x] No production behavior changed — symbol rename only