### PR TITLE
refactor: clean up BaseLock abstractions and provider patterns

### DIFF
--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -839,8 +839,9 @@ class BaseLock:
             ) from err
 
     @final
-    def _get_managed_slots(self) -> set[int]:
-        """Return set of slot numbers managed by Lock Code Manager for this lock."""
+    @property
+    def managed_slots(self) -> set[int]:
+        """Return slot numbers managed by Lock Code Manager for this lock."""
         return get_managed_slots(self.hass, self.lock.entity_id)
 
     @final

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -147,9 +147,10 @@ class BaseLock:
     parent) and handles it appropriately (e.g., retrying, logging).
 
     Do NOT raise generic exceptions, HomeAssistantError, or the bare
-    LockCodeManagerError directly — always use LockCodeManagerProviderError
-    or a subclass so callers can distinguish provider failures from
-    LCM-internal exceptions.
+    LockCodeManagerError for lock/integration failures — use
+    LockCodeManagerProviderError or a subclass so callers can distinguish
+    provider failures from LCM-internal errors. LockCodeManagerError is
+    reserved for programming errors such as a missing required override.
     """
 
     hass: HomeAssistant = field(repr=False)
@@ -629,6 +630,8 @@ class BaseLock:
         """Return True iff the lock's parent config entry is loaded.
 
         Providers override for integration-specific connection signals.
+        Raises ``LockCodeManagerError`` if ``lock_config_entry`` is None —
+        providers without a config entry must override this method.
         """
         if not self.lock_config_entry:
             raise LockCodeManagerError(
@@ -841,7 +844,7 @@ class BaseLock:
     @final
     @property
     def managed_slots(self) -> set[int]:
-        """Return slot numbers managed by Lock Code Manager for this lock."""
+        """Return slot numbers managed by any Lock Code Manager config entry that includes this lock."""
         return get_managed_slots(self.hass, self.lock.entity_id)
 
     @final

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -37,9 +37,10 @@ from ..const import (
     EVENT_LOCK_STATE_CHANGED,
 )
 from ..coordinator import LockUsercodeUpdateCoordinator
-from ..data import build_slot_unique_id, find_entry_for_lock_slot
+from ..data import build_slot_unique_id, find_entry_for_lock_slot, get_managed_slots
 from ..exceptions import (
     DuplicateCodeError,
+    LockCodeManagerError,
     LockDisconnected,
     ProviderNotImplementedError,
 )
@@ -424,7 +425,10 @@ class BaseLock:
     @callback
     def unsubscribe_push_updates(self) -> None:
         """Unsubscribe from push-based value updates."""
-        self.teardown_push_subscription()
+        try:
+            self.teardown_push_subscription()
+        except ProviderNotImplementedError:
+            pass
 
     @callback
     def teardown_push_subscription(self) -> None:
@@ -627,7 +631,11 @@ class BaseLock:
         Providers override for integration-specific connection signals.
         """
         if not self.lock_config_entry:
-            return False
+            raise LockCodeManagerError(
+                f"Lock {self.lock.entity_id} has no lock_config_entry. "
+                f"Providers without a config entry must override "
+                f"async_is_integration_connected()."
+            )
         return self.lock_config_entry.state == ConfigEntryState.LOADED
 
     @final
@@ -829,6 +837,11 @@ class BaseLock:
             raise LockDisconnected(
                 f"Service call {domain}.{service} failed: {err}"
             ) from err
+
+    @final
+    def _get_managed_slots(self) -> set[int]:
+        """Return set of slot numbers managed by Lock Code Manager for this lock."""
+        return get_managed_slots(self.hass, self.lock.entity_id)
 
     @final
     @callback

--- a/custom_components/lock_code_manager/providers/akuvox.py
+++ b/custom_components/lock_code_manager/providers/akuvox.py
@@ -18,9 +18,7 @@ from datetime import timedelta
 from typing import Any, Literal
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.exceptions import HomeAssistantError
 
-from ..data import get_managed_slots
 from ..exceptions import LockCodeManagerProviderError, LockDisconnected
 from ..models import SlotCode
 from ._base import BaseLock
@@ -111,21 +109,17 @@ class AkuvoxLock(BaseLock):
     async def _async_add_user(self, name: str, pin: str) -> None:
         """Add a new user with the given name and PIN."""
         entity_id = self.lock.entity_id
-        try:
-            await self.hass.services.async_call(
-                AKUVOX_DOMAIN,
-                "add_user",
-                service_data={
-                    "name": name,
-                    "private_pin": pin,
-                    "schedules": _DEFAULT_SCHEDULE_IDS,
-                    "lift_floor_num": _DEFAULT_LIFT_FLOOR_NUM,
-                },
-                target={"entity_id": entity_id},
-                blocking=True,
-            )
-        except HomeAssistantError as err:
-            raise LockDisconnected(f"Failed to add user on {entity_id}: {err}") from err
+        await self.async_call_service(
+            AKUVOX_DOMAIN,
+            "add_user",
+            service_data={
+                "name": name,
+                "private_pin": pin,
+                "schedules": _DEFAULT_SCHEDULE_IDS,
+                "lift_floor_num": _DEFAULT_LIFT_FLOOR_NUM,
+            },
+            target={"entity_id": entity_id},
+        )
 
     async def _async_modify_user(
         self,
@@ -141,38 +135,22 @@ class AkuvoxLock(BaseLock):
             service_data["name"] = name
         if pin is not None:
             service_data["private_pin"] = pin
-        try:
-            await self.hass.services.async_call(
-                AKUVOX_DOMAIN,
-                "modify_user",
-                service_data=service_data,
-                target={"entity_id": entity_id},
-                blocking=True,
-            )
-        except HomeAssistantError as err:
-            raise LockDisconnected(
-                f"Failed to modify user {device_user_id} on {entity_id}: {err}"
-            ) from err
+        await self.async_call_service(
+            AKUVOX_DOMAIN,
+            "modify_user",
+            service_data=service_data,
+            target={"entity_id": entity_id},
+        )
 
     async def _async_delete_user(self, device_user_id: str) -> None:
         """Delete a user by their device-internal ID."""
         entity_id = self.lock.entity_id
-        try:
-            await self.hass.services.async_call(
-                AKUVOX_DOMAIN,
-                "delete_user",
-                service_data={"id": device_user_id},
-                target={"entity_id": entity_id},
-                blocking=True,
-            )
-        except HomeAssistantError as err:
-            raise LockDisconnected(
-                f"Failed to delete user {device_user_id} on {entity_id}: {err}"
-            ) from err
-
-    def _get_managed_slots(self) -> set[int]:
-        """Return managed slot numbers for this lock."""
-        return get_managed_slots(self.hass, self.lock.entity_id)
+        await self.async_call_service(
+            AKUVOX_DOMAIN,
+            "delete_user",
+            service_data={"id": device_user_id},
+            target={"entity_id": entity_id},
+        )
 
     async def async_setup(self, config_entry: ConfigEntry) -> None:
         """Set up lock by tagging any pre-existing unmanaged users."""

--- a/custom_components/lock_code_manager/providers/akuvox.py
+++ b/custom_components/lock_code_manager/providers/akuvox.py
@@ -169,7 +169,7 @@ class AkuvoxLock(BaseLock):
         available managed slot and their names are updated on the device
         to include the ``[LCM:<slot>]`` tag via ``modify_user``.
         """
-        managed_slots = self._get_managed_slots()
+        managed_slots = self.managed_slots
         if not managed_slots:
             return
 
@@ -236,7 +236,7 @@ class AkuvoxLock(BaseLock):
 
         Only codes whose slot numbers fall within the managed set are returned.
         """
-        managed_slots = self._get_managed_slots()
+        managed_slots = self.managed_slots
         if not managed_slots:
             return {}
 

--- a/custom_components/lock_code_manager/providers/matter.py
+++ b/custom_components/lock_code_manager/providers/matter.py
@@ -23,7 +23,6 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import SupportsResponse, callback
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 
-from ..data import get_managed_slots
 from ..exceptions import (
     DuplicateCodeError,
     LockCodeManagerProviderError,
@@ -63,11 +62,6 @@ class MatterLock(BaseLock):
     def domain(self) -> str:
         """Return integration domain."""
         return MATTER_DOMAIN
-
-    @property
-    def supports_code_slot_events(self) -> bool:
-        """Return whether this lock supports code slot events."""
-        return True
 
     @property
     def supports_push(self) -> bool:
@@ -385,7 +379,7 @@ class MatterLock(BaseLock):
             resolved,
         )
 
-        if self.coordinator and self.coordinator.data is not None:
+        if self.coordinator:
             self.coordinator.push_update({code_slot: resolved})
 
     # -- Credential helpers --------------------------------------------------
@@ -424,7 +418,7 @@ class MatterLock(BaseLock):
         occupied slots are included so callers like the lock reset config flow
         step can detect codes not managed by Lock Code Manager.
         """
-        managed_slots = get_managed_slots(self.hass, self.lock.entity_id)
+        managed_slots = self._get_managed_slots()
 
         lock_data = await self._async_call_service(
             "get_lock_users",
@@ -539,7 +533,7 @@ class MatterLock(BaseLock):
                 )
         # Optimistic update: service call succeeded, push occupancy state
         # immediately. The LockUserChange event will confirm later.
-        if self.coordinator and self.coordinator.data is not None:
+        if self.coordinator:
             self.coordinator.push_update({code_slot: SlotCode.UNREADABLE_CODE})
         return True
 
@@ -563,7 +557,7 @@ class MatterLock(BaseLock):
         await self._clear_lock_credential(code_slot)
         # Optimistic update: clear succeeded, push empty state immediately.
         # The LockUserChange event will confirm later.
-        if self.coordinator and self.coordinator.data is not None:
+        if self.coordinator:
             self.coordinator.push_update({code_slot: SlotCode.EMPTY})
         return True
 

--- a/custom_components/lock_code_manager/providers/matter.py
+++ b/custom_components/lock_code_manager/providers/matter.py
@@ -418,7 +418,7 @@ class MatterLock(BaseLock):
         occupied slots are included so callers like the lock reset config flow
         step can detect codes not managed by Lock Code Manager.
         """
-        managed_slots = self._get_managed_slots()
+        managed_slots = self.managed_slots
 
         lock_data = await self._async_call_service(
             "get_lock_users",

--- a/custom_components/lock_code_manager/providers/schlage.py
+++ b/custom_components/lock_code_manager/providers/schlage.py
@@ -22,9 +22,7 @@ from datetime import timedelta
 from typing import Literal
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 
-from ..data import get_managed_slots
 from ..exceptions import LockCodeManagerProviderError, LockDisconnected
 from ..models import SlotCode
 from ._base import BaseLock
@@ -62,10 +60,6 @@ class SchlageLock(BaseLock):
         """Return scan interval for usercodes."""
         return timedelta(minutes=5)
 
-    def _get_managed_slots(self) -> set[int]:
-        """Return managed slot numbers for this lock."""
-        return get_managed_slots(self.hass, self.lock.entity_id)
-
     async def _async_get_codes(self) -> dict[str, dict[str, str]]:
         """Call ``schlage.get_codes`` and return the response dict.
 
@@ -97,32 +91,20 @@ class SchlageLock(BaseLock):
     async def _async_add_code(self, name: str, code: str) -> None:
         """Add a new code with the given name and PIN."""
         entity_id = self.lock.entity_id
-        try:
-            await self.hass.services.async_call(
-                SCHLAGE_DOMAIN,
-                "add_code",
-                service_data={"entity_id": entity_id, "name": name, "code": code},
-                blocking=True,
-            )
-        except (ServiceValidationError, HomeAssistantError) as err:
-            raise LockDisconnected(
-                f"Schlage add_code failed for {entity_id}: {err}"
-            ) from err
+        await self.async_call_service(
+            SCHLAGE_DOMAIN,
+            "add_code",
+            service_data={"entity_id": entity_id, "name": name, "code": code},
+        )
 
     async def _async_delete_code(self, name: str) -> None:
         """Delete a code by its full name (including any Lock Code Manager tag)."""
         entity_id = self.lock.entity_id
-        try:
-            await self.hass.services.async_call(
-                SCHLAGE_DOMAIN,
-                "delete_code",
-                service_data={"entity_id": entity_id, "name": name},
-                blocking=True,
-            )
-        except (ServiceValidationError, HomeAssistantError) as err:
-            raise LockDisconnected(
-                f"Schlage delete_code failed for {entity_id}: {err}"
-            ) from err
+        await self.async_call_service(
+            SCHLAGE_DOMAIN,
+            "delete_code",
+            service_data={"entity_id": entity_id, "name": name},
+        )
 
     async def async_is_device_available(self) -> bool:
         """Return whether the Schlage lock device is available for commands."""

--- a/custom_components/lock_code_manager/providers/schlage.py
+++ b/custom_components/lock_code_manager/providers/schlage.py
@@ -130,7 +130,7 @@ class SchlageLock(BaseLock):
         Discovers untagged codes and assigns them to the next available managed
         slot by renaming (add tagged, delete original).
         """
-        managed_slots = self._get_managed_slots()
+        managed_slots = self.managed_slots
         if not managed_slots:
             return
 
@@ -239,7 +239,7 @@ class SchlageLock(BaseLock):
         This method only reads and classifies codes; auto-tagging of unmanaged
         codes is handled by ``_async_tag_unmanaged_codes()``.
         """
-        managed_slots = self._get_managed_slots()
+        managed_slots = self.managed_slots
         if not managed_slots:
             return {}
 

--- a/custom_components/lock_code_manager/providers/virtual.py
+++ b/custom_components/lock_code_manager/providers/virtual.py
@@ -101,7 +101,7 @@ class VirtualLock(BaseLock):
         occupied slots are included so callers like the lock reset config
         flow step can detect codes not managed by Lock Code Manager.
         """
-        managed_slots = self._get_managed_slots()
+        managed_slots = self.managed_slots
         stored_slots = set()
         for k in self._data:
             try:

--- a/custom_components/lock_code_manager/providers/virtual.py
+++ b/custom_components/lock_code_manager/providers/virtual.py
@@ -10,7 +10,6 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.storage import Store
 
 from ..const import DOMAIN
-from ..data import get_managed_slots
 from ..models import SlotCode
 from ._base import BaseLock
 
@@ -41,6 +40,10 @@ class VirtualLock(BaseLock):
         """Return whether this lock supports code slot events."""
         return False
 
+    async def async_is_integration_connected(self) -> bool:
+        """Virtual locks are always connected."""
+        return True
+
     async def async_setup(self, config_entry: ConfigEntry) -> None:
         """Set up lock by provider."""
         self._store = Store(
@@ -54,10 +57,6 @@ class VirtualLock(BaseLock):
             await self._store.async_remove()
         else:
             await self._store.async_save(self._data)
-
-    async def async_is_integration_connected(self) -> bool:
-        """Return whether the integration is connected."""
-        return True
 
     async def async_hard_refresh_codes(self) -> dict[int, str | SlotCode]:
         """Reload from store and return all codes."""
@@ -102,7 +101,7 @@ class VirtualLock(BaseLock):
         occupied slots are included so callers like the lock reset config
         flow step can detect codes not managed by Lock Code Manager.
         """
-        managed_slots = get_managed_slots(self.hass, self.lock.entity_id)
+        managed_slots = self._get_managed_slots()
         stored_slots = set()
         for k in self._data:
             try:

--- a/custom_components/lock_code_manager/providers/zigbee2mqtt.py
+++ b/custom_components/lock_code_manager/providers/zigbee2mqtt.py
@@ -383,7 +383,7 @@ class Zigbee2MQTTLock(BaseLock):
             raise LockDisconnected("Could not determine MQTT topic")
 
         # Get configured code slots for this lock (any LCM entry that includes this lock).
-        code_slots = self._get_managed_slots()
+        code_slots = self.managed_slots
 
         if not code_slots:
             return {}

--- a/custom_components/lock_code_manager/providers/zigbee2mqtt.py
+++ b/custom_components/lock_code_manager/providers/zigbee2mqtt.py
@@ -20,7 +20,6 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
 
-from ..data import get_managed_slots
 from ..exceptions import LockDisconnected
 from ..models import SlotCode
 from ._base import BaseLock
@@ -194,24 +193,32 @@ class Zigbee2MQTTLock(BaseLock):
                     )
                     continue
 
-                if isinstance(user_info, dict):
-                    status = user_info.get("status")
-                    pin_code_present = "pin_code" in user_info
-                    pin_raw = user_info.get("pin_code")
+                if not isinstance(user_info, dict):
+                    LOGGER.debug(
+                        "Skipping unexpected user_info type %s for slot %s on %s",
+                        type(user_info).__name__,
+                        user_id_str,
+                        self.lock.entity_id,
+                    )
+                    continue
 
-                    # Zigbee2MQTT often omits pin_code when expose_pin is false (default on
-                    # several Yale models). Treating that as EMPTY makes the coordinator think
-                    # the slot is cleared, so disabling the slot skips clear_usercode while the
-                    # lock still holds the PIN. Only treat as EMPTY when MQTT exposes the field.
-                    if status == "enabled":
-                        if _mqtt_payload_pin_has_code_value(pin_raw):
-                            updates[user_id] = str(pin_raw)
-                        elif pin_code_present:
-                            updates[user_id] = SlotCode.EMPTY
-                        else:
-                            continue
-                    else:
+                status = user_info.get("status")
+                pin_code_present = "pin_code" in user_info
+                pin_raw = user_info.get("pin_code")
+
+                # Zigbee2MQTT often omits pin_code when expose_pin is false (default on
+                # several Yale models). Treating that as EMPTY makes the coordinator think
+                # the slot is cleared, so disabling the slot skips clear_usercode while the
+                # lock still holds the PIN. Only treat as EMPTY when MQTT exposes the field.
+                if status == "enabled":
+                    if _mqtt_payload_pin_has_code_value(pin_raw):
+                        updates[user_id] = str(pin_raw)
+                    elif pin_code_present:
                         updates[user_id] = SlotCode.EMPTY
+                    else:
+                        continue
+                else:
+                    updates[user_id] = SlotCode.EMPTY
 
             if updates and self.coordinator:
                 LOGGER.debug(
@@ -225,25 +232,31 @@ class Zigbee2MQTTLock(BaseLock):
         pin_code_data = payload.get("pin_code")
         if pin_code_data and isinstance(pin_code_data, dict):
             user_id = pin_code_data.get("user")
-            if user_id is not None:
-                try:
-                    user_id = int(user_id)
-                except (ValueError, TypeError):
-                    LOGGER.warning(
-                        "Ignoring pin_code payload with non-numeric user for %s",
-                        self.lock.entity_id,
-                    )
-                    return
+            if user_id is None:
+                LOGGER.debug(
+                    "Ignoring pin_code payload without user field for %s",
+                    self.lock.entity_id,
+                )
+                return
 
-                if user_id in self._pending_codes:
-                    future = self._pending_codes.pop(user_id)
-                    if not future.done():
-                        user_enabled = pin_code_data.get("user_enabled", False)
-                        pin_code = pin_code_data.get("pin_code")
-                        if user_enabled and _mqtt_payload_pin_has_code_value(pin_code):
-                            future.set_result(str(pin_code))
-                        else:
-                            future.set_result(None)
+            try:
+                user_id = int(user_id)
+            except (ValueError, TypeError):
+                LOGGER.warning(
+                    "Ignoring pin_code payload with non-numeric user for %s",
+                    self.lock.entity_id,
+                )
+                return
+
+            if user_id in self._pending_codes:
+                future = self._pending_codes.pop(user_id)
+                if not future.done():
+                    user_enabled = pin_code_data.get("user_enabled", False)
+                    pin_code = pin_code_data.get("pin_code")
+                    if user_enabled and _mqtt_payload_pin_has_code_value(pin_code):
+                        future.set_result(str(pin_code))
+                    else:
+                        future.set_result(None)
 
     async def _async_ensure_device_subscription(self) -> None:
         """Subscribe to the Z2M device topic; idempotent."""
@@ -370,7 +383,7 @@ class Zigbee2MQTTLock(BaseLock):
             raise LockDisconnected("Could not determine MQTT topic")
 
         # Get configured code slots for this lock (any LCM entry that includes this lock).
-        code_slots = get_managed_slots(self.hass, self.lock.entity_id)
+        code_slots = self._get_managed_slots()
 
         if not code_slots:
             return {}
@@ -411,8 +424,8 @@ class Zigbee2MQTTLock(BaseLock):
                 )
                 data[slot_num] = SlotCode.UNREADABLE_CODE
             except Exception as err:
-                LOGGER.debug(
-                    "Failed to get PIN for %s slot %s: %s",
+                LOGGER.warning(
+                    "Unexpected error getting PIN for %s slot %s: %s",
                     self.lock.entity_id,
                     slot_num,
                     err,

--- a/custom_components/lock_code_manager/providers/zwave_js.py
+++ b/custom_components/lock_code_manager/providers/zwave_js.py
@@ -53,7 +53,6 @@ from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import ATTR_DEVICE_ID, ATTR_ENTITY_ID
 from homeassistant.core import Event, callback
 
-from ..data import get_managed_slots
 from ..exceptions import LockDisconnected
 from ..models import SlotCode
 from ._base import BaseLock
@@ -121,11 +120,6 @@ class ZWaveJSLock(BaseLock):
     @property
     def supports_push(self) -> bool:
         """Return whether this lock supports push-based updates."""
-        return True
-
-    @property
-    def supports_code_slot_events(self) -> bool:
-        """Return whether this lock supports code slot events."""
         return True
 
     @property
@@ -354,15 +348,18 @@ class ZWaveJSLock(BaseLock):
         """Return integration domain."""
         return ZWAVE_JS_DOMAIN
 
+    def _clear_listeners(self) -> None:
+        """Unsubscribe and clear all HA event bus listeners."""
+        for listener in self._listeners:
+            listener()
+        self._listeners.clear()
+
     async def async_setup(self, config_entry: ConfigEntry) -> None:
         """Set up lock by provider.
 
         Idempotent: clears existing listeners before re-registering.
         """
-        listeners = list(self._listeners)
-        self._listeners.clear()
-        for listener in listeners:
-            listener()
+        self._clear_listeners()
         self._listeners.append(
             self.hass.bus.async_listen(
                 ZWAVE_JS_NOTIFICATION_EVENT,
@@ -373,10 +370,7 @@ class ZWaveJSLock(BaseLock):
 
     async def async_unload(self, remove_permanently: bool) -> None:
         """Unload lock."""
-        listeners = list(self._listeners)
-        self._listeners.clear()
-        for listener in listeners:
-            listener()
+        self._clear_listeners()
         await super().async_unload(remove_permanently)
 
     async def async_is_integration_connected(self) -> bool:
@@ -523,7 +517,7 @@ class ZWaveJSLock(BaseLock):
 
     async def async_get_usercodes(self) -> dict[int, str | SlotCode]:
         """Get dictionary of code slots and usercodes."""
-        code_slots = get_managed_slots(self.hass, self.lock.entity_id)
+        code_slots = self._get_managed_slots()
         data: dict[int, str | SlotCode] = {}
 
         if not await self.async_is_integration_connected():

--- a/custom_components/lock_code_manager/providers/zwave_js.py
+++ b/custom_components/lock_code_manager/providers/zwave_js.py
@@ -517,7 +517,7 @@ class ZWaveJSLock(BaseLock):
 
     async def async_get_usercodes(self) -> dict[int, str | SlotCode]:
         """Get dictionary of code slots and usercodes."""
-        code_slots = self._get_managed_slots()
+        code_slots = self.managed_slots
         data: dict[int, str | SlotCode] = {}
 
         if not await self.async_is_integration_connected():

--- a/tests/providers/helpers.py
+++ b/tests/providers/helpers.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from homeassistant.config_entries import ConfigEntryState
@@ -25,6 +26,7 @@ from homeassistant.core import HomeAssistant, SupportsResponse
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
+from custom_components.lock_code_manager.exceptions import LockCodeManagerError
 from custom_components.lock_code_manager.providers import BaseLock
 
 
@@ -81,7 +83,7 @@ class ServiceProviderConnectionTests:
         provider_domain: str,
         provider_lock_class: type[BaseLock],
     ) -> None:
-        """Test integration not connected when lock has no config entry."""
+        """Test integration raises when lock has no config entry."""
         entity_reg = er.async_get(hass)
         lock_entity = entity_reg.async_get_or_create(
             "lock",
@@ -96,7 +98,8 @@ class ServiceProviderConnectionTests:
             None,
             lock_entity,
         )
-        assert await lock.async_is_integration_connected() is False
+        with pytest.raises(LockCodeManagerError):
+            await lock.async_is_integration_connected()
 
 
 class ServiceProviderDeviceAvailabilityTests:

--- a/tests/providers/matter/test_matter.py
+++ b/tests/providers/matter/test_matter.py
@@ -1123,28 +1123,6 @@ class TestLockUserChangeEvent:
 
         mock_coordinator.push_update.assert_not_called()
 
-    def test_coordinator_data_none_no_push(
-        self, matter_lock_simple: MatterLock
-    ) -> None:
-        """LockUserChange skips push when coordinator.data is None."""
-        mock_coordinator = MagicMock()
-        mock_coordinator.data = None
-        matter_lock_simple.coordinator = mock_coordinator
-
-        matter_lock_simple._on_node_event(
-            None,
-            _make_node_event(
-                event_id=4,
-                data={
-                    "lockDataType": 6,  # PIN
-                    "dataOperationType": 0,  # Add
-                    "dataIndex": 1,
-                },
-            ),
-        )
-
-        mock_coordinator.push_update.assert_not_called()
-
     def test_unknown_operation_type_ignored(
         self, matter_lock_simple: MatterLock
     ) -> None:
@@ -1349,26 +1327,4 @@ class TestOptimisticPushUpdates:
         with pytest.raises(LockDisconnected):
             await matter_lock_simple.async_clear_usercode(5)
 
-        mock_coordinator.push_update.assert_not_called()
-
-    async def test_set_usercode_coordinator_data_none_no_push(
-        self,
-        hass: HomeAssistant,
-        matter_lock_simple: MatterLock,
-    ) -> None:
-        """async_set_usercode skips push when coordinator.data is None."""
-        mock_coordinator = MagicMock()
-        mock_coordinator.data = None
-        matter_lock_simple.coordinator = mock_coordinator
-
-        register_mock_service(
-            hass,
-            MATTER_DOMAIN,
-            "set_lock_credential",
-            AsyncMock(return_value={LOCK_ENTITY_ID: {}}),
-        )
-
-        result = await matter_lock_simple.async_set_usercode(3, "1234")
-
-        assert result is True
         mock_coordinator.push_update.assert_not_called()

--- a/tests/providers/test_zigbee2mqtt.py
+++ b/tests/providers/test_zigbee2mqtt.py
@@ -469,7 +469,7 @@ class TestAsyncGetUsercodes:
                 return_value=True,
             ),
             patch(
-                "custom_components.lock_code_manager.providers._base.BaseLock._get_managed_slots",
+                "custom_components.lock_code_manager.providers._base.get_managed_slots",
                 return_value=managed,
             ),
             patch(
@@ -517,7 +517,7 @@ class TestAsyncGetUsercodes:
                 return_value=True,
             ),
             patch(
-                "custom_components.lock_code_manager.providers._base.BaseLock._get_managed_slots",
+                "custom_components.lock_code_manager.providers._base.get_managed_slots",
                 return_value={3},
             ),
             patch(
@@ -552,7 +552,7 @@ class TestAsyncGetUsercodes:
                 return_value=True,
             ),
             patch(
-                "custom_components.lock_code_manager.providers._base.BaseLock._get_managed_slots",
+                "custom_components.lock_code_manager.providers._base.get_managed_slots",
                 return_value={11},
             ),
             patch(
@@ -586,7 +586,7 @@ class TestAsyncGetUsercodes:
                 return_value=True,
             ),
             patch(
-                "custom_components.lock_code_manager.providers._base.BaseLock._get_managed_slots",
+                "custom_components.lock_code_manager.providers._base.get_managed_slots",
                 return_value={7},
             ),
             patch(
@@ -634,7 +634,7 @@ class TestAsyncGetUsercodes:
                 return_value=True,
             ),
             patch(
-                "custom_components.lock_code_manager.providers._base.BaseLock._get_managed_slots",
+                "custom_components.lock_code_manager.providers._base.get_managed_slots",
                 return_value={1},
             ),
             pytest.raises(LockDisconnected, match="not a Zigbee2MQTT lock"),
@@ -694,7 +694,7 @@ class TestAsyncSetClearHardRefresh:
                 return_value=True,
             ),
             patch(
-                "custom_components.lock_code_manager.providers._base.BaseLock._get_managed_slots",
+                "custom_components.lock_code_manager.providers._base.get_managed_slots",
                 return_value=set(),
             ),
             patch(
@@ -1035,7 +1035,7 @@ class TestAsyncSetClearHardRefresh:
                 return_value=True,
             ),
             patch(
-                "custom_components.lock_code_manager.providers._base.BaseLock._get_managed_slots",
+                "custom_components.lock_code_manager.providers._base.get_managed_slots",
                 return_value={12},
             ),
             patch(
@@ -1066,7 +1066,7 @@ class TestAsyncSetClearHardRefresh:
                 return_value=True,
             ),
             patch(
-                "custom_components.lock_code_manager.providers._base.BaseLock._get_managed_slots",
+                "custom_components.lock_code_manager.providers._base.get_managed_slots",
                 return_value={21},
             ),
             patch(

--- a/tests/providers/test_zigbee2mqtt.py
+++ b/tests/providers/test_zigbee2mqtt.py
@@ -469,7 +469,7 @@ class TestAsyncGetUsercodes:
                 return_value=True,
             ),
             patch(
-                "custom_components.lock_code_manager.providers.zigbee2mqtt.get_managed_slots",
+                "custom_components.lock_code_manager.providers._base.BaseLock._get_managed_slots",
                 return_value=managed,
             ),
             patch(
@@ -517,7 +517,7 @@ class TestAsyncGetUsercodes:
                 return_value=True,
             ),
             patch(
-                "custom_components.lock_code_manager.providers.zigbee2mqtt.get_managed_slots",
+                "custom_components.lock_code_manager.providers._base.BaseLock._get_managed_slots",
                 return_value={3},
             ),
             patch(
@@ -552,7 +552,7 @@ class TestAsyncGetUsercodes:
                 return_value=True,
             ),
             patch(
-                "custom_components.lock_code_manager.providers.zigbee2mqtt.get_managed_slots",
+                "custom_components.lock_code_manager.providers._base.BaseLock._get_managed_slots",
                 return_value={11},
             ),
             patch(
@@ -586,7 +586,7 @@ class TestAsyncGetUsercodes:
                 return_value=True,
             ),
             patch(
-                "custom_components.lock_code_manager.providers.zigbee2mqtt.get_managed_slots",
+                "custom_components.lock_code_manager.providers._base.BaseLock._get_managed_slots",
                 return_value={7},
             ),
             patch(
@@ -634,7 +634,7 @@ class TestAsyncGetUsercodes:
                 return_value=True,
             ),
             patch(
-                "custom_components.lock_code_manager.providers.zigbee2mqtt.get_managed_slots",
+                "custom_components.lock_code_manager.providers._base.BaseLock._get_managed_slots",
                 return_value={1},
             ),
             pytest.raises(LockDisconnected, match="not a Zigbee2MQTT lock"),
@@ -694,7 +694,7 @@ class TestAsyncSetClearHardRefresh:
                 return_value=True,
             ),
             patch(
-                "custom_components.lock_code_manager.providers.zigbee2mqtt.get_managed_slots",
+                "custom_components.lock_code_manager.providers._base.BaseLock._get_managed_slots",
                 return_value=set(),
             ),
             patch(
@@ -1035,7 +1035,7 @@ class TestAsyncSetClearHardRefresh:
                 return_value=True,
             ),
             patch(
-                "custom_components.lock_code_manager.providers.zigbee2mqtt.get_managed_slots",
+                "custom_components.lock_code_manager.providers._base.BaseLock._get_managed_slots",
                 return_value={12},
             ),
             patch(
@@ -1066,7 +1066,7 @@ class TestAsyncSetClearHardRefresh:
                 return_value=True,
             ),
             patch(
-                "custom_components.lock_code_manager.providers.zigbee2mqtt.get_managed_slots",
+                "custom_components.lock_code_manager.providers._base.BaseLock._get_managed_slots",
                 return_value={21},
             ),
             patch(

--- a/tests/providers/virtual/conftest.py
+++ b/tests/providers/virtual/conftest.py
@@ -37,7 +37,7 @@ async def virtual_lock(hass: HomeAssistant) -> VirtualLock:
         hass,
         dr.async_get(hass),
         entity_reg,
-        config_entry,
+        None,
         lock_entity,
     )
     await lock.async_setup_internal(config_entry)
@@ -73,7 +73,7 @@ async def virtual_lock_with_slots(hass: HomeAssistant) -> VirtualLock:
         hass,
         dr.async_get(hass),
         entity_reg,
-        config_entry,
+        None,
         lock_entity,
     )
     await lock.async_setup_internal(config_entry)

--- a/tests/providers/virtual/test_virtual.py
+++ b/tests/providers/virtual/test_virtual.py
@@ -26,7 +26,7 @@ async def test_door_lock(virtual_lock: VirtualLock):
     assert lock._data["1"] == {"code": "1111", "name": "test"}
 
     # if we unload without removing permanently, the data should be saved
-    config_entry = lock.lock_config_entry
+    config_entry = lock._lcm_config_entry
     assert await lock.async_unload(False) is None
     assert await lock.async_setup_internal(config_entry) is None
     assert lock._data["1"] == {"code": "1111", "name": "test"}


### PR DESCRIPTION
## Proposed change

Cleans up provider abstractions — removes duplicated patterns, fixes inconsistencies, consolidates shared logic into the base class, and applies the same patterns to the new Zigbee2MQTT provider.

**Changes:**
- **`_get_managed_slots()` on BaseLock** — all 6 providers now use `self._get_managed_slots()` instead of importing and calling the module-level function. Underscore prefix avoids namespace collision with `data.get_managed_slots()`.
- **Schlage/Akuvox use `self.async_call_service()`** — removed manual `hass.services.async_call()` + error wrapping that duplicated what the base class already provides
- **`async_is_integration_connected` raises for None lock_config_entry** — a missing config entry is a programming error (provider must override), not a transient state. `LockCodeManagerError` is raised with a descriptive message.
- **`unsubscribe_push_updates` catches `ProviderNotImplementedError`** — matches the symmetric behavior of `subscribe_push_updates`
- **Removed redundant `supports_code_slot_events = True` overrides** — ZWaveJS and Matter were overriding to return the same value as the base default
- **Standardized optimistic push_update guard** — Matter had an unnecessary `coordinator.data is not None` check (data is always `{}`, never None)
- **ZWaveJS `_clear_listeners()` helper** — extracted to avoid duplicated copy-clear-iterate pattern in `async_setup` and `async_unload`
- **Zigbee2MQTT provider cleanup** — uses `self._get_managed_slots()`, adds logging for silently skipped non-dict user entries and pin_code responses without user field, elevates broad `except Exception` log in `async_get_usercodes` from debug to warning

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue:
- This PR is related to issue: