### PR TITLE
fix: make provider async_setup failure non-fatal

### DIFF
--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -168,6 +168,9 @@ class BaseLock:
     )
     _last_entry_state: ConfigEntryState | None = field(default=None, init=False)
     _setup_complete: asyncio.Event = field(default_factory=asyncio.Event, init=False)
+    _setup_succeeded: bool = field(default=False, init=False)
+    _setup_running: bool = field(default=False, init=False)
+    _lcm_config_entry: ConfigEntry | None = field(default=None, init=False)
     _push_retry: OneShotRetry | None = field(default=None, init=False)
     _push_disabled: bool = field(default=False, init=False)
     _rejected_code_slots: set[int] = field(default_factory=set, init=False)
@@ -379,6 +382,8 @@ class BaseLock:
     def subscribe_push_updates(self) -> None:
         """Subscribe to push-based value updates, scheduling a one-shot retry on transient failure.
 
+        Idempotent: safe to call when already subscribed (delegates to
+        ``setup_push_subscription`` which must be idempotent).
         ProviderNotImplementedError propagates.
         """
         # Block retry-driven calls after unsubscribe to prevent in-flight
@@ -465,11 +470,67 @@ class BaseLock:
         Provider ``async_setup()`` runs first so providers can initialize
         any state the coordinator needs during its first refresh.
         """
+        self._lcm_config_entry = config_entry
         try:
             await self.async_setup(config_entry)
+        except LockDisconnected as err:
+            LOGGER.warning(
+                "Provider setup failed for %s: %s. Coordinator will be "
+                "created but data will be unavailable until the lock "
+                "comes online. Setup will be retried when the lock "
+                "integration reconnects.",
+                self.lock.entity_id,
+                err,
+            )
+        else:
+            self._setup_succeeded = True
+
+        try:
             await self._async_setup_internal(config_entry)
         finally:
             self._setup_complete.set()
+
+    async def _async_on_integration_loaded(self) -> None:
+        """Handle provider integration LOADED transition.
+
+        Re-runs ``async_setup`` to re-initialize provider state (e.g.
+        re-register event listeners after an integration reload), then
+        refreshes the coordinator and subscribes to push updates.
+
+        Operations are chained sequentially so setup completes before
+        the coordinator refresh or push subscription begins.
+        """
+        if (
+            self._lcm_config_entry is None
+            or self._setup_running
+            or not self.lock_config_entry
+            or self.lock_config_entry.state != ConfigEntryState.LOADED
+        ):
+            return
+
+        self._setup_running = True
+        try:
+            await self.async_setup(self._lcm_config_entry)
+        except LockDisconnected:
+            LOGGER.debug(
+                "Provider setup failed for %s, will retry on next reconnect",
+                self.lock.entity_id,
+                exc_info=True,
+            )
+        else:
+            if not self._setup_succeeded:
+                LOGGER.info(
+                    "Provider setup succeeded for %s",
+                    self.lock.entity_id,
+                )
+            self._setup_succeeded = True
+        finally:
+            self._setup_running = False
+
+        if self.coordinator:
+            await self.coordinator.async_request_refresh()
+        if self.supports_push:
+            self.subscribe_push_updates()
 
     @final
     async def _async_setup_internal(self, config_entry: ConfigEntry) -> None:
@@ -525,7 +586,12 @@ class BaseLock:
     async def async_setup(self, config_entry: ConfigEntry) -> None:
         """Set up lock by provider.
 
-        Default is a no-op; providers override to do one-time async setup.
+        Default is a no-op; providers override for provider-specific setup
+        (e.g. registering event listeners, validating capabilities).
+
+        Implementations MUST be idempotent — this is called on initial load
+        and again on every provider integration reconnect. Clean up any
+        previous state before re-initializing.
         """
 
     @final
@@ -563,13 +629,10 @@ class BaseLock:
                 return
 
             if to_state == ConfigEntryState.LOADED:
-                if self.coordinator:
-                    self.hass.async_create_task(
-                        self.coordinator.async_request_refresh(),
-                        f"Refresh coordinator for {self.lock.entity_id} after reload",
-                    )
-                if self.supports_push:
-                    self.subscribe_push_updates()
+                self.hass.async_create_task(
+                    self._async_on_integration_loaded(),
+                    f"Provider reconnect for {self.lock.entity_id}",
+                )
             elif (
                 self.supports_push and self._last_entry_state == ConfigEntryState.LOADED
             ):

--- a/custom_components/lock_code_manager/providers/zwave_js.py
+++ b/custom_components/lock_code_manager/providers/zwave_js.py
@@ -354,7 +354,14 @@ class ZWaveJSLock(BaseLock):
         return ZWAVE_JS_DOMAIN
 
     async def async_setup(self, config_entry: ConfigEntry) -> None:
-        """Set up lock by provider."""
+        """Set up lock by provider.
+
+        Idempotent: clears existing listeners before re-registering.
+        """
+        listeners = list(self._listeners)
+        self._listeners.clear()
+        for listener in listeners:
+            listener()
         self._listeners.append(
             self.hass.bus.async_listen(
                 ZWAVE_JS_NOTIFICATION_EVENT,
@@ -365,9 +372,10 @@ class ZWaveJSLock(BaseLock):
 
     async def async_unload(self, remove_permanently: bool) -> None:
         """Unload lock."""
-        for listener in self._listeners:
-            listener()
+        listeners = list(self._listeners)
         self._listeners.clear()
+        for listener in listeners:
+            listener()
         await super().async_unload(remove_permanently)
 
     async def async_is_integration_connected(self) -> bool:

--- a/tests/providers/test_base.py
+++ b/tests/providers/test_base.py
@@ -3,11 +3,12 @@
 import asyncio
 from datetime import datetime, timedelta
 import time
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant, State, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
@@ -598,6 +599,115 @@ async def test_setup_defers_push_subscription_when_entry_not_loaded(
         assert lock.subscribe_calls == 0
 
     await lock.async_unload(False)
+
+
+async def test_async_setup_internal_creates_coordinator_when_setup_fails(
+    hass: HomeAssistant,
+):
+    """Test that coordinator is created even when async_setup raises."""
+    entity_reg = er.async_get(hass)
+    dev_reg = dr.async_get(hass)
+
+    config_entry = MockConfigEntry(domain=DOMAIN)
+    config_entry.add_to_hass(hass)
+
+    lock_entity = entity_reg.async_get_or_create(
+        "lock",
+        "test",
+        "test_lock_setup_fail",
+        config_entry=config_entry,
+    )
+
+    lock = BaseLock(
+        hass,
+        dev_reg,
+        entity_reg,
+        config_entry,
+        lock_entity,
+    )
+
+    # Make async_setup raise an exception
+    with (
+        patch.object(
+            lock,
+            "async_setup",
+            side_effect=LockDisconnected("provider unavailable"),
+        ),
+        patch(
+            "custom_components.lock_code_manager.coordinator."
+            "LockUsercodeUpdateCoordinator.async_config_entry_first_refresh"
+        ),
+        patch(
+            "custom_components.lock_code_manager.coordinator."
+            "LockUsercodeUpdateCoordinator.async_refresh"
+        ),
+    ):
+        # Should not raise even though async_setup failed
+        await lock.async_setup_internal(config_entry)
+
+    # Coordinator should still have been created
+    assert lock.coordinator is not None
+    # Setup complete should be signaled
+    assert lock._setup_complete.is_set()
+    # Setup should be marked as failed
+    assert lock._setup_succeeded is False
+
+    # Simulate reconnect: mock lock_config_entry as LOADED, async_setup succeeds
+    mock_entry = MagicMock()
+    mock_entry.state = ConfigEntryState.LOADED
+    lock.lock_config_entry = mock_entry
+    with patch.object(lock, "async_setup", return_value=None):
+        await lock._async_on_integration_loaded()
+
+    assert lock._setup_succeeded is True
+
+
+async def test_on_integration_loaded_skips_when_no_config_entry(
+    hass: HomeAssistant,
+):
+    """Test that _async_on_integration_loaded is a no-op when _lcm_config_entry is None."""
+    entity_reg = er.async_get(hass)
+    dev_reg = dr.async_get(hass)
+
+    config_entry = MockConfigEntry(domain=DOMAIN)
+    config_entry.add_to_hass(hass)
+
+    lock_entity = entity_reg.async_get_or_create(
+        "lock", "test", "test_lock_no_entry", config_entry=config_entry
+    )
+
+    lock = BaseLock(hass, dev_reg, entity_reg, config_entry, lock_entity)
+    # _lcm_config_entry is None (async_setup_internal never called)
+    assert lock._lcm_config_entry is None
+    # Should be a no-op, not raise
+    await lock._async_on_integration_loaded()
+    assert lock._setup_succeeded is False
+
+
+async def test_on_integration_loaded_retries_on_disconnect(
+    hass: HomeAssistant,
+):
+    """Test that _async_on_integration_loaded retries setup on LockDisconnected."""
+    entity_reg = er.async_get(hass)
+    dev_reg = dr.async_get(hass)
+
+    config_entry = MockConfigEntry(domain=DOMAIN)
+    config_entry.add_to_hass(hass)
+
+    lock_entity = entity_reg.async_get_or_create(
+        "lock", "test", "test_lock_retry", config_entry=config_entry
+    )
+
+    lock = BaseLock(hass, dev_reg, entity_reg, config_entry, lock_entity)
+    lock._lcm_config_entry = config_entry
+
+    # async_setup raises LockDisconnected — should not propagate
+    with patch.object(
+        lock, "async_setup", side_effect=LockDisconnected("still offline")
+    ):
+        await lock._async_on_integration_loaded()
+
+    assert lock._setup_succeeded is False
 
 
 async def test_set_usercode_skips_refresh_for_push_provider(

--- a/tests/providers/test_zwave_js.py
+++ b/tests/providers/test_zwave_js.py
@@ -115,6 +115,21 @@ async def test_connection_check_interval_is_none(zwave_js_lock: ZWaveJSLock) -> 
     assert zwave_js_lock.connection_check_interval is None
 
 
+async def test_setup_is_idempotent(
+    hass: HomeAssistant,
+    zwave_js_lock: ZWaveJSLock,
+    lock_code_manager_config_entry: MockConfigEntry,
+) -> None:
+    """Test that async_setup clears old listeners before re-registering."""
+    await zwave_js_lock.async_setup(lock_code_manager_config_entry)
+    assert len(zwave_js_lock._listeners) >= 1
+    count_after_first = len(zwave_js_lock._listeners)
+
+    # Call again — should not accumulate listeners
+    await zwave_js_lock.async_setup(lock_code_manager_config_entry)
+    assert len(zwave_js_lock._listeners) == count_after_first
+
+
 # CC version detection tests
 
 


### PR DESCRIPTION
## Proposed change

When a lock's provider integration (e.g. Matter) is unavailable at Home Assistant startup, the provider's `async_setup()` call raises an exception. Previously, this prevented `_async_setup_internal()` from running, so the coordinator was never created. Entities were created but remained `unavailable` with `restored: true` because they had no coordinator. When the provider integration came back online, the entities stayed stuck until the user manually reloaded the config entry.

This change catches `async_setup()` failures and logs a warning instead of letting the exception propagate. This allows `_async_setup_internal()` to always run and create the coordinator. The coordinator's first refresh will likely fail too (lock unavailable), but it handles that gracefully (returns `{}` during cold start). When the lock comes online, the existing config entry state listener triggers a refresh automatically.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: