### PR TITLE
refactor: move Schlage, Akuvox, and Virtual provider tests into dedicated modules

### DIFF
--- a/tests/providers/akuvox/__init__.py
+++ b/tests/providers/akuvox/__init__.py
@@ -1,0 +1,1 @@
+"""Akuvox provider tests."""

--- a/tests/providers/akuvox/conftest.py
+++ b/tests/providers/akuvox/conftest.py
@@ -1,0 +1,115 @@
+"""Akuvox provider test fixtures."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+from custom_components.lock_code_manager.const import (
+    CONF_ENABLED,
+    CONF_LOCKS,
+    CONF_NAME,
+    CONF_PIN,
+    CONF_SLOTS,
+    DOMAIN,
+)
+from custom_components.lock_code_manager.providers.akuvox import (
+    AKUVOX_DOMAIN,
+    AkuvoxLock,
+)
+
+LOCK_ENTITY_ID = "lock.local_akuvox_test_relay_a"
+
+
+@pytest.fixture
+async def akuvox_config_entry(hass: HomeAssistant) -> MockConfigEntry:
+    """Create a local_akuvox config entry."""
+    entry = MockConfigEntry(domain=AKUVOX_DOMAIN)
+    entry.add_to_hass(hass)
+    entry._async_set_state(hass, entry.state, None)
+    return entry
+
+
+@pytest.fixture
+async def akuvox_lock(
+    hass: HomeAssistant, akuvox_config_entry: MockConfigEntry
+) -> AkuvoxLock:
+    """Create an AkuvoxLock instance with a registered lock entity."""
+    entity_reg = er.async_get(hass)
+    lock_entity = entity_reg.async_get_or_create(
+        "lock",
+        "local_akuvox",
+        "test_relay_a",
+        config_entry=akuvox_config_entry,
+    )
+    return AkuvoxLock(
+        hass,
+        dr.async_get(hass),
+        entity_reg,
+        akuvox_config_entry,
+        lock_entity,
+    )
+
+
+@pytest.fixture
+async def lcm_config_entry(hass: HomeAssistant) -> MockConfigEntry:
+    """Create a Lock Code Manager config entry that manages slots 1 and 2."""
+    config = {
+        CONF_LOCKS: [LOCK_ENTITY_ID],
+        CONF_SLOTS: {
+            1: {CONF_NAME: "slot1", CONF_PIN: "1234", CONF_ENABLED: True},
+            2: {CONF_NAME: "slot2", CONF_PIN: "5678", CONF_ENABLED: True},
+        },
+    }
+    entry = MockConfigEntry(domain=DOMAIN, data=config, unique_id="test_akuvox_lcm")
+    entry.add_to_hass(hass)
+    return entry
+
+
+# --- Alias fixtures for shared test mixins ---
+
+
+@pytest.fixture
+def provider_lock(akuvox_lock: AkuvoxLock) -> AkuvoxLock:
+    """Alias akuvox_lock for shared test mixins."""
+    return akuvox_lock
+
+
+@pytest.fixture
+def provider_config_entry(akuvox_config_entry: MockConfigEntry) -> MockConfigEntry:
+    """Alias akuvox_config_entry for shared test mixins."""
+    return akuvox_config_entry
+
+
+@pytest.fixture
+def provider_domain() -> str:
+    """Return the provider integration domain."""
+    return AKUVOX_DOMAIN
+
+
+@pytest.fixture
+def provider_lock_class() -> type[AkuvoxLock]:
+    """Return the provider lock class."""
+    return AkuvoxLock
+
+
+def make_user(
+    device_id: str,
+    name: str,
+    private_pin: str = "",
+    source_type: str | None = "1",
+    user_type: str = "0",
+) -> dict[str, Any]:
+    """Create a user dict matching list_users response format."""
+    return {
+        "id": device_id,
+        "name": name,
+        "private_pin": private_pin,
+        "source_type": source_type,
+        "user_type": user_type,
+    }

--- a/tests/providers/akuvox/test_akuvox.py
+++ b/tests/providers/akuvox/test_akuvox.py
@@ -11,16 +11,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import device_registry as dr, entity_registry as er
 
-from custom_components.lock_code_manager.const import (
-    CONF_ENABLED,
-    CONF_LOCKS,
-    CONF_NAME,
-    CONF_PIN,
-    CONF_SLOTS,
-    DOMAIN,
-)
 from custom_components.lock_code_manager.exceptions import (
     LockCodeManagerError,
     LockDisconnected,
@@ -33,108 +24,12 @@ from custom_components.lock_code_manager.providers.akuvox import (
     _make_tagged_name,
     _parse_tag,
 )
-
-from .helpers import (
+from tests.providers.helpers import (
     ServiceProviderConnectionTests,
     register_mock_service,
 )
 
-LOCK_ENTITY_ID = "lock.local_akuvox_test_relay_a"
-
-
-# ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
-
-
-@pytest.fixture
-async def akuvox_config_entry(hass: HomeAssistant) -> MockConfigEntry:
-    """Create a local_akuvox config entry."""
-    entry = MockConfigEntry(domain=AKUVOX_DOMAIN)
-    entry.add_to_hass(hass)
-    entry._async_set_state(hass, entry.state, None)
-    return entry
-
-
-@pytest.fixture
-async def akuvox_lock(
-    hass: HomeAssistant, akuvox_config_entry: MockConfigEntry
-) -> AkuvoxLock:
-    """Create an AkuvoxLock instance with a registered lock entity."""
-    entity_reg = er.async_get(hass)
-    lock_entity = entity_reg.async_get_or_create(
-        "lock",
-        "local_akuvox",
-        "test_relay_a",
-        config_entry=akuvox_config_entry,
-    )
-    return AkuvoxLock(
-        hass,
-        dr.async_get(hass),
-        entity_reg,
-        akuvox_config_entry,
-        lock_entity,
-    )
-
-
-@pytest.fixture
-async def lcm_config_entry(hass: HomeAssistant) -> MockConfigEntry:
-    """Create a Lock Code Manager config entry that manages slots 1 and 2."""
-    config = {
-        CONF_LOCKS: [LOCK_ENTITY_ID],
-        CONF_SLOTS: {
-            1: {CONF_NAME: "slot1", CONF_PIN: "1234", CONF_ENABLED: True},
-            2: {CONF_NAME: "slot2", CONF_PIN: "5678", CONF_ENABLED: True},
-        },
-    }
-    entry = MockConfigEntry(domain=DOMAIN, data=config, unique_id="test_akuvox_lcm")
-    entry.add_to_hass(hass)
-    return entry
-
-
-# --- Alias fixtures for shared test mixins ---
-
-
-@pytest.fixture
-def provider_lock(akuvox_lock: AkuvoxLock) -> AkuvoxLock:
-    """Alias akuvox_lock for shared test mixins."""
-    return akuvox_lock
-
-
-@pytest.fixture
-def provider_config_entry(akuvox_config_entry: MockConfigEntry) -> MockConfigEntry:
-    """Alias akuvox_config_entry for shared test mixins."""
-    return akuvox_config_entry
-
-
-@pytest.fixture
-def provider_domain() -> str:
-    """Return the provider integration domain."""
-    return AKUVOX_DOMAIN
-
-
-@pytest.fixture
-def provider_lock_class() -> type[AkuvoxLock]:
-    """Return the provider lock class."""
-    return AkuvoxLock
-
-
-def _make_user(
-    device_id: str,
-    name: str,
-    private_pin: str = "",
-    source_type: str | None = "1",
-    user_type: str = "0",
-) -> dict[str, Any]:
-    """Create a user dict matching list_users response format."""
-    return {
-        "id": device_id,
-        "name": name,
-        "private_pin": private_pin,
-        "source_type": source_type,
-        "user_type": user_type,
-    }
-
+from .conftest import LOCK_ENTITY_ID, make_user
 
 # ---------------------------------------------------------------------------
 # Helper function tests
@@ -263,7 +158,7 @@ class TestGetUsercodes:
         mock_response = {
             LOCK_ENTITY_ID: {
                 "users": [
-                    _make_user("100", "[LCM:1] Guest", "1234"),
+                    make_user("100", "[LCM:1] Guest", "1234"),
                 ],
             },
         }
@@ -310,7 +205,7 @@ class TestGetUsercodes:
         mock_response = {
             LOCK_ENTITY_ID: {
                 "users": [
-                    _make_user("200", "Visitor", "9999"),
+                    make_user("200", "Visitor", "9999"),
                 ],
             },
         }
@@ -333,7 +228,7 @@ class TestGetUsercodes:
         mock_response = {
             LOCK_ENTITY_ID: {
                 "users": [
-                    _make_user("300", "Cloud User", "1111", source_type="2"),
+                    make_user("300", "Cloud User", "1111", source_type="2"),
                 ],
             },
         }
@@ -355,7 +250,7 @@ class TestGetUsercodes:
         mock_response = {
             LOCK_ENTITY_ID: {
                 "users": [
-                    _make_user("400", "[LCM:1] Empty Slot", ""),
+                    make_user("400", "[LCM:1] Empty Slot", ""),
                 ],
             },
         }
@@ -376,7 +271,7 @@ class TestGetUsercodes:
         mock_response = {
             LOCK_ENTITY_ID: {
                 "users": [
-                    _make_user("500", "[LCM:99] Outside", "5555"),
+                    make_user("500", "[LCM:99] Outside", "5555"),
                 ],
             },
         }
@@ -431,7 +326,7 @@ class TestSetUsercode:
         list_response = {
             LOCK_ENTITY_ID: {
                 "users": [
-                    _make_user("100", "[LCM:1] Guest", "1234"),
+                    make_user("100", "[LCM:1] Guest", "1234"),
                 ],
             },
         }
@@ -463,7 +358,7 @@ class TestSetUsercode:
         list_response = {
             LOCK_ENTITY_ID: {
                 "users": [
-                    _make_user("100", "[LCM:1] Guest", "1234"),
+                    make_user("100", "[LCM:1] Guest", "1234"),
                 ],
             },
         }
@@ -519,7 +414,7 @@ class TestClearUsercode:
         list_response = {
             LOCK_ENTITY_ID: {
                 "users": [
-                    _make_user("100", "[LCM:1] Guest", "1234"),
+                    make_user("100", "[LCM:1] Guest", "1234"),
                 ],
             },
         }
@@ -561,7 +456,7 @@ class TestClearUsercode:
         list_response = {
             LOCK_ENTITY_ID: {
                 "users": [
-                    _make_user("100", "[LCM:1] Guest", "1234"),
+                    make_user("100", "[LCM:1] Guest", "1234"),
                 ],
             },
         }
@@ -666,7 +561,7 @@ class TestAutoTagging:
         mock_response = {
             LOCK_ENTITY_ID: {
                 "users": [
-                    _make_user("200", "Visitor", "9999"),
+                    make_user("200", "Visitor", "9999"),
                 ],
             },
         }
@@ -698,8 +593,8 @@ class TestAutoTagging:
         mock_response = {
             LOCK_ENTITY_ID: {
                 "users": [
-                    _make_user("200", "Visitor A", "1111"),
-                    _make_user("201", "Visitor B", "2222"),
+                    make_user("200", "Visitor A", "1111"),
+                    make_user("201", "Visitor B", "2222"),
                 ],
             },
         }
@@ -756,12 +651,12 @@ class TestHardRefresh:
         # First call returns untagged user, second call returns tagged user
         untagged_response = {
             LOCK_ENTITY_ID: {
-                "users": [_make_user("200", "Visitor", "9999")],
+                "users": [make_user("200", "Visitor", "9999")],
             },
         }
         tagged_response = {
             LOCK_ENTITY_ID: {
-                "users": [_make_user("200", "[LCM:1] Visitor", "9999")],
+                "users": [make_user("200", "[LCM:1] Visitor", "9999")],
             },
         }
         list_handler = AsyncMock(side_effect=[untagged_response, tagged_response])

--- a/tests/providers/schlage/__init__.py
+++ b/tests/providers/schlage/__init__.py
@@ -1,0 +1,1 @@
+"""Schlage provider tests."""

--- a/tests/providers/schlage/conftest.py
+++ b/tests/providers/schlage/conftest.py
@@ -1,0 +1,96 @@
+"""Schlage provider test fixtures."""
+
+from __future__ import annotations
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+from custom_components.lock_code_manager.const import (
+    CONF_ENABLED,
+    CONF_LOCKS,
+    CONF_NAME,
+    CONF_PIN,
+    CONF_SLOTS,
+    DOMAIN,
+)
+from custom_components.lock_code_manager.providers.schlage import (
+    SCHLAGE_DOMAIN,
+    SchlageLock,
+)
+
+LOCK_ENTITY_ID = "lock.schlage_test_schlage_lock"
+
+
+@pytest.fixture
+async def schlage_config_entry(hass: HomeAssistant) -> MockConfigEntry:
+    """Create a Schlage config entry."""
+    entry = MockConfigEntry(domain=SCHLAGE_DOMAIN)
+    entry.add_to_hass(hass)
+    entry._async_set_state(hass, entry.state, None)
+    return entry
+
+
+@pytest.fixture
+async def schlage_lock(
+    hass: HomeAssistant, schlage_config_entry: MockConfigEntry
+) -> SchlageLock:
+    """Create a SchlageLock instance with a registered lock entity."""
+    entity_reg = er.async_get(hass)
+    lock_entity = entity_reg.async_get_or_create(
+        "lock",
+        "schlage",
+        "test_schlage_lock",
+        config_entry=schlage_config_entry,
+    )
+    return SchlageLock(
+        hass,
+        dr.async_get(hass),
+        entity_reg,
+        schlage_config_entry,
+        lock_entity,
+    )
+
+
+@pytest.fixture
+async def lcm_config_entry(hass: HomeAssistant) -> MockConfigEntry:
+    """Create a Lock Code Manager config entry that manages slots 1 and 2."""
+    config = {
+        CONF_LOCKS: [LOCK_ENTITY_ID],
+        CONF_SLOTS: {
+            1: {CONF_NAME: "slot1", CONF_PIN: "1234", CONF_ENABLED: True},
+            2: {CONF_NAME: "slot2", CONF_PIN: "5678", CONF_ENABLED: True},
+        },
+    }
+    entry = MockConfigEntry(domain=DOMAIN, data=config, unique_id="test_schlage_lcm")
+    entry.add_to_hass(hass)
+    return entry
+
+
+# --- Alias fixtures for shared test mixins ---
+
+
+@pytest.fixture
+def provider_lock(schlage_lock: SchlageLock) -> SchlageLock:
+    """Alias schlage_lock for shared test mixins."""
+    return schlage_lock
+
+
+@pytest.fixture
+def provider_config_entry(schlage_config_entry: MockConfigEntry) -> MockConfigEntry:
+    """Alias schlage_config_entry for shared test mixins."""
+    return schlage_config_entry
+
+
+@pytest.fixture
+def provider_domain() -> str:
+    """Return the provider integration domain."""
+    return SCHLAGE_DOMAIN
+
+
+@pytest.fixture
+def provider_lock_class() -> type[SchlageLock]:
+    """Return the provider lock class."""
+    return SchlageLock

--- a/tests/providers/schlage/test_schlage.py
+++ b/tests/providers/schlage/test_schlage.py
@@ -10,16 +10,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
-from homeassistant.helpers import device_registry as dr, entity_registry as er
 
-from custom_components.lock_code_manager.const import (
-    CONF_ENABLED,
-    CONF_LOCKS,
-    CONF_NAME,
-    CONF_PIN,
-    CONF_SLOTS,
-    DOMAIN,
-)
 from custom_components.lock_code_manager.exceptions import (
     LockCodeManagerError,
     LockDisconnected,
@@ -31,87 +22,13 @@ from custom_components.lock_code_manager.providers.schlage import (
     _make_tagged_name,
     _parse_tag,
 )
-
-from .helpers import (
+from tests.providers.helpers import (
     ServiceProviderConnectionTests,
     ServiceProviderDeviceAvailabilityTests,
     register_mock_service,
 )
 
-LOCK_ENTITY_ID = "lock.schlage_test_schlage_lock"
-
-
-@pytest.fixture
-async def schlage_config_entry(hass: HomeAssistant) -> MockConfigEntry:
-    """Create a Schlage config entry."""
-    entry = MockConfigEntry(domain=SCHLAGE_DOMAIN)
-    entry.add_to_hass(hass)
-    entry._async_set_state(hass, entry.state, None)
-    return entry
-
-
-@pytest.fixture
-async def schlage_lock(
-    hass: HomeAssistant, schlage_config_entry: MockConfigEntry
-) -> SchlageLock:
-    """Create a SchlageLock instance with a registered lock entity."""
-    entity_reg = er.async_get(hass)
-    lock_entity = entity_reg.async_get_or_create(
-        "lock",
-        "schlage",
-        "test_schlage_lock",
-        config_entry=schlage_config_entry,
-    )
-    return SchlageLock(
-        hass,
-        dr.async_get(hass),
-        entity_reg,
-        schlage_config_entry,
-        lock_entity,
-    )
-
-
-@pytest.fixture
-async def lcm_config_entry(hass: HomeAssistant) -> MockConfigEntry:
-    """Create a Lock Code Manager config entry that manages slots 1 and 2."""
-    config = {
-        CONF_LOCKS: [LOCK_ENTITY_ID],
-        CONF_SLOTS: {
-            1: {CONF_NAME: "slot1", CONF_PIN: "1234", CONF_ENABLED: True},
-            2: {CONF_NAME: "slot2", CONF_PIN: "5678", CONF_ENABLED: True},
-        },
-    }
-    entry = MockConfigEntry(domain=DOMAIN, data=config, unique_id="test_schlage_lcm")
-    entry.add_to_hass(hass)
-    return entry
-
-
-# --- Alias fixtures for shared test mixins ---
-
-
-@pytest.fixture
-def provider_lock(schlage_lock: SchlageLock) -> SchlageLock:
-    """Alias schlage_lock for shared test mixins."""
-    return schlage_lock
-
-
-@pytest.fixture
-def provider_config_entry(schlage_config_entry: MockConfigEntry) -> MockConfigEntry:
-    """Alias schlage_config_entry for shared test mixins."""
-    return schlage_config_entry
-
-
-@pytest.fixture
-def provider_domain() -> str:
-    """Return the provider integration domain."""
-    return SCHLAGE_DOMAIN
-
-
-@pytest.fixture
-def provider_lock_class() -> type[SchlageLock]:
-    """Return the provider lock class."""
-    return SchlageLock
-
+from .conftest import LOCK_ENTITY_ID
 
 # ---------------------------------------------------------------------------
 # Helper function tests

--- a/tests/providers/virtual/__init__.py
+++ b/tests/providers/virtual/__init__.py
@@ -1,0 +1,1 @@
+"""Virtual provider tests."""

--- a/tests/providers/virtual/conftest.py
+++ b/tests/providers/virtual/conftest.py
@@ -1,0 +1,80 @@
+"""Virtual provider test fixtures."""
+
+from __future__ import annotations
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+from custom_components.lock_code_manager.const import (
+    CONF_ENABLED,
+    CONF_LOCKS,
+    CONF_NAME,
+    CONF_PIN,
+    CONF_SLOTS,
+    DOMAIN,
+)
+from custom_components.lock_code_manager.providers.virtual import VirtualLock
+
+
+@pytest.fixture
+async def virtual_lock(hass: HomeAssistant) -> VirtualLock:
+    """Create a VirtualLock instance with a registered lock entity."""
+    entity_reg = er.async_get(hass)
+    config_entry = MockConfigEntry(domain=DOMAIN)
+    config_entry.add_to_hass(hass)
+
+    lock_entity = entity_reg.async_get_or_create(
+        "lock",
+        "test",
+        "test_lock",
+        config_entry=config_entry,
+    )
+
+    lock = VirtualLock(
+        hass,
+        dr.async_get(hass),
+        entity_reg,
+        config_entry,
+        lock_entity,
+    )
+    await lock.async_setup_internal(config_entry)
+    return lock
+
+
+@pytest.fixture
+async def virtual_lock_with_slots(hass: HomeAssistant) -> VirtualLock:
+    """Create a VirtualLock with configured slots for testing get_usercodes."""
+    entity_reg = er.async_get(hass)
+    lock_entity_id = "lock.test_test_lock_usercodes"
+
+    config = {
+        CONF_LOCKS: [lock_entity_id],
+        CONF_SLOTS: {
+            1: {CONF_NAME: "slot1", CONF_PIN: "1234", CONF_ENABLED: True},
+            2: {CONF_NAME: "slot2", CONF_PIN: "5678", CONF_ENABLED: True},
+        },
+    }
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data=config, unique_id="test_virtual_usercodes"
+    )
+    config_entry.add_to_hass(hass)
+
+    lock_entity = entity_reg.async_get_or_create(
+        "lock",
+        "test",
+        "test_lock_usercodes",
+        config_entry=config_entry,
+    )
+
+    lock = VirtualLock(
+        hass,
+        dr.async_get(hass),
+        entity_reg,
+        config_entry,
+        lock_entity,
+    )
+    await lock.async_setup_internal(config_entry)
+    return lock

--- a/tests/providers/virtual/test_virtual.py
+++ b/tests/providers/virtual/test_virtual.py
@@ -2,83 +2,8 @@
 
 from datetime import timedelta
 
-import pytest
-from pytest_homeassistant_custom_component.common import MockConfigEntry
-
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr, entity_registry as er
-
-from custom_components.lock_code_manager.const import (
-    CONF_ENABLED,
-    CONF_LOCKS,
-    CONF_NAME,
-    CONF_PIN,
-    CONF_SLOTS,
-    DOMAIN,
-)
 from custom_components.lock_code_manager.models import SlotCode
 from custom_components.lock_code_manager.providers.virtual import VirtualLock
-
-
-@pytest.fixture
-async def virtual_lock(hass: HomeAssistant) -> VirtualLock:
-    """Create a VirtualLock instance with a registered lock entity."""
-    entity_reg = er.async_get(hass)
-    config_entry = MockConfigEntry(domain=DOMAIN)
-    config_entry.add_to_hass(hass)
-
-    lock_entity = entity_reg.async_get_or_create(
-        "lock",
-        "test",
-        "test_lock",
-        config_entry=config_entry,
-    )
-
-    lock = VirtualLock(
-        hass,
-        dr.async_get(hass),
-        entity_reg,
-        config_entry,
-        lock_entity,
-    )
-    await lock.async_setup_internal(config_entry)
-    return lock
-
-
-@pytest.fixture
-async def virtual_lock_with_slots(hass: HomeAssistant) -> VirtualLock:
-    """Create a VirtualLock with configured slots for testing get_usercodes."""
-    entity_reg = er.async_get(hass)
-    lock_entity_id = "lock.test_test_lock_usercodes"
-
-    config = {
-        CONF_LOCKS: [lock_entity_id],
-        CONF_SLOTS: {
-            1: {CONF_NAME: "slot1", CONF_PIN: "1234", CONF_ENABLED: True},
-            2: {CONF_NAME: "slot2", CONF_PIN: "5678", CONF_ENABLED: True},
-        },
-    }
-    config_entry = MockConfigEntry(
-        domain=DOMAIN, data=config, unique_id="test_virtual_usercodes"
-    )
-    config_entry.add_to_hass(hass)
-
-    lock_entity = entity_reg.async_get_or_create(
-        "lock",
-        "test",
-        "test_lock_usercodes",
-        config_entry=config_entry,
-    )
-
-    lock = VirtualLock(
-        hass,
-        dr.async_get(hass),
-        entity_reg,
-        config_entry,
-        lock_entity,
-    )
-    await lock.async_setup_internal(config_entry)
-    return lock
 
 
 async def test_door_lock(virtual_lock: VirtualLock):


### PR DESCRIPTION
## Proposed change

Move the remaining three provider test files (Schlage, Akuvox, Virtual) into dedicated module directories under `tests/providers/`, mirroring the structure already established by `matter/` and `zwave_js/`.

For each provider:
- Created `tests/providers/<provider>/` with `__init__.py` (with docstring), `conftest.py`, and `test_<provider>.py`
- Extracted fixtures from test files into `conftest.py`
- Updated imports: `from .helpers import ...` becomes `from tests.providers.helpers import ...`

No test logic changes — this is structural only.

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue: