### PR TITLE
test: use shared fixtures in entity and sync tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -189,6 +189,14 @@ async def lock_code_manager_config_entry_fixture(hass: HomeAssistant):
     await hass.config_entries.async_unload(config_entry.entry_id)
 
 
+@pytest.fixture(name="mock_calendars")
+def mock_calendars_fixture(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> list[MockCalendarEntity]:
+    """Return the mock calendar entities created by mock_lock_config_entry."""
+    return hass.data["lock_code_manager_calendars"]
+
+
 def get_in_sync_entity_obj(hass: HomeAssistant, entity_id: str):
     """Get the in-sync entity object for a given entity ID.
 

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -83,12 +83,12 @@ async def _async_force_sync_cycle(
 
 async def test_binary_sensor_entity(
     hass: HomeAssistant,
-    mock_lock_config_entry,
+    mock_calendars,
     lock_code_manager_config_entry,
 ):
     """Walk through calendar, usage, enable/disable, and PIN updates for slot 2."""
     # Initial calendar/active state should be off
-    calendar_1, _ = hass.data["lock_code_manager_calendars"]
+    calendar_1, _ = mock_calendars
     state = hass.states.get("calendar.test_1")
     assert state
     assert state.state == STATE_OFF
@@ -209,13 +209,13 @@ async def test_binary_sensor_entity(
 
 async def test_startup_no_code_flapping_when_synced(
     hass: HomeAssistant,
-    mock_lock_config_entry,
+    mock_calendars,
     lock_code_manager_config_entry,
 ):
     """Test that codes aren't unnecessarily cleared/set on startup when already synced."""
     # Create a calendar event to make slot 2 active
     # (slot 2 has calendar.test_1 configured in BASE_CONFIG)
-    calendar_1, _ = hass.data["lock_code_manager_calendars"]
+    calendar_1, _ = mock_calendars
     now = dt_util.utcnow()
     start = now - timedelta(hours=1)
     end = now + timedelta(hours=1)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2,22 +2,12 @@
 
 import logging
 
-from pytest_homeassistant_custom_component.common import MockConfigEntry
-
 from homeassistant.core import HomeAssistant
 
-from custom_components.lock_code_manager.const import (
-    CONF_ENABLED,
-    CONF_LOCKS,
-    CONF_NAME,
-    CONF_PIN,
-    CONF_SLOTS,
-    DOMAIN,
-)
 from custom_components.lock_code_manager.models import SlotCode
 from custom_components.lock_code_manager.providers import BaseLock
 
-from .common import LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID
+from .common import LOCK_1_ENTITY_ID
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -25,23 +15,9 @@ _LOGGER = logging.getLogger(__name__)
 async def test_sensor_entity(
     hass: HomeAssistant,
     mock_lock_config_entry,
+    lock_code_manager_config_entry,
 ):
     """Test sensor entity shows lock code values."""
-    config = {
-        CONF_LOCKS: [LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID],
-        CONF_SLOTS: {
-            1: {CONF_NAME: "test1", CONF_PIN: "1234", CONF_ENABLED: True},
-            2: {CONF_NAME: "test2", CONF_PIN: "5678", CONF_ENABLED: True},
-        },
-    }
-
-    config_entry = MockConfigEntry(
-        domain=DOMAIN, data=config, unique_id="Test Sensor", title="Test LCM"
-    )
-    config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
-
     for code_slot, pin in ((1, "1234"), (2, "5678")):
         state = hass.states.get(f"sensor.test_1_code_slot_{code_slot}")
         assert state
@@ -50,30 +26,14 @@ async def test_sensor_entity(
         assert state
         assert state.state == pin
 
-    await hass.config_entries.async_unload(config_entry.entry_id)
-
 
 async def test_sensor_native_value_with_slot_code(
     hass: HomeAssistant,
     mock_lock_config_entry,
+    lock_code_manager_config_entry,
 ):
     """Test sensor native_value handles SlotCode.EMPTY and SlotCode.UNREADABLE_CODE."""
-    config = {
-        CONF_LOCKS: [LOCK_1_ENTITY_ID],
-        CONF_SLOTS: {
-            "1": {CONF_NAME: "test1", CONF_PIN: "1234", CONF_ENABLED: True},
-        },
-    }
-
-    config_entry = MockConfigEntry(
-        domain=DOMAIN, data=config, unique_id="Test SlotCode Sensor", title="Test LCM"
-    )
-    config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    # Get the lock provider and its coordinator
-    lock: BaseLock = next(iter(config_entry.runtime_data.locks.values()))
+    lock: BaseLock = lock_code_manager_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
     coordinator = lock.coordinator
     assert coordinator is not None
 
@@ -97,5 +57,3 @@ async def test_sensor_native_value_with_slot_code(
     state = hass.states.get("sensor.test_1_code_slot_1")
     assert state is not None
     assert state.state == "5678"
-
-    await hass.config_entries.async_unload(config_entry.entry_id)


### PR DESCRIPTION
## Proposed change

Replace manual test setup patterns with shared fixtures for consistency:

- Add a `mock_calendars` fixture in `conftest.py` that exposes the mock calendar entities, replacing direct `hass.data["lock_code_manager_calendars"]` access in `test_binary_sensor.py`
- Use the shared `lock_code_manager_config_entry` fixture in `test_sensor.py` instead of manually constructing `MockConfigEntry` instances with duplicate config

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue:

🤖 Generated with [Claude Code](https://claude.com/claude-code)