### PR TITLE
fix: split Matter exception handling and add hard refresh interval

### DIFF
--- a/custom_components/lock_code_manager/exceptions.py
+++ b/custom_components/lock_code_manager/exceptions.py
@@ -83,6 +83,16 @@ class LockDisconnected(LockCodeManagerProviderError):
     """Raised when lock can't be communicated with."""
 
 
+class LockOperationFailed(LockCodeManagerProviderError):
+    """Raised when the lock is reachable but the operation failed.
+
+    This covers cases like the lock not supporting a requested operation
+    or the provider rejecting the command for a lock-side reason. Unlike
+    ``LockDisconnected``, the lock is online — the specific operation
+    just could not be completed.
+    """
+
+
 class ProviderNotImplementedError(LockCodeManagerProviderError, NotImplementedError):
     """Raised when a provider method that subclasses must override is called."""
 

--- a/custom_components/lock_code_manager/providers/matter.py
+++ b/custom_components/lock_code_manager/providers/matter.py
@@ -81,6 +81,16 @@ class MatterLock(BaseLock):
         return timedelta(minutes=5)
 
     @property
+    def hard_refresh_interval(self) -> timedelta | None:
+        """Return interval between hard refreshes for drift detection.
+
+        Matter locks support push events for local changes, but API-initiated
+        changes bypass push notifications. Periodic hard refresh catches drift
+        from external tools or missed events.
+        """
+        return timedelta(hours=1)
+
+    @property
     def _matter_node_id(self) -> int | None:
         """Resolve the Matter node ID from the device registry."""
         if not self.device_entry:
@@ -131,7 +141,12 @@ class MatterLock(BaseLock):
                 blocking=True,
                 return_response=return_response,
             )
-        except (ServiceValidationError, HomeAssistantError) as err:
+        except ServiceValidationError as err:
+            raise LockCodeManagerProviderError(
+                f"Matter service {MATTER_DOMAIN}.{service} rejected input for "
+                f"{entity_id}: {err}"
+            ) from err
+        except HomeAssistantError as err:
             raise LockDisconnected(
                 f"Matter service {MATTER_DOMAIN}.{service} failed for "
                 f"{entity_id}: {err}"

--- a/custom_components/lock_code_manager/sync.py
+++ b/custom_components/lock_code_manager/sync.py
@@ -52,7 +52,7 @@ from .const import (
     SYNC_ATTEMPT_WINDOW,
     TICK_INTERVAL,
 )
-from .exceptions import CodeRejectedError, LockDisconnected
+from .exceptions import CodeRejectedError, LockDisconnected, LockOperationFailed
 from .models import SlotCode
 from .util import async_disable_slot
 
@@ -556,7 +556,7 @@ class SlotSyncManager:
                     f"Fix the issue and re-enable the slot.",
                 )
                 return
-            except LockDisconnected as err:
+            except (LockDisconnected, LockOperationFailed) as err:
                 _LOGGER.info(
                     "%s: Lock disconnected during %s usercode: %s. Will retry on next tick.",
                     self._log_prefix,

--- a/tests/providers/test_matter.py
+++ b/tests/providers/test_matter.py
@@ -11,7 +11,7 @@ import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from homeassistant.core import HomeAssistant, SupportsResponse
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from custom_components.lock_code_manager.const import (
@@ -25,6 +25,7 @@ from custom_components.lock_code_manager.const import (
 from custom_components.lock_code_manager.exceptions import (
     DuplicateCodeError,
     LockCodeManagerError,
+    LockCodeManagerProviderError,
     LockDisconnected,
 )
 from custom_components.lock_code_manager.models import SlotCode
@@ -137,6 +138,11 @@ async def test_supports_push(matter_lock: MatterLock) -> None:
 async def test_usercode_scan_interval(matter_lock: MatterLock) -> None:
     """Test that scan interval is 5 minutes."""
     assert matter_lock.usercode_scan_interval == timedelta(minutes=5)
+
+
+async def test_hard_refresh_interval(matter_lock: MatterLock) -> None:
+    """Test that hard refresh interval is 1 hour for drift detection."""
+    assert matter_lock.hard_refresh_interval == timedelta(hours=1)
 
 
 # ---------------------------------------------------------------------------
@@ -544,6 +550,43 @@ async def test_service_call_failure_raises_lock_disconnected(
 
     with pytest.raises(LockDisconnected, match="connection lost"):
         await matter_lock.async_set_usercode(1, "1234")
+
+
+async def test_service_validation_error_raises_provider_error(
+    hass: HomeAssistant, matter_lock: MatterLock
+) -> None:
+    """Test that ServiceValidationError raises LockCodeManagerProviderError, not LockDisconnected."""
+    handler = AsyncMock(side_effect=ServiceValidationError("invalid data"))
+    register_mock_service(hass, MATTER_DOMAIN, "set_lock_credential", handler)
+
+    with pytest.raises(LockCodeManagerProviderError, match="rejected input"):
+        await matter_lock.async_set_usercode(1, "1234")
+
+
+async def test_set_usercode_user_name_failure_does_not_propagate(
+    hass: HomeAssistant, matter_lock: MatterLock
+) -> None:
+    """Test that a user name set failure does not propagate when credential set succeeds."""
+    register_mock_service(
+        hass,
+        MATTER_DOMAIN,
+        "set_lock_credential",
+        AsyncMock(
+            return_value={
+                LOCK_ENTITY_ID: {"credential_index": 1, "user_index": 1},
+            }
+        ),
+    )
+    register_mock_service(
+        hass,
+        MATTER_DOMAIN,
+        "set_lock_user",
+        AsyncMock(side_effect=HomeAssistantError("500 Internal Server Error")),
+    )
+
+    result = await matter_lock.async_set_usercode(1, "1234", name="Test")
+
+    assert result is True
 
 
 async def test_set_usercode_duplicate_direct_raises_immediately(

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -16,6 +16,7 @@ from homeassistant.helpers.issue_registry import (
 )
 
 from custom_components.lock_code_manager.const import DOMAIN
+from custom_components.lock_code_manager.exceptions import LockOperationFailed
 from custom_components.lock_code_manager.models import SlotCode
 from custom_components.lock_code_manager.sync import SlotState, SlotSyncManager
 
@@ -354,3 +355,37 @@ class TestSlotDisabledIssueCleanup:
 
         # The issue should be deleted since slot is back in sync
         assert issue_registry.async_get_issue(DOMAIN, issue_id) is None
+
+
+class TestLockOperationFailedRetry:
+    """Tests that LockOperationFailed triggers retry, not slot disable."""
+
+    async def test_lock_operation_failed_triggers_retry(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """LockOperationFailed during sync sets dirty for retry instead of disabling slot."""
+        entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
+        manager = entity_obj._sync_manager
+
+        # Force out-of-sync state so _perform_sync is called:
+        # set coordinator data to EMPTY so the slot appears to need a set
+        manager._in_sync = False
+        manager._dirty = True
+        manager._coordinator.data[1] = SlotCode.EMPTY
+
+        with patch.object(
+            manager,
+            "_perform_sync",
+            new_callable=AsyncMock,
+            side_effect=LockOperationFailed("service validation failed"),
+        ):
+            await manager._async_tick()
+            await hass.async_block_till_done()
+
+        # Should retry (dirty=True) rather than disable the slot
+        assert manager._dirty is True
+        # Slot should not have been disabled (in_sync stays False, not None)
+        assert manager._in_sync is False


### PR DESCRIPTION
## Proposed change

Three improvements to Matter provider resilience:

### 1. Split exception handling in `_async_call_service`

Previously, both `ServiceValidationError` and `HomeAssistantError` mapped to `LockDisconnected`. Now:
- `ServiceValidationError` (bad input, our bug) → `LockCodeManagerProviderError`
- `HomeAssistantError` (lock communication failure) → `LockDisconnected`

This ensures validation errors (e.g. wrong parameter names) are correctly categorized as provider errors, not connectivity issues.

### 2. New `LockOperationFailed` exception

Added for cases where the lock is reachable but the operation failed (e.g. unsupported operation, lock-side error). Currently used in the sync manager retry path alongside `LockDisconnected` — both trigger retry behavior instead of disabling the slot. Available for future use by providers that can distinguish operational failures from connectivity issues.

### 3. Matter `hard_refresh_interval`

Added 1-hour periodic drift check for Matter locks. Push events only fire for local (keypad) operations — API-initiated changes and missed events are caught by periodic polling.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

🤖 Generated with [Claude Code](https://claude.com/claude-code)