### PR TITLE
ci: enable Codecov Test Analytics for pytest and vitest

### DIFF
--- a/.github/workflows/frontend-checks.yml
+++ b/.github/workflows/frontend-checks.yml
@@ -56,10 +56,20 @@ jobs:
       - name: Install dependencies
         run: yarn install
       - name: Run tests
-        run: yarn test --coverage --coverage.reporter=json
+        run: >-
+          yarn test --coverage --coverage.reporter=json
+          --reporter=default --reporter=junit
+          --outputFile.junit=junit.xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: typescript
           files: ./coverage/coverage-final.json
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: typescript
+          files: junit.xml

--- a/.github/workflows/python-checks.yml
+++ b/.github/workflows/python-checks.yml
@@ -96,7 +96,7 @@ jobs:
         # CI-only deps installed separately to keep requirements_dev.txt lightweight
         run: |
           uv pip install --system pytest-cov pytest-github-actions-annotate-failures
-          pytest ./tests/ --cov=custom_components/lock_code_manager/ --cov-report=xml
+          pytest ./tests/ --cov=custom_components/lock_code_manager/ --cov-report=xml --junitxml=junit.xml
       - name: Upload coverage to Codecov
         if: matrix.python-version == needs.setup.outputs.target-python
         uses: codecov/codecov-action@v6
@@ -104,3 +104,10 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: python
           files: coverage.xml
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() && matrix.python-version == needs.setup.outputs.target-python }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: python
+          files: junit.xml

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ docs/
 .serena/
 .github/hooks/
 .opencode/
+junit.xml


### PR DESCRIPTION
## Proposed change

Enable [Codecov Test Analytics](https://docs.codecov.com/docs/test-analytics) to track test durations, flaky tests, and failure trends across both test suites.

### Changes

- **python-checks.yml**: Add \`--junitxml=junit.xml\` to pytest command; upload via \`codecov/test-results-action@v1\`
- **frontend-checks.yml**: Add \`--reporter=junit --outputFile.junit=junit.xml\` to vitest command; upload via \`codecov/test-results-action@v1\`
- **.gitignore**: Add \`junit.xml\` (already present, no-op)

Both upload steps use \`if: \${{ !cancelled() }}\` so test results are reported even on failure (required for failure tracking in Codecov).

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Test plan

- [x] Verified vitest JUnit output locally (\`yarn test --reporter=junit --outputFile.junit=junit.xml\` produces valid XML)
- [x] Pre-commit hooks pass (yamllint, actionlint)
- [x] No test behavior changes — just added output reporters