### PR TITLE
refactor: replace sync flags with SyncState state machine for per-lock error isolation

### DIFF
--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -598,6 +598,9 @@ async def async_unload_entry(
             )
             if not still_managed:
                 async_delete_issue(hass, DOMAIN, f"lock_offline_{lock_entity_id}")
+            async_delete_issue(
+                hass, DOMAIN, f"slot_suspended_{entry_id}_{lock_entity_id}"
+            )
 
     if not hass_data.get(CONF_LOCKS):
         await _async_cleanup_strategy_resource(hass, hass_data)

--- a/custom_components/lock_code_manager/binary_sensor.py
+++ b/custom_components/lock_code_manager/binary_sensor.py
@@ -277,8 +277,10 @@ class LockCodeManagerCodeSlotInSyncEntity(
         )
 
     @property
-    def extra_state_attributes(self) -> dict[str, str | None]:
+    def extra_state_attributes(self) -> dict[str, str]:
         """Return extra state attributes."""
+        if self._attr_sync_status is None:
+            return {}
         return {ATTR_SYNC_STATUS: self._attr_sync_status}
 
     async def async_added_to_hass(self) -> None:

--- a/custom_components/lock_code_manager/binary_sensor.py
+++ b/custom_components/lock_code_manager/binary_sensor.py
@@ -29,6 +29,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import (
     ATTR_ACTIVE,
     ATTR_IN_SYNC,
+    ATTR_SYNC_STATUS,
     CONF_NUMBER_OF_USES,
     EVENT_PIN_USED,
 )
@@ -249,10 +250,13 @@ class LockCodeManagerCodeSlotInSyncEntity(
         )
         CoordinatorEntity.__init__(self, coordinator)
 
+        self._attr_sync_status: str | None = None
+
         @callback
         def _sync_and_write_state(in_sync: bool | None) -> None:
             """Sync _attr_is_on from manager and write HA state."""
             self._attr_is_on = in_sync
+            self._attr_sync_status = self._sync_manager.sync_status
             self.async_write_ha_state()
 
         self._sync_manager = SlotSyncManager(
@@ -271,6 +275,11 @@ class LockCodeManagerCodeSlotInSyncEntity(
         return BaseLockCodeManagerCodeSlotPerLockEntity._is_available(self) and (
             int(self.slot_num) in self.coordinator.data
         )
+
+    @property
+    def extra_state_attributes(self) -> dict[str, str | None]:
+        """Return extra state attributes."""
+        return {ATTR_SYNC_STATUS: self._attr_sync_status}
 
     async def async_added_to_hass(self) -> None:
         """Handle entity added to hass."""

--- a/custom_components/lock_code_manager/const.py
+++ b/custom_components/lock_code_manager/const.py
@@ -89,6 +89,7 @@ CONF_START_SLOT = "start_slot"
 ATTR_ACTIVE = "active"
 ATTR_CODE = "code"
 ATTR_IN_SYNC = "in_sync"
+ATTR_SYNC_STATUS = "sync_status"
 
 # Code slot properties
 CONF_NUMBER_OF_USES = "number_of_uses"

--- a/custom_components/lock_code_manager/coordinator.py
+++ b/custom_components/lock_code_manager/coordinator.py
@@ -175,6 +175,7 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator[dict[int, str | SlotCo
         _reset_backoff (successful poll or push update).
         """
         self._suspended = True
+        _LOGGER.info("Sync suspended for %s", self._lock.lock.entity_id)
 
     def _reset_backoff(self) -> None:
         """Reset failure counter and restore original update interval."""

--- a/custom_components/lock_code_manager/coordinator.py
+++ b/custom_components/lock_code_manager/coordinator.py
@@ -57,7 +57,7 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator[dict[int, str | SlotCo
             config_entry=config_entry,
         )
         self.data: dict[int, str | SlotCode] = {}
-        self._suspended: bool = False
+        self._slot_sync_mgrs_suspended: bool = False
         self._config_entry = config_entry
         self._consecutive_failures: int = 0
         self._original_update_interval: timedelta | None = update_interval
@@ -162,27 +162,27 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator[dict[int, str | SlotCo
             )
 
     @property
-    def suspended(self) -> bool:
-        """Return whether sync operations are suspended for this lock."""
-        return self._suspended
+    def slot_sync_mgrs_suspended(self) -> bool:
+        """Return whether slot sync operations are suspended for this lock."""
+        return self._slot_sync_mgrs_suspended
 
-    def suspend(self) -> None:
-        """Suspend sync operations for this lock.
+    def suspend_slot_sync_mgrs(self) -> None:
+        """Suspend slot sync managers for this lock.
 
         Called by any SlotSyncManager that hits a circuit breaker or
         unexpected error. All sync managers for this lock will see the
         flag and stop retrying. Cleared automatically on recovery via
         _reset_backoff (successful poll or push update).
         """
-        self._suspended = True
-        _LOGGER.info("Sync suspended for %s", self._lock.lock.entity_id)
+        self._slot_sync_mgrs_suspended = True
+        _LOGGER.info("Slot sync suspended for %s", self._lock.lock.entity_id)
         # Notify listeners so other SlotSyncManagers for this lock
         # transition to SUSPENDED on their next _request_sync_check.
         self.async_update_listeners()
 
     def _reset_backoff(self) -> None:
         """Reset failure counter and restore original update interval."""
-        self._suspended = False
+        self._slot_sync_mgrs_suspended = False
         if self._consecutive_failures > 0:
             _LOGGER.info(
                 "Lock %s recovered after %d consecutive failures",

--- a/custom_components/lock_code_manager/coordinator.py
+++ b/custom_components/lock_code_manager/coordinator.py
@@ -57,7 +57,7 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator[dict[int, str | SlotCo
             config_entry=config_entry,
         )
         self.data: dict[int, str | SlotCode] = {}
-        self.suspended: bool = False
+        self._suspended: bool = False
         self._config_entry = config_entry
         self._consecutive_failures: int = 0
         self._original_update_interval: timedelta | None = update_interval
@@ -161,9 +161,24 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator[dict[int, str | SlotCo
                 },
             )
 
+    @property
+    def suspended(self) -> bool:
+        """Return whether sync operations are suspended for this lock."""
+        return self._suspended
+
+    def suspend(self) -> None:
+        """Suspend sync operations for this lock.
+
+        Called by any SlotSyncManager that hits a circuit breaker or
+        unexpected error. All sync managers for this lock will see the
+        flag and stop retrying. Cleared automatically on recovery via
+        _reset_backoff (successful poll or push update).
+        """
+        self._suspended = True
+
     def _reset_backoff(self) -> None:
         """Reset failure counter and restore original update interval."""
-        self.suspended = False
+        self._suspended = False
         if self._consecutive_failures > 0:
             _LOGGER.info(
                 "Lock %s recovered after %d consecutive failures",

--- a/custom_components/lock_code_manager/coordinator.py
+++ b/custom_components/lock_code_manager/coordinator.py
@@ -57,6 +57,7 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator[dict[int, str | SlotCo
             config_entry=config_entry,
         )
         self.data: dict[int, str | SlotCode] = {}
+        self.suspended: bool = False
         self._config_entry = config_entry
         self._consecutive_failures: int = 0
         self._original_update_interval: timedelta | None = update_interval
@@ -162,6 +163,7 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator[dict[int, str | SlotCo
 
     def _reset_backoff(self) -> None:
         """Reset failure counter and restore original update interval."""
+        self.suspended = False
         if self._consecutive_failures > 0:
             _LOGGER.info(
                 "Lock %s recovered after %d consecutive failures",

--- a/custom_components/lock_code_manager/coordinator.py
+++ b/custom_components/lock_code_manager/coordinator.py
@@ -176,6 +176,9 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator[dict[int, str | SlotCo
         """
         self._suspended = True
         _LOGGER.info("Sync suspended for %s", self._lock.lock.entity_id)
+        # Notify listeners so other SlotSyncManagers for this lock
+        # transition to SUSPENDED on their next _request_sync_check.
+        self.async_update_listeners()
 
     def _reset_backoff(self) -> None:
         """Reset failure counter and restore original update interval."""

--- a/custom_components/lock_code_manager/models.py
+++ b/custom_components/lock_code_manager/models.py
@@ -21,6 +21,24 @@ if TYPE_CHECKING:
     from .providers import BaseLock
 
 
+class SyncState(StrEnum):
+    """State machine for slot sync reconciliation.
+
+    LOADING: initial state, waiting for entity states to resolve.
+    SYNCED: desired state matches actual state on the lock.
+    OUT_OF_SYNC: mismatch detected, pending sync on next tick.
+    SYNCING: sync operation in progress.
+    SUSPENDED: circuit breaker tripped or unexpected error; awaiting
+        coordinator recovery (suspended flag cleared).
+    """
+
+    LOADING = "loading"
+    SYNCED = "synced"
+    OUT_OF_SYNC = "out_of_sync"
+    SYNCING = "syncing"
+    SUSPENDED = "suspended"
+
+
 class SlotCode(StrEnum):
     """Sentinel values for slot codes in coordinator data.
 

--- a/custom_components/lock_code_manager/models.py
+++ b/custom_components/lock_code_manager/models.py
@@ -25,7 +25,7 @@ class SyncState(StrEnum):
     """State machine for slot sync reconciliation.
 
     LOADING: initial state, waiting for entity states to resolve.
-    SYNCED: desired state matches actual state on the lock.
+    IN_SYNC: desired state matches actual state on the lock.
     OUT_OF_SYNC: mismatch detected, pending sync on next tick.
     SYNCING: sync operation in progress.
     SUSPENDED: circuit breaker tripped or unexpected error; awaiting
@@ -33,7 +33,7 @@ class SyncState(StrEnum):
     """
 
     LOADING = "loading"
-    SYNCED = "synced"
+    IN_SYNC = "in_sync"
     OUT_OF_SYNC = "out_of_sync"
     SYNCING = "syncing"
     SUSPENDED = "suspended"

--- a/custom_components/lock_code_manager/providers/zwave_js.py
+++ b/custom_components/lock_code_manager/providers/zwave_js.py
@@ -27,6 +27,7 @@ from zwave_js_server.const.command_class.notification import (
     AccessControlNotificationEvent,
     NotificationType,
 )
+from zwave_js_server.exceptions import FailedZWaveCommand
 from zwave_js_server.model.node import Node
 from zwave_js_server.util.lock import (
     get_usercode,
@@ -446,7 +447,7 @@ class ZWaveJSLock(BaseLock):
         if self._usercode_cc_version < 2:
             try:
                 await get_usercode_from_node(self.node, code_slot)
-            except Exception as err:
+            except FailedZWaveCommand as err:
                 raise LockDisconnected(
                     f"Post-set verification poll failed for "
                     f"{self.lock.entity_id} slot {code_slot}: {err}"
@@ -494,7 +495,7 @@ class ZWaveJSLock(BaseLock):
         if self._usercode_cc_version < 2:
             try:
                 await get_usercode_from_node(self.node, code_slot)
-            except Exception as err:
+            except FailedZWaveCommand as err:
                 raise LockDisconnected(
                     f"Post-clear verification poll failed for "
                     f"{self.lock.entity_id} slot {code_slot}: {err}"

--- a/custom_components/lock_code_manager/providers/zwave_js.py
+++ b/custom_components/lock_code_manager/providers/zwave_js.py
@@ -440,12 +440,17 @@ class ZWaveJSLock(BaseLock):
         # V1 locks don't reliably update the Z-Wave JS value cache after set.
         # Poll the slot directly from the device to force-update the cache
         # before the coordinator reads it, preventing sync loops.
-        # No try-except: if the poll fails, we must not proceed with the
-        # optimistic update since async_request_refresh() would overwrite it
-        # with stale cache data, reintroducing the sync loop. Letting the
-        # error propagate allows the sync mechanism to retry the operation.
+        # Wrap as LockDisconnected so failures route to the retry path instead
+        # of leaking a raw FailedZWaveCommand into the generic exception handler,
+        # which would otherwise suspend the lock.
         if self._usercode_cc_version < 2:
-            await get_usercode_from_node(self.node, code_slot)
+            try:
+                await get_usercode_from_node(self.node, code_slot)
+            except Exception as err:
+                raise LockDisconnected(
+                    f"Post-set verification poll failed for "
+                    f"{self.lock.entity_id} slot {code_slot}: {err}"
+                ) from err
         # Optimistic update: Z-Wave command succeeded (lock acknowledged), but the
         # value cache updates asynchronously via push notification. Update coordinator
         # immediately to prevent sync loops from reading stale cache data.
@@ -483,10 +488,17 @@ class ZWaveJSLock(BaseLock):
         # V1 locks don't reliably update the Z-Wave JS value cache after clear.
         # Poll the slot directly from the device to force-update the cache
         # before the coordinator reads it, preventing sync loops.
-        # See comment in async_set_usercode for why this is not wrapped in
-        # try-except.
+        # Wrap as LockDisconnected so failures route to the retry path instead
+        # of leaking a raw FailedZWaveCommand into the generic exception handler,
+        # which would otherwise suspend the lock.
         if self._usercode_cc_version < 2:
-            await get_usercode_from_node(self.node, code_slot)
+            try:
+                await get_usercode_from_node(self.node, code_slot)
+            except Exception as err:
+                raise LockDisconnected(
+                    f"Post-clear verification poll failed for "
+                    f"{self.lock.entity_id} slot {code_slot}: {err}"
+                ) from err
         # Optimistic update: Z-Wave command succeeded (lock acknowledged), but the
         # value cache updates asynchronously via push notification. Update coordinator
         # immediately to prevent sync loops from reading stale cache data.

--- a/custom_components/lock_code_manager/repairs.py
+++ b/custom_components/lock_code_manager/repairs.py
@@ -66,6 +66,6 @@ async def async_create_fix_flow(
     """Create a fix flow for a repair issue."""
     if issue_id == "number_of_uses_deprecated":
         return NumberOfUsesDeprecatedFlow()
-    if issue_id.startswith("slot_disabled_") or issue_id.startswith("pin_required_"):
+    if issue_id.startswith(("slot_disabled_", "pin_required_", "slot_suspended_")):
         return AcknowledgeRepairFlow()
     raise ValueError(f"Unknown issue: {issue_id}")

--- a/custom_components/lock_code_manager/strings.json
+++ b/custom_components/lock_code_manager/strings.json
@@ -82,7 +82,7 @@
         "state_attributes": {
           "sync_status": {
             "state": {
-              "synced": "Synced",
+              "in_sync": "In sync",
               "out_of_sync": "Out of sync",
               "syncing": "Syncing",
               "suspended": "Suspended"

--- a/custom_components/lock_code_manager/strings.json
+++ b/custom_components/lock_code_manager/strings.json
@@ -78,7 +78,17 @@
         "name": "active"
       },
       "in_sync": {
-        "name": "Code slot {slot_num} in sync"
+        "name": "Code slot {slot_num} in sync",
+        "state_attributes": {
+          "sync_status": {
+            "state": {
+              "synced": "Synced",
+              "out_of_sync": "Out of sync",
+              "syncing": "Syncing",
+              "suspended": "Suspended"
+            }
+          }
+        }
       }
     },
     "event": {
@@ -181,6 +191,17 @@
           "init": {
             "title": "PIN required for slot {slot_num}",
             "description": "A PIN is required to enable slot {slot_num} on the lock configuration **{config_entry_title}**. Please set a PIN before enabling this slot.\n\nClick **Submit** to acknowledge this issue."
+          }
+        }
+      }
+    },
+    "slot_suspended": {
+      "title": "Lock Code Manager: Sync suspended for {lock_name}",
+      "fix_flow": {
+        "step": {
+          "init": {
+            "title": "Sync suspended for {lock_name}",
+            "description": "Sync has been suspended for lock `{lock_entity_id}`.\n\n**Reason:** {reason}\n\nThe lock will resume syncing automatically when it recovers. Click **Submit** to acknowledge this issue."
           }
         }
       }

--- a/custom_components/lock_code_manager/sync.py
+++ b/custom_components/lock_code_manager/sync.py
@@ -376,7 +376,7 @@ class SlotSyncManager:
     def _suspend_lock(self, reason: str) -> None:
         """Suspend this lock and create a per-lock repair issue."""
         self._state = SyncState.SUSPENDED
-        self._coordinator.suspended = True
+        self._coordinator.suspend()
         self._reset_sync_tracker()
         self._write_state()
 

--- a/custom_components/lock_code_manager/sync.py
+++ b/custom_components/lock_code_manager/sync.py
@@ -88,7 +88,7 @@ class SlotSyncManager:
     Compares desired state (from entity states: active, PIN) against actual
     state (from coordinator data) and drives set/clear operations to reconcile.
 
-    Uses a state machine (SyncState) with five states: LOADING, SYNCED,
+    Uses a state machine (SyncState) with five states: LOADING, IN_SYNC,
     OUT_OF_SYNC, SYNCING, SUSPENDED. State changes mark the slot for
     re-evaluation; reconciliation happens on the next tick. Includes circuit
     breaker protection that suspends the lock after repeated sync failures.
@@ -97,7 +97,7 @@ class SlotSyncManager:
     manager.sync_status for display.
 
     State mutation rules:
-        - ``_request_sync_check`` transitions SYNCED -> OUT_OF_SYNC or
+        - ``_request_sync_check`` transitions IN_SYNC -> OUT_OF_SYNC or
           SUSPENDED -> OUT_OF_SYNC for immediate UI feedback.
         - ``_async_tick_impl`` is the single authoritative place for all
           other state transitions, circuit breaker, sync operations,
@@ -175,7 +175,7 @@ class SlotSyncManager:
         """Return current sync state (None = not yet determined)."""
         if self._state is SyncState.LOADING:
             return None
-        return self._state is SyncState.SYNCED
+        return self._state is SyncState.IN_SYNC
 
     @property
     def sync_status(self) -> str | None:
@@ -442,11 +442,11 @@ class SlotSyncManager:
     def _request_sync_check(self, *_args: Any) -> None:
         """Request a sync check on the next tick.
 
-        Transitions SYNCED -> OUT_OF_SYNC if calculate_in_sync returns False.
+        Transitions IN_SYNC -> OUT_OF_SYNC if calculate_in_sync returns False.
         Transitions SUSPENDED -> OUT_OF_SYNC if the coordinator is no longer suspended.
         No-op for LOADING, OUT_OF_SYNC, SYNCING.
         """
-        if self._state is SyncState.SYNCED:
+        if self._state is SyncState.IN_SYNC:
             slot_state = self._resolve_slot_state()
             if slot_state is not None and not self.calculate_in_sync(slot_state):
                 self._state = SyncState.OUT_OF_SYNC
@@ -486,7 +486,7 @@ class SlotSyncManager:
         # _request_sync_check from firing for entities not yet tracked
         self._try_upgrade_state_tracking()
 
-        if self._state in (SyncState.SYNCED, SyncState.SYNCING, SyncState.SUSPENDED):
+        if self._state in (SyncState.IN_SYNC, SyncState.SYNCING, SyncState.SUSPENDED):
             return
 
         await self._async_tick_impl()
@@ -519,7 +519,7 @@ class SlotSyncManager:
                 return
 
             if expected_in_sync:
-                self._state = SyncState.SYNCED
+                self._state = SyncState.IN_SYNC
                 if slot_state.active_state == STATE_ON:
                     async_delete_issue(
                         self._hass,
@@ -550,7 +550,7 @@ class SlotSyncManager:
 
         if expected_in_sync:
             # Became in sync without us doing anything (external change)
-            self._state = SyncState.SYNCED
+            self._state = SyncState.IN_SYNC
             self._reset_sync_tracker()
             self._write_state()
             if slot_state.active_state == STATE_ON:
@@ -599,7 +599,7 @@ class SlotSyncManager:
             # After disable, the slot active switch turns off. The next
             # _request_sync_check will see the slot as in-sync (no code
             # desired, no code on lock). Set to OUT_OF_SYNC so the next
-            # tick resolves to SYNCED.
+            # tick resolves to IN_SYNC.
             self._state = SyncState.OUT_OF_SYNC
             return
         except (LockDisconnected, LockOperationFailed) as err:
@@ -648,7 +648,7 @@ class SlotSyncManager:
         # Check if sync actually worked
         slot_state = self._resolve_slot_state()
         if slot_state is not None and self.calculate_in_sync(slot_state):
-            self._state = SyncState.SYNCED
+            self._state = SyncState.IN_SYNC
             self._reset_sync_tracker()
             self._write_state()
             if slot_state.active_state == STATE_ON:

--- a/custom_components/lock_code_manager/sync.py
+++ b/custom_components/lock_code_manager/sync.py
@@ -522,11 +522,12 @@ class SlotSyncManager:
                         DOMAIN,
                         f"slot_disabled_{self._config_entry.entry_id}_{self._slot_num}",
                     )
-                    async_delete_issue(
-                        self._hass,
-                        DOMAIN,
-                        f"slot_suspended_{self._config_entry.entry_id}_{self._lock.lock.entity_id}",
-                    )
+                # Per-lock issue: clear regardless of slot active state
+                async_delete_issue(
+                    self._hass,
+                    DOMAIN,
+                    f"slot_suspended_{self._config_entry.entry_id}_{self._lock.lock.entity_id}",
+                )
             else:
                 self._state = SyncState.OUT_OF_SYNC
 
@@ -555,11 +556,12 @@ class SlotSyncManager:
                     DOMAIN,
                     f"slot_disabled_{self._config_entry.entry_id}_{self._slot_num}",
                 )
-                async_delete_issue(
-                    self._hass,
-                    DOMAIN,
-                    f"slot_suspended_{self._config_entry.entry_id}_{self._lock.lock.entity_id}",
-                )
+            # Per-lock issue: clear regardless of slot active state
+            async_delete_issue(
+                self._hass,
+                DOMAIN,
+                f"slot_suspended_{self._config_entry.entry_id}_{self._lock.lock.entity_id}",
+            )
             return
 
         # Circuit breaker check (set operations only)
@@ -653,11 +655,12 @@ class SlotSyncManager:
                     DOMAIN,
                     f"slot_disabled_{self._config_entry.entry_id}_{self._slot_num}",
                 )
-                async_delete_issue(
-                    self._hass,
-                    DOMAIN,
-                    f"slot_suspended_{self._config_entry.entry_id}_{self._lock.lock.entity_id}",
-                )
+            # Per-lock issue: clear regardless of slot active state
+            async_delete_issue(
+                self._hass,
+                DOMAIN,
+                f"slot_suspended_{self._config_entry.entry_id}_{self._lock.lock.entity_id}",
+            )
         else:
             self._state = SyncState.OUT_OF_SYNC
             self._write_state()

--- a/custom_components/lock_code_manager/sync.py
+++ b/custom_components/lock_code_manager/sync.py
@@ -585,6 +585,7 @@ class SlotSyncManager:
 
         # Perform sync
         self._state = SyncState.SYNCING
+        self._write_state()
         try:
             await self._perform_sync(slot_state)
         except CodeRejectedError as err:

--- a/custom_components/lock_code_manager/sync.py
+++ b/custom_components/lock_code_manager/sync.py
@@ -376,7 +376,7 @@ class SlotSyncManager:
     def _suspend_lock(self, reason: str) -> None:
         """Suspend this lock and create a per-lock repair issue."""
         self._state = SyncState.SUSPENDED
-        self._coordinator.suspend()
+        self._coordinator.suspend_slot_sync_mgrs()
         self._reset_sync_tracker()
         self._write_state()
 
@@ -454,7 +454,7 @@ class SlotSyncManager:
                 self._reset_sync_tracker()
                 self._write_state()
         elif self._state is SyncState.SUSPENDED:
-            if not self._coordinator.suspended:
+            if not self._coordinator.slot_sync_mgrs_suspended:
                 self._state = SyncState.OUT_OF_SYNC
                 self._write_state()
 
@@ -540,7 +540,7 @@ class SlotSyncManager:
             return
 
         # -- OUT_OF_SYNC: check coordinator suspend flag, then attempt sync --
-        if self._coordinator.suspended:
+        if self._coordinator.slot_sync_mgrs_suspended:
             self._state = SyncState.SUSPENDED
             self._write_state()
             return

--- a/custom_components/lock_code_manager/sync.py
+++ b/custom_components/lock_code_manager/sync.py
@@ -442,7 +442,8 @@ class SlotSyncManager:
     def _request_sync_check(self, *_args: Any) -> None:
         """Request a sync check on the next tick.
 
-        Transitions IN_SYNC -> OUT_OF_SYNC if calculate_in_sync returns False.
+        Transitions IN_SYNC -> OUT_OF_SYNC if calculate_in_sync returns False
+        (also resets circuit breaker since the sync target changed).
         Transitions SUSPENDED -> OUT_OF_SYNC if the coordinator is no longer suspended.
         No-op for LOADING, OUT_OF_SYNC, SYNCING.
         """
@@ -452,11 +453,6 @@ class SlotSyncManager:
                 self._state = SyncState.OUT_OF_SYNC
                 self._reset_sync_tracker()
                 self._write_state()
-        elif self._state is SyncState.OUT_OF_SYNC:
-            # Sync target changed (PIN edited, slot toggled) while already
-            # out of sync — reset circuit breaker so stale attempt counts
-            # from a prior sync cycle don't trip the breaker prematurely.
-            self._reset_sync_tracker()
         elif self._state is SyncState.SUSPENDED:
             if not self._coordinator.suspended:
                 self._state = SyncState.OUT_OF_SYNC

--- a/custom_components/lock_code_manager/sync.py
+++ b/custom_components/lock_code_manager/sync.py
@@ -602,7 +602,7 @@ class SlotSyncManager:
             return
         except (LockDisconnected, LockOperationFailed) as err:
             _LOGGER.info(
-                "%s: Lock disconnected during %s usercode: %s. Will retry on next tick.",
+                "%s: Lock operation failed during %s usercode: %s. Will retry on next tick.",
                 self._log_prefix,
                 "set" if slot_state.active_state == STATE_ON else "clear",
                 err,

--- a/custom_components/lock_code_manager/sync.py
+++ b/custom_components/lock_code_manager/sync.py
@@ -450,7 +450,13 @@ class SlotSyncManager:
             slot_state = self._resolve_slot_state()
             if slot_state is not None and not self.calculate_in_sync(slot_state):
                 self._state = SyncState.OUT_OF_SYNC
+                self._reset_sync_tracker()
                 self._write_state()
+        elif self._state is SyncState.OUT_OF_SYNC:
+            # Sync target changed (PIN edited, slot toggled) while already
+            # out of sync — reset circuit breaker so stale attempt counts
+            # from a prior sync cycle don't trip the breaker prematurely.
+            self._reset_sync_tracker()
         elif self._state is SyncState.SUSPENDED:
             if not self._coordinator.suspended:
                 self._state = SyncState.OUT_OF_SYNC
@@ -519,6 +525,11 @@ class SlotSyncManager:
                         self._hass,
                         DOMAIN,
                         f"slot_disabled_{self._config_entry.entry_id}_{self._slot_num}",
+                    )
+                    async_delete_issue(
+                        self._hass,
+                        DOMAIN,
+                        f"slot_suspended_{self._config_entry.entry_id}_{self._lock.lock.entity_id}",
                     )
             else:
                 self._state = SyncState.OUT_OF_SYNC

--- a/custom_components/lock_code_manager/sync.py
+++ b/custom_components/lock_code_manager/sync.py
@@ -1,13 +1,12 @@
 """Slot sync manager — owns desired vs actual reconciliation.
 
 Compares entity states (active, PIN, name) against coordinator data (actual lock
-code) and drives set/clear operations to reconcile. Uses a periodic tick for
-retries and circuit-breaking (disable slot after max failures).
+code) and drives set/clear operations to reconcile. Uses a state machine
+(SyncState enum) with periodic tick for retries and per-lock suspension on
+repeated failures.
 
 Tick interval: 5 seconds (TICK_INTERVAL)
 Circuit breaker: 3 attempts within 5 minutes (MAX_SYNC_ATTEMPTS, SYNC_ATTEMPT_WINDOW)
-
-Extracted from binary_sensor.py to separate domain logic from entity state display.
 """
 
 from __future__ import annotations
@@ -53,7 +52,7 @@ from .const import (
     TICK_INTERVAL,
 )
 from .exceptions import CodeRejectedError, LockDisconnected, LockOperationFailed
-from .models import SlotCode
+from .models import SlotCode, SyncState
 from .util import async_disable_slot
 
 if TYPE_CHECKING:
@@ -89,21 +88,20 @@ class SlotSyncManager:
     Compares desired state (from entity states: active, PIN) against actual
     state (from coordinator data) and drives set/clear operations to reconcile.
 
-    The manager discovers entity IDs from the entity registry, subscribes to
-    their state changes and coordinator updates, and drives sync operations
-    via periodic ticks. State changes mark the slot dirty; reconciliation
-    happens on the next tick. Includes circuit breaker protection that
-    disables the slot after repeated sync failures within a time window.
+    Uses a state machine (SyncState) with five states: LOADING, SYNCED,
+    OUT_OF_SYNC, SYNCING, SUSPENDED. State changes mark the slot for
+    re-evaluation; reconciliation happens on the next tick. Includes circuit
+    breaker protection that suspends the lock after repeated sync failures.
 
-    The in-sync binary sensor entity reads manager.in_sync for display.
+    The in-sync binary sensor entity reads manager.in_sync and
+    manager.sync_status for display.
 
     State mutation rules:
-        - ``_update_in_sync_display`` is read-only: updates ``_in_sync``
-          for instant UI feedback but does not modify sync state.
+        - ``_request_sync_check`` transitions SYNCED -> OUT_OF_SYNC or
+          SUSPENDED -> OUT_OF_SYNC for immediate UI feedback.
         - ``_async_tick_impl`` is the single authoritative place for all
-          sync state mutations: circuit breaker, sync operations,
-          ``_last_set_pin``, transition detection via ``_tick_in_sync``.
-        - ``_mark_dirty`` only sets ``_dirty = True``.
+          other state transitions, circuit breaker, sync operations,
+          and ``_last_set_pin`` changes.
 
     Lifecycle methods (async_start, async_stop) are idempotent and re-entrant.
     """
@@ -143,15 +141,11 @@ class SlotSyncManager:
             ATTR_CODE: (SENSOR_DOMAIN, f"{base_uid}|{ATTR_CODE}|{lock_entity_id}"),
         }
 
-        # State — _in_sync is the display state (updated by both the tick
-        # and the display callback for instant UI). _tick_in_sync is the
-        # tick's own view, updated only by the tick, used for transition
-        # detection (circuit breaker reset).
-        self._in_sync: bool | None = None
-        self._tick_in_sync: bool | None = None
+        # Sync state machine — single source of truth replacing _dirty,
+        # _in_sync, and _tick_in_sync.
+        self._state: SyncState = SyncState.LOADING
         self._entity_id_map: dict[str, str] = {}
         self._tracked_entity_ids: set[str] = set()
-        self._dirty: bool = False
 
         # Track the last PIN we successfully set, so we can detect when the
         # configured PIN changes while the lock code is UNKNOWN (masked/write-only).
@@ -179,14 +173,22 @@ class SlotSyncManager:
     @property
     def in_sync(self) -> bool | None:
         """Return current sync state (None = not yet determined)."""
-        return self._in_sync
+        if self._state is SyncState.LOADING:
+            return None
+        return self._state is SyncState.SYNCED
+
+    @property
+    def sync_status(self) -> str | None:
+        """Return granular sync status for dashboard display."""
+        if self._state is SyncState.LOADING:
+            return None
+        return self._state.value
 
     async def async_start(self) -> None:
         """Start the sync manager -- discover entities, subscribe, initial tick."""
         if self._started:
             return
         self._started = True
-        self._dirty = True
         self._setup_state_tracking()
         self._setup_coordinator_listener()
         self._tick_unsub = async_track_time_interval(
@@ -371,6 +373,31 @@ class SlotSyncManager:
         finally:
             self._reset_sync_tracker()
 
+    def _suspend_lock(self, reason: str) -> None:
+        """Suspend this lock and create a per-lock repair issue."""
+        self._state = SyncState.SUSPENDED
+        self._coordinator.suspended = True
+        self._reset_sync_tracker()
+        self._write_state()
+
+        issue_id = (
+            f"slot_suspended_{self._config_entry.entry_id}_{self._lock.lock.entity_id}"
+        )
+        async_create_issue(
+            self._hass,
+            DOMAIN,
+            issue_id,
+            is_fixable=True,
+            is_persistent=True,
+            severity=IssueSeverity.WARNING,
+            translation_key="slot_suspended",
+            translation_placeholders={
+                "lock_entity_id": self._lock.lock.entity_id,
+                "lock_name": self._lock.display_name or self._lock.lock.entity_id,
+                "reason": reason,
+            },
+        )
+
     # -- Attempt tracking + circuit breaker ----------------------------------
 
     def _reset_sync_tracker(self) -> None:
@@ -412,96 +439,68 @@ class SlotSyncManager:
         self._state_writer(self.in_sync)
 
     @callback
-    def _mark_dirty(self, *_args: Any) -> None:
-        """Mark slot as needing sync check on next tick.
+    def _request_sync_check(self, *_args: Any) -> None:
+        """Request a sync check on the next tick.
 
-        Also immediately updates the display state (in_sync) if it changed,
-        so the UI reflects changes without waiting for the next tick.
+        Transitions SYNCED -> OUT_OF_SYNC if calculate_in_sync returns False.
+        Transitions SUSPENDED -> OUT_OF_SYNC if the coordinator is no longer suspended.
+        No-op for LOADING, OUT_OF_SYNC, SYNCING.
         """
-        self._dirty = True
-        self._update_in_sync_display()
+        if self._state is SyncState.SYNCED:
+            slot_state = self._resolve_slot_state()
+            if slot_state is not None and not self.calculate_in_sync(slot_state):
+                self._state = SyncState.OUT_OF_SYNC
+                self._write_state()
+        elif self._state is SyncState.SUSPENDED:
+            if not self._coordinator.suspended:
+                self._state = SyncState.OUT_OF_SYNC
+                self._write_state()
 
     @callback
-    def _mark_dirty_if_relevant(self, event: Event[EventStateChangedData]) -> None:
-        """Mark dirty only if the state change is for a tracked entity.
+    def _request_sync_check_if_relevant(
+        self, event: Event[EventStateChangedData]
+    ) -> None:
+        """Request sync check only if the state change is for a tracked entity.
 
-        Used by the catch-all state tracking fallback to avoid setting dirty
-        on every HA state change. Falls back to always-dirty if entity IDs
-        haven't been discovered yet.
+        Used by the catch-all state tracking fallback to avoid unnecessary
+        checks on every HA state change. Falls back to always-checking if
+        entity IDs haven't been discovered yet.
         """
         if not self._tracked_entity_ids or (
             event.data["entity_id"] in self._tracked_entity_ids
         ):
-            self._dirty = True
-            self._update_in_sync_display()
-
-    @callback
-    def _update_in_sync_display(self) -> None:
-        """Update the in_sync display state immediately if it changed.
-
-        Read-only with respect to sync state — updates ``_in_sync`` and
-        writes the entity state for instant UI feedback, but does not
-        modify the circuit breaker tracker or any other sync state.
-        All sync state mutations happen exclusively in ``_async_tick_impl``.
-        """
-        if self._in_sync is None:
-            return
-        slot_state = self._resolve_slot_state()
-        if slot_state is None:
-            return
-        expected = self.calculate_in_sync(slot_state)
-        if expected != self._in_sync:
-            self._in_sync = expected
-            self._write_state()
+            self._request_sync_check()
 
     async def _async_tick(self, _now: datetime | None = None) -> None:
         """Periodic reconciliation tick."""
         if not self._started:
             return
 
-        # Try upgrading before the dirty check — catch-all mode may prevent
-        # dirty from being set for entities not yet in _tracked_entity_ids
+        # Try upgrading before the state check — catch-all mode may prevent
+        # _request_sync_check from firing for entities not yet tracked
         self._try_upgrade_state_tracking()
 
-        if not self._dirty:
+        if self._state in (SyncState.SYNCED, SyncState.SYNCING, SyncState.SUSPENDED):
             return
 
-        self._dirty = False
         await self._async_tick_impl()
 
     async def _async_tick_impl(self) -> None:
-        """Core tick logic — called from _async_tick after dirty check.
+        """Core tick logic — called from _async_tick for LOADING and OUT_OF_SYNC states.
 
         This is the single authoritative place for all sync state mutations:
         circuit breaker tracking, sync operations, and ``_last_set_pin``
-        changes. The display callback (``_update_in_sync_display``) may
-        update ``_in_sync`` for immediate UI feedback, but the tick is the
-        only place that acts on sync state transitions.
+        changes.
         """
         slot_state = self._resolve_slot_state()
         if slot_state is None:
-            # State resolution failed — retry on next tick. We always retry
-            # (not just during initial load) because the coordinator may not
-            # have data yet for a newly enabled slot.
-            self._dirty = True
+            # State resolution failed — stay in current state and retry.
             return
 
         expected_in_sync = self.calculate_in_sync(slot_state)
 
-        # Reset circuit breaker when the tick detects any in_sync
-        # transition. Uses _tick_in_sync (tick-only state) instead of
-        # _in_sync (which the display callback may have already updated).
-        # True→False: sync target changed (PIN edit), prior attempts
-        # should not count. False→True: sync succeeded, clean slate.
-        if self._tick_in_sync is not None and self._tick_in_sync != expected_in_sync:
-            self._reset_sync_tracker()
-        self._tick_in_sync = expected_in_sync
-
-        # Initial load: detect sync state without performing sync operations.
-        # This prevents premature sync attempts during entity setup when dependent
-        # entities (active, code sensor) may not yet be registered. If out of sync,
-        # we schedule a sync for the next tick after entities are ready.
-        if self._in_sync is None:
+        # -- LOADING: detect initial sync state without performing operations --
+        if self._state is SyncState.LOADING:
             if slot_state.active_state not in (STATE_ON, STATE_OFF):
                 if not self._logged_invalid_state:
                     _LOGGER.debug(
@@ -511,128 +510,158 @@ class SlotSyncManager:
                         slot_state.active_state,
                     )
                     self._logged_invalid_state = True
-                self._dirty = True  # retry next tick
                 return
 
-            self._in_sync = expected_in_sync
-            _LOGGER.debug(
-                "%s: Initial state loaded, in_sync=%s",
-                self._log_prefix,
-                expected_in_sync,
-            )
-            if expected_in_sync and slot_state.active_state == STATE_ON:
-                # Clear any persisted slot_disabled issue from before restart,
-                # but only if the slot is enabled — a disabled slot can be
-                # "in sync" (no code desired, no code on lock) without the
-                # circuit breaker condition being resolved.
-                async_delete_issue(
-                    self._hass,
-                    DOMAIN,
-                    f"slot_disabled_{self._config_entry.entry_id}_{self._slot_num}",
-                )
-            self._write_state()
-            if not expected_in_sync:
-                self._dirty = True  # schedule sync on next tick
-            return
-
-        # Out of sync: perform sync
-        if not expected_in_sync:
-            self._in_sync = False
-            self._write_state()
-
-            # Circuit breaker
-            if slot_state.active_state == STATE_ON and self._sync_attempts_exceeded():
-                _LOGGER.error(
-                    "%s: Sync attempts exceeded (%s in %s window), disabling slot",
-                    self._log_prefix,
-                    self._sync_attempt_count,
-                    SYNC_ATTEMPT_WINDOW,
-                )
-                await self._disable_slot(
-                    f"Lock **{self._lock.lock.entity_id}**: slot "
-                    f"**{self._slot_num}** failed to sync after "
-                    f"{self._sync_attempt_count} consecutive attempts. "
-                    f"The lock may be rejecting the code silently. "
-                    f"Slot {self._slot_num} has been disabled. Check the "
-                    f"code and re-enable the slot.",
-                )
-                return
-
-            # Perform sync operation (may raise)
-            try:
-                await self._perform_sync(slot_state)
-            except CodeRejectedError as err:
-                _LOGGER.error("%s: Code rejected: %s", self._log_prefix, err)
-                await self._disable_slot(
-                    f"Lock **{err.lock_entity_id}**: slot **{err.code_slot}** "
-                    f"has been disabled. {err}\n\n"
-                    f"Fix the issue and re-enable the slot.",
-                )
-                return
-            except (LockDisconnected, LockOperationFailed) as err:
-                _LOGGER.info(
-                    "%s: Lock disconnected during %s usercode: %s. Will retry on next tick.",
-                    self._log_prefix,
-                    "set" if slot_state.active_state == STATE_ON else "clear",
-                    err,
-                )
-                self._dirty = True
-                return
-            except Exception as err:
-                _LOGGER.exception(
-                    "%s: Unexpected error during %s usercode - this may indicate a bug. "
-                    "Slot will be disabled to prevent infinite retry loop. Error: %s: %s",
-                    self._log_prefix,
-                    "set" if slot_state.active_state == STATE_ON else "clear",
-                    type(err).__name__,
-                    err,
-                )
-                # For unexpected errors, disable the slot immediately rather than
-                # retrying forever. This prevents infinite retries of programming errors.
-                await self._disable_slot(
-                    f"Lock **{self._lock.lock.entity_id}**: slot **{self._slot_num}** "
-                    f"encountered an unexpected error during sync. This may indicate a bug "
-                    f"in the lock code manager integration. Check logs for details and "
-                    f"report this issue.\n\nError: {type(err).__name__}: {err}",
-                )
-                return
+            if expected_in_sync:
+                self._state = SyncState.SYNCED
+                if slot_state.active_state == STATE_ON:
+                    async_delete_issue(
+                        self._hass,
+                        DOMAIN,
+                        f"slot_disabled_{self._config_entry.entry_id}_{self._slot_num}",
+                    )
             else:
-                # Sync succeeded - refresh coordinator to verify
-                # Skip for push providers — they update coordinator optimistically
-                # via push_update() and refreshing from cache could read stale data.
-                if not self._lock.supports_push:
-                    try:
-                        await self._coordinator.async_refresh()
-                    except Exception:  # noqa: BLE001
-                        _LOGGER.exception(
-                            "%s: Coordinator refresh failed after sync operation. "
-                            "Sync may have succeeded but verification failed. "
-                            "Will retry on next tick.",
-                            self._log_prefix,
-                        )
-                        # Still mark dirty so we retry, but log at ERROR level
-                        self._dirty = True
+                self._state = SyncState.OUT_OF_SYNC
 
+            _LOGGER.debug(
+                "%s: Initial state loaded, state=%s",
+                self._log_prefix,
+                self._state.value,
+            )
+            self._write_state()
             return
 
-        # Back in sync
-        if not self._in_sync:
-            self._in_sync = True
+        # -- OUT_OF_SYNC: check coordinator suspend flag, then attempt sync --
+        if self._coordinator.suspended:
+            self._state = SyncState.SUSPENDED
             self._write_state()
-            # Only clear slot_disabled when the slot is enabled — a disabled
-            # slot can be "in sync" without the issue being resolved
+            return
+
+        if expected_in_sync:
+            # Became in sync without us doing anything (external change)
+            self._state = SyncState.SYNCED
+            self._reset_sync_tracker()
+            self._write_state()
             if slot_state.active_state == STATE_ON:
                 async_delete_issue(
                     self._hass,
                     DOMAIN,
                     f"slot_disabled_{self._config_entry.entry_id}_{self._slot_num}",
                 )
+                async_delete_issue(
+                    self._hass,
+                    DOMAIN,
+                    f"slot_suspended_{self._config_entry.entry_id}_{self._lock.lock.entity_id}",
+                )
+            return
+
+        # Circuit breaker check (set operations only)
+        if slot_state.active_state == STATE_ON and self._sync_attempts_exceeded():
+            _LOGGER.error(
+                "%s: Sync attempts exceeded (%s in %s window), suspending lock",
+                self._log_prefix,
+                self._sync_attempt_count,
+                SYNC_ATTEMPT_WINDOW,
+            )
+            self._suspend_lock(
+                f"Lock **{self._lock.lock.entity_id}**: slot "
+                f"**{self._slot_num}** failed to sync after "
+                f"{self._sync_attempt_count} consecutive attempts. "
+                f"The lock may be rejecting the code silently or "
+                f"experiencing communication issues. "
+                f"Sync has been suspended for this lock. It will "
+                f"resume automatically when the lock recovers.",
+            )
+            return
+
+        # Perform sync
+        self._state = SyncState.SYNCING
+        try:
+            await self._perform_sync(slot_state)
+        except CodeRejectedError as err:
+            _LOGGER.error("%s: Code rejected: %s", self._log_prefix, err)
+            await self._disable_slot(
+                f"Lock **{err.lock_entity_id}**: slot **{err.code_slot}** "
+                f"has been disabled. {err}\n\n"
+                f"Fix the issue and re-enable the slot.",
+            )
+            # After disable, the slot active switch turns off. The next
+            # _request_sync_check will see the slot as in-sync (no code
+            # desired, no code on lock). Set to OUT_OF_SYNC so the next
+            # tick resolves to SYNCED.
+            self._state = SyncState.OUT_OF_SYNC
+            return
+        except (LockDisconnected, LockOperationFailed) as err:
+            _LOGGER.info(
+                "%s: Lock disconnected during %s usercode: %s. Will retry on next tick.",
+                self._log_prefix,
+                "set" if slot_state.active_state == STATE_ON else "clear",
+                err,
+            )
+            self._state = SyncState.OUT_OF_SYNC
+            return
+        except Exception as err:
+            _LOGGER.exception(
+                "%s: Unexpected error during %s usercode. "
+                "Sync suspended for this lock to prevent infinite retry loop. "
+                "Error: %s: %s",
+                self._log_prefix,
+                "set" if slot_state.active_state == STATE_ON else "clear",
+                type(err).__name__,
+                err,
+            )
+            self._suspend_lock(
+                f"Lock **{self._lock.lock.entity_id}**: slot **{self._slot_num}** "
+                f"encountered an unexpected error during sync. This may indicate a bug "
+                f"in the lock code manager integration. Check logs for details and "
+                f"report this issue.\n\nError: {type(err).__name__}: {err}",
+            )
+            return
+        else:
+            # Sync succeeded — refresh coordinator to verify.
+            # Skip for push providers — they update coordinator optimistically
+            # via push_update() and refreshing from cache could read stale data.
+            if not self._lock.supports_push:
+                try:
+                    await self._coordinator.async_refresh()
+                except Exception:  # noqa: BLE001
+                    _LOGGER.exception(
+                        "%s: Coordinator refresh failed after sync operation. "
+                        "Sync may have succeeded but verification failed. "
+                        "Will retry on next tick.",
+                        self._log_prefix,
+                    )
+                    self._state = SyncState.OUT_OF_SYNC
+                    return
+
+        # Check if sync actually worked
+        slot_state = self._resolve_slot_state()
+        if slot_state is not None and self.calculate_in_sync(slot_state):
+            self._state = SyncState.SYNCED
+            self._reset_sync_tracker()
+            self._write_state()
+            if slot_state.active_state == STATE_ON:
+                async_delete_issue(
+                    self._hass,
+                    DOMAIN,
+                    f"slot_disabled_{self._config_entry.entry_id}_{self._slot_num}",
+                )
+                async_delete_issue(
+                    self._hass,
+                    DOMAIN,
+                    f"slot_suspended_{self._config_entry.entry_id}_{self._lock.lock.entity_id}",
+                )
+        else:
+            self._state = SyncState.OUT_OF_SYNC
+            self._write_state()
 
     # -- State tracking subscriptions ----------------------------------------
 
     def _setup_coordinator_listener(self) -> None:
         """Subscribe to coordinator updates."""
-        self._coordinator_unsub = self._coordinator.async_add_listener(self._mark_dirty)
+        self._coordinator_unsub = self._coordinator.async_add_listener(
+            self._request_sync_check
+        )
 
     @callback
     def _cleanup_state_tracking(self) -> None:
@@ -657,7 +686,7 @@ class SlotSyncManager:
         self._state_tracking_unsub = async_track_state_change_event(
             self._hass,
             self._tracked_entity_ids,
-            self._mark_dirty,
+            self._request_sync_check,
         )
         self._tracking_all_states = False
         _LOGGER.debug(
@@ -671,7 +700,7 @@ class SlotSyncManager:
 
         If all entity IDs are available, tracks only those specific entities.
         Otherwise, tracks all state changes via a catch-all subscription that
-        filters by tracked entity IDs in _mark_dirty_if_relevant. The catch-all
+        filters by tracked entity IDs in _request_sync_check_if_relevant. The catch-all
         is upgraded to targeted tracking in _try_upgrade_state_tracking(), which
         runs at the start of each tick (safe because it's outside a callback).
         """
@@ -681,14 +710,14 @@ class SlotSyncManager:
             self._state_tracking_unsub = async_track_state_change_event(
                 self._hass,
                 self._tracked_entity_ids,
-                self._mark_dirty,
+                self._request_sync_check,
             )
             self._tracking_all_states = False
         else:
             tracker = async_track_state_change_filtered(
                 self._hass,
                 TrackStates(True, set(), set()),
-                self._mark_dirty_if_relevant,
+                self._request_sync_check_if_relevant,
             )
             self._state_tracking_unsub = tracker.async_remove
             self._tracking_all_states = True

--- a/custom_components/lock_code_manager/translations/en.json
+++ b/custom_components/lock_code_manager/translations/en.json
@@ -82,7 +82,7 @@
         "state_attributes": {
           "sync_status": {
             "state": {
-              "synced": "Synced",
+              "in_sync": "In sync",
               "out_of_sync": "Out of sync",
               "syncing": "Syncing",
               "suspended": "Suspended"

--- a/custom_components/lock_code_manager/translations/en.json
+++ b/custom_components/lock_code_manager/translations/en.json
@@ -78,7 +78,17 @@
         "name": "active"
       },
       "in_sync": {
-        "name": "Code slot {slot_num} in sync"
+        "name": "Code slot {slot_num} in sync",
+        "state_attributes": {
+          "sync_status": {
+            "state": {
+              "synced": "Synced",
+              "out_of_sync": "Out of sync",
+              "syncing": "Syncing",
+              "suspended": "Suspended"
+            }
+          }
+        }
       }
     },
     "event": {
@@ -181,6 +191,17 @@
           "init": {
             "title": "PIN required for slot {slot_num}",
             "description": "A PIN is required to enable slot {slot_num} on the lock configuration **{config_entry_title}**. Please set a PIN before enabling this slot.\n\nClick **Submit** to acknowledge this issue."
+          }
+        }
+      }
+    },
+    "slot_suspended": {
+      "title": "Lock Code Manager: Sync suspended for {lock_name}",
+      "fix_flow": {
+        "step": {
+          "init": {
+            "title": "Sync suspended for {lock_name}",
+            "description": "Sync has been suspended for lock `{lock_entity_id}`.\n\n**Reason:** {reason}\n\nThe lock will resume syncing automatically when it recovers. Click **Submit** to acknowledge this issue."
           }
         }
       }

--- a/custom_components/lock_code_manager/websocket.py
+++ b/custom_components/lock_code_manager/websocket.py
@@ -84,6 +84,7 @@ from .const import (
     ATTR_SCHEDULE_NEXT_EVENT,
     ATTR_SLOT,
     ATTR_SLOT_NUM,
+    ATTR_SYNC_STATUS,
     ATTR_USERCODE,
     CONDITION_ENTITY_DOMAINS,
     CONF_CONDITIONS,
@@ -755,6 +756,11 @@ def _build_lock_status(
     in_sync_entity_id = in_sync_map.get(lock_entity_id)
     in_sync = _get_bool_state(hass, in_sync_entity_id)
     last_synced = _get_last_changed(hass, in_sync_entity_id)
+    sync_status: str | None = None
+    if in_sync_entity_id:
+        in_sync_state = hass.states.get(in_sync_entity_id)
+        if in_sync_state:
+            sync_status = in_sync_state.attributes.get(ATTR_SYNC_STATUS)
 
     # Get code from coordinator — SlotCode sentinels pass through as strings
     coordinator = lock.coordinator
@@ -775,6 +781,8 @@ def _build_lock_status(
         CONF_NAME: lock_name,
         ATTR_IN_SYNC: in_sync,
     }
+    if sync_status:
+        lock_status[ATTR_SYNC_STATUS] = sync_status
     if last_synced:
         lock_status[ATTR_LAST_SYNCED] = last_synced
     if code_on_lock is not None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.setup import async_setup_component
 
 from custom_components.lock_code_manager.const import DOMAIN
+from custom_components.lock_code_manager.models import SyncState
 from custom_components.lock_code_manager.providers import INTEGRATIONS_CLASS_MAP
 from custom_components.lock_code_manager.providers._base import BaseLock
 
@@ -213,13 +214,16 @@ async def async_trigger_sync_tick(
 ) -> None:
     """Manually trigger a sync tick for an in-sync entity.
 
-    Encapsulates the pattern of marking an entity dirty and triggering an
-    immediate tick, useful for testing tick-based sync behavior without
-    waiting for the natural 5-second tick interval.
+    Encapsulates the pattern of forcing an entity into a tickable state and
+    triggering an immediate tick, useful for testing tick-based sync behavior
+    without waiting for the natural 5-second tick interval.
     """
     entity_obj = get_in_sync_entity_obj(hass, entity_id)
-    if set_dirty:
-        entity_obj._sync_manager._dirty = True
+    if set_dirty and entity_obj._sync_manager._state not in (
+        SyncState.LOADING,
+        SyncState.OUT_OF_SYNC,
+    ):
+        entity_obj._sync_manager._state = SyncState.OUT_OF_SYNC
     await entity_obj._sync_manager._async_tick()
     await hass.async_block_till_done()
 
@@ -230,11 +234,10 @@ async def async_initial_tick(hass: HomeAssistant, entity_id: str) -> None:
     During entity setup, the initial tick in async_start may fail if dependent
     entities (active, code sensor) are not yet registered. This helper triggers
     a tick to complete initial state loading, but only if the entity hasn't
-    been initialized yet (_in_sync is None).
+    been initialized yet (state is LOADING).
     """
     entity_obj = get_in_sync_entity_obj(hass, entity_id)
-    if entity_obj._sync_manager._in_sync is None:
-        entity_obj._sync_manager._dirty = True
+    if entity_obj._sync_manager._state is SyncState.LOADING:
         await entity_obj._sync_manager._async_tick()
         await hass.async_block_till_done()
 
@@ -247,7 +250,10 @@ async def async_trigger_sync_tick_for_manager(
     Useful when you already have the entity object or need to trigger
     ticks on multiple managers in a loop.
     """
-    if set_dirty:
-        sync_manager._dirty = True
+    if set_dirty and sync_manager._state not in (
+        SyncState.LOADING,
+        SyncState.OUT_OF_SYNC,
+    ):
+        sync_manager._state = SyncState.OUT_OF_SYNC
     await sync_manager._async_tick()
     await hass.async_block_till_done()

--- a/tests/providers/zwave_js/test_zwave_js.py
+++ b/tests/providers/zwave_js/test_zwave_js.py
@@ -33,7 +33,10 @@ from custom_components.lock_code_manager.const import (
     DOMAIN,
     EVENT_LOCK_STATE_CHANGED,
 )
-from custom_components.lock_code_manager.exceptions import DuplicateCodeError
+from custom_components.lock_code_manager.exceptions import (
+    DuplicateCodeError,
+    LockDisconnected,
+)
 from custom_components.lock_code_manager.models import (
     LockCodeManagerConfigEntryRuntimeData,
     SlotCode,
@@ -589,6 +592,62 @@ async def test_v2_set_usercode_does_not_poll_slot(
     mock_get_usercode_from_node.assert_not_called()
 
     await zwave_js_lock_v2.async_unload(False)
+
+
+async def test_v1_set_usercode_poll_failure_raises_lock_disconnected(
+    hass: HomeAssistant,
+    zwave_js_lock: ZWaveJSLock,
+    zwave_integration: MockConfigEntry,
+    mock_get_usercode_from_node,
+) -> None:
+    """Test that a V1 set poll failure raises LockDisconnected.
+
+    When get_usercode_from_node raises after a V1 set operation, the error
+    should be wrapped as LockDisconnected so it routes into the retry path
+    instead of the generic exception handler that would suspend the lock.
+    """
+    lcm_entry = MockConfigEntry(domain=DOMAIN, data={CONF_LOCKS: [], CONF_SLOTS: {}})
+    lcm_entry.add_to_hass(hass)
+    await zwave_js_lock.async_setup_internal(lcm_entry)
+
+    mock_coordinator = MagicMock()
+    mock_coordinator.data = {4: ""}
+    zwave_js_lock.coordinator = mock_coordinator
+
+    mock_get_usercode_from_node.side_effect = RuntimeError("Z-Wave command failed")
+
+    with pytest.raises(LockDisconnected, match="Post-set verification poll failed"):
+        await zwave_js_lock.async_set_usercode(4, "5678", "Test User")
+
+    await zwave_js_lock.async_unload(False)
+
+
+async def test_v1_clear_usercode_poll_failure_raises_lock_disconnected(
+    hass: HomeAssistant,
+    zwave_js_lock: ZWaveJSLock,
+    zwave_integration: MockConfigEntry,
+    mock_get_usercode_from_node,
+) -> None:
+    """Test that a V1 clear poll failure raises LockDisconnected.
+
+    When get_usercode_from_node raises after a V1 clear operation, the error
+    should be wrapped as LockDisconnected so it routes into the retry path
+    instead of the generic exception handler that would suspend the lock.
+    """
+    lcm_entry = MockConfigEntry(domain=DOMAIN, data={CONF_LOCKS: [], CONF_SLOTS: {}})
+    lcm_entry.add_to_hass(hass)
+    await zwave_js_lock.async_setup_internal(lcm_entry)
+
+    mock_coordinator = MagicMock()
+    mock_coordinator.data = {2: "1234"}
+    zwave_js_lock.coordinator = mock_coordinator
+
+    mock_get_usercode_from_node.side_effect = RuntimeError("Z-Wave command failed")
+
+    with pytest.raises(LockDisconnected, match="Post-clear verification poll failed"):
+        await zwave_js_lock.async_clear_usercode(2)
+
+    await zwave_js_lock.async_unload(False)
 
 
 async def test_set_usercode_no_coordinator(

--- a/tests/providers/zwave_js/test_zwave_js.py
+++ b/tests/providers/zwave_js/test_zwave_js.py
@@ -14,6 +14,7 @@ from zwave_js_server.const.command_class.lock import (
     CodeSlotStatus,
 )
 from zwave_js_server.event import Event as ZwaveEvent
+from zwave_js_server.exceptions import FailedZWaveCommand
 from zwave_js_server.model.node import Node
 
 from homeassistant.components.zwave_js.const import DOMAIN as ZWAVE_JS_DOMAIN
@@ -614,7 +615,9 @@ async def test_v1_set_usercode_poll_failure_raises_lock_disconnected(
     mock_coordinator.data = {4: ""}
     zwave_js_lock.coordinator = mock_coordinator
 
-    mock_get_usercode_from_node.side_effect = RuntimeError("Z-Wave command failed")
+    mock_get_usercode_from_node.side_effect = FailedZWaveCommand(
+        "msg_id", 202, "Node presumed dead"
+    )
 
     with pytest.raises(LockDisconnected, match="Post-set verification poll failed"):
         await zwave_js_lock.async_set_usercode(4, "5678", "Test User")
@@ -642,9 +645,62 @@ async def test_v1_clear_usercode_poll_failure_raises_lock_disconnected(
     mock_coordinator.data = {2: "1234"}
     zwave_js_lock.coordinator = mock_coordinator
 
-    mock_get_usercode_from_node.side_effect = RuntimeError("Z-Wave command failed")
+    mock_get_usercode_from_node.side_effect = FailedZWaveCommand(
+        "msg_id", 202, "Node presumed dead"
+    )
 
     with pytest.raises(LockDisconnected, match="Post-clear verification poll failed"):
+        await zwave_js_lock.async_clear_usercode(2)
+
+    await zwave_js_lock.async_unload(False)
+
+
+async def test_v1_set_usercode_poll_non_zwave_error_propagates(
+    hass: HomeAssistant,
+    zwave_js_lock: ZWaveJSLock,
+    zwave_integration: MockConfigEntry,
+    mock_get_usercode_from_node,
+) -> None:
+    """Non-Z-Wave errors from V1 post-set poll propagate uncaught.
+
+    Only FailedZWaveCommand is wrapped as LockDisconnected. Other
+    exceptions (programming errors) should propagate so the sync
+    manager's generic handler can suspend the lock and surface the bug.
+    """
+    lcm_entry = MockConfigEntry(domain=DOMAIN, data={CONF_LOCKS: [], CONF_SLOTS: {}})
+    lcm_entry.add_to_hass(hass)
+    await zwave_js_lock.async_setup_internal(lcm_entry)
+
+    mock_coordinator = MagicMock()
+    mock_coordinator.data = {4: ""}
+    zwave_js_lock.coordinator = mock_coordinator
+
+    mock_get_usercode_from_node.side_effect = RuntimeError("unexpected bug")
+
+    with pytest.raises(RuntimeError, match="unexpected bug"):
+        await zwave_js_lock.async_set_usercode(4, "5678", "Test User")
+
+    await zwave_js_lock.async_unload(False)
+
+
+async def test_v1_clear_usercode_poll_non_zwave_error_propagates(
+    hass: HomeAssistant,
+    zwave_js_lock: ZWaveJSLock,
+    zwave_integration: MockConfigEntry,
+    mock_get_usercode_from_node,
+) -> None:
+    """Non-Z-Wave errors from V1 post-clear poll propagate uncaught."""
+    lcm_entry = MockConfigEntry(domain=DOMAIN, data={CONF_LOCKS: [], CONF_SLOTS: {}})
+    lcm_entry.add_to_hass(hass)
+    await zwave_js_lock.async_setup_internal(lcm_entry)
+
+    mock_coordinator = MagicMock()
+    mock_coordinator.data = {2: "1234"}
+    zwave_js_lock.coordinator = mock_coordinator
+
+    mock_get_usercode_from_node.side_effect = RuntimeError("unexpected bug")
+
+    with pytest.raises(RuntimeError, match="unexpected bug"):
         await zwave_js_lock.async_clear_usercode(2)
 
     await zwave_js_lock.async_unload(False)

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -472,7 +472,7 @@ async def test_in_sync_waits_for_missing_pin_state(
         hass, in_sync_entity_obj._sync_manager, set_dirty=False
     )
 
-    assert in_sync_entity_obj._sync_manager._state is SyncState.SYNCED, (
+    assert in_sync_entity_obj._sync_manager._state is SyncState.IN_SYNC, (
         "In-sync sensor should initialize once dependent states are available"
     )
 
@@ -1040,7 +1040,7 @@ async def test_sync_tracker_does_not_fire_breaker_with_expired_window(
     await hass.async_block_till_done()
 
     # Sync succeeded — lock should be SYNCED, not SUSPENDED
-    assert sync_mgr._state is SyncState.SYNCED
+    assert sync_mgr._state is SyncState.IN_SYNC
     # Tracker reset after successful sync
     assert sync_mgr._sync_attempt_count == 0
 

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -1030,7 +1030,7 @@ async def test_sync_tracker_does_not_fire_breaker_with_expired_window(
     )
     await hass.async_block_till_done()
 
-    # _request_sync_check transitions SYNCED -> OUT_OF_SYNC
+    # _request_sync_check transitions IN_SYNC -> OUT_OF_SYNC
     assert sync_mgr._state is SyncState.OUT_OF_SYNC
 
     # Tick fires — expired window causes _record_sync_attempt to reset
@@ -1039,7 +1039,7 @@ async def test_sync_tracker_does_not_fire_breaker_with_expired_window(
     await sync_mgr._async_tick()
     await hass.async_block_till_done()
 
-    # Sync succeeded — lock should be SYNCED, not SUSPENDED
+    # Sync succeeded — lock should be IN_SYNC, not SUSPENDED
     assert sync_mgr._state is SyncState.IN_SYNC
     # Tracker reset after successful sync
     assert sync_mgr._sync_attempt_count == 0

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -47,6 +47,7 @@ from custom_components.lock_code_manager.coordinator import (
     LockUsercodeUpdateCoordinator,
 )
 from custom_components.lock_code_manager.exceptions import DuplicateCodeError
+from custom_components.lock_code_manager.models import SyncState
 
 from .common import (
     BASE_CONFIG,
@@ -298,7 +299,7 @@ async def test_startup_detects_out_of_sync_code(
 
     # Force out-of-sync state: reset code on the lock to mismatch
     lock_provider.codes[1] = "1234"
-    in_sync_entity_obj._sync_manager._in_sync = False
+    in_sync_entity_obj._sync_manager._state = SyncState.OUT_OF_SYNC
 
     # Trigger a tick to perform the sync operation
     await async_trigger_sync_tick(hass, in_sync_entity)
@@ -422,7 +423,7 @@ async def test_startup_waits_for_valid_active_state(
     in_sync_entity_obj = get_in_sync_entity_obj(hass, in_sync_entity)
 
     # Reset to simulate pre-initial-load state
-    in_sync_entity_obj._sync_manager._in_sync = None
+    in_sync_entity_obj._sync_manager._state = SyncState.LOADING
 
     # Set the active entity to unavailable
     hass.states.async_set(active_entity_id, STATE_UNAVAILABLE)
@@ -433,8 +434,8 @@ async def test_startup_waits_for_valid_active_state(
         hass, in_sync_entity_obj._sync_manager, set_dirty=False
     )
 
-    # Verify initial state is still not loaded (is_on still None)
-    assert in_sync_entity_obj._sync_manager._in_sync is None
+    # Verify initial state is still not loaded (still LOADING)
+    assert in_sync_entity_obj._sync_manager._state is SyncState.LOADING
 
     await hass.config_entries.async_unload(config_entry.entry_id)
 
@@ -448,7 +449,7 @@ async def test_in_sync_waits_for_missing_pin_state(
     in_sync_entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
 
     # Simulate pre-initialization state
-    in_sync_entity_obj._sync_manager._in_sync = None
+    in_sync_entity_obj._sync_manager._state = SyncState.LOADING
 
     # Remove the PIN entity state so _ensure_entities_ready() fails
     hass.states.async_remove(SLOT_1_PIN_ENTITY)
@@ -459,7 +460,7 @@ async def test_in_sync_waits_for_missing_pin_state(
     )
 
     # Entity should still be waiting on initial state
-    assert in_sync_entity_obj._sync_manager._in_sync is None, (
+    assert in_sync_entity_obj._sync_manager._state is SyncState.LOADING, (
         "In-sync sensor should not initialize when PIN state is missing"
     )
 
@@ -471,7 +472,7 @@ async def test_in_sync_waits_for_missing_pin_state(
         hass, in_sync_entity_obj._sync_manager, set_dirty=False
     )
 
-    assert in_sync_entity_obj._sync_manager._in_sync is True, (
+    assert in_sync_entity_obj._sync_manager._state is SyncState.SYNCED, (
         "In-sync sensor should initialize once dependent states are available"
     )
 
@@ -645,8 +646,8 @@ async def test_coordinator_refresh_failure_schedules_retry(
 
     in_sync_entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
 
-    # Clear dirty flag to establish baseline
-    in_sync_entity_obj._sync_manager._dirty = False
+    # Ensure manager is in a tickable state
+    in_sync_entity_obj._sync_manager._state = SyncState.OUT_OF_SYNC
 
     # Patch coordinator refresh to fail BEFORE changing PIN
     # This way the failure happens during the sync triggered by the PIN change
@@ -669,9 +670,9 @@ async def test_coordinator_refresh_failure_schedules_retry(
         await in_sync_entity_obj._sync_manager._async_tick()
         await hass.async_block_till_done()
 
-    # Dirty flag should be set due to coordinator refresh failure
-    assert in_sync_entity_obj._sync_manager._dirty, (
-        "Dirty flag should be set when coordinator refresh fails after sync"
+    # State should be OUT_OF_SYNC due to coordinator refresh failure
+    assert in_sync_entity_obj._sync_manager._state is SyncState.OUT_OF_SYNC, (
+        "State should be OUT_OF_SYNC when coordinator refresh fails after sync"
     )
 
 
@@ -687,11 +688,12 @@ async def test_coordinator_update_triggers_sync_on_external_change(
     automatically sync to restore the configured code.
 
     With the tick-based design:
-    1. Coordinator updates trigger _mark_dirty() via the coordinator listener
+    1. Coordinator updates trigger _request_sync_check() via the coordinator listener
     2. The next periodic tick performs reconciliation and syncs if needed
 
-    This test verifies that the dirty flag is set on coordinator updates and
-    the subsequent tick detects the mismatch and performs the sync operation.
+    This test verifies that coordinator updates transition the state to
+    OUT_OF_SYNC and the subsequent tick detects the mismatch and performs
+    the sync operation.
     """
     # Use config without calendar so both slots are active
     config = {
@@ -931,10 +933,7 @@ async def test_sync_attempts_exceeded_disables_slot(
     )
     await hass.async_block_till_done()
 
-    # Simulate that the tick has already processed the out-of-sync state
-    # (so _tick_in_sync matches the current state and no transition reset)
     sync_mgr = in_sync_entity_obj._sync_manager
-    sync_mgr._tick_in_sync = False
 
     # Pre-load the tracker to simulate repeated failures on the same PIN
     now = dt_util.utcnow()
@@ -942,13 +941,13 @@ async def test_sync_attempts_exceeded_disables_slot(
     sync_mgr._sync_attempt_first = now
 
     # Trigger tick — circuit breaker should fire before attempting sync
-    sync_mgr._dirty = True
+    sync_mgr._state = SyncState.OUT_OF_SYNC
     await sync_mgr._async_tick()
     await hass.async_block_till_done()
 
-    # Slot should be disabled
-    enabled_state = hass.states.get(SLOT_1_ENABLED_ENTITY)
-    assert enabled_state.state == STATE_OFF
+    # Lock should be suspended (not slot disabled)
+    assert sync_mgr._state is SyncState.SUSPENDED
+    assert coordinator.suspended is True
 
     # The "9999" code should never have been sent to the lock — the tracker
     # check fires BEFORE the sync operation
@@ -986,9 +985,9 @@ async def test_sync_tracker_resets_when_back_in_sync(
     await hass.async_block_till_done()
     await _async_force_sync_cycle(hass, coordinator)
 
-    # Tick performs sync → coordinator refreshes → _update_in_sync_display
-    # detects back in sync and resets tracker immediately
-    in_sync_entity_obj._sync_manager._dirty = True
+    # Tick performs sync → coordinator refreshes → detects back in sync
+    # and resets tracker immediately
+    in_sync_entity_obj._sync_manager._state = SyncState.OUT_OF_SYNC
     await in_sync_entity_obj._sync_manager._async_tick()
     await hass.async_block_till_done()
 
@@ -999,17 +998,15 @@ async def test_sync_tracker_resets_when_back_in_sync(
     assert not in_sync_entity_obj._sync_manager._sync_attempts_exceeded()
 
 
-async def test_sync_tracker_resets_on_pin_change_in_tick(
+async def test_sync_tracker_does_not_fire_breaker_with_expired_window(
     hass: HomeAssistant,
     mock_lock_config_entry,
     lock_code_manager_config_entry,
 ):
-    """Test that the tick resets the circuit breaker when sync target changes.
+    """Test that stale sync attempts outside the window do not trigger the circuit breaker.
 
-    When a PIN changes while the slot is in sync, the tick detects the
-    True→False transition and resets the tracker before checking the
-    circuit breaker. This prevents stale attempt counts from a prior
-    sync cycle from incorrectly triggering the breaker.
+    When the attempt window expires, _record_sync_attempt resets the counter,
+    preventing stale counts from triggering the breaker on a new sync cycle.
     """
     await async_initial_tick(hass, SLOT_1_IN_SYNC_ENTITY)
 
@@ -1019,13 +1016,11 @@ async def test_sync_tracker_resets_on_pin_change_in_tick(
     # Verify in sync
     assert hass.states.get(SLOT_1_IN_SYNC_ENTITY).state == STATE_ON
 
-    # Simulate prior sync attempts (as if a previous sync cycle ran)
-    now = dt_util.utcnow()
+    # Simulate prior sync attempts from an EXPIRED window
     sync_mgr._sync_attempt_count = MAX_SYNC_ATTEMPTS - 1
-    sync_mgr._sync_attempt_first = now
+    sync_mgr._sync_attempt_first = dt_util.utcnow() - SYNC_ATTEMPT_WINDOW * 2
 
-    # Change PIN — the display callback updates _in_sync to False for UI,
-    # but does NOT reset the tracker (that's the tick's job now)
+    # Change PIN to trigger out-of-sync
     await hass.services.async_call(
         TEXT_DOMAIN,
         TEXT_SERVICE_SET_VALUE,
@@ -1035,23 +1030,19 @@ async def test_sync_tracker_resets_on_pin_change_in_tick(
     )
     await hass.async_block_till_done()
 
-    # The display callback set _in_sync = False but tracker is untouched
-    assert sync_mgr._in_sync is False
-    assert sync_mgr._sync_attempt_count == MAX_SYNC_ATTEMPTS - 1
+    # _request_sync_check transitions SYNCED -> OUT_OF_SYNC
+    assert sync_mgr._state is SyncState.OUT_OF_SYNC
 
-    # Tick fires — detects True→False transition, resets tracker BEFORE
-    # checking circuit breaker, then performs sync
-    sync_mgr._dirty = True
+    # Tick fires — expired window causes _record_sync_attempt to reset
+    # the counter, so the breaker does not fire. Sync succeeds and
+    # resets the tracker.
     await sync_mgr._async_tick()
     await hass.async_block_till_done()
 
-    # Tracker should have been reset (the old attempts cleared) and then
-    # one new attempt recorded for the sync operation
-    assert sync_mgr._sync_attempt_count == 1
-
-    # Slot should NOT be disabled (circuit breaker didn't fire)
-    enabled_state = hass.states.get(SLOT_1_ENABLED_ENTITY)
-    assert enabled_state.state == STATE_ON
+    # Sync succeeded — lock should be SYNCED, not SUSPENDED
+    assert sync_mgr._state is SyncState.SYNCED
+    # Tracker reset after successful sync
+    assert sync_mgr._sync_attempt_count == 0
 
 
 async def test_sync_tracker_expired_window_resets(
@@ -1114,7 +1105,7 @@ async def test_invalid_active_state_during_initial_load(
     in_sync_entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
 
     # Reset to simulate pre-initial-load state
-    in_sync_entity_obj._sync_manager._in_sync = None
+    in_sync_entity_obj._sync_manager._state = SyncState.LOADING
     in_sync_entity_obj._sync_manager._logged_invalid_state = False
 
     # Set active entity to an invalid state (not ON or OFF)
@@ -1123,7 +1114,6 @@ async def test_invalid_active_state_during_initial_load(
 
     # Trigger multiple ticks — should keep retrying without crashing
     for _ in range(5):
-        in_sync_entity_obj._sync_manager._dirty = True
         await in_sync_entity_obj._sync_manager._async_tick()
         await hass.async_block_till_done()
 
@@ -1131,21 +1121,18 @@ async def test_invalid_active_state_during_initial_load(
     assert in_sync_entity_obj._sync_manager._logged_invalid_state is True
 
     # Initial state is still not loaded due to invalid state
-    assert in_sync_entity_obj._sync_manager._in_sync is None
+    assert in_sync_entity_obj._sync_manager._state is SyncState.LOADING
 
 
-async def test_unexpected_error_during_sync_disables_slot(
+async def test_unexpected_error_during_sync_suspends_lock(
     hass: HomeAssistant,
     mock_lock_config_entry,
     lock_code_manager_config_entry,
 ):
-    """Test that unexpected errors during sync operation disable the slot."""
+    """Test that unexpected errors during sync operation suspend the lock."""
     in_sync_entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
     lock_provider = lock_code_manager_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
     coordinator = lock_provider.coordinator
-
-    # Reset to simulate out-of-sync state
-    in_sync_entity_obj._sync_manager._in_sync = True
 
     # Mock _perform_sync to raise an unexpected exception
     async def mock_perform_sync_unexpected_error(*args, **kwargs):
@@ -1157,24 +1144,17 @@ async def test_unexpected_error_during_sync_disables_slot(
         "_perform_sync",
         new=mock_perform_sync_unexpected_error,
     ):
-        # Change PIN to trigger sync cycle
-        await hass.services.async_call(
-            TEXT_DOMAIN,
-            TEXT_SERVICE_SET_VALUE,
-            service_data={ATTR_VALUE: "9999"},
-            target={ATTR_ENTITY_ID: SLOT_1_PIN_ENTITY},
-            blocking=True,
-        )
-        await hass.async_block_till_done()
-        await _async_force_sync_cycle(hass, coordinator)
+        # Force out-of-sync state
+        in_sync_entity_obj._sync_manager._state = SyncState.OUT_OF_SYNC
+        in_sync_entity_obj._sync_manager._coordinator.data[1] = "wrong_code"
 
         # Trigger tick to attempt sync (which will fail with unexpected error)
-        in_sync_entity_obj._sync_manager._dirty = True
         await in_sync_entity_obj._sync_manager._async_tick()
         await hass.async_block_till_done()
 
-        # Verify that the slot was disabled (in_sync set to False due to error)
-        assert in_sync_entity_obj._sync_manager._in_sync is False
+        # Verify that the lock was suspended
+        assert in_sync_entity_obj._sync_manager._state is SyncState.SUSPENDED
+        assert coordinator.suspended is True
 
 
 async def test_sync_manager_handles_string_slot_num(

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -947,7 +947,7 @@ async def test_sync_attempts_exceeded_disables_slot(
 
     # Lock should be suspended (not slot disabled)
     assert sync_mgr._state is SyncState.SUSPENDED
-    assert coordinator.suspended is True
+    assert coordinator.slot_sync_mgrs_suspended is True
 
     # The "9999" code should never have been sent to the lock — the tracker
     # check fires BEFORE the sync operation
@@ -1154,7 +1154,7 @@ async def test_unexpected_error_during_sync_suspends_lock(
 
         # Verify that the lock was suspended
         assert in_sync_entity_obj._sync_manager._state is SyncState.SUSPENDED
-        assert coordinator.suspended is True
+        assert coordinator.slot_sync_mgrs_suspended is True
 
 
 async def test_sync_manager_handles_string_slot_num(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -754,7 +754,7 @@ async def test_coordinator_suspended_cleared_on_successful_poll(
     hass: HomeAssistant, poll_lock, poll_coordinator
 ) -> None:
     """Successful poll clears suspended flag."""
-    poll_coordinator.suspended = True
+    poll_coordinator.suspend()
     await poll_coordinator.async_refresh()
     assert poll_coordinator.suspended is False
 
@@ -763,7 +763,7 @@ async def test_coordinator_suspended_cleared_on_push_update(
     hass: HomeAssistant, push_lock, push_coordinator
 ) -> None:
     """Push update clears suspended flag."""
-    push_coordinator.suspended = True
+    push_coordinator.suspend()
     push_coordinator.push_update({1: "1234"})
     assert push_coordinator.suspended is False
 
@@ -772,7 +772,7 @@ async def test_coordinator_suspended_not_cleared_on_failed_poll(
     hass: HomeAssistant, poll_lock, poll_coordinator
 ) -> None:
     """Failed poll does not clear suspended flag."""
-    poll_coordinator.suspended = True
+    poll_coordinator.suspend()
     poll_lock.set_connected(False)
     await poll_coordinator.async_refresh()
     assert poll_coordinator.suspended is True

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -747,35 +747,35 @@ async def test_coordinator_suspended_flag_defaults_false(
 ) -> None:
     """Coordinator starts with suspended=False."""
     coordinator = LockUsercodeUpdateCoordinator(hass, poll_lock, lcm_config_entry)
-    assert coordinator.suspended is False
+    assert coordinator.slot_sync_mgrs_suspended is False
 
 
 async def test_coordinator_suspended_cleared_on_successful_poll(
     hass: HomeAssistant, poll_lock, poll_coordinator
 ) -> None:
     """Successful poll clears suspended flag."""
-    poll_coordinator.suspend()
+    poll_coordinator.suspend_slot_sync_mgrs()
     await poll_coordinator.async_refresh()
-    assert poll_coordinator.suspended is False
+    assert poll_coordinator.slot_sync_mgrs_suspended is False
 
 
 async def test_coordinator_suspended_cleared_on_push_update(
     hass: HomeAssistant, push_lock, push_coordinator
 ) -> None:
     """Push update clears suspended flag."""
-    push_coordinator.suspend()
+    push_coordinator.suspend_slot_sync_mgrs()
     push_coordinator.push_update({1: "1234"})
-    assert push_coordinator.suspended is False
+    assert push_coordinator.slot_sync_mgrs_suspended is False
 
 
 async def test_coordinator_suspended_not_cleared_on_failed_poll(
     hass: HomeAssistant, poll_lock, poll_coordinator
 ) -> None:
     """Failed poll does not clear suspended flag."""
-    poll_coordinator.suspend()
+    poll_coordinator.suspend_slot_sync_mgrs()
     poll_lock.set_connected(False)
     await poll_coordinator.async_refresh()
-    assert poll_coordinator.suspended is True
+    assert poll_coordinator.slot_sync_mgrs_suspended is True
 
 
 async def test_lock_offline_issue_persists_across_shutdown(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -742,6 +742,42 @@ async def test_poll_failure_alert_dismissed_on_recovery(
     assert issue_registry.async_get_issue(DOMAIN, issue_id) is None
 
 
+async def test_coordinator_suspended_flag_defaults_false(
+    hass: HomeAssistant, poll_lock, lcm_config_entry
+) -> None:
+    """Coordinator starts with suspended=False."""
+    coordinator = LockUsercodeUpdateCoordinator(hass, poll_lock, lcm_config_entry)
+    assert coordinator.suspended is False
+
+
+async def test_coordinator_suspended_cleared_on_successful_poll(
+    hass: HomeAssistant, poll_lock, poll_coordinator
+) -> None:
+    """Successful poll clears suspended flag."""
+    poll_coordinator.suspended = True
+    await poll_coordinator.async_refresh()
+    assert poll_coordinator.suspended is False
+
+
+async def test_coordinator_suspended_cleared_on_push_update(
+    hass: HomeAssistant, push_lock, push_coordinator
+) -> None:
+    """Push update clears suspended flag."""
+    push_coordinator.suspended = True
+    push_coordinator.push_update({1: "1234"})
+    assert push_coordinator.suspended is False
+
+
+async def test_coordinator_suspended_not_cleared_on_failed_poll(
+    hass: HomeAssistant, poll_lock, poll_coordinator
+) -> None:
+    """Failed poll does not clear suspended flag."""
+    poll_coordinator.suspended = True
+    poll_lock.set_connected(False)
+    await poll_coordinator.async_refresh()
+    assert poll_coordinator.suspended is True
+
+
 async def test_lock_offline_issue_persists_across_shutdown(
     poll_coordinator: LockUsercodeUpdateCoordinator,
     poll_lock: MockLCMLock,

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -432,7 +432,7 @@ class TestSyncStateMachine:
         mock_lock_config_entry,
         lock_code_manager_config_entry,
     ) -> None:
-        """LOADING transitions to SYNCED when already in sync."""
+        """LOADING transitions to IN_SYNC when already in sync."""
         entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
         manager = entity_obj._sync_manager
         # The mock lock has code "1234" in slot 1, and the config also has "1234".
@@ -446,7 +446,7 @@ class TestSyncStateMachine:
         mock_lock_config_entry,
         lock_code_manager_config_entry,
     ) -> None:
-        """SYNCED transitions to OUT_OF_SYNC when coordinator data changes."""
+        """IN_SYNC transitions to OUT_OF_SYNC when coordinator data changes."""
         entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
         manager = entity_obj._sync_manager
         await async_trigger_sync_tick(hass, SLOT_1_IN_SYNC_ENTITY)
@@ -462,7 +462,7 @@ class TestSyncStateMachine:
         mock_lock_config_entry,
         lock_code_manager_config_entry,
     ) -> None:
-        """OUT_OF_SYNC transitions through SYNCING to SYNCED on success."""
+        """OUT_OF_SYNC transitions through SYNCING to IN_SYNC on success."""
         entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
         manager = entity_obj._sync_manager
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -409,7 +409,7 @@ class TestSyncStateMachine:
         # (they may not be registered), but after full setup + a tick,
         # the manager should transition out of LOADING.
         await async_trigger_sync_tick(hass, SLOT_1_IN_SYNC_ENTITY, set_dirty=False)
-        assert manager._state in (SyncState.SYNCED, SyncState.OUT_OF_SYNC)
+        assert manager._state in (SyncState.IN_SYNC, SyncState.OUT_OF_SYNC)
 
     async def test_loading_to_out_of_sync(
         self,
@@ -438,7 +438,7 @@ class TestSyncStateMachine:
         # The mock lock has code "1234" in slot 1, and the config also has "1234".
         # Trigger a tick to complete initial loading.
         await async_trigger_sync_tick(hass, SLOT_1_IN_SYNC_ENTITY, set_dirty=False)
-        assert manager._state is SyncState.SYNCED
+        assert manager._state is SyncState.IN_SYNC
 
     async def test_synced_to_out_of_sync_on_state_change(
         self,
@@ -450,7 +450,7 @@ class TestSyncStateMachine:
         entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
         manager = entity_obj._sync_manager
         await async_trigger_sync_tick(hass, SLOT_1_IN_SYNC_ENTITY)
-        assert manager._state is SyncState.SYNCED
+        assert manager._state is SyncState.IN_SYNC
 
         manager._coordinator.data[1] = SlotCode.EMPTY
         manager._request_sync_check()
@@ -468,14 +468,14 @@ class TestSyncStateMachine:
 
         # First get out of LOADING state
         await async_trigger_sync_tick(hass, SLOT_1_IN_SYNC_ENTITY, set_dirty=False)
-        assert manager._state is SyncState.SYNCED
+        assert manager._state is SyncState.IN_SYNC
 
         manager._coordinator.data[1] = SlotCode.EMPTY
         manager._request_sync_check()
         assert manager._state is SyncState.OUT_OF_SYNC
 
         await async_trigger_sync_tick(hass, SLOT_1_IN_SYNC_ENTITY, set_dirty=False)
-        assert manager._state is SyncState.SYNCED
+        assert manager._state is SyncState.IN_SYNC
 
     async def test_syncing_to_out_of_sync_on_lock_disconnected(
         self,
@@ -644,7 +644,7 @@ class TestSyncStatusAttribute:
 
         state = hass.states.get(SLOT_1_IN_SYNC_ENTITY)
         assert state is not None
-        assert state.attributes.get("sync_status") == "synced"
+        assert state.attributes.get("sync_status") == "in_sync"
 
     async def test_sync_status_out_of_sync(
         self,

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -629,6 +629,112 @@ class TestSyncStateMachine:
         mock_disable.assert_called_once()
         assert manager._coordinator.suspended is False
 
+    async def test_suspend_creates_repair_issue(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """Suspension creates a per-lock slot_suspended repair issue."""
+        entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
+        manager = entity_obj._sync_manager
+
+        manager._state = SyncState.OUT_OF_SYNC
+        manager._coordinator.data[1] = SlotCode.EMPTY
+
+        with patch.object(
+            manager,
+            "_perform_sync",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("unexpected"),
+        ):
+            await manager._async_tick()
+            await hass.async_block_till_done()
+
+        issue_registry = async_get_issue_registry(hass)
+        entry_id = lock_code_manager_config_entry.entry_id
+        lock_entity_id = manager._lock.lock.entity_id
+        issue = issue_registry.async_get_issue(
+            DOMAIN, f"slot_suspended_{entry_id}_{lock_entity_id}"
+        )
+        assert issue is not None
+        assert issue.severity == IssueSeverity.WARNING
+
+    async def test_slot_suspended_issue_deleted_on_recovery(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """slot_suspended repair issue is deleted when slot comes back in sync."""
+        entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
+        manager = entity_obj._sync_manager
+        entry_id = lock_code_manager_config_entry.entry_id
+        lock_entity_id = manager._lock.lock.entity_id
+
+        # Create a slot_suspended issue
+        issue_id = f"slot_suspended_{entry_id}_{lock_entity_id}"
+        async_create_issue(
+            hass,
+            DOMAIN,
+            issue_id,
+            is_fixable=True,
+            is_persistent=True,
+            severity=IssueSeverity.WARNING,
+            translation_key="slot_suspended",
+            translation_placeholders={
+                "lock_entity_id": lock_entity_id,
+                "lock_name": lock_entity_id,
+                "reason": "test",
+            },
+        )
+
+        issue_registry = async_get_issue_registry(hass)
+        assert issue_registry.async_get_issue(DOMAIN, issue_id) is not None
+
+        # Set manager to OUT_OF_SYNC so the tick evaluates sync state
+        manager._state = SyncState.OUT_OF_SYNC
+
+        # Trigger a tick — coordinator has matching code so slot resolves to in sync
+        await async_trigger_sync_tick(hass, SLOT_1_IN_SYNC_ENTITY, set_dirty=False)
+
+        assert manager._state is SyncState.IN_SYNC
+        assert issue_registry.async_get_issue(DOMAIN, issue_id) is None
+
+    async def test_post_sync_verification_failure_stays_out_of_sync(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """Sync succeeds but post-sync check shows still out of sync."""
+        entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
+        manager = entity_obj._sync_manager
+
+        manager._state = SyncState.OUT_OF_SYNC
+        manager._coordinator.data[1] = SlotCode.EMPTY
+
+        # _perform_sync succeeds but coordinator data stays EMPTY
+        # (simulating a lock that silently rejects the code).
+        # Also prevent coordinator refresh from re-fetching real data.
+        with (
+            patch.object(
+                manager,
+                "_perform_sync",
+                new_callable=AsyncMock,
+            ),
+            patch.object(
+                manager._coordinator,
+                "async_refresh",
+                new_callable=AsyncMock,
+            ),
+        ):
+            await manager._async_tick()
+            await hass.async_block_till_done()
+
+        # Sync "succeeded" but verify check shows still out of sync
+        assert manager._state is SyncState.OUT_OF_SYNC
+
 
 class TestSyncStatusAttribute:
     """Tests for sync_status extra state attribute."""

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -574,9 +574,9 @@ class TestSyncStateMachine:
         manager = entity_obj._sync_manager
 
         manager._state = SyncState.SUSPENDED
-        manager._coordinator.suspended = True
+        manager._coordinator.suspend()
 
-        manager._coordinator.suspended = False
+        manager._coordinator._suspended = False
         manager._request_sync_check()
 
         assert manager._state is SyncState.OUT_OF_SYNC
@@ -592,7 +592,7 @@ class TestSyncStateMachine:
         manager = entity_obj._sync_manager
 
         manager._state = SyncState.SUSPENDED
-        manager._coordinator.suspended = True
+        manager._coordinator.suspend()
 
         manager._request_sync_check()
         assert manager._state is SyncState.SUSPENDED
@@ -674,7 +674,7 @@ class TestSyncStatusAttribute:
         entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
         manager = entity_obj._sync_manager
 
-        manager._coordinator.suspended = True
+        manager._coordinator.suspend()
         manager._state = SyncState.SUSPENDED
         manager._write_state()
         await hass.async_block_till_done()

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -628,3 +628,57 @@ class TestSyncStateMachine:
 
         mock_disable.assert_called_once()
         assert manager._coordinator.suspended is False
+
+
+class TestSyncStatusAttribute:
+    """Tests for sync_status extra state attribute."""
+
+    async def test_sync_status_synced(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """sync_status is 'synced' when in sync."""
+        await async_trigger_sync_tick(hass, SLOT_1_IN_SYNC_ENTITY)
+
+        state = hass.states.get(SLOT_1_IN_SYNC_ENTITY)
+        assert state is not None
+        assert state.attributes.get("sync_status") == "synced"
+
+    async def test_sync_status_out_of_sync(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """sync_status is 'out_of_sync' when out of sync."""
+        entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
+        manager = entity_obj._sync_manager
+
+        manager._state = SyncState.OUT_OF_SYNC
+        manager._write_state()
+        await hass.async_block_till_done()
+
+        state = hass.states.get(SLOT_1_IN_SYNC_ENTITY)
+        assert state is not None
+        assert state.attributes.get("sync_status") == "out_of_sync"
+
+    async def test_sync_status_suspended(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """sync_status is 'suspended' when suspended."""
+        entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
+        manager = entity_obj._sync_manager
+
+        manager._coordinator.suspended = True
+        manager._state = SyncState.SUSPENDED
+        manager._write_state()
+        await hass.async_block_till_done()
+
+        state = hass.states.get(SLOT_1_IN_SYNC_ENTITY)
+        assert state is not None
+        assert state.attributes.get("sync_status") == "suspended"

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -524,7 +524,7 @@ class TestSyncStateMachine:
             await hass.async_block_till_done()
 
         assert manager._state is SyncState.SUSPENDED
-        assert manager._coordinator.suspended is True
+        assert manager._coordinator.slot_sync_mgrs_suspended is True
 
     async def test_syncing_to_suspended_on_circuit_breaker(
         self,
@@ -545,7 +545,7 @@ class TestSyncStateMachine:
         await hass.async_block_till_done()
 
         assert manager._state is SyncState.SUSPENDED
-        assert manager._coordinator.suspended is True
+        assert manager._coordinator.slot_sync_mgrs_suspended is True
 
     async def test_suspended_skips_tick(
         self,
@@ -574,9 +574,9 @@ class TestSyncStateMachine:
         manager = entity_obj._sync_manager
 
         manager._state = SyncState.SUSPENDED
-        manager._coordinator.suspend()
+        manager._coordinator.suspend_slot_sync_mgrs()
 
-        manager._coordinator._suspended = False
+        manager._coordinator._slot_sync_mgrs_suspended = False
         manager._request_sync_check()
 
         assert manager._state is SyncState.OUT_OF_SYNC
@@ -592,7 +592,7 @@ class TestSyncStateMachine:
         manager = entity_obj._sync_manager
 
         manager._state = SyncState.SUSPENDED
-        manager._coordinator.suspend()
+        manager._coordinator.suspend_slot_sync_mgrs()
 
         manager._request_sync_check()
         assert manager._state is SyncState.SUSPENDED
@@ -627,7 +627,7 @@ class TestSyncStateMachine:
             await hass.async_block_till_done()
 
         mock_disable.assert_called_once()
-        assert manager._coordinator.suspended is False
+        assert manager._coordinator.slot_sync_mgrs_suspended is False
 
     async def test_suspend_creates_repair_issue(
         self,
@@ -780,7 +780,7 @@ class TestSyncStatusAttribute:
         entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
         manager = entity_obj._sync_manager
 
-        manager._coordinator.suspend()
+        manager._coordinator.suspend_slot_sync_mgrs()
         manager._state = SyncState.SUSPENDED
         manager._write_state()
         await hass.async_block_till_done()

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -14,10 +14,15 @@ from homeassistant.helpers.issue_registry import (
     async_create_issue,
     async_get as async_get_issue_registry,
 )
+from homeassistant.util import dt as dt_util
 
-from custom_components.lock_code_manager.const import DOMAIN
-from custom_components.lock_code_manager.exceptions import LockOperationFailed
-from custom_components.lock_code_manager.models import SlotCode
+from custom_components.lock_code_manager.const import DOMAIN, MAX_SYNC_ATTEMPTS
+from custom_components.lock_code_manager.exceptions import (
+    CodeRejectedError,
+    LockDisconnected,
+    LockOperationFailed,
+)
+from custom_components.lock_code_manager.models import SlotCode, SyncState
 from custom_components.lock_code_manager.sync import SlotState, SlotSyncManager
 
 from .common import SLOT_1_IN_SYNC_ENTITY
@@ -348,7 +353,7 @@ class TestSlotDisabledIssueCleanup:
         assert issue_registry.async_get_issue(DOMAIN, issue_id) is not None
 
         # Initialize the manager state so it thinks it was out of sync
-        manager._in_sync = False
+        manager._state = SyncState.OUT_OF_SYNC
 
         # Trigger a tick that will find the slot in sync (coordinator has matching code)
         await async_trigger_sync_tick(hass, SLOT_1_IN_SYNC_ENTITY)
@@ -372,8 +377,7 @@ class TestLockOperationFailedRetry:
 
         # Force out-of-sync state so _perform_sync is called:
         # set coordinator data to EMPTY so the slot appears to need a set
-        manager._in_sync = False
-        manager._dirty = True
+        manager._state = SyncState.OUT_OF_SYNC
         manager._coordinator.data[1] = SlotCode.EMPTY
 
         with patch.object(
@@ -385,7 +389,242 @@ class TestLockOperationFailedRetry:
             await manager._async_tick()
             await hass.async_block_till_done()
 
-        # Should retry (dirty=True) rather than disable the slot
-        assert manager._dirty is True
-        # Slot should not have been disabled (in_sync stays False, not None)
-        assert manager._in_sync is False
+        # Should retry (OUT_OF_SYNC) rather than disable the slot
+        assert manager._state is SyncState.OUT_OF_SYNC
+
+
+class TestSyncStateMachine:
+    """Tests for SyncState transitions in SlotSyncManager."""
+
+    async def test_initial_state_is_loading(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """Manager starts in LOADING then transitions after a tick resolves entities."""
+        entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
+        manager = entity_obj._sync_manager
+        # The initial tick during async_start may not resolve entities yet
+        # (they may not be registered), but after full setup + a tick,
+        # the manager should transition out of LOADING.
+        await async_trigger_sync_tick(hass, SLOT_1_IN_SYNC_ENTITY, set_dirty=False)
+        assert manager._state in (SyncState.SYNCED, SyncState.OUT_OF_SYNC)
+
+    async def test_loading_to_out_of_sync(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """LOADING transitions to OUT_OF_SYNC when slot is not in sync on startup."""
+        entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
+        manager = entity_obj._sync_manager
+        manager._state = SyncState.LOADING
+        # Make coordinator data mismatch (slot active but lock has empty code)
+        manager._coordinator.data[1] = SlotCode.EMPTY
+        await async_trigger_sync_tick(hass, SLOT_1_IN_SYNC_ENTITY, set_dirty=False)
+        assert manager._state is SyncState.OUT_OF_SYNC
+
+    async def test_loading_to_synced(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """LOADING transitions to SYNCED when already in sync."""
+        entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
+        manager = entity_obj._sync_manager
+        # The mock lock has code "1234" in slot 1, and the config also has "1234".
+        # Trigger a tick to complete initial loading.
+        await async_trigger_sync_tick(hass, SLOT_1_IN_SYNC_ENTITY, set_dirty=False)
+        assert manager._state is SyncState.SYNCED
+
+    async def test_synced_to_out_of_sync_on_state_change(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """SYNCED transitions to OUT_OF_SYNC when coordinator data changes."""
+        entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
+        manager = entity_obj._sync_manager
+        await async_trigger_sync_tick(hass, SLOT_1_IN_SYNC_ENTITY)
+        assert manager._state is SyncState.SYNCED
+
+        manager._coordinator.data[1] = SlotCode.EMPTY
+        manager._request_sync_check()
+        assert manager._state is SyncState.OUT_OF_SYNC
+
+    async def test_out_of_sync_to_synced_after_successful_sync(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """OUT_OF_SYNC transitions through SYNCING to SYNCED on success."""
+        entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
+        manager = entity_obj._sync_manager
+
+        # First get out of LOADING state
+        await async_trigger_sync_tick(hass, SLOT_1_IN_SYNC_ENTITY, set_dirty=False)
+        assert manager._state is SyncState.SYNCED
+
+        manager._coordinator.data[1] = SlotCode.EMPTY
+        manager._request_sync_check()
+        assert manager._state is SyncState.OUT_OF_SYNC
+
+        await async_trigger_sync_tick(hass, SLOT_1_IN_SYNC_ENTITY, set_dirty=False)
+        assert manager._state is SyncState.SYNCED
+
+    async def test_syncing_to_out_of_sync_on_lock_disconnected(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """SYNCING transitions to OUT_OF_SYNC on LockDisconnected."""
+        entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
+        manager = entity_obj._sync_manager
+
+        manager._state = SyncState.OUT_OF_SYNC
+        manager._coordinator.data[1] = SlotCode.EMPTY
+
+        with patch.object(
+            manager,
+            "_perform_sync",
+            new_callable=AsyncMock,
+            side_effect=LockDisconnected("test"),
+        ):
+            await manager._async_tick()
+            await hass.async_block_till_done()
+
+        assert manager._state is SyncState.OUT_OF_SYNC
+
+    async def test_syncing_to_suspended_on_unexpected_error(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """SYNCING transitions to SUSPENDED on generic exception."""
+        entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
+        manager = entity_obj._sync_manager
+
+        manager._state = SyncState.OUT_OF_SYNC
+        manager._coordinator.data[1] = SlotCode.EMPTY
+
+        with patch.object(
+            manager,
+            "_perform_sync",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("unexpected"),
+        ):
+            await manager._async_tick()
+            await hass.async_block_till_done()
+
+        assert manager._state is SyncState.SUSPENDED
+        assert manager._coordinator.suspended is True
+
+    async def test_syncing_to_suspended_on_circuit_breaker(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """Circuit breaker trips transitions to SUSPENDED."""
+        entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
+        manager = entity_obj._sync_manager
+
+        manager._state = SyncState.OUT_OF_SYNC
+        manager._coordinator.data[1] = SlotCode.EMPTY
+        manager._sync_attempt_count = MAX_SYNC_ATTEMPTS
+        manager._sync_attempt_first = dt_util.utcnow()
+
+        await manager._async_tick()
+        await hass.async_block_till_done()
+
+        assert manager._state is SyncState.SUSPENDED
+        assert manager._coordinator.suspended is True
+
+    async def test_suspended_skips_tick(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """SUSPENDED state skips tick processing."""
+        entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
+        manager = entity_obj._sync_manager
+
+        manager._state = SyncState.SUSPENDED
+
+        with patch.object(manager, "_async_tick_impl") as mock_tick_impl:
+            await manager._async_tick()
+            mock_tick_impl.assert_not_called()
+
+    async def test_suspended_to_out_of_sync_on_coordinator_recovery(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """SUSPENDED transitions to OUT_OF_SYNC when coordinator clears suspended flag."""
+        entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
+        manager = entity_obj._sync_manager
+
+        manager._state = SyncState.SUSPENDED
+        manager._coordinator.suspended = True
+
+        manager._coordinator.suspended = False
+        manager._request_sync_check()
+
+        assert manager._state is SyncState.OUT_OF_SYNC
+
+    async def test_suspended_stays_suspended_when_coordinator_still_suspended(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """SUSPENDED stays SUSPENDED when coordinator flag is still set."""
+        entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
+        manager = entity_obj._sync_manager
+
+        manager._state = SyncState.SUSPENDED
+        manager._coordinator.suspended = True
+
+        manager._request_sync_check()
+        assert manager._state is SyncState.SUSPENDED
+
+    async def test_code_rejected_still_disables_slot(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """CodeRejectedError still calls _disable_slot (profile-wide)."""
+        entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
+        manager = entity_obj._sync_manager
+
+        manager._state = SyncState.OUT_OF_SYNC
+        manager._coordinator.data[1] = SlotCode.EMPTY
+
+        with (
+            patch.object(
+                manager,
+                "_perform_sync",
+                new_callable=AsyncMock,
+                side_effect=CodeRejectedError(1, "lock.test_1"),
+            ),
+            patch.object(
+                manager,
+                "_disable_slot",
+                new_callable=AsyncMock,
+            ) as mock_disable,
+        ):
+            await manager._async_tick()
+            await hass.async_block_till_done()
+
+        mock_disable.assert_called_once()
+        assert manager._coordinator.suspended is False


### PR DESCRIPTION
## Proposed change

Replaces the three independent boolean flags (`_dirty`, `_in_sync`, `_tick_in_sync`) in `SlotSyncManager` with an explicit `SyncState` enum state machine. This isolates lock failures per-lock instead of per-profile, so one unreachable lock no longer disables slots across all locks in the profile.

**State machine states:** `LOADING` → `IN_SYNC` ↔ `OUT_OF_SYNC` → `SYNCING` → `IN_SYNC` | `OUT_OF_SYNC` | `SUSPENDED`

**Key changes:**
- **`SyncState` enum** (`LOADING`, `IN_SYNC`, `OUT_OF_SYNC`, `SYNCING`, `SUSPENDED`) replaces three boolean flags, making impossible states unrepresentable
- **Per-lock suspension**: Circuit breaker and unexpected errors now call `coordinator.suspend_slot_sync_mgrs()` (per-lock scope) instead of `_disable_slot` (profile-wide scope). `CodeRejectedError`/`DuplicateCodeError` still disable the slot profile-wide since the code itself is bad.
- **`sync_status` attribute** on the in-sync binary sensor: `in_sync`, `out_of_sync`, `syncing`, `suspended` — with translations for dashboard styling
- **`slot_suspended` repair issue**: Per-lock repair issue created on suspension, auto-cleared on recovery and on config entry unload
- **Z-Wave error wrapping**: `get_usercode_from_node()` failures (`FailedZWaveCommand`) in V1 locks now raise `LockDisconnected` instead of leaking into the generic exception handler, routing them into the retry path

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #1061
- This PR is related to issue: