### PR TITLE
feat: add code slot events to Zigbee2MQTT provider

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -30,14 +30,6 @@
 **Cannot support:** esphome (no API), august/yale/yalexs_ble/yale_smart_alarm
 (library limitations)
 
-### Zigbee2MQTT provider
-
-- **Code slot events** — Map Z2M lock/unlock actions with user identifiers to
-  `async_fire_code_slot_event()`. Currently `supports_code_slot_events = False`.
-- **Narrow broad `except Exception` in `async_get_usercodes`** — The wait_for
-  catch after TimeoutError catches all exceptions. Consider narrowing or
-  documenting why it must remain broad.
-
 ### Matter provider
 
 - **Direct Matter client commands** — Replace HA service calls

--- a/custom_components/lock_code_manager/providers/zigbee2mqtt.py
+++ b/custom_components/lock_code_manager/providers/zigbee2mqtt.py
@@ -28,6 +28,27 @@ from .const import LOGGER
 # Default Zigbee2MQTT base topic
 DEFAULT_BASE_TOPIC = "zigbee2mqtt"
 
+# Zigbee2MQTT action values for lock/unlock events triggered by PIN entry.
+# These come from the DoorLock cluster's OperatingEventNotification and
+# ProgrammingEventNotification via zigbee-herdsman-converters.
+_Z2M_LOCK_ACTIONS_LOCKED = frozenset(
+    {
+        "lock",
+        "keypad_lock",
+        "manual_lock",
+        "rf_lock",
+    }
+)
+_Z2M_LOCK_ACTIONS_UNLOCKED = frozenset(
+    {
+        "unlock",
+        "keypad_unlock",
+        "manual_unlock",
+        "rf_unlock",
+    }
+)
+_Z2M_LOCK_ACTIONS = _Z2M_LOCK_ACTIONS_LOCKED | _Z2M_LOCK_ACTIONS_UNLOCKED
+
 
 def _mqtt_payload_pin_has_code_value(pin_raw: Any) -> bool:
     """Return True when MQTT exposes a usable PIN value (including numeric zero).
@@ -67,8 +88,8 @@ class Zigbee2MQTTLock(BaseLock):
 
     @property
     def supports_code_slot_events(self) -> bool:
-        """Return False until Z2M lock/unlock actions map to ``async_fire_code_slot_event``."""
-        return False
+        """Return whether this lock supports code slot events."""
+        return True
 
     @property
     def usercode_scan_interval(self) -> timedelta:
@@ -162,14 +183,39 @@ class Zigbee2MQTTLock(BaseLock):
     @callback
     def _process_z2m_device_payload(self, payload: dict[str, Any]) -> None:
         """Apply device-topic JSON on the Home Assistant event loop."""
+        action = payload.get("action")
+
+        # Handle lock/unlock actions with user identification (keypad PIN usage)
+        if action in _Z2M_LOCK_ACTIONS:
+            action_user = payload.get("action_user")
+            if action_user is not None:
+                try:
+                    code_slot = int(action_user)
+                except (ValueError, TypeError):
+                    LOGGER.debug(
+                        "Ignoring %s with non-numeric action_user %r for %s",
+                        action,
+                        action_user,
+                        self.lock.entity_id,
+                    )
+                    return
+                to_locked = action in _Z2M_LOCK_ACTIONS_LOCKED
+                self.async_fire_code_slot_event(
+                    code_slot=code_slot,
+                    to_locked=to_locked,
+                    action_text=action,
+                    source_data=payload,
+                )
+            return
+
         # Handle pin_code added / deleted (Z2M action events, not the users object)
-        if payload.get("action") in ("pin_code_added", "pin_code_deleted"):
+        if action in ("pin_code_added", "pin_code_deleted"):
             action_user = payload.get("action_user")
             if action_user is not None:
                 LOGGER.debug(
                     "Lock %s received %s for user %s",
                     self.lock.entity_id,
-                    payload.get("action"),
+                    action,
                     action_user,
                 )
                 if self.coordinator:
@@ -423,7 +469,11 @@ class Zigbee2MQTTLock(BaseLock):
                     slot_num,
                 )
                 data[slot_num] = SlotCode.UNREADABLE_CODE
-            except Exception as err:
+            except Exception as err:  # noqa: BLE001
+                # Broad catch is intentional: the future is resolved by the MQTT
+                # callback, and any exception from resolution (InvalidStateError,
+                # data processing errors) should not crash the entire refresh.
+                # CancelledError is BaseException in Python 3.9+ and propagates.
                 LOGGER.warning(
                     "Unexpected error getting PIN for %s slot %s: %s",
                     self.lock.entity_id,

--- a/tests/providers/zigbee2mqtt/test_payload.py
+++ b/tests/providers/zigbee2mqtt/test_payload.py
@@ -142,3 +142,84 @@ async def test_mqtt_payload_invalid_json_ignored(
         await hass.async_block_till_done()
 
     lock.coordinator.push_update.assert_not_called()
+
+
+def test_keypad_unlock_action_fires_code_slot_event() -> None:
+    """keypad_unlock with action_user fires async_fire_code_slot_event."""
+    lock = _minimal_lock()
+    lock.coordinator = MagicMock()
+    lock.async_fire_code_slot_event = MagicMock()
+
+    lock._process_z2m_device_payload({"action": "keypad_unlock", "action_user": 3})
+
+    lock.async_fire_code_slot_event.assert_called_once_with(
+        code_slot=3,
+        to_locked=False,
+        action_text="keypad_unlock",
+        source_data={"action": "keypad_unlock", "action_user": 3},
+    )
+
+
+def test_keypad_lock_action_fires_code_slot_event() -> None:
+    """keypad_lock with action_user fires event with to_locked=True."""
+    lock = _minimal_lock()
+    lock.coordinator = MagicMock()
+    lock.async_fire_code_slot_event = MagicMock()
+
+    lock._process_z2m_device_payload({"action": "keypad_lock", "action_user": 1})
+
+    lock.async_fire_code_slot_event.assert_called_once_with(
+        code_slot=1,
+        to_locked=True,
+        action_text="keypad_lock",
+        source_data={"action": "keypad_lock", "action_user": 1},
+    )
+
+
+def test_lock_action_without_action_user_does_not_fire_event() -> None:
+    """Lock action without action_user is ignored (manual key turn, no PIN)."""
+    lock = _minimal_lock()
+    lock.coordinator = MagicMock()
+    lock.async_fire_code_slot_event = MagicMock()
+
+    lock._process_z2m_device_payload({"action": "manual_lock"})
+
+    lock.async_fire_code_slot_event.assert_not_called()
+
+
+def test_lock_action_with_non_numeric_user_is_ignored() -> None:
+    """Lock action with non-numeric action_user is ignored."""
+    lock = _minimal_lock()
+    lock.coordinator = MagicMock()
+    lock.async_fire_code_slot_event = MagicMock()
+
+    lock._process_z2m_device_payload({"action": "keypad_unlock", "action_user": "bad"})
+
+    lock.async_fire_code_slot_event.assert_not_called()
+
+
+def test_rf_unlock_action_fires_event() -> None:
+    """rf_unlock with action_user fires event."""
+    lock = _minimal_lock()
+    lock.coordinator = MagicMock()
+    lock.async_fire_code_slot_event = MagicMock()
+
+    lock._process_z2m_device_payload({"action": "rf_unlock", "action_user": 5})
+
+    lock.async_fire_code_slot_event.assert_called_once_with(
+        code_slot=5,
+        to_locked=False,
+        action_text="rf_unlock",
+        source_data={"action": "rf_unlock", "action_user": 5},
+    )
+
+
+def test_unknown_action_does_not_fire_event() -> None:
+    """An unrecognized action value is ignored entirely."""
+    lock = _minimal_lock()
+    lock.coordinator = MagicMock()
+    lock.async_fire_code_slot_event = MagicMock()
+
+    lock._process_z2m_device_payload({"action": "something_else", "action_user": 1})
+
+    lock.async_fire_code_slot_event.assert_not_called()


### PR DESCRIPTION
## Proposed change

Implements the two remaining Zigbee2MQTT provider TODOs:

**Code slot events:** Maps Z2M lock/unlock actions with user identification to `async_fire_code_slot_event()`. Handles all DoorLock cluster action types:
- `keypad_lock` / `keypad_unlock` — PIN pad used
- `rf_lock` / `rf_unlock` — remote command with user ID
- `manual_lock` / `manual_unlock` — physical key/thumb turn with user ID
- `lock` / `unlock` — generic lock/unlock with user ID

Actions without `action_user` are ignored (e.g., manual key turn with no PIN identification). Non-numeric `action_user` values are logged and ignored.

`supports_code_slot_events` changed from `False` to `True`.

**Broad except documentation:** Added a `noqa: BLE001` comment explaining why the `except Exception` in `async_get_usercodes` is intentional (future is resolved by MQTT callback, `CancelledError` is `BaseException` in Python 3.9+ and propagates naturally).

6 new tests in `test_payload.py` covering all action types and edge cases.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue:
- This PR is related to issue: #1063