### PR TITLE
refactor: move sync state mutations exclusively into the tick

### DIFF
--- a/custom_components/lock_code_manager/sync.py
+++ b/custom_components/lock_code_manager/sync.py
@@ -428,9 +428,10 @@ class SlotSyncManager:
     def _update_in_sync_display(self) -> None:
         """Update the in_sync display state immediately if it changed.
 
-        This is a read-only check — no sync operations are performed.
-        Allows the UI to reflect state changes instantly while the tick
-        handles actual sync operations.
+        Read-only with respect to sync state — updates ``_in_sync`` and
+        writes the entity state for instant UI feedback, but does not
+        modify the circuit breaker tracker or any other sync state.
+        All sync state mutations happen exclusively in ``_async_tick_impl``.
         """
         if self._in_sync is None:
             return
@@ -440,13 +441,6 @@ class SlotSyncManager:
         expected = self.calculate_in_sync(slot_state)
         if expected != self._in_sync:
             self._in_sync = expected
-            # Reset circuit breaker on any transition between in-sync and
-            # out-of-sync. A True→False transition means the reconciliation
-            # state changed (for example, due to a desired-state edit or
-            # lock-side drift), so prior attempts should not carry over.
-            # False→True means sync succeeded and the tracker should be clean
-            # for next time.
-            self._reset_sync_tracker()
             self._write_state()
 
     async def _async_tick(self, _now: datetime | None = None) -> None:
@@ -465,7 +459,14 @@ class SlotSyncManager:
         await self._async_tick_impl()
 
     async def _async_tick_impl(self) -> None:
-        """Core tick logic — called from _async_tick after dirty check."""
+        """Core tick logic — called from _async_tick after dirty check.
+
+        This is the single authoritative place for all sync state mutations:
+        circuit breaker tracking, sync operations, and ``_last_set_pin``
+        changes. The display callback (``_update_in_sync_display``) may
+        update ``_in_sync`` for immediate UI feedback, but the tick is the
+        only place that acts on sync state transitions.
+        """
         slot_state = self._resolve_slot_state()
         if slot_state is None:
             # State resolution failed — retry on next tick. We always retry
@@ -474,7 +475,16 @@ class SlotSyncManager:
             self._dirty = True
             return
 
+        prev_in_sync = self._in_sync
         expected_in_sync = self.calculate_in_sync(slot_state)
+
+        # Reset circuit breaker on any transition. True→False means the
+        # sync target changed (PIN edited, slot re-enabled) so prior
+        # attempts should not count. False→True is handled below in the
+        # "Back in sync" block. This is the ONLY place the tracker is
+        # reset — the display callback does not touch it.
+        if prev_in_sync is not None and prev_in_sync and not expected_in_sync:
+            self._reset_sync_tracker()
 
         # Initial load: detect sync state without performing sync operations.
         # This prevents premature sync attempts during entity setup when dependent

--- a/custom_components/lock_code_manager/sync.py
+++ b/custom_components/lock_code_manager/sync.py
@@ -135,8 +135,12 @@ class SlotSyncManager:
             ATTR_CODE: (SENSOR_DOMAIN, f"{base_uid}|{ATTR_CODE}|{lock_entity_id}"),
         }
 
-        # State
+        # State — _in_sync is the display state (updated by both the tick
+        # and the display callback for instant UI). _tick_in_sync is the
+        # tick's own view, updated only by the tick, used for transition
+        # detection (circuit breaker reset).
         self._in_sync: bool | None = None
+        self._tick_in_sync: bool | None = None
         self._entity_id_map: dict[str, str] = {}
         self._tracked_entity_ids: set[str] = set()
         self._dirty: bool = False
@@ -475,16 +479,16 @@ class SlotSyncManager:
             self._dirty = True
             return
 
-        prev_in_sync = self._in_sync
         expected_in_sync = self.calculate_in_sync(slot_state)
 
-        # Reset circuit breaker on any transition. True→False means the
-        # sync target changed (PIN edited, slot re-enabled) so prior
-        # attempts should not count. False→True is handled below in the
-        # "Back in sync" block. This is the ONLY place the tracker is
-        # reset — the display callback does not touch it.
-        if prev_in_sync is not None and prev_in_sync and not expected_in_sync:
+        # Reset circuit breaker when the tick detects any in_sync
+        # transition. Uses _tick_in_sync (tick-only state) instead of
+        # _in_sync (which the display callback may have already updated).
+        # True→False: sync target changed (PIN edit), prior attempts
+        # should not count. False→True: sync succeeded, clean slate.
+        if self._tick_in_sync is not None and self._tick_in_sync != expected_in_sync:
             self._reset_sync_tracker()
+        self._tick_in_sync = expected_in_sync
 
         # Initial load: detect sync state without performing sync operations.
         # This prevents premature sync attempts during entity setup when dependent
@@ -621,7 +625,6 @@ class SlotSyncManager:
         if not self._in_sync:
             self._in_sync = True
             self._write_state()
-            self._reset_sync_tracker()
             # Only clear slot_disabled when the slot is enabled — a disabled
             # slot can be "in sync" without the issue being resolved
             if slot_state.active_state == STATE_ON:

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -931,14 +931,19 @@ async def test_sync_attempts_exceeded_disables_slot(
     )
     await hass.async_block_till_done()
 
-    # Pre-load the tracker AFTER the PIN change to simulate repeated failures
-    # on the same PIN (a PIN change resets the tracker, so we must load after)
+    # Simulate that the tick has already processed the out-of-sync state
+    # (so _tick_in_sync matches the current state and no transition reset)
+    sync_mgr = in_sync_entity_obj._sync_manager
+    sync_mgr._tick_in_sync = False
+
+    # Pre-load the tracker to simulate repeated failures on the same PIN
     now = dt_util.utcnow()
-    in_sync_entity_obj._sync_manager._sync_attempt_count = MAX_SYNC_ATTEMPTS
-    in_sync_entity_obj._sync_manager._sync_attempt_first = now
+    sync_mgr._sync_attempt_count = MAX_SYNC_ATTEMPTS
+    sync_mgr._sync_attempt_first = now
 
     # Trigger tick — circuit breaker should fire before attempting sync
-    await in_sync_entity_obj._sync_manager._async_tick()
+    sync_mgr._dirty = True
+    await sync_mgr._async_tick()
     await hass.async_block_till_done()
 
     # Slot should be disabled
@@ -992,6 +997,61 @@ async def test_sync_tracker_resets_when_back_in_sync(
     synced_state = hass.states.get(SLOT_1_IN_SYNC_ENTITY)
     assert synced_state.state == STATE_ON
     assert not in_sync_entity_obj._sync_manager._sync_attempts_exceeded()
+
+
+async def test_sync_tracker_resets_on_pin_change_in_tick(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """Test that the tick resets the circuit breaker when sync target changes.
+
+    When a PIN changes while the slot is in sync, the tick detects the
+    True→False transition and resets the tracker before checking the
+    circuit breaker. This prevents stale attempt counts from a prior
+    sync cycle from incorrectly triggering the breaker.
+    """
+    await async_initial_tick(hass, SLOT_1_IN_SYNC_ENTITY)
+
+    in_sync_entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
+    sync_mgr = in_sync_entity_obj._sync_manager
+
+    # Verify in sync
+    assert hass.states.get(SLOT_1_IN_SYNC_ENTITY).state == STATE_ON
+
+    # Simulate prior sync attempts (as if a previous sync cycle ran)
+    now = dt_util.utcnow()
+    sync_mgr._sync_attempt_count = MAX_SYNC_ATTEMPTS - 1
+    sync_mgr._sync_attempt_first = now
+
+    # Change PIN — the display callback updates _in_sync to False for UI,
+    # but does NOT reset the tracker (that's the tick's job now)
+    await hass.services.async_call(
+        TEXT_DOMAIN,
+        TEXT_SERVICE_SET_VALUE,
+        service_data={ATTR_VALUE: "9999"},
+        target={ATTR_ENTITY_ID: SLOT_1_PIN_ENTITY},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    # The display callback set _in_sync = False but tracker is untouched
+    assert sync_mgr._in_sync is False
+    assert sync_mgr._sync_attempt_count == MAX_SYNC_ATTEMPTS - 1
+
+    # Tick fires — detects True→False transition, resets tracker BEFORE
+    # checking circuit breaker, then performs sync
+    sync_mgr._dirty = True
+    await sync_mgr._async_tick()
+    await hass.async_block_till_done()
+
+    # Tracker should have been reset (the old attempts cleared) and then
+    # one new attempt recorded for the sync operation
+    assert sync_mgr._sync_attempt_count == 1
+
+    # Slot should NOT be disabled (circuit breaker didn't fire)
+    enabled_state = hass.states.get(SLOT_1_ENABLED_ENTITY)
+    assert enabled_state.state == STATE_ON
 
 
 async def test_sync_tracker_expired_window_resets(


### PR DESCRIPTION
## Proposed change

Consolidates sync state mutations into `_async_tick_impl`, making the display callback truly read-only.

### Before

`_update_in_sync_display` (the callback that fires on every state change) had a side effect: it reset the circuit breaker tracker on in_sync transitions. This meant two code paths could modify sync state — the display callback and the tick — creating a race window.

### After

`_update_in_sync_display` only updates `_in_sync` and writes entity state for instant UI feedback. It does not touch the circuit breaker tracker.

`_async_tick_impl` is now the single authoritative place for all sync state mutations:
- Circuit breaker tracker reset (True→False transition detected at tick start)
- Sync operations (set/clear usercode)
- `_last_set_pin` changes
- "Back in sync" tracker reset (False→True)

### Trade-off

The circuit breaker reset now happens at the next tick (0-5 seconds) instead of immediately on state change. This has no practical impact — no sync attempts happen between the state change and the tick, so the stale tracker values are never read before the tick resets them.

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

🤖 Generated with [Claude Code](https://claude.com/claude-code)