### PR TITLE
docs: add project conventions to AGENTS.md, prefer prek

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,16 +186,9 @@ See `TODO.md` for implementation details.
 scripts/setup
 ```
 
-Creates Python 3.13 venv, installs dependencies with uv, sets up pre-commit hooks, and installs Node dependencies.
-
-**pre-commit on Python 3.14 (macOS)**: `scripts/setup` installs pre-commit
-as a uv tool pinned to Python 3.13 (`uv tool install --python 3.13
-pre-commit`). If your `pre-commit` was previously installed via Homebrew
-and Homebrew's Python is 3.14, it will fail on macOS with
-`Symbol not found: _XML_SetAllocTrackerActivationThreshold` — Python 3.14's
-bundled `pyexpat` is built against a newer `libexpat` than the one
-`/usr/lib/libexpat.1.dylib` provides. Run `brew uninstall pre-commit` so
-the uv-managed binary at `~/.local/bin/pre-commit` is the one in `PATH`.
+Creates Python 3.13 venv, installs dependencies with uv, sets up git hooks
+(preferring `prek` with fallback to uv-managed `pre-commit`), and installs
+Node dependencies.
 
 ### Testing
 
@@ -238,7 +231,7 @@ yarn watch                     # Watch mode for development
 - Python: Ruff for linting/formatting (line length: 88)
 - Import order: future → stdlib → third-party → homeassistant → first-party → local
 - **No inline/local imports** — always import at the top of the file. Restructure modules to avoid circular dependencies.
-- **No `nonlocal`/`local`/`global`** — use mutable containers or restructure instead.
+- **No `nonlocal`/`global`** — use mutable containers or restructure instead.
 - Type annotations: Keep older style (`dict[str, Any]` not `dict[str, Any] | None` where possible)
 - Docstrings: Required for all public functions. Prefer prose explaining intent over mechanical
   re-statements of parameters. Do NOT add Google-style `Args:`/`Returns:` sections — type

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,8 +22,17 @@ entities.
   either make changes as needed or explain why you are not addressing a comment (comments that you make
   code changes for don't need a response). Resolve all comments as you address them or respond to them.
   Provide a summary of what was done or not done and ask for confirmation before committing the changes.
-- When running hass, pre-commit, or any other python driven commands, always run from the venv
-- Before committing, ensure pre-commit succeeds and tests pass.
+- When running hass or any other python driven commands, always run from the venv
+- Before committing, ensure pre-commit checks succeed and tests pass.
+- Use `prek` instead of `pre-commit` for running pre-commit checks (`prek run --all-files`).
+  `prek` is a faster drop-in replacement.
+
+### Git conventions
+
+- **Never amend commits after a PR has been created.** Always commit forward. Squash-on-merge
+  handles the final cleanup. Separate commits show what changed in response to each review round.
+- Force-push is only acceptable for rebasing onto an updated base branch, not for rewriting history.
+- Tests go with code changes in the same PR. Test-only PRs are only for refactoring existing tests.
 
 ## External repositories/directories that are relevant
 
@@ -210,7 +219,7 @@ yarn test:coverage              # Run with coverage
 ### Linting
 
 ```bash
-pre-commit run --all-files     # Run all linters
+prek run --all-files           # Run all linters (preferred over pre-commit)
 ruff check                     # Python linting
 ruff format                    # Python formatting
 yarn lint                      # TypeScript/JavaScript linting
@@ -228,17 +237,52 @@ yarn watch                     # Watch mode for development
 
 - Python: Ruff for linting/formatting (line length: 88)
 - Import order: future → stdlib → third-party → homeassistant → first-party → local
+- **No inline/local imports** — always import at the top of the file. Restructure modules to avoid circular dependencies.
+- **No `nonlocal`/`local`/`global`** — use mutable containers or restructure instead.
 - Type annotations: Keep older style (`dict[str, Any]` not `dict[str, Any] | None` where possible)
-- Docstrings: Google style, required for all public functions
+- Docstrings: Required for all public functions. Prefer prose explaining intent over mechanical
+  re-statements of parameters. Do NOT add Google-style `Args:`/`Returns:` sections — type
+  annotations already convey type/shape. Mention parameters and return values inline only when
+  their semantics are non-obvious.
+- **Spell out acronyms** in code comments instead of using abbreviations.
+- **Prefer idiomatic Python** — comprehensions over loops, `next()` over `for`/`break`, concise expressions.
 - Async: Prefer async/await; use `hass.async_add_executor_job()` to wrap sync code
 
 ## Testing Notes
 
 - Uses `pytest-homeassistant-custom-component` for HA test utilities
-- `tests/conftest.py`: Shared fixtures
-- `tests/common.py`: Helper functions for setting up test config entries and coordinators
-- Mock Z-Wave JS nodes and events for testing lock providers
-- Tests verify entity creation/removal through config changes
+- `tests/conftest.py`: Shared fixtures (`mock_lock_config_entry`, `lock_code_manager_config_entry`)
+- `tests/common.py`: `MockLCMLock` (in-memory provider), mock entities, test constants
+- `tests/providers/helpers.py`: Shared test mixins for service-based providers
+
+### Test philosophy
+
+**Mock at the boundary, not the code under test.** Let as much end-to-end code run as possible.
+
+- **Provider tests**: Mock the external integration (Z-Wave client, Matter client), not LCM's own
+  `async_call_service`. Service calls should flow through the real HA service layer to the mock client.
+- **Integration tests**: Use `mock_lock_config_entry` (creates prerequisite lock entities) and
+  `lock_code_manager_config_entry` (runs real `async_setup_entry`). Don't manually inject `hass.data`.
+- **Pure-logic tests** (e.g., `calculate_in_sync`): Fine to use mocks since they test isolated logic.
+
+### Test structure
+
+Provider tests live in dedicated modules mirroring the integration's test patterns:
+
+```text
+tests/providers/
+  matter/          # conftest.py, helpers.py, fixtures/, test_matter.py
+  zwave_js/        # conftest.py, fixtures/, test_zwave_js.py
+  schlage/         # conftest.py, test_schlage.py
+  ...
+  helpers.py       # Shared test mixins (ServiceProviderConnectionTests, etc.)
+```
+
+### Test conventions
+
+- **Minimize caplog text assertions** — prefer checking parameters or structured data.
+- Provider `async_setup` must be idempotent — tests verify it can be called multiple times.
+- Don't use `MagicMock()` for coordinators when the real coordinator can be used.
 
 ## Adding Lock Provider Support
 

--- a/scripts/setup
+++ b/scripts/setup
@@ -53,14 +53,13 @@ fi
 pip install --upgrade uv
 uv pip install -r requirements_dev.txt
 
-# Install prek (fast Rust-based pre-commit replacement).
-# Falls back to pre-commit if prek is not available.
+# Install git hooks. Prefer prek (fast Rust-based replacement).
+# If prek is unavailable, use a uv-managed pre-commit pinned to Python 3.13
+# instead of whatever pre-commit binary may already be on PATH (a Homebrew
+# install linked against Python 3.14 fails on macOS).
 if command -v prek &> /dev/null; then
   prek install
-elif command -v pre-commit &> /dev/null; then
-  pre-commit install
 else
-  # Install pre-commit as a uv-managed tool pinned to Python 3.13.
   uv tool install --force --python 3.13 pre-commit
   pre-commit install
 fi

--- a/scripts/setup
+++ b/scripts/setup
@@ -53,19 +53,17 @@ fi
 pip install --upgrade uv
 uv pip install -r requirements_dev.txt
 
-# Install pre-commit as a uv-managed tool pinned to Python 3.13.
-# Avoids relying on whatever pre-commit (and underlying Python) the
-# user has on PATH — a Homebrew install linked against Python 3.14
-# fails on macOS with "_XML_SetAllocTrackerActivationThreshold not
-# found" because 3.14's bundled pyexpat is built against a newer
-# libexpat than the one /usr/lib/libexpat.1.dylib provides.
-# uv puts the binary at ~/.local/bin/pre-commit which typically wins
-# over /opt/homebrew/bin in $PATH. If you have an existing Homebrew
-# install of pre-commit, run `brew uninstall pre-commit` to remove
-# the broken one.
-uv tool install --force --python 3.13 pre-commit
-
-pre-commit install
+# Install prek (fast Rust-based pre-commit replacement).
+# Falls back to pre-commit if prek is not available.
+if command -v prek &> /dev/null; then
+  prek install
+elif command -v pre-commit &> /dev/null; then
+  pre-commit install
+else
+  # Install pre-commit as a uv-managed tool pinned to Python 3.13.
+  uv tool install --force --python 3.13 pre-commit
+  pre-commit install
+fi
 yarn install
 
 # Setup directories for HA and linking

--- a/scripts/setup-devcontainer
+++ b/scripts/setup-devcontainer
@@ -65,6 +65,9 @@ fi
 if command -v prek &> /dev/null; then
   prek install
 else
+  if ! command -v pre-commit &> /dev/null; then
+    python3 -m pip install pre-commit
+  fi
   pre-commit install
 fi
 yarn install

--- a/scripts/setup-devcontainer
+++ b/scripts/setup-devcontainer
@@ -62,7 +62,11 @@ then
     python3 -m pip install aiousbwatcher==1.1.1
 fi
 
-pre-commit install
+if command -v prek &> /dev/null; then
+  prek install
+else
+  pre-commit install
+fi
 yarn install
 
 # Setup directories for HA and linking


### PR DESCRIPTION
## Proposed change

Adds accumulated project conventions to AGENTS.md and switches local dev tooling to prefer `prek` (Rust-based pre-commit replacement).

### AGENTS.md additions

**Git conventions:**
- Never amend commits after PR creation — commit forward
- Tests go with code changes in the same PR

**Code style:**
- No inline/local imports
- No nonlocal/local/global
- Prose docstrings (no Args:/Returns: sections)
- Spell out acronyms, prefer idiomatic Python

**Testing philosophy:**
- Mock at the boundary, let e2e code run
- Provider test module structure documented
- Real coordinators over MagicMock

### prek preference

- `scripts/setup` and `scripts/setup-devcontainer` now prefer `prek` with fallback to `pre-commit`
- `.claude/CLAUDE.md` updated to reference `prek`
- CI continues using `pre-commit.ci` unchanged

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

🤖 Generated with [Claude Code](https://claude.com/claude-code)