### PR TITLE
refactor: use shared mock locks and fixtures in coordinator tests

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Literal
 
 from homeassistant.components.calendar import CalendarEntity, CalendarEvent
@@ -63,6 +63,7 @@ class MockLCMLock(BaseLock):
         """Initialize mock lock."""
         super().__init__(*args, **kwargs)
         self._connected = True
+        self._hard_refresh_interval: timedelta | None = None
         self.codes: dict[int, str] = {1: "1234", 2: "5678"}
         self.service_calls: defaultdict[str, list] = defaultdict(list)
 
@@ -70,6 +71,11 @@ class MockLCMLock(BaseLock):
     def domain(self) -> str:
         """Return integration domain."""
         return "test"
+
+    @property
+    def hard_refresh_interval(self) -> timedelta | None:
+        """Return configurable hard refresh interval."""
+        return self._hard_refresh_interval
 
     def set_connected(self, connected: bool) -> None:
         """Set connection state for testing."""
@@ -117,6 +123,31 @@ class MockLCMLock(BaseLock):
         snapshot = self.codes.copy()
         self.service_calls["get_usercodes"].append(snapshot)
         return snapshot
+
+
+@dataclass(repr=False, eq=False)
+class MockLCMPushLock(MockLCMLock):
+    """Mock lock that supports push-based updates."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize mock push lock."""
+        super().__init__(*args, **kwargs)
+        self._supports_push = True
+        self._subscribe_called = False
+        self._unsubscribe_called = False
+
+    @property
+    def supports_push(self) -> bool:
+        """Return whether this lock supports push-based updates."""
+        return self._supports_push
+
+    def setup_push_subscription(self) -> None:
+        """Subscribe to push-based value updates."""
+        self._subscribe_called = True
+
+    def teardown_push_subscription(self) -> None:
+        """Unsubscribe from push-based value updates."""
+        self._unsubscribe_called = True
 
 
 class MockLockEntity(LockEntity):

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,8 +1,6 @@
 """Test the coordinator module."""
 
-from dataclasses import dataclass, field
 from datetime import timedelta
-from typing import Literal
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -25,74 +23,79 @@ from custom_components.lock_code_manager.coordinator import (
     LockUsercodeUpdateCoordinator,
 )
 from custom_components.lock_code_manager.exceptions import LockDisconnected
-from custom_components.lock_code_manager.providers._base import BaseLock
 from custom_components.lock_code_manager.providers.virtual import VirtualLock
 
-
-@dataclass(repr=False, eq=False)
-class MockLockWithHardRefresh(BaseLock):
-    """Mock lock with configurable hard_refresh_interval."""
-
-    _hard_refresh_interval: timedelta | None = field(default=None, init=False)
-    _is_connected: bool = field(default=True, init=False)
-
-    @property
-    def domain(self) -> str:
-        """Return integration domain."""
-        return "test"
-
-    @property
-    def hard_refresh_interval(self) -> timedelta | None:
-        """Return configurable hard refresh interval."""
-        return self._hard_refresh_interval
-
-    async def async_is_integration_connected(self) -> bool:
-        """Return whether the integration's client/driver/broker is connected."""
-        return self._is_connected
-
-    async def async_hard_refresh_codes(self) -> dict[int, str | None]:
-        """Perform hard refresh and return all codes."""
-        return await self.async_get_usercodes()
-
-    async def async_get_usercodes(self) -> dict[int, str | None]:
-        """Return dictionary of code slots and usercodes."""
-        return {}
-
-    async def async_set_usercode(
-        self,
-        code_slot: int,
-        usercode: str,
-        name: str | None = None,
-        source: Literal["sync", "direct"] = "direct",
-    ) -> bool:
-        """Set a usercode on a code slot."""
-        return True
-
-    async def async_clear_usercode(self, code_slot: int) -> bool:
-        """Clear a usercode on a code slot."""
-        return True
+from .common import MockLCMLock, MockLCMPushLock
 
 
-@dataclass(repr=False, eq=False)
-class MockLockWithPush(MockLockWithHardRefresh):
-    """Mock lock that supports push-based updates."""
+def _make_lock(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    cls: type[MockLCMLock] = MockLCMLock,
+) -> MockLCMLock:
+    """Create a mock lock instance bound to a config entry."""
+    entity_reg = er.async_get(hass)
+    lock_entity = entity_reg.async_get_or_create(
+        "lock",
+        "test",
+        "test_lock",
+        config_entry=config_entry,
+    )
+    return cls(
+        hass,
+        dr.async_get(hass),
+        entity_reg,
+        config_entry,
+        lock_entity,
+    )
 
-    _supports_push: bool = field(default=True, init=False)
-    _subscribe_called: bool = field(default=False, init=False)
-    _unsubscribe_called: bool = field(default=False, init=False)
 
-    @property
-    def supports_push(self) -> bool:
-        """Return whether this lock supports push-based updates."""
-        return self._supports_push
+def _make_coordinator(
+    hass: HomeAssistant,
+    lock: MockLCMLock,
+    config_entry: MockConfigEntry,
+) -> LockUsercodeUpdateCoordinator:
+    """Create a coordinator for a mock lock."""
+    return LockUsercodeUpdateCoordinator(hass, lock, config_entry)
 
-    def setup_push_subscription(self) -> None:
-        """Subscribe to push-based value updates."""
-        self._subscribe_called = True
 
-    def teardown_push_subscription(self) -> None:
-        """Unsubscribe from push-based value updates."""
-        self._unsubscribe_called = True
+@pytest.fixture
+def lcm_config_entry(hass: HomeAssistant) -> MockConfigEntry:
+    """Return a minimal config entry added to hass."""
+    entry = MockConfigEntry(domain=DOMAIN)
+    entry.add_to_hass(hass)
+    return entry
+
+
+@pytest.fixture
+def poll_lock(hass: HomeAssistant, lcm_config_entry: MockConfigEntry) -> MockLCMLock:
+    """Return a poll-based mock lock."""
+    return _make_lock(hass, lcm_config_entry)
+
+
+@pytest.fixture
+def push_lock(
+    hass: HomeAssistant, lcm_config_entry: MockConfigEntry
+) -> MockLCMPushLock:
+    """Return a push-based mock lock."""
+    return _make_lock(hass, lcm_config_entry, cls=MockLCMPushLock)
+
+
+@pytest.fixture
+def poll_coordinator(
+    hass: HomeAssistant, poll_lock: MockLCMLock, lcm_config_entry: MockConfigEntry
+) -> LockUsercodeUpdateCoordinator:
+    """Return a coordinator with a poll-based lock."""
+    return _make_coordinator(hass, poll_lock, lcm_config_entry)
+
+
+@pytest.fixture
+def push_coordinator(
+    hass: HomeAssistant, push_lock: MockLCMPushLock, lcm_config_entry: MockConfigEntry
+) -> LockUsercodeUpdateCoordinator:
+    """Return a coordinator with a push-based lock (with hard refresh enabled)."""
+    push_lock._hard_refresh_interval = timedelta(hours=1)
+    return _make_coordinator(hass, push_lock, lcm_config_entry)
 
 
 async def test_drift_timer_not_created_without_hard_refresh_interval(
@@ -128,220 +131,83 @@ async def test_drift_timer_not_created_without_hard_refresh_interval(
 
 async def test_drift_timer_created_for_lock_with_hard_refresh_interval(
     hass: HomeAssistant,
+    poll_lock: MockLCMLock,
+    lcm_config_entry: MockConfigEntry,
 ):
     """Test that drift detection timer IS created when hard_refresh_interval is set."""
-    entity_reg = er.async_get(hass)
-    config_entry = MockConfigEntry(domain=DOMAIN)
-    config_entry.add_to_hass(hass)
+    poll_lock._hard_refresh_interval = timedelta(hours=1)
 
-    lock_entity = entity_reg.async_get_or_create(
-        "lock",
-        "test",
-        "test_lock",
-        config_entry=config_entry,
-    )
-
-    lock = MockLockWithHardRefresh(
-        hass,
-        dr.async_get(hass),
-        entity_reg,
-        config_entry,
-        lock_entity,
-    )
-    lock._hard_refresh_interval = timedelta(hours=1)
-
-    coordinator = LockUsercodeUpdateCoordinator(hass, lock, config_entry)
+    coordinator = _make_coordinator(hass, poll_lock, lcm_config_entry)
 
     # With hard_refresh_interval set, drift timer SHOULD be created
     assert coordinator._drift_unsub is not None
 
 
 async def test_coordinator_disables_polling_for_push_enabled_lock(
-    hass: HomeAssistant,
+    push_coordinator: LockUsercodeUpdateCoordinator,
 ):
     """Test that coordinator disables polling when lock supports push."""
-    entity_reg = er.async_get(hass)
-    config_entry = MockConfigEntry(domain=DOMAIN)
-    config_entry.add_to_hass(hass)
-
-    lock_entity = entity_reg.async_get_or_create(
-        "lock",
-        "test",
-        "test_lock",
-        config_entry=config_entry,
-    )
-
-    lock = MockLockWithPush(
-        hass,
-        dr.async_get(hass),
-        entity_reg,
-        config_entry,
-        lock_entity,
-    )
-
-    coordinator = LockUsercodeUpdateCoordinator(hass, lock, config_entry)
-
     # When supports_push is True, update_interval should be None (polling disabled)
-    assert coordinator.update_interval is None
+    assert push_coordinator.update_interval is None
 
 
 async def test_coordinator_enables_polling_for_non_push_lock(
-    hass: HomeAssistant,
+    poll_coordinator: LockUsercodeUpdateCoordinator,
+    poll_lock: MockLCMLock,
 ):
     """Test that coordinator enables polling when lock doesn't support push."""
-    entity_reg = er.async_get(hass)
-    config_entry = MockConfigEntry(domain=DOMAIN)
-    config_entry.add_to_hass(hass)
-
-    lock_entity = entity_reg.async_get_or_create(
-        "lock",
-        "test",
-        "test_lock",
-        config_entry=config_entry,
-    )
-
-    lock = MockLockWithHardRefresh(
-        hass,
-        dr.async_get(hass),
-        entity_reg,
-        config_entry,
-        lock_entity,
-    )
-
-    coordinator = LockUsercodeUpdateCoordinator(hass, lock, config_entry)
-
     # When supports_push is False, update_interval should be set (polling enabled)
-    assert coordinator.update_interval == lock.usercode_scan_interval
+    assert poll_coordinator.update_interval == poll_lock.usercode_scan_interval
 
 
 async def test_push_update_updates_coordinator_data(
-    hass: HomeAssistant,
+    push_coordinator: LockUsercodeUpdateCoordinator,
 ):
     """Test that push_update correctly updates coordinator data."""
-    entity_reg = er.async_get(hass)
-    config_entry = MockConfigEntry(domain=DOMAIN)
-    config_entry.add_to_hass(hass)
-
-    lock_entity = entity_reg.async_get_or_create(
-        "lock",
-        "test",
-        "test_lock",
-        config_entry=config_entry,
-    )
-
-    lock = MockLockWithPush(
-        hass,
-        dr.async_get(hass),
-        entity_reg,
-        config_entry,
-        lock_entity,
-    )
-
-    coordinator = LockUsercodeUpdateCoordinator(hass, lock, config_entry)
-    coordinator.data = {1: "1111", 2: "2222"}
+    push_coordinator.data = {1: "1111", 2: "2222"}
 
     # Push a single update
-    coordinator.push_update({1: "9999"})
+    push_coordinator.push_update({1: "9999"})
 
     # Verify data was updated
-    assert coordinator.data[1] == "9999"
-    assert coordinator.data[2] == "2222"  # Unchanged
+    assert push_coordinator.data[1] == "9999"
+    assert push_coordinator.data[2] == "2222"  # Unchanged
 
 
 async def test_push_update_bulk_updates(
-    hass: HomeAssistant,
+    push_coordinator: LockUsercodeUpdateCoordinator,
 ):
     """Test that push_update correctly handles bulk updates."""
-    entity_reg = er.async_get(hass)
-    config_entry = MockConfigEntry(domain=DOMAIN)
-    config_entry.add_to_hass(hass)
-
-    lock_entity = entity_reg.async_get_or_create(
-        "lock",
-        "test",
-        "test_lock",
-        config_entry=config_entry,
-    )
-
-    lock = MockLockWithPush(
-        hass,
-        dr.async_get(hass),
-        entity_reg,
-        config_entry,
-        lock_entity,
-    )
-
-    coordinator = LockUsercodeUpdateCoordinator(hass, lock, config_entry)
-    coordinator.data = {1: "1111", 2: "2222", 3: "3333"}
+    push_coordinator.data = {1: "1111", 2: "2222", 3: "3333"}
 
     # Push bulk update
-    coordinator.push_update({1: "9999", 3: ""})
+    push_coordinator.push_update({1: "9999", 3: ""})
 
     # Verify all updates applied
-    assert coordinator.data[1] == "9999"
-    assert coordinator.data[2] == "2222"  # Unchanged
-    assert coordinator.data[3] == ""  # Cleared
+    assert push_coordinator.data[1] == "9999"
+    assert push_coordinator.data[2] == "2222"  # Unchanged
+    assert push_coordinator.data[3] == ""  # Cleared
 
 
 async def test_push_update_ignores_empty_updates(
-    hass: HomeAssistant,
+    push_coordinator: LockUsercodeUpdateCoordinator,
 ):
     """Test that push_update ignores empty update dict."""
-    entity_reg = er.async_get(hass)
-    config_entry = MockConfigEntry(domain=DOMAIN)
-    config_entry.add_to_hass(hass)
-
-    lock_entity = entity_reg.async_get_or_create(
-        "lock",
-        "test",
-        "test_lock",
-        config_entry=config_entry,
-    )
-
-    lock = MockLockWithPush(
-        hass,
-        dr.async_get(hass),
-        entity_reg,
-        config_entry,
-        lock_entity,
-    )
-
-    coordinator = LockUsercodeUpdateCoordinator(hass, lock, config_entry)
-    coordinator.data = {1: "1111"}
+    push_coordinator.data = {1: "1111"}
 
     # Track async_set_updated_data calls
-    with patch.object(coordinator, "async_set_updated_data") as mock_set_updated:
-        coordinator.push_update({})
+    with patch.object(push_coordinator, "async_set_updated_data") as mock_set_updated:
+        push_coordinator.push_update({})
 
         # Should not call async_set_updated_data for empty updates
         mock_set_updated.assert_not_called()
 
 
 async def test_push_update_notifies_listeners(
-    hass: HomeAssistant,
+    push_coordinator: LockUsercodeUpdateCoordinator,
 ):
     """Test that push_update notifies coordinator listeners."""
-    entity_reg = er.async_get(hass)
-    config_entry = MockConfigEntry(domain=DOMAIN)
-    config_entry.add_to_hass(hass)
-
-    lock_entity = entity_reg.async_get_or_create(
-        "lock",
-        "test",
-        "test_lock",
-        config_entry=config_entry,
-    )
-
-    lock = MockLockWithPush(
-        hass,
-        dr.async_get(hass),
-        entity_reg,
-        config_entry,
-        lock_entity,
-    )
-
-    coordinator = LockUsercodeUpdateCoordinator(hass, lock, config_entry)
-    coordinator.data = {1: "1111"}
+    push_coordinator.data = {1: "1111"}
 
     # Track listener callbacks
     listener_called = [False]
@@ -350,10 +216,10 @@ async def test_push_update_notifies_listeners(
     def listener():
         listener_called[0] = True
 
-    coordinator.async_add_listener(listener)
+    push_coordinator.async_add_listener(listener)
 
     # Push an update
-    coordinator.push_update({1: "9999"})
+    push_coordinator.push_update({1: "9999"})
 
     # Verify listener was called
     assert listener_called[0]
@@ -375,7 +241,7 @@ async def test_subscribe_push_updates_called_during_setup(
         config_entry=mock_lock_config_entry,
     )
 
-    lock = MockLockWithPush(
+    lock = MockLCMPushLock(
         hass,
         dr.async_get(hass),
         entity_reg,
@@ -401,27 +267,10 @@ async def test_subscribe_push_updates_called_during_setup(
 
 async def test_unsubscribe_push_updates_called_during_unload(
     hass: HomeAssistant,
+    push_lock: MockLCMPushLock,
+    lcm_config_entry: MockConfigEntry,
 ):
     """Test that unsubscribe_push_updates is called during async_unload."""
-    entity_reg = er.async_get(hass)
-    config_entry = MockConfigEntry(domain=DOMAIN)
-    config_entry.add_to_hass(hass)
-
-    lock_entity = entity_reg.async_get_or_create(
-        "lock",
-        "test",
-        "test_lock",
-        config_entry=config_entry,
-    )
-
-    lock = MockLockWithPush(
-        hass,
-        dr.async_get(hass),
-        entity_reg,
-        config_entry,
-        lock_entity,
-    )
-
     # Setup first
     with (
         patch(
@@ -433,38 +282,22 @@ async def test_unsubscribe_push_updates_called_during_unload(
             "LockUsercodeUpdateCoordinator.async_refresh"
         ),
     ):
-        await lock.async_setup_internal(config_entry)
+        await push_lock.async_setup_internal(lcm_config_entry)
 
     # Unload
-    assert not lock._unsubscribe_called
-    await lock.async_unload(remove_permanently=False)
-    assert lock._unsubscribe_called
+    assert not push_lock._unsubscribe_called
+    await push_lock.async_unload(remove_permanently=False)
+    assert push_lock._unsubscribe_called
 
 
 async def test_subscribe_push_not_called_for_non_push_lock(
     hass: HomeAssistant,
+    push_lock: MockLCMPushLock,
+    lcm_config_entry: MockConfigEntry,
 ):
     """Test that subscribe_push_updates is NOT called for non-push locks."""
-    entity_reg = er.async_get(hass)
-    config_entry = MockConfigEntry(domain=DOMAIN)
-    config_entry.add_to_hass(hass)
-
-    lock_entity = entity_reg.async_get_or_create(
-        "lock",
-        "test",
-        "test_lock",
-        config_entry=config_entry,
-    )
-
-    lock = MockLockWithPush(
-        hass,
-        dr.async_get(hass),
-        entity_reg,
-        config_entry,
-        lock_entity,
-    )
     # Disable push support
-    lock._supports_push = False
+    push_lock._supports_push = False
 
     # Mock coordinator refreshes
     with (
@@ -477,519 +310,384 @@ async def test_subscribe_push_not_called_for_non_push_lock(
             "LockUsercodeUpdateCoordinator.async_refresh"
         ),
     ):
-        await lock.async_setup_internal(config_entry)
+        await push_lock.async_setup_internal(lcm_config_entry)
         # subscribe_push_updates should NOT have been called
-        assert not lock._subscribe_called
+        assert not push_lock._subscribe_called
 
 
 async def test_async_shutdown_cleans_up_drift_timer(
-    hass: HomeAssistant,
+    push_coordinator: LockUsercodeUpdateCoordinator,
 ):
     """Test that async_shutdown cleans up the drift detection timer."""
-    entity_reg = er.async_get(hass)
-    config_entry = MockConfigEntry(domain=DOMAIN)
-    config_entry.add_to_hass(hass)
-
-    lock_entity = entity_reg.async_get_or_create(
-        "lock",
-        "test",
-        "test_lock",
-        config_entry=config_entry,
-    )
-
-    lock = MockLockWithPush(
-        hass,
-        dr.async_get(hass),
-        entity_reg,
-        config_entry,
-        lock_entity,
-    )
-    lock._hard_refresh_interval = timedelta(hours=1)
-
-    coordinator = LockUsercodeUpdateCoordinator(hass, lock, config_entry)
-
-    # Drift timer should be set up
-    assert coordinator._drift_unsub is not None
+    # Drift timer should be set up (push_coordinator fixture sets hard_refresh_interval)
+    assert push_coordinator._drift_unsub is not None
 
     # Shutdown coordinator
-    await coordinator.async_shutdown()
+    await push_coordinator.async_shutdown()
 
     # Drift timer should be cleaned up
-    assert coordinator._drift_unsub is None
+    assert push_coordinator._drift_unsub is None
 
 
 async def test_drift_check_calls_hard_refresh(
-    hass: HomeAssistant,
+    push_coordinator: LockUsercodeUpdateCoordinator,
+    push_lock: MockLCMPushLock,
 ):
     """Test that _async_drift_check calls async_internal_hard_refresh_codes."""
-    entity_reg = er.async_get(hass)
-    config_entry = MockConfigEntry(domain=DOMAIN)
-    config_entry.add_to_hass(hass)
-
-    lock_entity = entity_reg.async_get_or_create(
-        "lock",
-        "test",
-        "test_lock",
-        config_entry=config_entry,
-    )
-
-    lock = MockLockWithPush(
-        hass,
-        dr.async_get(hass),
-        entity_reg,
-        config_entry,
-        lock_entity,
-    )
-    lock._hard_refresh_interval = timedelta(hours=1)
-
-    coordinator = LockUsercodeUpdateCoordinator(hass, lock, config_entry)
-
     # Mock the hard refresh method. Return a real dict so the coordinator's
     # int-key normalization (applied to drift-check results) can iterate it.
     mock_hard_refresh = AsyncMock(return_value={1: "1234"})
 
-    with patch.object(lock, "async_internal_hard_refresh_codes", mock_hard_refresh):
-        await coordinator._async_drift_check(dt_util.utcnow())
+    with patch.object(
+        push_lock, "async_internal_hard_refresh_codes", mock_hard_refresh
+    ):
+        await push_coordinator._async_drift_check(dt_util.utcnow())
 
         mock_hard_refresh.assert_called_once()
 
 
 async def test_coordinator_lock_property(
-    hass: HomeAssistant,
+    poll_coordinator: LockUsercodeUpdateCoordinator,
+    poll_lock: MockLCMLock,
 ):
     """Test that coordinator.lock returns the lock instance."""
-    entity_reg = er.async_get(hass)
-    config_entry = MockConfigEntry(domain=DOMAIN)
-    config_entry.add_to_hass(hass)
-
-    lock_entity = entity_reg.async_get_or_create(
-        "lock",
-        "test",
-        "test_lock",
-        config_entry=config_entry,
-    )
-
-    lock = MockLockWithHardRefresh(
-        hass,
-        dr.async_get(hass),
-        entity_reg,
-        config_entry,
-        lock_entity,
-    )
-
-    coordinator = LockUsercodeUpdateCoordinator(hass, lock, config_entry)
-
-    # Verify lock property returns the lock
-    assert coordinator.lock is lock
+    assert poll_coordinator.lock is poll_lock
 
 
 async def test_drift_check_skips_before_initial_success(
-    hass: HomeAssistant,
+    push_coordinator: LockUsercodeUpdateCoordinator,
+    push_lock: MockLCMPushLock,
 ):
     """Test that _async_drift_check skips if initial data hasn't loaded."""
-    entity_reg = er.async_get(hass)
-    config_entry = MockConfigEntry(domain=DOMAIN)
-    config_entry.add_to_hass(hass)
-
-    lock_entity = entity_reg.async_get_or_create(
-        "lock",
-        "test",
-        "test_lock",
-        config_entry=config_entry,
-    )
-
-    lock = MockLockWithPush(
-        hass,
-        dr.async_get(hass),
-        entity_reg,
-        config_entry,
-        lock_entity,
-    )
-    lock._hard_refresh_interval = timedelta(hours=1)
-
-    coordinator = LockUsercodeUpdateCoordinator(hass, lock, config_entry)
     # Simulate no successful update yet
-    coordinator.last_update_success = False
+    push_coordinator.last_update_success = False
 
     mock_hard_refresh = AsyncMock()
-    with patch.object(lock, "async_internal_hard_refresh_codes", mock_hard_refresh):
-        await coordinator._async_drift_check(dt_util.utcnow())
+    with patch.object(
+        push_lock, "async_internal_hard_refresh_codes", mock_hard_refresh
+    ):
+        await push_coordinator._async_drift_check(dt_util.utcnow())
 
         # Should not call hard refresh when last_update_success is False
         mock_hard_refresh.assert_not_called()
 
 
 async def test_drift_check_handles_hard_refresh_error(
-    hass: HomeAssistant,
+    push_coordinator: LockUsercodeUpdateCoordinator,
+    push_lock: MockLCMPushLock,
 ):
     """Test that _async_drift_check handles hard refresh errors gracefully."""
-    entity_reg = er.async_get(hass)
-    config_entry = MockConfigEntry(domain=DOMAIN)
-    config_entry.add_to_hass(hass)
-
-    lock_entity = entity_reg.async_get_or_create(
-        "lock",
-        "test",
-        "test_lock",
-        config_entry=config_entry,
-    )
-
-    lock = MockLockWithPush(
-        hass,
-        dr.async_get(hass),
-        entity_reg,
-        config_entry,
-        lock_entity,
-    )
-    lock._hard_refresh_interval = timedelta(hours=1)
-
-    coordinator = LockUsercodeUpdateCoordinator(hass, lock, config_entry)
-    coordinator.last_update_success = True
-    coordinator.data = {1: "1234"}
+    push_coordinator.last_update_success = True
+    push_coordinator.data = {1: "1234"}
 
     # Mock hard refresh to raise an exception
     mock_hard_refresh = AsyncMock(side_effect=LockDisconnected("Lock offline"))
-    with patch.object(lock, "async_internal_hard_refresh_codes", mock_hard_refresh):
+    with patch.object(
+        push_lock, "async_internal_hard_refresh_codes", mock_hard_refresh
+    ):
         # Should not raise, should handle gracefully
-        await coordinator._async_drift_check(dt_util.utcnow())
+        await push_coordinator._async_drift_check(dt_util.utcnow())
 
         # Data should remain unchanged
-        assert coordinator.data == {1: "1234"}
+        assert push_coordinator.data == {1: "1234"}
 
 
 # --- Backoff tests ---
 
 
-def _create_poll_coordinator(
-    hass: HomeAssistant,
-) -> tuple[LockUsercodeUpdateCoordinator, MockLockWithHardRefresh]:
-    """Create a coordinator with a poll-based (non-push) lock."""
-    entity_reg = er.async_get(hass)
-    config_entry = MockConfigEntry(domain=DOMAIN)
-    config_entry.add_to_hass(hass)
-
-    lock_entity = entity_reg.async_get_or_create(
-        "lock",
-        "test",
-        "test_lock",
-        config_entry=config_entry,
-    )
-
-    lock = MockLockWithHardRefresh(
-        hass,
-        dr.async_get(hass),
-        entity_reg,
-        config_entry,
-        lock_entity,
-    )
-
-    coordinator = LockUsercodeUpdateCoordinator(hass, lock, config_entry)
-    return coordinator, lock
-
-
-def _create_push_coordinator(
-    hass: HomeAssistant,
-) -> tuple[LockUsercodeUpdateCoordinator, MockLockWithPush]:
-    """Create a coordinator with a push-based lock."""
-    entity_reg = er.async_get(hass)
-    config_entry = MockConfigEntry(domain=DOMAIN)
-    config_entry.add_to_hass(hass)
-
-    lock_entity = entity_reg.async_get_or_create(
-        "lock",
-        "test",
-        "test_lock",
-        config_entry=config_entry,
-    )
-
-    lock = MockLockWithPush(
-        hass,
-        dr.async_get(hass),
-        entity_reg,
-        config_entry,
-        lock_entity,
-    )
-    lock._hard_refresh_interval = timedelta(hours=1)
-
-    coordinator = LockUsercodeUpdateCoordinator(hass, lock, config_entry)
-    return coordinator, lock
-
-
-async def test_backoff_failure_counter_increments(hass: HomeAssistant) -> None:
+async def test_backoff_failure_counter_increments(
+    poll_coordinator: LockUsercodeUpdateCoordinator,
+    poll_lock: MockLCMLock,
+) -> None:
     """Test that consecutive failure counter increments on each failure."""
-    coordinator, lock = _create_poll_coordinator(hass)
     # last_update_success=True is required for UpdateFailed to be raised on next failure.
-    coordinator.last_update_success = True
+    poll_coordinator.last_update_success = True
 
     mock_get = AsyncMock(side_effect=LockDisconnected("Lock offline"))
-    with patch.object(lock, "async_internal_get_usercodes", mock_get):
+    with patch.object(poll_lock, "async_internal_get_usercodes", mock_get):
         for i in range(1, 4):
             with pytest.raises(UpdateFailed):
-                await coordinator.async_get_usercodes()
-            assert coordinator._consecutive_failures == i
+                await poll_coordinator.async_get_usercodes()
+            assert poll_coordinator._consecutive_failures == i
 
 
 async def test_backoff_first_failure_returns_empty_dict(
-    hass: HomeAssistant,
+    poll_coordinator: LockUsercodeUpdateCoordinator,
+    poll_lock: MockLCMLock,
 ) -> None:
     """Test that first failure returns empty dict when no prior success."""
-    coordinator, lock = _create_poll_coordinator(hass)
     # No successful update yet
-    coordinator.last_update_success = False
+    poll_coordinator.last_update_success = False
 
     mock_get = AsyncMock(side_effect=LockDisconnected("Lock offline"))
-    with patch.object(lock, "async_internal_get_usercodes", mock_get):
-        result = await coordinator.async_get_usercodes()
+    with patch.object(poll_lock, "async_internal_get_usercodes", mock_get):
+        result = await poll_coordinator.async_get_usercodes()
 
     assert result == {}
-    assert coordinator._consecutive_failures == 1
+    assert poll_coordinator._consecutive_failures == 1
 
 
 async def test_backoff_subsequent_failure_raises_update_failed(
-    hass: HomeAssistant,
+    poll_coordinator: LockUsercodeUpdateCoordinator,
+    poll_lock: MockLCMLock,
 ) -> None:
     """Test that subsequent failures raise UpdateFailed after prior success."""
-    coordinator, lock = _create_poll_coordinator(hass)
-    coordinator.last_update_success = True
+    poll_coordinator.last_update_success = True
 
     mock_get = AsyncMock(side_effect=LockDisconnected("Lock offline"))
-    with patch.object(lock, "async_internal_get_usercodes", mock_get):
+    with patch.object(poll_lock, "async_internal_get_usercodes", mock_get):
         with pytest.raises(UpdateFailed):
-            await coordinator.async_get_usercodes()
+            await poll_coordinator.async_get_usercodes()
 
-    assert coordinator._consecutive_failures == 1
+    assert poll_coordinator._consecutive_failures == 1
 
 
-async def test_backoff_activates_after_threshold(hass: HomeAssistant) -> None:
+async def test_backoff_activates_after_threshold(
+    poll_coordinator: LockUsercodeUpdateCoordinator,
+    poll_lock: MockLCMLock,
+) -> None:
     """Test that backoff activates after BACKOFF_FAILURE_THRESHOLD failures."""
-    coordinator, lock = _create_poll_coordinator(hass)
-    original_interval = coordinator.update_interval
-    coordinator.last_update_success = True
+    original_interval = poll_coordinator.update_interval
+    poll_coordinator.last_update_success = True
 
     mock_get = AsyncMock(side_effect=LockDisconnected("Lock offline"))
-    with patch.object(lock, "async_internal_get_usercodes", mock_get):
+    with patch.object(poll_lock, "async_internal_get_usercodes", mock_get):
         # Failures below threshold should not change interval
         for _ in range(BACKOFF_FAILURE_THRESHOLD - 1):
             with pytest.raises(UpdateFailed):
-                await coordinator.async_get_usercodes()
+                await poll_coordinator.async_get_usercodes()
 
-        assert coordinator.update_interval == original_interval
+        assert poll_coordinator.update_interval == original_interval
 
         # Failure at threshold should activate backoff
         with pytest.raises(UpdateFailed):
-            await coordinator.async_get_usercodes()
+            await poll_coordinator.async_get_usercodes()
 
-        assert coordinator._consecutive_failures == BACKOFF_FAILURE_THRESHOLD
+        assert poll_coordinator._consecutive_failures == BACKOFF_FAILURE_THRESHOLD
         expected_backoff = timedelta(
             seconds=BACKOFF_INITIAL_SECONDS * 2**0  # 2^(3-3) = 1
         )
-        assert coordinator.update_interval == expected_backoff
+        assert poll_coordinator.update_interval == expected_backoff
 
 
 async def test_backoff_interval_increases_exponentially(
-    hass: HomeAssistant,
+    poll_coordinator: LockUsercodeUpdateCoordinator,
+    poll_lock: MockLCMLock,
 ) -> None:
     """Test that update_interval increases exponentially for poll-based providers."""
-    coordinator, lock = _create_poll_coordinator(hass)
-    coordinator.last_update_success = True
+    poll_coordinator.last_update_success = True
 
     mock_get = AsyncMock(side_effect=LockDisconnected("Lock offline"))
-    with patch.object(lock, "async_internal_get_usercodes", mock_get):
+    with patch.object(poll_lock, "async_internal_get_usercodes", mock_get):
         # Reach threshold + additional failures
         for _ in range(BACKOFF_FAILURE_THRESHOLD + 3):
             with pytest.raises(UpdateFailed):
-                await coordinator.async_get_usercodes()
+                await poll_coordinator.async_get_usercodes()
 
     # After threshold+3 failures, exponent = 3, backoff = 60 * 2^3 = 480s
     expected_backoff = timedelta(seconds=BACKOFF_INITIAL_SECONDS * 2**3)
-    assert coordinator.update_interval == expected_backoff
+    assert poll_coordinator.update_interval == expected_backoff
 
 
-async def test_backoff_caps_at_max(hass: HomeAssistant) -> None:
+async def test_backoff_caps_at_max(
+    poll_coordinator: LockUsercodeUpdateCoordinator,
+    poll_lock: MockLCMLock,
+) -> None:
     """Test that backoff interval is capped at BACKOFF_MAX_SECONDS."""
-    coordinator, lock = _create_poll_coordinator(hass)
-    coordinator.last_update_success = True
+    poll_coordinator.last_update_success = True
 
     mock_get = AsyncMock(side_effect=LockDisconnected("Lock offline"))
-    with patch.object(lock, "async_internal_get_usercodes", mock_get):
+    with patch.object(poll_lock, "async_internal_get_usercodes", mock_get):
         # Many failures to exceed max
         for _ in range(BACKOFF_FAILURE_THRESHOLD + 20):
             with pytest.raises(UpdateFailed):
-                await coordinator.async_get_usercodes()
+                await poll_coordinator.async_get_usercodes()
 
-    assert coordinator.update_interval == timedelta(seconds=BACKOFF_MAX_SECONDS)
+    assert poll_coordinator.update_interval == timedelta(seconds=BACKOFF_MAX_SECONDS)
 
 
-async def test_backoff_resets_on_success(hass: HomeAssistant) -> None:
+async def test_backoff_resets_on_success(
+    poll_coordinator: LockUsercodeUpdateCoordinator,
+    poll_lock: MockLCMLock,
+) -> None:
     """Test that counters and interval reset on success."""
-    coordinator, lock = _create_poll_coordinator(hass)
-    original_interval = coordinator.update_interval
-    coordinator.last_update_success = True
+    original_interval = poll_coordinator.update_interval
+    poll_coordinator.last_update_success = True
 
     mock_get_fail = AsyncMock(side_effect=LockDisconnected("Lock offline"))
-    with patch.object(lock, "async_internal_get_usercodes", mock_get_fail):
+    with patch.object(poll_lock, "async_internal_get_usercodes", mock_get_fail):
         # Accumulate failures past threshold
         for _ in range(BACKOFF_FAILURE_THRESHOLD + 1):
             with pytest.raises(UpdateFailed):
-                await coordinator.async_get_usercodes()
+                await poll_coordinator.async_get_usercodes()
 
-    assert coordinator._consecutive_failures == BACKOFF_FAILURE_THRESHOLD + 1
-    assert coordinator.update_interval != original_interval
+    assert poll_coordinator._consecutive_failures == BACKOFF_FAILURE_THRESHOLD + 1
+    assert poll_coordinator.update_interval != original_interval
 
     # Now succeed
     mock_get_success = AsyncMock(return_value={1: "1234"})
-    with patch.object(lock, "async_internal_get_usercodes", mock_get_success):
-        result = await coordinator.async_get_usercodes()
+    with patch.object(poll_lock, "async_internal_get_usercodes", mock_get_success):
+        result = await poll_coordinator.async_get_usercodes()
 
     assert result == {1: "1234"}
-    assert coordinator._consecutive_failures == 0
-    assert coordinator.update_interval == original_interval
+    assert poll_coordinator._consecutive_failures == 0
+    assert poll_coordinator.update_interval == original_interval
 
 
 async def test_backoff_no_reset_when_no_prior_failures(
-    hass: HomeAssistant,
+    poll_coordinator: LockUsercodeUpdateCoordinator,
+    poll_lock: MockLCMLock,
 ) -> None:
     """Test that success with no prior failures does not modify interval."""
-    coordinator, lock = _create_poll_coordinator(hass)
-    original_interval = coordinator.update_interval
+    original_interval = poll_coordinator.update_interval
 
     mock_get = AsyncMock(return_value={1: "1234"})
-    with patch.object(lock, "async_internal_get_usercodes", mock_get):
-        result = await coordinator.async_get_usercodes()
+    with patch.object(poll_lock, "async_internal_get_usercodes", mock_get):
+        result = await poll_coordinator.async_get_usercodes()
 
     assert result == {1: "1234"}
-    assert coordinator._consecutive_failures == 0
-    assert coordinator.update_interval == original_interval
+    assert poll_coordinator._consecutive_failures == 0
+    assert poll_coordinator.update_interval == original_interval
 
 
-async def test_drift_check_skipped_during_backoff(hass: HomeAssistant) -> None:
+async def test_drift_check_skipped_during_backoff(
+    push_coordinator: LockUsercodeUpdateCoordinator,
+    push_lock: MockLCMPushLock,
+) -> None:
     """Test that drift check is skipped when in backoff."""
-    coordinator, lock = _create_push_coordinator(hass)
-    coordinator.last_update_success = True
-    coordinator._consecutive_failures = BACKOFF_FAILURE_THRESHOLD
+    push_coordinator.last_update_success = True
+    push_coordinator._consecutive_failures = BACKOFF_FAILURE_THRESHOLD
 
     mock_hard_refresh = AsyncMock()
-    with patch.object(lock, "async_internal_hard_refresh_codes", mock_hard_refresh):
-        await coordinator._async_drift_check(dt_util.utcnow())
+    with patch.object(
+        push_lock, "async_internal_hard_refresh_codes", mock_hard_refresh
+    ):
+        await push_coordinator._async_drift_check(dt_util.utcnow())
 
         # Hard refresh should NOT be called during backoff
         mock_hard_refresh.assert_not_called()
 
 
 async def test_drift_check_runs_below_backoff_threshold(
-    hass: HomeAssistant,
+    push_coordinator: LockUsercodeUpdateCoordinator,
+    push_lock: MockLCMPushLock,
 ) -> None:
     """Test that drift check runs when failures are below threshold."""
-    coordinator, lock = _create_push_coordinator(hass)
-    coordinator.last_update_success = True
-    coordinator._consecutive_failures = BACKOFF_FAILURE_THRESHOLD - 1
+    push_coordinator.last_update_success = True
+    push_coordinator._consecutive_failures = BACKOFF_FAILURE_THRESHOLD - 1
 
     mock_hard_refresh = AsyncMock(return_value={1: "1234"})
-    with patch.object(lock, "async_internal_hard_refresh_codes", mock_hard_refresh):
-        await coordinator._async_drift_check(dt_util.utcnow())
+    with patch.object(
+        push_lock, "async_internal_hard_refresh_codes", mock_hard_refresh
+    ):
+        await push_coordinator._async_drift_check(dt_util.utcnow())
 
         # Hard refresh SHOULD be called below threshold
         mock_hard_refresh.assert_called_once()
 
 
 async def test_backoff_push_provider_does_not_change_interval(
-    hass: HomeAssistant,
+    push_coordinator: LockUsercodeUpdateCoordinator,
+    push_lock: MockLCMPushLock,
 ) -> None:
     """Test that push-based providers do not modify update_interval during backoff."""
-    coordinator, lock = _create_push_coordinator(hass)
     # Push providers have update_interval=None
-    assert coordinator.update_interval is None
-    coordinator.last_update_success = True
+    assert push_coordinator.update_interval is None
+    push_coordinator.last_update_success = True
 
     mock_get = AsyncMock(side_effect=LockDisconnected("Lock offline"))
-    with patch.object(lock, "async_internal_get_usercodes", mock_get):
+    with patch.object(push_lock, "async_internal_get_usercodes", mock_get):
         for _ in range(BACKOFF_FAILURE_THRESHOLD + 2):
             with pytest.raises(UpdateFailed):
-                await coordinator.async_get_usercodes()
+                await push_coordinator.async_get_usercodes()
 
     # update_interval should remain None for push providers
-    assert coordinator.update_interval is None
+    assert push_coordinator.update_interval is None
     # But failure counter should still be tracked
-    assert coordinator._consecutive_failures == BACKOFF_FAILURE_THRESHOLD + 2
+    assert push_coordinator._consecutive_failures == BACKOFF_FAILURE_THRESHOLD + 2
 
 
 async def test_backoff_init_stores_original_interval(
-    hass: HomeAssistant,
+    poll_coordinator: LockUsercodeUpdateCoordinator,
+    poll_lock: MockLCMLock,
 ) -> None:
     """Test that __init__ stores the original update interval."""
-    coordinator, lock = _create_poll_coordinator(hass)
-    assert coordinator._original_update_interval == lock.usercode_scan_interval
-    assert coordinator._consecutive_failures == 0
+    assert (
+        poll_coordinator._original_update_interval == poll_lock.usercode_scan_interval
+    )
+    assert poll_coordinator._consecutive_failures == 0
 
 
 async def test_backoff_init_push_stores_none_interval(
-    hass: HomeAssistant,
+    push_coordinator: LockUsercodeUpdateCoordinator,
 ) -> None:
     """Test that __init__ stores None for push-based providers."""
-    coordinator, _ = _create_push_coordinator(hass)
-    assert coordinator._original_update_interval is None
-    assert coordinator._consecutive_failures == 0
+    assert push_coordinator._original_update_interval is None
+    assert push_coordinator._consecutive_failures == 0
 
 
-async def test_push_update_resets_backoff(hass: HomeAssistant) -> None:
+async def test_push_update_resets_backoff(
+    push_coordinator: LockUsercodeUpdateCoordinator,
+    push_lock: MockLCMPushLock,
+) -> None:
     """Test that push_update resets backoff state when data changes."""
-    coordinator, lock = _create_push_coordinator(hass)
-    coordinator.last_update_success = True
+    push_coordinator.last_update_success = True
 
     # Simulate failures past threshold
     mock_get = AsyncMock(side_effect=LockDisconnected("Lock offline"))
-    with patch.object(lock, "async_internal_get_usercodes", mock_get):
+    with patch.object(push_lock, "async_internal_get_usercodes", mock_get):
         for _ in range(BACKOFF_FAILURE_THRESHOLD + 2):
             with pytest.raises(UpdateFailed):
-                await coordinator.async_get_usercodes()
+                await push_coordinator.async_get_usercodes()
 
-    assert coordinator._consecutive_failures == BACKOFF_FAILURE_THRESHOLD + 2
+    assert push_coordinator._consecutive_failures == BACKOFF_FAILURE_THRESHOLD + 2
 
     # Push update with new data should reset backoff
-    coordinator.data = {1: "old"}
-    coordinator.push_update({1: "1234"})
+    push_coordinator.data = {1: "old"}
+    push_coordinator.push_update({1: "1234"})
 
-    assert coordinator._consecutive_failures == 0
+    assert push_coordinator._consecutive_failures == 0
 
 
 async def test_push_update_no_reset_when_data_unchanged(
-    hass: HomeAssistant,
+    push_coordinator: LockUsercodeUpdateCoordinator,
+    push_lock: MockLCMPushLock,
 ) -> None:
     """Test that push_update does not reset backoff when data is unchanged."""
-    coordinator, lock = _create_push_coordinator(hass)
-    coordinator.last_update_success = True
+    push_coordinator.last_update_success = True
 
     # Simulate failures past threshold
     mock_get = AsyncMock(side_effect=LockDisconnected("Lock offline"))
-    with patch.object(lock, "async_internal_get_usercodes", mock_get):
+    with patch.object(push_lock, "async_internal_get_usercodes", mock_get):
         for _ in range(BACKOFF_FAILURE_THRESHOLD + 1):
             with pytest.raises(UpdateFailed):
-                await coordinator.async_get_usercodes()
+                await push_coordinator.async_get_usercodes()
 
-    assert coordinator._consecutive_failures == BACKOFF_FAILURE_THRESHOLD + 1
+    assert push_coordinator._consecutive_failures == BACKOFF_FAILURE_THRESHOLD + 1
 
     # Push update with same data should NOT reset backoff
-    coordinator.data = {1: "1234"}
-    coordinator.push_update({1: "1234"})
+    push_coordinator.data = {1: "1234"}
+    push_coordinator.push_update({1: "1234"})
 
-    assert coordinator._consecutive_failures == BACKOFF_FAILURE_THRESHOLD + 1
+    assert push_coordinator._consecutive_failures == BACKOFF_FAILURE_THRESHOLD + 1
 
 
 async def test_poll_failure_alert_created_after_threshold(
+    poll_coordinator: LockUsercodeUpdateCoordinator,
+    poll_lock: MockLCMLock,
     hass: HomeAssistant,
 ) -> None:
     """Test that a repair issue is created after POLL_FAILURE_ALERT_THRESHOLD failures."""
-    coordinator, lock = _create_poll_coordinator(hass)
-    coordinator.last_update_success = True
+    poll_coordinator.last_update_success = True
 
     mock_get = AsyncMock(side_effect=LockDisconnected("Lock offline"))
-    with patch.object(lock, "async_internal_get_usercodes", mock_get):
+    with patch.object(poll_lock, "async_internal_get_usercodes", mock_get):
         for _ in range(POLL_FAILURE_ALERT_THRESHOLD):
             with pytest.raises(UpdateFailed):
-                await coordinator.async_get_usercodes()
+                await poll_coordinator.async_get_usercodes()
 
     issue_registry = async_get_issue_registry(hass)
-    issue_id = f"lock_offline_{lock.lock.entity_id}"
+    issue_id = f"lock_offline_{poll_lock.lock.entity_id}"
     issue = issue_registry.async_get_issue(DOMAIN, issue_id)
     assert issue is not None
     assert issue.severity == "warning"
@@ -997,71 +695,74 @@ async def test_poll_failure_alert_created_after_threshold(
 
 
 async def test_poll_failure_alert_not_created_before_threshold(
+    poll_coordinator: LockUsercodeUpdateCoordinator,
+    poll_lock: MockLCMLock,
     hass: HomeAssistant,
 ) -> None:
     """Test that no repair issue exists before reaching the alert threshold."""
-    coordinator, lock = _create_poll_coordinator(hass)
-    coordinator.last_update_success = True
+    poll_coordinator.last_update_success = True
 
     mock_get = AsyncMock(side_effect=LockDisconnected("Lock offline"))
-    with patch.object(lock, "async_internal_get_usercodes", mock_get):
+    with patch.object(poll_lock, "async_internal_get_usercodes", mock_get):
         for _ in range(POLL_FAILURE_ALERT_THRESHOLD - 1):
             with pytest.raises(UpdateFailed):
-                await coordinator.async_get_usercodes()
+                await poll_coordinator.async_get_usercodes()
 
     issue_registry = async_get_issue_registry(hass)
-    issue_id = f"lock_offline_{lock.lock.entity_id}"
+    issue_id = f"lock_offline_{poll_lock.lock.entity_id}"
     issue = issue_registry.async_get_issue(DOMAIN, issue_id)
     assert issue is None
 
 
 async def test_poll_failure_alert_dismissed_on_recovery(
+    poll_coordinator: LockUsercodeUpdateCoordinator,
+    poll_lock: MockLCMLock,
     hass: HomeAssistant,
 ) -> None:
     """Test that the repair issue is dismissed when the lock recovers."""
-    coordinator, lock = _create_poll_coordinator(hass)
-    coordinator.last_update_success = True
+    poll_coordinator.last_update_success = True
 
     mock_get_fail = AsyncMock(side_effect=LockDisconnected("Lock offline"))
-    with patch.object(lock, "async_internal_get_usercodes", mock_get_fail):
+    with patch.object(poll_lock, "async_internal_get_usercodes", mock_get_fail):
         for _ in range(POLL_FAILURE_ALERT_THRESHOLD):
             with pytest.raises(UpdateFailed):
-                await coordinator.async_get_usercodes()
+                await poll_coordinator.async_get_usercodes()
 
     # Verify issue exists
     issue_registry = async_get_issue_registry(hass)
-    issue_id = f"lock_offline_{lock.lock.entity_id}"
+    issue_id = f"lock_offline_{poll_lock.lock.entity_id}"
     assert issue_registry.async_get_issue(DOMAIN, issue_id) is not None
 
     # Now succeed
     mock_get_success = AsyncMock(return_value={1: "1234"})
-    with patch.object(lock, "async_internal_get_usercodes", mock_get_success):
-        await coordinator.async_get_usercodes()
+    with patch.object(poll_lock, "async_internal_get_usercodes", mock_get_success):
+        await poll_coordinator.async_get_usercodes()
 
     # Issue should be dismissed
     assert issue_registry.async_get_issue(DOMAIN, issue_id) is None
 
 
 async def test_lock_offline_issue_persists_across_shutdown(
+    poll_coordinator: LockUsercodeUpdateCoordinator,
+    poll_lock: MockLCMLock,
     hass: HomeAssistant,
 ) -> None:
     """Test that lock_offline repair issue persists across coordinator shutdown.
 
     The issue is persistent and only cleaned up on entry unload or recovery.
     """
-    coordinator, lock = _create_poll_coordinator(hass)
-    coordinator.last_update_success = True
+    poll_coordinator.last_update_success = True
 
     mock_get_fail = AsyncMock(side_effect=LockDisconnected("Lock offline"))
-    with patch.object(lock, "async_internal_get_usercodes", mock_get_fail):
+    with patch.object(poll_lock, "async_internal_get_usercodes", mock_get_fail):
         for _ in range(POLL_FAILURE_ALERT_THRESHOLD):
             with pytest.raises(UpdateFailed):
-                await coordinator.async_get_usercodes()
+                await poll_coordinator.async_get_usercodes()
 
     issue_registry = async_get_issue_registry(hass)
-    issue_id = f"lock_offline_{lock.lock.entity_id}"
+    issue_id = f"lock_offline_{poll_lock.lock.entity_id}"
     assert issue_registry.async_get_issue(DOMAIN, issue_id) is not None
 
     # Shutdown should NOT delete the issue — it persists across restarts
-    await coordinator.async_shutdown()
+    await poll_coordinator.async_shutdown()
     assert issue_registry.async_get_issue(DOMAIN, issue_id) is not None


### PR DESCRIPTION
## Proposed change

Clean up coordinator tests by replacing locally-defined `MockLockWithHardRefresh` and `MockLockWithPush` classes with shared test infrastructure from `tests/common.py`. This eliminates ~270 lines of duplicated boilerplate while preserving all 35 test scenarios.

Changes:
- Extended `MockLCMLock` in `tests/common.py` with a configurable `hard_refresh_interval` property (defaults to `None`, matching `BaseLock`)
- Added `MockLCMPushLock` subclass in `tests/common.py` for push-based lock testing with subscription tracking
- Replaced all manual lock/coordinator construction boilerplate in `tests/test_coordinator.py` with shared fixtures (`lcm_config_entry`, `poll_lock`, `push_lock`, `poll_coordinator`, `push_coordinator`) and helpers (`_make_lock`, `_make_coordinator`)
- Removed redundant `MagicMock`/`dataclass` imports and the two local mock lock classes

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue:

🤖 Generated with [Claude Code](https://claude.com/claude-code)