### PR TITLE
fix: pass user_index to set_lock_user instead of credential_index

### DIFF
--- a/custom_components/lock_code_manager/providers/matter.py
+++ b/custom_components/lock_code_manager/providers/matter.py
@@ -358,9 +358,9 @@ class MatterLock(BaseLock):
 
     # -- Credential helpers --------------------------------------------------
 
-    async def _set_lock_credential(self, code_slot: int, usercode: str) -> None:
-        """Send set_lock_credential to the lock."""
-        await self._async_call_service(
+    async def _set_lock_credential(self, code_slot: int, usercode: str) -> int | None:
+        """Send set_lock_credential to the lock and return the user_index."""
+        result = await self._async_call_service(
             "set_lock_credential",
             {
                 "entity_id": self.lock.entity_id,
@@ -369,6 +369,7 @@ class MatterLock(BaseLock):
                 "credential_index": code_slot,
             },
         )
+        return result.get("user_index")
 
     async def _clear_lock_credential(self, code_slot: int) -> None:
         """Send clear_lock_credential to the lock."""
@@ -460,8 +461,9 @@ class MatterLock(BaseLock):
         DuplicateCodeError without clearing, since the slot may hold a
         different user's credential that should not be silently removed.
         """
+        user_index: int | None = None
         try:
-            await self._set_lock_credential(code_slot, usercode)
+            user_index = await self._set_lock_credential(code_slot, usercode)
         except LockDisconnected as err:
             if "duplicate" not in str(err).lower():
                 raise
@@ -477,7 +479,7 @@ class MatterLock(BaseLock):
             )
             try:
                 await self._clear_lock_credential(code_slot)
-                await self._set_lock_credential(code_slot, usercode)
+                user_index = await self._set_lock_credential(code_slot, usercode)
             except LockDisconnected as retry_err:
                 if "duplicate" in str(retry_err).lower():
                     raise DuplicateCodeError(
@@ -485,13 +487,13 @@ class MatterLock(BaseLock):
                         lock_entity_id=self.lock.entity_id,
                     ) from retry_err
                 raise
-        if name is not None:
+        if name is not None and user_index is not None:
             try:
                 await self._async_call_service(
                     "set_lock_user",
                     {
                         "entity_id": self.lock.entity_id,
-                        "credential_index": code_slot,
+                        "user_index": user_index,
                         "user_name": name,
                     },
                 )

--- a/tests/providers/test_matter.py
+++ b/tests/providers/test_matter.py
@@ -357,18 +357,34 @@ async def test_get_usercodes_invalid_credential_index_skipped(
 
 
 async def test_set_usercode(hass: HomeAssistant, matter_lock: MatterLock) -> None:
-    """Test set_usercode calls the correct Matter services."""
+    """Test set_usercode calls the correct Matter services with user_index."""
     calls: list[dict[str, Any]] = []
 
-    async def _capture_call(call):
+    async def _capture_credential_call(call):
+        calls.append({"service": call.service, "data": dict(call.data)})
+        return {
+            LOCK_ENTITY_ID: {
+                "credential_index": 1,
+                "user_index": 1,
+                "next_credential_index": 2,
+            }
+        }
+
+    async def _capture_user_call(call):
         calls.append({"service": call.service, "data": dict(call.data)})
         return {LOCK_ENTITY_ID: {}}
 
     register_mock_service(
-        hass, MATTER_DOMAIN, "set_lock_credential", AsyncMock(side_effect=_capture_call)
+        hass,
+        MATTER_DOMAIN,
+        "set_lock_credential",
+        AsyncMock(side_effect=_capture_credential_call),
     )
     register_mock_service(
-        hass, MATTER_DOMAIN, "set_lock_user", AsyncMock(side_effect=_capture_call)
+        hass,
+        MATTER_DOMAIN,
+        "set_lock_user",
+        AsyncMock(side_effect=_capture_user_call),
     )
 
     result = await matter_lock.async_set_usercode(1, "1234", "User One")
@@ -380,15 +396,40 @@ async def test_set_usercode(hass: HomeAssistant, matter_lock: MatterLock) -> Non
     assert calls[0]["data"]["credential_type"] == "pin"
     assert calls[0]["data"]["credential_data"] == "1234"
     assert calls[0]["data"]["credential_index"] == 1
-    # Second call: set_lock_user
+    # Second call: set_lock_user with user_index (not credential_index)
     assert calls[1]["service"] == "set_lock_user"
+    assert calls[1]["data"]["user_index"] == 1
     assert calls[1]["data"]["user_name"] == "User One"
+    assert "credential_index" not in calls[1]["data"]
 
 
 async def test_set_usercode_no_name(
     hass: HomeAssistant, matter_lock: MatterLock
 ) -> None:
     """Test set_usercode without a name only calls set_lock_credential."""
+    calls: list[str] = []
+
+    async def _capture_call(call):
+        calls.append(call.service)
+        return {LOCK_ENTITY_ID: {"credential_index": 3, "user_index": 3}}
+
+    register_mock_service(
+        hass, MATTER_DOMAIN, "set_lock_credential", AsyncMock(side_effect=_capture_call)
+    )
+    register_mock_service(
+        hass, MATTER_DOMAIN, "set_lock_user", AsyncMock(side_effect=_capture_call)
+    )
+
+    result = await matter_lock.async_set_usercode(3, "9999")
+
+    assert result is True
+    assert calls == ["set_lock_credential"]
+
+
+async def test_set_usercode_skips_name_when_no_user_index(
+    hass: HomeAssistant, matter_lock: MatterLock
+) -> None:
+    """Test set_usercode skips set_lock_user when response has no user_index."""
     calls: list[str] = []
 
     async def _capture_call(call):
@@ -402,7 +443,7 @@ async def test_set_usercode_no_name(
         hass, MATTER_DOMAIN, "set_lock_user", AsyncMock(side_effect=_capture_call)
     )
 
-    result = await matter_lock.async_set_usercode(3, "9999")
+    result = await matter_lock.async_set_usercode(1, "1234", "User One")
 
     assert result is True
     assert calls == ["set_lock_credential"]


### PR DESCRIPTION
## Proposed change

`async_set_usercode` calls `set_lock_user` to set the user's name after setting the credential, but was passing `credential_index` as a parameter. `set_lock_user` only accepts `user_index`, `user_name`, `user_type`, and `credential_rule` — the extra `credential_index` key causes a `ServiceValidationError` that gets caught as `LockCodeManagerProviderError` and silently logged as a warning.

This fix captures the `user_index` returned by `set_lock_credential` and passes it to `set_lock_user`. If no `user_index` is returned, the `set_lock_user` call is skipped entirely.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR is related to issue: depends on #1044

🤖 Generated with [Claude Code](https://claude.com/claude-code)