### PR TITLE
fix: reset circuit breaker on in_sync state transitions

### DIFF
--- a/custom_components/lock_code_manager/sync.py
+++ b/custom_components/lock_code_manager/sync.py
@@ -584,9 +584,12 @@ class SlotSyncManager:
                 )
                 return
             else:
-                # Sync succeeded - refresh coordinator to verify
-                # Skip for push providers — they update coordinator optimistically
-                # via push_update() and refreshing from cache could read stale data.
+                # Sync succeeded — reset circuit breaker immediately so a
+                # subsequent PIN change doesn't inherit stale attempt counts.
+                self._reset_sync_tracker()
+                # Refresh coordinator to verify. Skip for push providers —
+                # they update coordinator optimistically via push_update()
+                # and refreshing from cache could read stale data.
                 if not self._lock.supports_push:
                     try:
                         await self._coordinator.async_refresh()

--- a/custom_components/lock_code_manager/sync.py
+++ b/custom_components/lock_code_manager/sync.py
@@ -440,10 +440,12 @@ class SlotSyncManager:
         expected = self.calculate_in_sync(slot_state)
         if expected != self._in_sync:
             self._in_sync = expected
-            # Reset circuit breaker on any transition: True→False means the
-            # sync target changed (e.g. PIN edited), so prior attempts should
-            # not count against the new target. False→True means sync
-            # succeeded and the tracker should be clean for next time.
+            # Reset circuit breaker on any transition between in-sync and
+            # out-of-sync. A True→False transition means the reconciliation
+            # state changed (for example, due to a desired-state edit or
+            # lock-side drift), so prior attempts should not carry over.
+            # False→True means sync succeeded and the tracker should be clean
+            # for next time.
             self._reset_sync_tracker()
             self._write_state()
 

--- a/custom_components/lock_code_manager/sync.py
+++ b/custom_components/lock_code_manager/sync.py
@@ -440,8 +440,11 @@ class SlotSyncManager:
         expected = self.calculate_in_sync(slot_state)
         if expected != self._in_sync:
             self._in_sync = expected
-            if expected:
-                self._reset_sync_tracker()
+            # Reset circuit breaker on any transition: True→False means the
+            # sync target changed (e.g. PIN edited), so prior attempts should
+            # not count against the new target. False→True means sync
+            # succeeded and the tracker should be clean for next time.
+            self._reset_sync_tracker()
             self._write_state()
 
     async def _async_tick(self, _now: datetime | None = None) -> None:
@@ -584,12 +587,9 @@ class SlotSyncManager:
                 )
                 return
             else:
-                # Sync succeeded — reset circuit breaker immediately so a
-                # subsequent PIN change doesn't inherit stale attempt counts.
-                self._reset_sync_tracker()
-                # Refresh coordinator to verify. Skip for push providers —
-                # they update coordinator optimistically via push_update()
-                # and refreshing from cache could read stale data.
+                # Sync succeeded - refresh coordinator to verify
+                # Skip for push providers — they update coordinator optimistically
+                # via push_update() and refreshing from cache could read stale data.
                 if not self._lock.supports_push:
                     try:
                         await self._coordinator.async_refresh()

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -921,13 +921,7 @@ async def test_sync_attempts_exceeded_disables_slot(
 
     in_sync_entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
 
-    # Pre-load the tracker with MAX_SYNC_ATTEMPTS successful attempts within the window
-    now = dt_util.utcnow()
-    in_sync_entity_obj._sync_manager._sync_attempt_count = MAX_SYNC_ATTEMPTS
-    in_sync_entity_obj._sync_manager._sync_attempt_first = now
-
-    # Change PIN to trigger sync — the circuit breaker should fire BEFORE
-    # attempting another sync, disabling the slot
+    # Change PIN to trigger sync
     await hass.services.async_call(
         TEXT_DOMAIN,
         TEXT_SERVICE_SET_VALUE,
@@ -937,7 +931,13 @@ async def test_sync_attempts_exceeded_disables_slot(
     )
     await hass.async_block_till_done()
 
-    # Trigger tick to attempt sync (circuit breaker will fire)
+    # Pre-load the tracker AFTER the PIN change to simulate repeated failures
+    # on the same PIN (a PIN change resets the tracker, so we must load after)
+    now = dt_util.utcnow()
+    in_sync_entity_obj._sync_manager._sync_attempt_count = MAX_SYNC_ATTEMPTS
+    in_sync_entity_obj._sync_manager._sync_attempt_first = now
+
+    # Trigger tick — circuit breaker should fire before attempting sync
     await in_sync_entity_obj._sync_manager._async_tick()
     await hass.async_block_till_done()
 


### PR DESCRIPTION
## Proposed change

The circuit breaker tracker (sync attempt counter) was only reset when the sync manager observed in-sync state on the **next tick** after a successful sync. If a PIN change occurred between the successful sync and the next tick, stale attempt counts from the previous sync cycle could trigger the circuit breaker incorrectly — disabling the slot instead of running the intended duplicate detection path.

### Fix

Reset `_reset_sync_tracker()` on **any `_in_sync` state transition** in `_update_in_sync_display`:

- **True→False** (PIN changed, slot re-enabled): prior attempts should not count against the new sync target
- **False→True** (sync succeeded): tracker should be clean for next time

This avoids the original bug without weakening the circuit breaker for silently-failing slots — the tracker is only reset when the sync state actually changes, not on every successful set operation.

### How it was discovered

During live Matter lock testing, changing a slot's PIN to a duplicate value triggered the circuit breaker ("Sync attempts exceeded 3 in 5 minute window") instead of the `DuplicateCodeError` path, because sync attempts from a prior reconnect cycle were still in the tracker.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

🤖 Generated with [Claude Code](https://claude.com/claude-code)