### PR TITLE
fix: auto-detect service response support in Matter provider

### DIFF
--- a/custom_components/lock_code_manager/providers/matter.py
+++ b/custom_components/lock_code_manager/providers/matter.py
@@ -16,7 +16,7 @@ from typing import Any
 from matter_server.common.models import EventType
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import callback
+from homeassistant.core import SupportsResponse, callback
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 
 from ..data import get_managed_slots
@@ -112,26 +112,32 @@ class MatterLock(BaseLock):
     ) -> dict[str, Any]:
         """Call a Matter service and return the per-entity dict.
 
+        Auto-detects whether the service supports responses. Void services
+        (SupportsResponse.NONE) are called without return_response and return
+        an empty dict. Services that support responses are validated for the
+        expected per-entity structure.
+
         Raises LockDisconnected on service failure or
         LockCodeManagerProviderError on malformed response.
         """
-        # Bypasses BaseLock.async_call_service because Matter responses are
-        # wrapped per entity_id and need structural validation that raises
-        # LockCodeManagerProviderError (not LockDisconnected) on bad shape.
         entity_id = self.lock.entity_id
+        resp_support = self.hass.services.supports_response(MATTER_DOMAIN, service)
+        return_response = resp_support != SupportsResponse.NONE
         try:
             result = await self.hass.services.async_call(
                 MATTER_DOMAIN,
                 service,
                 service_data,
                 blocking=True,
-                return_response=True,
+                return_response=return_response,
             )
         except (ServiceValidationError, HomeAssistantError) as err:
             raise LockDisconnected(
                 f"Matter service {MATTER_DOMAIN}.{service} failed for "
                 f"{entity_id}: {err}"
             ) from err
+        if not return_response:
+            return {}
         if not isinstance(result, dict) or entity_id not in result:
             raise LockCodeManagerProviderError(
                 f"Matter service {MATTER_DOMAIN}.{service} returned no data for "

--- a/tests/providers/test_matter.py
+++ b/tests/providers/test_matter.py
@@ -10,7 +10,7 @@ from matter_server.common.models import MatterNodeEvent
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, SupportsResponse
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
@@ -520,6 +520,35 @@ async def test_set_usercode_duplicate_raises_duplicate_code_error(
         await matter_lock.async_set_usercode(1, "1234")
     assert exc_info.value.code_slot == 1
     assert exc_info.value.lock_entity_id == LOCK_ENTITY_ID
+
+
+async def test_async_call_service_void_service(
+    hass: HomeAssistant, matter_lock: MatterLock
+) -> None:
+    """Test _async_call_service works with void services that do not return responses.
+
+    Void services (SupportsResponse.NONE) should be called without
+    return_response=True and return an empty dict without raising
+    LockCodeManagerProviderError.
+    """
+    handler = AsyncMock(return_value=None)
+
+    async def _service_handler(call):
+        return await handler(call)
+
+    hass.services.async_register(
+        MATTER_DOMAIN,
+        "void_service",
+        _service_handler,
+        supports_response=SupportsResponse.NONE,
+    )
+
+    result = await matter_lock._async_call_service(
+        "void_service", {"entity_id": matter_lock.lock.entity_id}
+    )
+
+    assert result == {}
+    assert handler.call_count == 1
 
 
 async def test_get_usercodes_multiple_credential_types(


### PR DESCRIPTION
## Proposed change

The `_async_call_service` method in the Matter provider hardcoded `return_response=True` when calling `hass.services.async_call`. This breaks void services like `clear_lock_credential` that raise `ServiceValidationError("An action which does not return responses can't be called with return_response=True")`.

Now auto-detects whether the service supports responses using `hass.services.supports_response(domain, service)` and sets `return_response` accordingly. For void services (`SupportsResponse.NONE`), skips response validation and returns an empty dict.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- Adds a test verifying `_async_call_service` correctly handles void services (registered with `SupportsResponse.NONE`)
- All existing tests continue to pass since mock services use `SupportsResponse.OPTIONAL`