### PR TITLE
fix: handle Matter duplicate PIN status on restart

### DIFF
--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -635,13 +635,20 @@ class BaseLock:
         )
 
     async def async_set_usercode(
-        self, code_slot: int, usercode: str, name: str | None = None
+        self,
+        code_slot: int,
+        usercode: str,
+        name: str | None = None,
+        source: Literal["sync", "direct"] = "direct",
     ) -> bool:
         """Set a usercode on a code slot.
 
         Returns True if the value was changed, False if already set to this
         value. If the provider cannot determine whether a change occurred,
         return True so the coordinator refreshes and verifies the state.
+
+        ``source`` indicates whether the call originates from the sync
+        manager ("sync") or a user action ("direct").
         """
         self._raise_not_implemented(
             "async_set_usercode",
@@ -689,6 +696,7 @@ class BaseLock:
             usercode,
             pre_execute=_pre_execute_checks,
             name=name,
+            source=source,
         )
         # Refresh coordinator to update entity states from cache (only if changed).
         # Skip for push-based providers — they update the coordinator optimistically

--- a/custom_components/lock_code_manager/providers/akuvox.py
+++ b/custom_components/lock_code_manager/providers/akuvox.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import Any
+from typing import Any, Literal
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.exceptions import HomeAssistantError
@@ -288,7 +288,11 @@ class AkuvoxLock(BaseLock):
         return result
 
     async def async_set_usercode(
-        self, code_slot: int, usercode: str, name: str | None = None
+        self,
+        code_slot: int,
+        usercode: str,
+        name: str | None = None,
+        source: Literal["sync", "direct"] = "direct",
     ) -> bool:
         """Set user code on a virtual slot.
 

--- a/custom_components/lock_code_manager/providers/matter.py
+++ b/custom_components/lock_code_manager/providers/matter.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import timedelta
-from typing import Any
+from typing import Any, Literal
 
 from matter_server.common.models import EventType
 
@@ -350,6 +350,31 @@ class MatterLock(BaseLock):
         if self.coordinator and self.coordinator.data is not None:
             self.coordinator.push_update({code_slot: resolved})
 
+    # -- Credential helpers --------------------------------------------------
+
+    async def _set_lock_credential(self, code_slot: int, usercode: str) -> None:
+        """Send set_lock_credential to the lock."""
+        await self._async_call_service(
+            "set_lock_credential",
+            {
+                "entity_id": self.lock.entity_id,
+                "credential_type": "pin",
+                "credential_data": usercode,
+                "credential_index": code_slot,
+            },
+        )
+
+    async def _clear_lock_credential(self, code_slot: int) -> None:
+        """Send clear_lock_credential to the lock."""
+        await self._async_call_service(
+            "clear_lock_credential",
+            {
+                "entity_id": self.lock.entity_id,
+                "credential_type": "pin",
+                "credential_index": code_slot,
+            },
+        )
+
     # -- Usercode CRUD -------------------------------------------------------
 
     async def async_get_usercodes(self) -> dict[int, str | SlotCode]:
@@ -406,7 +431,11 @@ class MatterLock(BaseLock):
         }
 
     async def async_set_usercode(
-        self, code_slot: int, usercode: str, name: str | None = None
+        self,
+        code_slot: int,
+        usercode: str,
+        name: str | None = None,
+        source: Literal["sync", "direct"] = "direct",
     ) -> bool:
         """Set a usercode on a code slot.
 
@@ -414,27 +443,42 @@ class MatterLock(BaseLock):
         the credential value actually changed. Pushes SlotCode.UNKNOWN to the
         coordinator immediately — the LockUserChange event will confirm.
 
-        If the lock returns a "duplicate" status, the PIN already exists on
-        another slot. This raises DuplicateCodeError so the sync manager can
-        disable the slot and notify the user.
+        If the lock returns a "duplicate" status during sync (source="sync"),
+        the credential is cleared on that slot and the set is retried. This
+        handles the common case where _last_set_pin is lost after a Home
+        Assistant restart and the lock rejects a re-set of the same PIN. If
+        the retry also returns "duplicate", the PIN truly exists on a different
+        slot and DuplicateCodeError is raised.
+
+        For direct (user-initiated) calls, a duplicate immediately raises
+        DuplicateCodeError without clearing, since the slot may hold a
+        different user's credential that should not be silently removed.
         """
         try:
-            await self._async_call_service(
-                "set_lock_credential",
-                {
-                    "entity_id": self.lock.entity_id,
-                    "credential_type": "pin",
-                    "credential_data": usercode,
-                    "credential_index": code_slot,
-                },
-            )
+            await self._set_lock_credential(code_slot, usercode)
         except LockDisconnected as err:
-            if "duplicate" in str(err).lower():
+            if "duplicate" not in str(err).lower():
+                raise
+            if source != "sync":
                 raise DuplicateCodeError(
                     code_slot=code_slot,
                     lock_entity_id=self.lock.entity_id,
                 ) from err
-            raise
+            LOGGER.debug(
+                "Lock %s: duplicate on slot %s, clearing and retrying",
+                self.lock.entity_id,
+                code_slot,
+            )
+            try:
+                await self._clear_lock_credential(code_slot)
+                await self._set_lock_credential(code_slot, usercode)
+            except LockDisconnected as retry_err:
+                if "duplicate" in str(retry_err).lower():
+                    raise DuplicateCodeError(
+                        code_slot=code_slot,
+                        lock_entity_id=self.lock.entity_id,
+                    ) from retry_err
+                raise
         if name is not None:
             try:
                 await self._async_call_service(
@@ -476,14 +520,7 @@ class MatterLock(BaseLock):
         if not lock_data.get("credential_exists"):
             return False
 
-        await self._async_call_service(
-            "clear_lock_credential",
-            {
-                "entity_id": self.lock.entity_id,
-                "credential_type": "pin",
-                "credential_index": code_slot,
-            },
-        )
+        await self._clear_lock_credential(code_slot)
         # Optimistic update: clear succeeded, push empty state immediately.
         # The LockUserChange event will confirm later.
         if self.coordinator and self.coordinator.data is not None:

--- a/custom_components/lock_code_manager/providers/schlage.py
+++ b/custom_components/lock_code_manager/providers/schlage.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import timedelta
+from typing import Literal
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
@@ -303,7 +304,11 @@ class SchlageLock(BaseLock):
         }
 
     async def async_set_usercode(
-        self, code_slot: int, usercode: str, name: str | None = None
+        self,
+        code_slot: int,
+        usercode: str,
+        name: str | None = None,
+        source: Literal["sync", "direct"] = "direct",
     ) -> bool:
         """Set user code on a virtual slot.
 

--- a/custom_components/lock_code_manager/providers/virtual.py
+++ b/custom_components/lock_code_manager/providers/virtual.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 import logging
-from typing import TypedDict
+from typing import Literal, TypedDict
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.storage import Store
@@ -65,7 +65,11 @@ class VirtualLock(BaseLock):
         return await self.async_get_usercodes()
 
     async def async_set_usercode(
-        self, code_slot: int, usercode: str, name: str | None = None
+        self,
+        code_slot: int,
+        usercode: str,
+        name: str | None = None,
+        source: Literal["sync", "direct"] = "direct",
     ) -> bool:
         """
         Set a usercode on a code slot.

--- a/custom_components/lock_code_manager/providers/zwave_js.py
+++ b/custom_components/lock_code_manager/providers/zwave_js.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass, field
 from datetime import timedelta
 import functools
 import logging
-from typing import Any
+from typing import Any, Literal
 
 from zwave_js_server.client import Client
 from zwave_js_server.const import CommandClass, NodeStatus
@@ -393,7 +393,11 @@ class ZWaveJSLock(BaseLock):
         return await self.async_get_usercodes()
 
     async def async_set_usercode(
-        self, code_slot: int, usercode: str, name: str | None = None
+        self,
+        code_slot: int,
+        usercode: str,
+        name: str | None = None,
+        source: Literal["sync", "direct"] = "direct",
     ) -> bool:
         """
         Set a usercode on a code slot.

--- a/tests/common.py
+++ b/tests/common.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Literal
 
 from homeassistant.components.calendar import CalendarEntity, CalendarEvent
 from homeassistant.components.lock import LockEntity
@@ -84,7 +85,11 @@ class MockLCMLock(BaseLock):
         return await self.async_get_usercodes()
 
     async def async_set_usercode(
-        self, code_slot: int, usercode: str, name: str | None = None
+        self,
+        code_slot: int,
+        usercode: str,
+        name: str | None = None,
+        source: Literal["sync", "direct"] = "direct",
     ) -> bool:
         """Set a usercode on a code slot.
 

--- a/tests/providers/test_matter.py
+++ b/tests/providers/test_matter.py
@@ -505,10 +505,10 @@ async def test_service_call_failure_raises_lock_disconnected(
         await matter_lock.async_set_usercode(1, "1234")
 
 
-async def test_set_usercode_duplicate_raises_duplicate_code_error(
+async def test_set_usercode_duplicate_direct_raises_immediately(
     hass: HomeAssistant, matter_lock: MatterLock
 ) -> None:
-    """Test that a duplicate status from the lock raises DuplicateCodeError."""
+    """Test that a duplicate on a direct (user-initiated) call raises immediately."""
     handler = AsyncMock(
         side_effect=HomeAssistantError(
             "Failed to set credential: lock returned status `duplicate`"
@@ -520,6 +520,52 @@ async def test_set_usercode_duplicate_raises_duplicate_code_error(
         await matter_lock.async_set_usercode(1, "1234")
     assert exc_info.value.code_slot == 1
     assert exc_info.value.lock_entity_id == LOCK_ENTITY_ID
+    # Only one set attempt, no clear-and-retry for direct calls
+    assert handler.call_count == 1
+
+
+async def test_set_usercode_duplicate_sync_retries_after_clear(
+    hass: HomeAssistant, matter_lock: MatterLock
+) -> None:
+    """Test that a duplicate during sync clears and retries successfully."""
+    set_handler = AsyncMock(
+        side_effect=[
+            HomeAssistantError(
+                "Failed to set credential: lock returned status `duplicate`"
+            ),
+            {LOCK_ENTITY_ID: {"credential_index": 1, "user_index": 1}},
+        ]
+    )
+    clear_handler = AsyncMock(return_value={LOCK_ENTITY_ID: {}})
+    register_mock_service(hass, MATTER_DOMAIN, "set_lock_credential", set_handler)
+    register_mock_service(hass, MATTER_DOMAIN, "clear_lock_credential", clear_handler)
+
+    result = await matter_lock.async_set_usercode(1, "1234", source="sync")
+
+    assert result is True
+    assert set_handler.call_count == 2
+    assert clear_handler.call_count == 1
+
+
+async def test_set_usercode_duplicate_sync_persistent_raises(
+    hass: HomeAssistant, matter_lock: MatterLock
+) -> None:
+    """Test that a persistent duplicate during sync raises after retry."""
+    set_handler = AsyncMock(
+        side_effect=HomeAssistantError(
+            "Failed to set credential: lock returned status `duplicate`"
+        )
+    )
+    clear_handler = AsyncMock(return_value={LOCK_ENTITY_ID: {}})
+    register_mock_service(hass, MATTER_DOMAIN, "set_lock_credential", set_handler)
+    register_mock_service(hass, MATTER_DOMAIN, "clear_lock_credential", clear_handler)
+
+    with pytest.raises(DuplicateCodeError) as exc_info:
+        await matter_lock.async_set_usercode(1, "1234", source="sync")
+    assert exc_info.value.code_slot == 1
+    assert exc_info.value.lock_entity_id == LOCK_ENTITY_ID
+    assert set_handler.call_count == 2
+    assert clear_handler.call_count == 1
 
 
 async def test_get_usercodes_multiple_credential_types(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass, field
 from datetime import timedelta
+from typing import Literal
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -58,7 +59,11 @@ class MockLockWithHardRefresh(BaseLock):
         return {}
 
     async def async_set_usercode(
-        self, code_slot: int, usercode: str, name: str | None = None
+        self,
+        code_slot: int,
+        usercode: str,
+        name: str | None = None,
+        source: Literal["sync", "direct"] = "direct",
     ) -> bool:
         """Set a usercode on a code slot."""
         return True


### PR DESCRIPTION
## Proposed change

After an HA restart, `_last_set_pin` (in-memory only) is lost, so LCM treats `UNKNOWN` slots as out-of-sync and tries to re-set the PIN. The lock rejects this with a "duplicate" status because the PIN already exists on that same slot. Previously this raised `DuplicateCodeError` which disabled the slot — a critical bug for Matter lock users on every restart.

### Sync-initiated calls (source="sync")

When a "duplicate" status is received during sync reconciliation:
1. Clear the credential on that slot (safe because LCM owns it)
2. Retry the set
3. If the retry *also* returns "duplicate", the PIN truly exists on a different slot — only then raise `DuplicateCodeError`

### Direct (user-initiated) calls

A duplicate immediately raises `DuplicateCodeError` without clearing, since the slot may hold a different user's credential that should not be silently removed.

### Other changes

- Adds `source` parameter (`"sync"` | `"direct"`) to `async_set_usercode` across all providers so they can distinguish the call origin
- Extracts `_set_lock_credential` and `_clear_lock_credential` helper methods to reduce duplication

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

🤖 Generated with [Claude Code](https://claude.com/claude-code)