### PR TITLE
refactor: migrate Matter provider to direct lock_helpers, fix credential key bug, upgrade to Python 3.14

### DIFF
--- a/.github/workflows/python-checks.yml
+++ b/.github/workflows/python-checks.yml
@@ -8,9 +8,9 @@ on:
 
 env:
   # Target Python version for coverage and static analysis
-  TARGET_PYTHON: "3.13"
+  TARGET_PYTHON: "3.14"
   # Additional Python versions to test (JSON array, can be empty: '[]')
-  OTHER_PYTHON_VERSIONS: '["3.14"]'
+  OTHER_PYTHON_VERSIONS: '["3.15"]'
 
 jobs:
   setup:

--- a/.github/workflows/python-checks.yml
+++ b/.github/workflows/python-checks.yml
@@ -10,7 +10,8 @@ env:
   # Target Python version for coverage and static analysis
   TARGET_PYTHON: "3.14"
   # Additional Python versions to test (JSON array, can be empty: '[]')
-  OTHER_PYTHON_VERSIONS: '["3.15"]'
+  # Python 3.15 blocked on pyo3-ffi support (Rust Python bindings)
+  OTHER_PYTHON_VERSIONS: '[]'
 
 jobs:
   setup:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,7 +216,7 @@ See `TODO.md` for implementation details.
 scripts/setup
 ```
 
-Creates Python 3.13 venv, installs dependencies with uv, sets up git hooks
+Creates Python 3.14 venv, installs dependencies with uv, sets up git hooks
 (preferring `prek` with fallback to uv-managed `pre-commit`), and installs
 Node dependencies.
 

--- a/custom_components/lock_code_manager/providers/matter.py
+++ b/custom_components/lock_code_manager/providers/matter.py
@@ -1,6 +1,6 @@
 """Matter lock provider.
 
-Handles PIN credential management via Matter lock services.
+Handles PIN credential management via Matter lock helpers.
 PINs are write-only: occupied slots report SlotCode.UNREADABLE_CODE, cleared slots report
 SlotCode.EMPTY. Subscribes to DoorLock cluster events via the push framework for
 code slot tracking (LockOperation) and occupancy updates (LockUserChange).
@@ -19,11 +19,21 @@ from homeassistant.components.matter.helpers import (
     get_matter,
     get_node_from_device_entry,
 )
+from homeassistant.components.matter.lock_helpers import (
+    SetCredentialFailedError,
+    clear_lock_credential,
+    get_lock_credential_status,
+    get_lock_info,
+    get_lock_users,
+    set_lock_credential,
+    set_lock_user,
+)
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import SupportsResponse, callback
+from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 
 from ..exceptions import (
+    CodeRejectedError,
     DuplicateCodeError,
     LockCodeManagerProviderError,
     LockDisconnected,
@@ -31,22 +41,6 @@ from ..exceptions import (
 from ..models import SlotCode
 from ._base import BaseLock
 from .const import LOGGER
-
-MATTER_DOMAIN = "matter"
-
-
-def _is_duplicate_error(err: Exception) -> bool:
-    """Check whether a Matter service error indicates a duplicate credential.
-
-    Inspects the original cause's translation_placeholders for a typed status
-    check (HA 2026.3+), falling back to string matching for older versions.
-    """
-    cause = err.__cause__ or err
-    placeholders = getattr(cause, "translation_placeholders", None)
-    if isinstance(placeholders, dict) and placeholders.get("status") == "duplicate":
-        return True
-    return "duplicate" in str(err).lower()
-
 
 # DoorLock cluster ID (0x0101 = 257)
 _DOOR_LOCK_CLUSTER_ID = 257
@@ -75,7 +69,7 @@ class MatterLock(BaseLock):
     @property
     def domain(self) -> str:
         """Return integration domain."""
-        return MATTER_DOMAIN
+        return "matter"
 
     @property
     def supports_push(self) -> bool:
@@ -139,63 +133,29 @@ class MatterLock(BaseLock):
             )
             return None
 
-    async def _async_call_service(
-        self,
-        service: str,
-        service_data: dict[str, Any],
-    ) -> dict[str, Any]:
-        """Call a Matter service and return the per-entity dict.
-
-        Auto-detects whether the service supports responses. Void services
-        (SupportsResponse.NONE) are called without return_response and return
-        an empty dict. Services that support responses are validated for the
-        expected per-entity structure.
-
-        Raises LockDisconnected on service failure or
-        LockCodeManagerProviderError on malformed response.
-        """
-        entity_id = self.lock.entity_id
-        resp_support = self.hass.services.supports_response(MATTER_DOMAIN, service)
-        return_response = resp_support != SupportsResponse.NONE
-        try:
-            result = await self.hass.services.async_call(
-                MATTER_DOMAIN,
-                service,
-                service_data,
-                blocking=True,
-                return_response=return_response,
-            )
-        except ServiceValidationError as err:
-            raise LockCodeManagerProviderError(
-                f"Matter service {MATTER_DOMAIN}.{service} rejected input for "
-                f"{entity_id}: {err}"
-            ) from err
-        except HomeAssistantError as err:
+    def _require_client_and_node(self) -> tuple[Any, Any]:
+        """Get client and node, raising LockDisconnected if unavailable."""
+        client = self._get_matter_client()
+        node = self._get_matter_node()
+        if not client or not node:
             raise LockDisconnected(
-                f"Matter service {MATTER_DOMAIN}.{service} failed for "
-                f"{entity_id}: {err}"
-            ) from err
-        if not return_response:
-            return {}
-        if not isinstance(result, dict) or entity_id not in result:
-            raise LockCodeManagerProviderError(
-                f"Matter service {MATTER_DOMAIN}.{service} returned no data for "
-                f"{entity_id}"
+                f"Matter client or node unavailable for {self.lock.entity_id}"
             )
-        entity_data = result[entity_id]
-        if not isinstance(entity_data, dict):
-            raise LockCodeManagerProviderError(
-                f"Matter service {MATTER_DOMAIN}.{service} returned non-dict data "
-                f"for {entity_id}: {type(entity_data).__name__}"
-            )
-        return entity_data
+        return client, node
 
     async def async_setup(self, config_entry: ConfigEntry) -> None:
         """Validate the lock supports Matter user management."""
-        lock_info = await self._async_call_service(
-            "get_lock_info",
-            {"entity_id": self.lock.entity_id},
-        )
+        client, node = self._require_client_and_node()
+        try:
+            lock_info = await get_lock_info(client, node)
+        except ServiceValidationError as err:
+            raise LockCodeManagerProviderError(
+                f"Matter get_lock_info rejected input for {self.lock.entity_id}: {err}"
+            ) from err
+        except HomeAssistantError as err:
+            raise LockDisconnected(
+                f"Matter get_lock_info failed for {self.lock.entity_id}: {err}"
+            ) from err
         if not lock_info.get("supports_user_management"):
             raise LockCodeManagerProviderError(
                 f"Matter lock {self.lock.entity_id} does not support user management"
@@ -213,11 +173,9 @@ class MatterLock(BaseLock):
     async def async_is_device_available(self) -> bool:
         """Return whether the Matter lock device is available for commands."""
         try:
-            await self._async_call_service(
-                "get_lock_info",
-                {"entity_id": self.lock.entity_id},
-            )
-        except LockCodeManagerProviderError as err:
+            client, node = self._require_client_and_node()
+            await get_lock_info(client, node)
+        except (LockCodeManagerProviderError, HomeAssistantError) as err:
             LOGGER.debug(
                 "Lock %s: availability check failed: %s",
                 self.lock.entity_id,
@@ -399,28 +357,57 @@ class MatterLock(BaseLock):
     # -- Credential helpers --------------------------------------------------
 
     async def _set_lock_credential(self, code_slot: int, usercode: str) -> int | None:
-        """Send set_lock_credential to the lock and return the user_index."""
-        result = await self._async_call_service(
-            "set_lock_credential",
-            {
-                "entity_id": self.lock.entity_id,
-                "credential_type": "pin",
-                "credential_data": usercode,
-                "credential_index": code_slot,
-            },
-        )
+        """Send set_lock_credential to the lock and return the user_index.
+
+        Raises SetCredentialFailedError on lock rejection,
+        LockCodeManagerProviderError on invalid input,
+        LockDisconnected on communication failure.
+        """
+        client, node = self._require_client_and_node()
+        try:
+            result = await set_lock_credential(
+                client,
+                node,
+                credential_type="pin",
+                credential_data=usercode,
+                credential_index=code_slot,
+            )
+        except SetCredentialFailedError:
+            raise
+        except ServiceValidationError as err:
+            raise LockCodeManagerProviderError(
+                f"Matter set_lock_credential rejected input for "
+                f"{self.lock.entity_id}: {err}"
+            ) from err
+        except HomeAssistantError as err:
+            raise LockDisconnected(
+                f"Matter set_lock_credential failed for {self.lock.entity_id}: {err}"
+            ) from err
         return result.get("user_index")
 
     async def _clear_lock_credential(self, code_slot: int) -> None:
-        """Send clear_lock_credential to the lock."""
-        await self._async_call_service(
-            "clear_lock_credential",
-            {
-                "entity_id": self.lock.entity_id,
-                "credential_type": "pin",
-                "credential_index": code_slot,
-            },
-        )
+        """Send clear_lock_credential to the lock.
+
+        Raises LockCodeManagerProviderError on invalid input,
+        LockDisconnected on communication failure.
+        """
+        client, node = self._require_client_and_node()
+        try:
+            await clear_lock_credential(
+                client,
+                node,
+                credential_type="pin",
+                credential_index=code_slot,
+            )
+        except ServiceValidationError as err:
+            raise LockCodeManagerProviderError(
+                f"Matter clear_lock_credential rejected input for "
+                f"{self.lock.entity_id}: {err}"
+            ) from err
+        except HomeAssistantError as err:
+            raise LockDisconnected(
+                f"Matter clear_lock_credential failed for {self.lock.entity_id}: {err}"
+            ) from err
 
     # -- Usercode CRUD -------------------------------------------------------
 
@@ -433,11 +420,19 @@ class MatterLock(BaseLock):
         step can detect codes not managed by Lock Code Manager.
         """
         managed_slots = self.managed_slots
+        client, node = self._require_client_and_node()
 
-        lock_data = await self._async_call_service(
-            "get_lock_users",
-            {"entity_id": self.lock.entity_id},
-        )
+        try:
+            lock_data = await get_lock_users(client, node)
+        except ServiceValidationError as err:
+            raise LockCodeManagerProviderError(
+                f"Matter get_lock_users rejected input for {self.lock.entity_id}: {err}"
+            ) from err
+        except HomeAssistantError as err:
+            raise LockDisconnected(
+                f"Matter get_lock_users failed for {self.lock.entity_id}: {err}"
+            ) from err
+
         users = lock_data.get("users")
         if not isinstance(users, list):
             raise LockCodeManagerProviderError(
@@ -493,9 +488,14 @@ class MatterLock(BaseLock):
         """
         try:
             return await self._set_lock_credential(code_slot, usercode)
-        except LockDisconnected as err:
-            if not _is_duplicate_error(err):
-                raise
+        except SetCredentialFailedError as err:
+            status = (err.translation_placeholders or {}).get("status", "")
+            if status != "duplicate":
+                raise CodeRejectedError(
+                    code_slot=code_slot,
+                    lock_entity_id=self.lock.entity_id,
+                    reason=str(err),
+                ) from err
             if source != "sync":
                 raise DuplicateCodeError(
                     code_slot=code_slot,
@@ -512,26 +512,30 @@ class MatterLock(BaseLock):
 
         try:
             return await self._set_lock_credential(code_slot, usercode)
-        except LockDisconnected as retry_err:
-            if _is_duplicate_error(retry_err):
+        except SetCredentialFailedError as retry_err:
+            status = (retry_err.translation_placeholders or {}).get("status", "")
+            if status == "duplicate":
                 raise DuplicateCodeError(
                     code_slot=code_slot,
                     lock_entity_id=self.lock.entity_id,
                 ) from retry_err
-            raise
+            raise CodeRejectedError(
+                code_slot=code_slot,
+                lock_entity_id=self.lock.entity_id,
+                reason=str(retry_err),
+            ) from retry_err
 
     async def _set_user_name(self, user_index: int, name: str, code_slot: int) -> None:
         """Set the user name for a credential slot, logging on failure."""
+        client, node = self._require_client_and_node()
         try:
-            await self._async_call_service(
-                "set_lock_user",
-                {
-                    "entity_id": self.lock.entity_id,
-                    "user_index": user_index,
-                    "user_name": name,
-                },
+            await set_lock_user(
+                client,
+                node,
+                user_index=user_index,
+                user_name=name,
             )
-        except LockCodeManagerProviderError:
+        except HomeAssistantError:
             LOGGER.warning(
                 "Lock %s: credential set on slot %s but failed to set user name '%s'",
                 self.lock.entity_id,
@@ -559,7 +563,7 @@ class MatterLock(BaseLock):
         if name is not None and user_index is not None:
             await self._set_user_name(user_index, name, code_slot)
 
-        # Optimistic update: service call succeeded, push occupancy state
+        # Optimistic update: call succeeded, push occupancy state
         # immediately. The LockUserChange event will confirm later.
         if self.coordinator:
             self.coordinator.push_update({code_slot: SlotCode.UNREADABLE_CODE})
@@ -571,14 +575,25 @@ class MatterLock(BaseLock):
         Returns True if a credential was cleared, False if the slot was already
         empty. Pushes SlotCode.EMPTY to the coordinator immediately on success.
         """
-        lock_data = await self._async_call_service(
-            "get_lock_credential_status",
-            {
-                "entity_id": self.lock.entity_id,
-                "credential_type": "pin",
-                "credential_index": code_slot,
-            },
-        )
+        client, node = self._require_client_and_node()
+        try:
+            lock_data = await get_lock_credential_status(
+                client,
+                node,
+                credential_type="pin",
+                credential_index=code_slot,
+            )
+        except ServiceValidationError as err:
+            raise LockCodeManagerProviderError(
+                f"Matter get_lock_credential_status rejected input for "
+                f"{self.lock.entity_id}: {err}"
+            ) from err
+        except HomeAssistantError as err:
+            raise LockDisconnected(
+                f"Matter get_lock_credential_status failed for "
+                f"{self.lock.entity_id}: {err}"
+            ) from err
+
         if not lock_data.get("credential_exists"):
             return False
 

--- a/custom_components/lock_code_manager/providers/matter.py
+++ b/custom_components/lock_code_manager/providers/matter.py
@@ -34,6 +34,20 @@ from .const import LOGGER
 
 MATTER_DOMAIN = "matter"
 
+
+def _is_duplicate_error(err: Exception) -> bool:
+    """Check whether a Matter service error indicates a duplicate credential.
+
+    Inspects the original cause's translation_placeholders for a typed status
+    check (HA 2026.3+), falling back to string matching for older versions.
+    """
+    cause = err.__cause__ or err
+    placeholders = getattr(cause, "translation_placeholders", None)
+    if isinstance(placeholders, dict) and placeholders.get("status") == "duplicate":
+        return True
+    return "duplicate" in str(err).lower()
+
+
 # DoorLock cluster ID (0x0101 = 257)
 _DOOR_LOCK_CLUSTER_ID = 257
 
@@ -348,7 +362,7 @@ class MatterLock(BaseLock):
             return
         try:
             code_slot = int(raw_index)
-        except (TypeError, ValueError):
+        except TypeError, ValueError:
             LOGGER.warning(
                 "Lock %s: LockUserChange has non-integer dataIndex %r, ignoring",
                 self.lock.entity_id,
@@ -435,14 +449,14 @@ class MatterLock(BaseLock):
         occupied_slots: set[int] = set()
         for user in users:
             for credential in user.get("credentials", []):
-                if credential.get("credential_type") != "pin":
+                if credential.get("type") != "pin":
                     continue
-                cred_index = credential.get("credential_index")
+                cred_index = credential.get("index")
                 if cred_index is None:
                     continue
                 try:
                     occupied_slots.add(int(cred_index))
-                except (TypeError, ValueError):
+                except TypeError, ValueError:
                     LOGGER.warning(
                         "Lock %s: skipping credential with invalid index %r",
                         self.lock.entity_id,
@@ -491,7 +505,7 @@ class MatterLock(BaseLock):
         try:
             user_index = await self._set_lock_credential(code_slot, usercode)
         except LockDisconnected as err:
-            if "duplicate" not in str(err).lower():
+            if not _is_duplicate_error(err):
                 raise
             if source != "sync":
                 raise DuplicateCodeError(
@@ -507,7 +521,7 @@ class MatterLock(BaseLock):
                 await self._clear_lock_credential(code_slot)
                 user_index = await self._set_lock_credential(code_slot, usercode)
             except LockDisconnected as retry_err:
-                if "duplicate" in str(retry_err).lower():
+                if _is_duplicate_error(retry_err):
                     raise DuplicateCodeError(
                         code_slot=code_slot,
                         lock_entity_id=self.lock.entity_id,

--- a/custom_components/lock_code_manager/providers/matter.py
+++ b/custom_components/lock_code_manager/providers/matter.py
@@ -477,6 +477,68 @@ class MatterLock(BaseLock):
             for slot in all_slots
         }
 
+    async def _set_credential_with_duplicate_handling(
+        self,
+        code_slot: int,
+        usercode: str,
+        source: Literal["sync", "direct"],
+    ) -> int | None:
+        """Set a credential, handling duplicate status.
+
+        For sync operations, clears the slot and retries on duplicate (handles
+        the restart case where _last_set_pin is lost). For direct operations,
+        raises DuplicateCodeError immediately.
+
+        Returns the user_index from the set response.
+        """
+        try:
+            return await self._set_lock_credential(code_slot, usercode)
+        except LockDisconnected as err:
+            if not _is_duplicate_error(err):
+                raise
+            if source != "sync":
+                raise DuplicateCodeError(
+                    code_slot=code_slot,
+                    lock_entity_id=self.lock.entity_id,
+                ) from err
+
+        # Sync duplicate: clear and retry
+        LOGGER.debug(
+            "Lock %s: duplicate on slot %s, clearing and retrying",
+            self.lock.entity_id,
+            code_slot,
+        )
+        await self._clear_lock_credential(code_slot)
+
+        try:
+            return await self._set_lock_credential(code_slot, usercode)
+        except LockDisconnected as retry_err:
+            if _is_duplicate_error(retry_err):
+                raise DuplicateCodeError(
+                    code_slot=code_slot,
+                    lock_entity_id=self.lock.entity_id,
+                ) from retry_err
+            raise
+
+    async def _set_user_name(self, user_index: int, name: str, code_slot: int) -> None:
+        """Set the user name for a credential slot, logging on failure."""
+        try:
+            await self._async_call_service(
+                "set_lock_user",
+                {
+                    "entity_id": self.lock.entity_id,
+                    "user_index": user_index,
+                    "user_name": name,
+                },
+            )
+        except LockCodeManagerProviderError:
+            LOGGER.warning(
+                "Lock %s: credential set on slot %s but failed to set user name '%s'",
+                self.lock.entity_id,
+                code_slot,
+                name,
+            )
+
     async def async_set_usercode(
         self,
         code_slot: int,
@@ -487,64 +549,16 @@ class MatterLock(BaseLock):
         """Set a usercode on a code slot.
 
         Returns True unconditionally because Matter does not reveal whether
-        the credential value actually changed. Pushes SlotCode.UNREADABLE_CODE to the
-        coordinator immediately — the LockUserChange event will confirm.
-
-        If the lock returns a "duplicate" status during sync (source="sync"),
-        the credential is cleared on that slot and the set is retried. This
-        handles the common case where _last_set_pin is lost after a Home
-        Assistant restart and the lock rejects a re-set of the same PIN. If
-        the retry also returns "duplicate", the PIN truly exists on a different
-        slot and DuplicateCodeError is raised.
-
-        For direct (user-initiated) calls, a duplicate immediately raises
-        DuplicateCodeError without clearing, since the slot may hold a
-        different user's credential that should not be silently removed.
+        the credential value actually changed. Pushes SlotCode.UNREADABLE_CODE
+        to the coordinator immediately — the LockUserChange event will confirm.
         """
-        user_index: int | None = None
-        try:
-            user_index = await self._set_lock_credential(code_slot, usercode)
-        except LockDisconnected as err:
-            if not _is_duplicate_error(err):
-                raise
-            if source != "sync":
-                raise DuplicateCodeError(
-                    code_slot=code_slot,
-                    lock_entity_id=self.lock.entity_id,
-                ) from err
-            LOGGER.debug(
-                "Lock %s: duplicate on slot %s, clearing and retrying",
-                self.lock.entity_id,
-                code_slot,
-            )
-            try:
-                await self._clear_lock_credential(code_slot)
-                user_index = await self._set_lock_credential(code_slot, usercode)
-            except LockDisconnected as retry_err:
-                if _is_duplicate_error(retry_err):
-                    raise DuplicateCodeError(
-                        code_slot=code_slot,
-                        lock_entity_id=self.lock.entity_id,
-                    ) from retry_err
-                raise
+        user_index = await self._set_credential_with_duplicate_handling(
+            code_slot, usercode, source
+        )
+
         if name is not None and user_index is not None:
-            try:
-                await self._async_call_service(
-                    "set_lock_user",
-                    {
-                        "entity_id": self.lock.entity_id,
-                        "user_index": user_index,
-                        "user_name": name,
-                    },
-                )
-            except LockCodeManagerProviderError:
-                LOGGER.warning(
-                    "Lock %s: credential set on slot %s but failed to set "
-                    "user name '%s'",
-                    self.lock.entity_id,
-                    code_slot,
-                    name,
-                )
+            await self._set_user_name(user_index, name, code_slot)
+
         # Optimistic update: service call succeeded, push occupancy state
         # immediately. The LockUserChange event will confirm later.
         if self.coordinator:

--- a/custom_components/lock_code_manager/providers/virtual.py
+++ b/custom_components/lock_code_manager/providers/virtual.py
@@ -106,7 +106,7 @@ class VirtualLock(BaseLock):
         for k in self._data:
             try:
                 stored_slots.add(int(k))
-            except (TypeError, ValueError):
+            except TypeError, ValueError:
                 _LOGGER.warning(
                     "Virtual lock %s: skipping stored slot with invalid key %r",
                     self.lock.entity_id,

--- a/custom_components/lock_code_manager/providers/zigbee2mqtt.py
+++ b/custom_components/lock_code_manager/providers/zigbee2mqtt.py
@@ -191,7 +191,7 @@ class Zigbee2MQTTLock(BaseLock):
             if action_user is not None:
                 try:
                     code_slot = int(action_user)
-                except (ValueError, TypeError):
+                except ValueError, TypeError:
                     LOGGER.debug(
                         "Ignoring %s with non-numeric action_user %r for %s",
                         action,
@@ -231,7 +231,7 @@ class Zigbee2MQTTLock(BaseLock):
             for user_id_str, user_info in users_data.items():
                 try:
                     user_id = int(user_id_str)
-                except (ValueError, TypeError):
+                except ValueError, TypeError:
                     LOGGER.warning(
                         "Skipping non-numeric Zigbee2MQTT user key %r for %s",
                         user_id_str,
@@ -287,7 +287,7 @@ class Zigbee2MQTTLock(BaseLock):
 
             try:
                 user_id = int(user_id)
-            except (ValueError, TypeError):
+            except ValueError, TypeError:
                 LOGGER.warning(
                     "Ignoring pin_code payload with non-numeric user for %s",
                     self.lock.entity_id,

--- a/custom_components/lock_code_manager/providers/zwave_js.py
+++ b/custom_components/lock_code_manager/providers/zwave_js.py
@@ -153,7 +153,7 @@ class ZWaveJSLock(BaseLock):
         """Return whether a code slot is in use."""
         try:
             return get_usercode(self.node, code_slot)[ATTR_IN_USE]
-        except (KeyError, ValueError):
+        except KeyError, ValueError:
             return None
 
     def _slot_expects_pin(self, code_slot: int) -> bool:

--- a/custom_components/lock_code_manager/sync.py
+++ b/custom_components/lock_code_manager/sync.py
@@ -235,12 +235,22 @@ class SlotSyncManager:
         return not missing
 
     def _ensure_entities_ready(self) -> bool:
-        """Ensure all dependent entities exist with valid states."""
+        """Ensure all dependent entities exist with valid states.
+
+        The name entity (CONF_NAME) is optional — STATE_UNKNOWN is its
+        normal state when no name is configured, so we only block on
+        STATE_UNAVAILABLE for it.
+        """
         for key in (CONF_PIN, CONF_NAME, ATTR_ACTIVE, ATTR_CODE):
             if key not in self._entity_id_map:
                 return False
             state = self._get_entity_state(key)
-            if state is None or state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
+            if state is None or state == STATE_UNAVAILABLE:
+                _LOGGER.debug("%s: Waiting for %s state", self._log_prefix, key)
+                return False
+            # Name is optional — STATE_UNKNOWN is valid (no name configured).
+            # All other entities must have a definite state.
+            if key != CONF_NAME and state == STATE_UNKNOWN:
                 _LOGGER.debug("%s: Waiting for %s state", self._log_prefix, key)
                 return False
         return True

--- a/custom_components/lock_code_manager/websocket.py
+++ b/custom_components/lock_code_manager/websocket.py
@@ -152,7 +152,7 @@ def _get_number_state(hass: HomeAssistant, entity_id: str | None) -> int | None:
         if state.state and state.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
             try:
                 return int(float(state.state))
-            except (ValueError, TypeError):
+            except ValueError, TypeError:
                 return None
     return None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,10 @@
 [project]
 name = "lock-code-manager"
 version = "0.0.0"
-requires-python = ">=3.13"
+requires-python = ">=3.14"
 
 [tool.ruff]
+target-version = "py314"
 lint.select = ["D", "E", "F", "G", "I", "PLC", "PLE", "PLR", "PLW", "UP", "W"]
 lint.ignore = [
     "D203",    # 1 blank line required before class docstring (conflicts with D211)

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,7 +4,7 @@ aiofiles==25.1.0
 aiousbwatcher==1.1.2
 colorlog==6.10.1
 debugpy==1.8.20
-homeassistant>=2026.2.0b0
+homeassistant>=2026.4.0b0
 pyserial==3.5
 python-matter-server==8.1.2
 pyudev==0.24.4

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,3 +1,3 @@
 pylint-strict-informational>=0.1
 pytest>=8.0.2
-pytest-homeassistant-custom-component==0.13.316
+pytest-homeassistant-custom-component==0.13.324

--- a/tests/providers/matter/conftest.py
+++ b/tests/providers/matter/conftest.py
@@ -23,11 +23,7 @@ from custom_components.lock_code_manager.const import (
     CONF_SLOTS,
     DOMAIN,
 )
-from custom_components.lock_code_manager.providers.matter import (
-    MATTER_DOMAIN,
-    MatterLock,
-)
-from tests.providers.helpers import register_mock_service
+from custom_components.lock_code_manager.providers.matter import MatterLock
 
 from .helpers import create_node_from_fixture, setup_matter_integration_with_node
 
@@ -35,6 +31,9 @@ MOCK_FABRIC_ID = 12341234
 MOCK_COMPR_FABRIC_ID = 1234
 
 SIMPLE_LOCK_ENTITY_ID = "lock.matter_test_matter_lock"
+
+# Module path where lock_helpers functions are imported in the provider
+_PROVIDER_MODULE = "custom_components.lock_code_manager.providers.matter"
 
 
 @pytest.fixture(name="matter_client")
@@ -100,7 +99,7 @@ async def matter_lock(hass: HomeAssistant, matter_node: MatterNode) -> MatterLoc
 @pytest.fixture
 async def matter_config_entry(hass: HomeAssistant) -> MockConfigEntry:
     """Create a standalone Matter config entry (for tests that don't need the full integration)."""
-    entry = MockConfigEntry(domain=MATTER_DOMAIN)
+    entry = MockConfigEntry(domain="matter")
     entry.add_to_hass(hass)
     entry._async_set_state(hass, entry.state, None)
     return entry
@@ -180,62 +179,47 @@ async def lock_entity(hass: HomeAssistant, matter_node: MatterNode) -> er.Regist
 
 
 @pytest.fixture
-def matter_mock_services(
-    hass: HomeAssistant,
-    lock_entity: er.RegistryEntry,
-) -> dict[str, AsyncMock]:
-    """Register mock Matter services needed for the full LCM setup path.
+def matter_mock_helpers() -> dict[str, AsyncMock]:
+    """Provide mock lock_helpers functions and patch them into the provider module.
 
-    Returns a dict of service name to handler so E2E tests can inspect
+    Returns a dict of helper name to AsyncMock so E2E tests can inspect
     call counts or swap side effects.
     """
-    entity_id = lock_entity.entity_id
-    handlers: dict[str, AsyncMock] = {}
+    helpers: dict[str, AsyncMock] = {}
 
     # get_lock_info: called by MatterLock.async_setup() and availability checks
-    handlers["get_lock_info"] = AsyncMock(
+    helpers["get_lock_info"] = AsyncMock(
         return_value={
-            entity_id: {
-                "supports_user_management": True,
-                "supported_credential_types": ["pin"],
-            },
+            "supports_user_management": True,
+            "supported_credential_types": ["pin"],
         }
     )
 
     # get_lock_users: called by async_get_usercodes (coordinator refresh)
-    handlers["get_lock_users"] = AsyncMock(
+    helpers["get_lock_users"] = AsyncMock(
         return_value={
-            entity_id: {
-                "max_users": 10,
-                "users": [],
-            },
+            "max_users": 10,
+            "users": [],
         }
     )
 
     # set_lock_credential: called by async_set_usercode
-    handlers["set_lock_credential"] = AsyncMock(
-        return_value={entity_id: {"credential_index": 1, "user_index": 1}},
+    helpers["set_lock_credential"] = AsyncMock(
+        return_value={"credential_index": 1, "user_index": 1},
     )
 
     # set_lock_user: called by async_set_usercode when a name is provided
-    handlers["set_lock_user"] = AsyncMock(
-        return_value={entity_id: {}},
-    )
+    helpers["set_lock_user"] = AsyncMock(return_value={})
 
     # get_lock_credential_status: called by async_clear_usercode
-    handlers["get_lock_credential_status"] = AsyncMock(
-        return_value={entity_id: {"credential_exists": True}},
+    helpers["get_lock_credential_status"] = AsyncMock(
+        return_value={"credential_exists": True}
     )
 
     # clear_lock_credential: called by async_clear_usercode
-    handlers["clear_lock_credential"] = AsyncMock(
-        return_value={entity_id: {}},
-    )
+    helpers["clear_lock_credential"] = AsyncMock(return_value={})
 
-    for service_name, handler in handlers.items():
-        register_mock_service(hass, MATTER_DOMAIN, service_name, handler)
-
-    return handlers
+    return helpers
 
 
 @pytest.fixture
@@ -243,12 +227,13 @@ async def lcm_config_entry(
     hass: HomeAssistant,
     matter_node: MatterNode,
     lock_entity: er.RegistryEntry,
-    matter_mock_services: dict[str, AsyncMock],
+    matter_mock_helpers: dict[str, AsyncMock],
 ) -> MockConfigEntry:
     """Set up a full LCM config entry managing the Matter lock.
 
     This goes through the real async_setup_entry path: LCM discovers the
     lock entity is from the matter platform and instantiates MatterLock.
+    The lock_helpers functions are patched at the provider module level.
     """
     lcm_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -259,12 +244,37 @@ async def lcm_config_entry(
         unique_id="test_matter_e2e",
     )
     lcm_entry.add_to_hass(hass)
-    assert await hass.config_entries.async_setup(lcm_entry.entry_id)
-    await hass.async_block_till_done()
+    with (
+        patch(
+            f"{_PROVIDER_MODULE}.get_lock_info", matter_mock_helpers["get_lock_info"]
+        ),
+        patch(
+            f"{_PROVIDER_MODULE}.get_lock_users",
+            matter_mock_helpers["get_lock_users"],
+        ),
+        patch(
+            f"{_PROVIDER_MODULE}.set_lock_credential",
+            matter_mock_helpers["set_lock_credential"],
+        ),
+        patch(
+            f"{_PROVIDER_MODULE}.set_lock_user",
+            matter_mock_helpers["set_lock_user"],
+        ),
+        patch(
+            f"{_PROVIDER_MODULE}.get_lock_credential_status",
+            matter_mock_helpers["get_lock_credential_status"],
+        ),
+        patch(
+            f"{_PROVIDER_MODULE}.clear_lock_credential",
+            matter_mock_helpers["clear_lock_credential"],
+        ),
+    ):
+        assert await hass.config_entries.async_setup(lcm_entry.entry_id)
+        await hass.async_block_till_done()
 
-    yield lcm_entry
+        yield lcm_entry
 
-    await hass.config_entries.async_unload(lcm_entry.entry_id)
+        await hass.config_entries.async_unload(lcm_entry.entry_id)
 
 
 def get_matter_lock(

--- a/tests/providers/matter/test_e2e.py
+++ b/tests/providers/matter/test_e2e.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -10,11 +10,10 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from custom_components.lock_code_manager.models import SlotCode
-from custom_components.lock_code_manager.providers.matter import (
-    MATTER_DOMAIN,
-    MatterLock,
-)
-from tests.providers.helpers import register_mock_service
+from custom_components.lock_code_manager.providers.matter import MatterLock
+
+# Module path where lock_helpers functions are imported in the provider
+_PROVIDER_MODULE = "custom_components.lock_code_manager.providers.matter"
 
 
 class TestFullSetupLifecycle:
@@ -41,45 +40,76 @@ class TestFullSetupLifecycle:
 
 
 class TestSetAndClearUsercodes:
-    """Verify set/clear operations call the correct Matter services."""
+    """Verify set/clear operations call the correct Matter helpers."""
 
     async def test_set_usercode(
         self,
         hass: HomeAssistant,
         e2e_matter_lock: MatterLock,
-        matter_mock_services: dict[str, AsyncMock],
+        matter_mock_helpers: dict[str, AsyncMock],
     ) -> None:
-        """Set a code via the provider and verify the Matter service was called."""
-        matter_mock_services["set_lock_credential"].reset_mock()
-        result = await e2e_matter_lock.async_set_usercode(4, "5678", "Test User")
+        """Set a code via the provider and verify the Matter helper was called."""
+        matter_mock_helpers["set_lock_credential"].reset_mock()
+        with (
+            patch(
+                f"{_PROVIDER_MODULE}.set_lock_credential",
+                matter_mock_helpers["set_lock_credential"],
+            ),
+            patch(
+                f"{_PROVIDER_MODULE}.set_lock_user",
+                matter_mock_helpers["set_lock_user"],
+            ),
+        ):
+            result = await e2e_matter_lock.async_set_usercode(4, "5678", "Test User")
 
         assert result is True
-        assert matter_mock_services["set_lock_credential"].call_count >= 1
+        assert matter_mock_helpers["set_lock_credential"].call_count >= 1
 
     async def test_clear_usercode(
         self,
         hass: HomeAssistant,
         e2e_matter_lock: MatterLock,
-        matter_mock_services: dict[str, AsyncMock],
+        matter_mock_helpers: dict[str, AsyncMock],
     ) -> None:
-        """Clear a code via the provider and verify the Matter service was called."""
-        matter_mock_services["clear_lock_credential"].reset_mock()
-        result = await e2e_matter_lock.async_clear_usercode(2)
+        """Clear a code via the provider and verify the Matter helper was called."""
+        matter_mock_helpers["clear_lock_credential"].reset_mock()
+        with (
+            patch(
+                f"{_PROVIDER_MODULE}.get_lock_credential_status",
+                matter_mock_helpers["get_lock_credential_status"],
+            ),
+            patch(
+                f"{_PROVIDER_MODULE}.clear_lock_credential",
+                matter_mock_helpers["clear_lock_credential"],
+            ),
+        ):
+            result = await e2e_matter_lock.async_clear_usercode(2)
 
         assert result is True
-        assert matter_mock_services["clear_lock_credential"].call_count >= 1
+        assert matter_mock_helpers["clear_lock_credential"].call_count >= 1
 
     async def test_set_usercode_optimistic_update(
         self,
         hass: HomeAssistant,
         e2e_matter_lock: MatterLock,
+        matter_mock_helpers: dict[str, AsyncMock],
     ) -> None:
         """After set, the coordinator has the optimistic UNREADABLE_CODE value.
 
         Matter PINs are write-only so optimistic updates use UNREADABLE_CODE
         instead of the actual PIN value.
         """
-        await e2e_matter_lock.async_set_usercode(4, "5678", "Test User")
+        with (
+            patch(
+                f"{_PROVIDER_MODULE}.set_lock_credential",
+                matter_mock_helpers["set_lock_credential"],
+            ),
+            patch(
+                f"{_PROVIDER_MODULE}.set_lock_user",
+                matter_mock_helpers["set_lock_user"],
+            ),
+        ):
+            await e2e_matter_lock.async_set_usercode(4, "5678", "Test User")
 
         assert e2e_matter_lock.coordinator.data.get(4) is SlotCode.UNREADABLE_CODE
 
@@ -87,9 +117,20 @@ class TestSetAndClearUsercodes:
         self,
         hass: HomeAssistant,
         e2e_matter_lock: MatterLock,
+        matter_mock_helpers: dict[str, AsyncMock],
     ) -> None:
         """After clear, the coordinator has SlotCode.EMPTY."""
-        await e2e_matter_lock.async_clear_usercode(2)
+        with (
+            patch(
+                f"{_PROVIDER_MODULE}.get_lock_credential_status",
+                matter_mock_helpers["get_lock_credential_status"],
+            ),
+            patch(
+                f"{_PROVIDER_MODULE}.clear_lock_credential",
+                matter_mock_helpers["clear_lock_credential"],
+            ),
+        ):
+            await e2e_matter_lock.async_clear_usercode(2)
 
         assert e2e_matter_lock.coordinator.data.get(2) is SlotCode.EMPTY
 
@@ -102,7 +143,7 @@ class TestGetUsercodes:
         hass: HomeAssistant,
         e2e_matter_lock: MatterLock,
         lock_entity: er.RegistryEntry,
-        matter_mock_services: dict[str, AsyncMock],
+        matter_mock_helpers: dict[str, AsyncMock],
     ) -> None:
         """Get usercodes returns slot occupancy from Matter.
 
@@ -110,35 +151,26 @@ class TestGetUsercodes:
         be EMPTY. When the mock reports a user with a PIN credential on
         slot 1, that slot should become UNREADABLE_CODE.
         """
-        entity_id = lock_entity.entity_id
-
         # Override the get_lock_users mock to report an occupied slot
-        matter_mock_services["get_lock_users"] = AsyncMock(
+        mock_get_lock_users = AsyncMock(
             return_value={
-                entity_id: {
-                    "max_users": 10,
-                    "users": [
-                        {
-                            "user_index": 1,
-                            "credentials": [
-                                {
-                                    "type": "pin",
-                                    "index": 1,
-                                }
-                            ],
-                        },
-                    ],
-                },
+                "max_users": 10,
+                "users": [
+                    {
+                        "user_index": 1,
+                        "credentials": [
+                            {
+                                "type": "pin",
+                                "index": 1,
+                            }
+                        ],
+                    },
+                ],
             }
         )
-        register_mock_service(
-            hass,
-            MATTER_DOMAIN,
-            "get_lock_users",
-            matter_mock_services["get_lock_users"],
-        )
 
-        codes = await e2e_matter_lock.async_get_usercodes()
+        with patch(f"{_PROVIDER_MODULE}.get_lock_users", mock_get_lock_users):
+            codes = await e2e_matter_lock.async_get_usercodes()
 
         assert codes[1] is SlotCode.UNREADABLE_CODE
         assert codes[2] is SlotCode.EMPTY

--- a/tests/providers/matter/test_e2e.py
+++ b/tests/providers/matter/test_e2e.py
@@ -122,8 +122,8 @@ class TestGetUsercodes:
                             "user_index": 1,
                             "credentials": [
                                 {
-                                    "credential_type": "pin",
-                                    "credential_index": 1,
+                                    "type": "pin",
+                                    "index": 1,
                                 }
                             ],
                         },

--- a/tests/providers/matter/test_provider.py
+++ b/tests/providers/matter/test_provider.py
@@ -246,12 +246,12 @@ async def test_get_usercodes_unmanaged_occupied_slots(
                         {
                             "credentials": [
                                 {
-                                    "credential_type": "pin",
-                                    "credential_index": 5,
+                                    "type": "pin",
+                                    "index": 5,
                                 },
                                 {
-                                    "credential_type": "pin",
-                                    "credential_index": 8,
+                                    "type": "pin",
+                                    "index": 8,
                                 },
                             ]
                         }
@@ -279,8 +279,8 @@ async def test_get_usercodes_invalid_credential_index_skipped(
                     "users": [
                         {
                             "credentials": [
-                                {"credential_type": "pin", "credential_index": "bad"},
-                                {"credential_type": "pin", "credential_index": 3},
+                                {"type": "pin", "index": "bad"},
+                                {"type": "pin", "index": 3},
                             ]
                         }
                     ]
@@ -389,7 +389,7 @@ async def test_hard_refresh_codes(
                 {
                     "user_index": 1,
                     "credentials": [
-                        {"credential_type": "pin", "credential_index": 2},
+                        {"type": "pin", "index": 2},
                     ],
                 }
             ],
@@ -562,8 +562,8 @@ async def test_get_usercodes_multiple_credential_types(
                 {
                     "user_index": 1,
                     "credentials": [
-                        {"credential_type": "rfid", "credential_index": 1},
-                        {"credential_type": "pin", "credential_index": 2},
+                        {"type": "rfid", "index": 1},
+                        {"type": "pin", "index": 2},
                     ],
                 },
             ],

--- a/tests/providers/matter/test_provider.py
+++ b/tests/providers/matter/test_provider.py
@@ -4,16 +4,17 @@ from __future__ import annotations
 
 from datetime import timedelta
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from matter_server.common.models import EventType, MatterNodeEvent
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from homeassistant.core import HomeAssistant, SupportsResponse
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 
 from custom_components.lock_code_manager.exceptions import (
+    CodeRejectedError,
     DuplicateCodeError,
     LockCodeManagerError,
     LockCodeManagerProviderError,
@@ -21,17 +22,27 @@ from custom_components.lock_code_manager.exceptions import (
 )
 from custom_components.lock_code_manager.models import SlotCode
 from custom_components.lock_code_manager.providers.matter import (
-    MATTER_DOMAIN,
     MatterLock,
+    SetCredentialFailedError,
 )
-from tests.providers.helpers import (
-    ServiceProviderConnectionTests,
-    ServiceProviderDeviceAvailabilityTests,
-    register_mock_service,
-)
+from tests.providers.helpers import ServiceProviderConnectionTests
 
 # Simple fixture entity ID (for service-level tests without full integration)
 LOCK_ENTITY_ID = "lock.matter_test_matter_lock"
+
+# Module path where lock_helpers functions are imported in the provider
+_PROVIDER_MODULE = "custom_components.lock_code_manager.providers.matter"
+
+
+def _make_set_credential_failed_error(
+    status: str = "duplicate",
+) -> HomeAssistantError:
+    """Create a mock SetCredentialFailedError with translation_placeholders."""
+    err = SetCredentialFailedError(
+        f"Failed to set credential: lock returned status `{status}`"
+    )
+    err.translation_placeholders = {"status": status}
+    return err
 
 
 @pytest.fixture
@@ -43,7 +54,7 @@ def provider_config_entry(matter_config_entry: MockConfigEntry) -> MockConfigEnt
 @pytest.fixture
 def provider_domain() -> str:
     """Return the provider integration domain."""
-    return MATTER_DOMAIN
+    return "matter"
 
 
 @pytest.fixture
@@ -59,7 +70,7 @@ def provider_lock_class() -> type[MatterLock]:
 
 async def test_domain_property(matter_lock_simple: MatterLock) -> None:
     """Test that domain returns 'matter'."""
-    assert matter_lock_simple.domain == MATTER_DOMAIN
+    assert matter_lock_simple.domain == "matter"
 
 
 async def test_supports_code_slot_events(matter_lock_simple: MatterLock) -> None:
@@ -91,41 +102,47 @@ class TestConnection(ServiceProviderConnectionTests):
     """Connection tests for Matter provider using shared mixin."""
 
 
-class TestDeviceAvailability(ServiceProviderDeviceAvailabilityTests):
-    """Device availability tests for Matter provider using shared mixin."""
+class TestDeviceAvailability:
+    """Device availability tests for Matter provider."""
 
-    availability_service = "get_lock_info"
+    async def test_is_device_available_success(
+        self, hass: HomeAssistant, matter_lock_simple: MatterLock
+    ) -> None:
+        """Test device availability returns True on successful helper call."""
+        mock_get_lock_info = AsyncMock(return_value={})
+        with (
+            patch.object(
+                matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+            ),
+            patch.object(
+                matter_lock_simple, "_get_matter_node", return_value=MagicMock()
+            ),
+            patch(f"{_PROVIDER_MODULE}.get_lock_info", mock_get_lock_info),
+        ):
+            assert await matter_lock_simple.async_is_device_available() is True
 
+    async def test_is_device_available_error(
+        self, hass: HomeAssistant, matter_lock_simple: MatterLock
+    ) -> None:
+        """Test device availability returns False when helper call fails."""
+        mock_get_lock_info = AsyncMock(side_effect=HomeAssistantError("device offline"))
+        with (
+            patch.object(
+                matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+            ),
+            patch.object(
+                matter_lock_simple, "_get_matter_node", return_value=MagicMock()
+            ),
+            patch(f"{_PROVIDER_MODULE}.get_lock_info", mock_get_lock_info),
+        ):
+            assert await matter_lock_simple.async_is_device_available() is False
 
-# ---------------------------------------------------------------------------
-# _async_call_service response validation tests
-# ---------------------------------------------------------------------------
-
-
-async def test_async_call_service_missing_entity_data(
-    hass: HomeAssistant, matter_lock_simple: MatterLock
-) -> None:
-    """Test _async_call_service raises when response has no data for entity."""
-    handler = AsyncMock(return_value={"wrong_entity_id": {}})
-    register_mock_service(hass, MATTER_DOMAIN, "get_lock_info", handler)
-
-    with pytest.raises(LockCodeManagerProviderError, match="returned no data"):
-        await matter_lock_simple._async_call_service(
-            "get_lock_info", {"entity_id": matter_lock_simple.lock.entity_id}
-        )
-
-
-async def test_async_call_service_non_dict_entity_data(
-    hass: HomeAssistant, matter_lock_simple: MatterLock
-) -> None:
-    """Test _async_call_service raises when entity data is not a dict."""
-    handler = AsyncMock(return_value={LOCK_ENTITY_ID: "not_a_dict"})
-    register_mock_service(hass, MATTER_DOMAIN, "get_lock_info", handler)
-
-    with pytest.raises(LockCodeManagerProviderError, match="returned non-dict"):
-        await matter_lock_simple._async_call_service(
-            "get_lock_info", {"entity_id": matter_lock_simple.lock.entity_id}
-        )
+    async def test_is_device_available_no_client(
+        self, hass: HomeAssistant, matter_lock_simple: MatterLock
+    ) -> None:
+        """Test device availability returns False when client unavailable."""
+        with patch.object(matter_lock_simple, "_get_matter_client", return_value=None):
+            assert await matter_lock_simple.async_is_device_available() is False
 
 
 # ---------------------------------------------------------------------------
@@ -139,17 +156,21 @@ async def test_setup(
     simple_lcm_config_entry: MockConfigEntry,
 ) -> None:
     """Test that setup validates lock supports user management and PIN credentials."""
-    mock_response = {
-        LOCK_ENTITY_ID: {
+    mock_get_lock_info = AsyncMock(
+        return_value={
             "supports_user_management": True,
             "supported_credential_types": ["pin"],
-        },
-    }
-    handler = AsyncMock(return_value=mock_response)
-    register_mock_service(hass, MATTER_DOMAIN, "get_lock_info", handler)
-
-    await matter_lock_simple.async_setup(simple_lcm_config_entry)
-    assert handler.call_count == 1
+        }
+    )
+    with (
+        patch.object(
+            matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+        ),
+        patch.object(matter_lock_simple, "_get_matter_node", return_value=MagicMock()),
+        patch(f"{_PROVIDER_MODULE}.get_lock_info", mock_get_lock_info),
+    ):
+        await matter_lock_simple.async_setup(simple_lcm_config_entry)
+    assert mock_get_lock_info.call_count == 1
 
 
 async def test_setup_unsupported_lock(
@@ -158,16 +179,18 @@ async def test_setup_unsupported_lock(
     simple_lcm_config_entry: MockConfigEntry,
 ) -> None:
     """Test that setup raises when lock does not support user management."""
-    mock_response = {
-        LOCK_ENTITY_ID: {
-            "supports_user_management": False,
-        },
-    }
-    handler = AsyncMock(return_value=mock_response)
-    register_mock_service(hass, MATTER_DOMAIN, "get_lock_info", handler)
-
-    with pytest.raises(LockCodeManagerError, match="does not support user management"):
-        await matter_lock_simple.async_setup(simple_lcm_config_entry)
+    mock_get_lock_info = AsyncMock(return_value={"supports_user_management": False})
+    with (
+        patch.object(
+            matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+        ),
+        patch.object(matter_lock_simple, "_get_matter_node", return_value=MagicMock()),
+        patch(f"{_PROVIDER_MODULE}.get_lock_info", mock_get_lock_info),
+    ):
+        with pytest.raises(
+            LockCodeManagerError, match="does not support user management"
+        ):
+            await matter_lock_simple.async_setup(simple_lcm_config_entry)
 
 
 async def test_setup_no_pin_support(
@@ -176,17 +199,23 @@ async def test_setup_no_pin_support(
     simple_lcm_config_entry: MockConfigEntry,
 ) -> None:
     """Test that setup raises when lock supports users but not PIN credentials."""
-    mock_response = {
-        LOCK_ENTITY_ID: {
+    mock_get_lock_info = AsyncMock(
+        return_value={
             "supports_user_management": True,
             "supported_credential_types": ["rfid"],
-        },
-    }
-    handler = AsyncMock(return_value=mock_response)
-    register_mock_service(hass, MATTER_DOMAIN, "get_lock_info", handler)
-
-    with pytest.raises(LockCodeManagerError, match="does not support PIN credentials"):
-        await matter_lock_simple.async_setup(simple_lcm_config_entry)
+        }
+    )
+    with (
+        patch.object(
+            matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+        ),
+        patch.object(matter_lock_simple, "_get_matter_node", return_value=MagicMock()),
+        patch(f"{_PROVIDER_MODULE}.get_lock_info", mock_get_lock_info),
+    ):
+        with pytest.raises(
+            LockCodeManagerError, match="does not support PIN credentials"
+        ):
+            await matter_lock_simple.async_setup(simple_lcm_config_entry)
 
 
 # ---------------------------------------------------------------------------
@@ -200,16 +229,15 @@ async def test_get_usercodes_no_users(
     simple_lcm_config_entry: MockConfigEntry,
 ) -> None:
     """Test get_usercodes when no users exist on the lock."""
-    mock_response = {
-        LOCK_ENTITY_ID: {
-            "max_users": 10,
-            "users": [],
-        },
-    }
-    handler = AsyncMock(return_value=mock_response)
-    register_mock_service(hass, MATTER_DOMAIN, "get_lock_users", handler)
-
-    codes = await matter_lock_simple.async_get_usercodes()
+    mock_get_lock_users = AsyncMock(return_value={"max_users": 10, "users": []})
+    with (
+        patch.object(
+            matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+        ),
+        patch.object(matter_lock_simple, "_get_matter_node", return_value=MagicMock()),
+        patch(f"{_PROVIDER_MODULE}.get_lock_users", mock_get_lock_users),
+    ):
+        codes = await matter_lock_simple.async_get_usercodes()
 
     assert codes[1] is SlotCode.EMPTY
     assert codes[2] is SlotCode.EMPTY
@@ -220,13 +248,15 @@ async def test_get_usercodes_no_configured_slots(
     matter_lock_simple: MatterLock,
 ) -> None:
     """Test get_usercodes returns empty dict when no slots configured and no occupied slots."""
-    register_mock_service(
-        hass,
-        MATTER_DOMAIN,
-        "get_lock_users",
-        AsyncMock(return_value={LOCK_ENTITY_ID: {"users": []}}),
-    )
-    codes = await matter_lock_simple.async_get_usercodes()
+    mock_get_lock_users = AsyncMock(return_value={"users": []})
+    with (
+        patch.object(
+            matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+        ),
+        patch.object(matter_lock_simple, "_get_matter_node", return_value=MagicMock()),
+        patch(f"{_PROVIDER_MODULE}.get_lock_users", mock_get_lock_users),
+    ):
+        codes = await matter_lock_simple.async_get_usercodes()
     assert codes == {}
 
 
@@ -235,32 +265,26 @@ async def test_get_usercodes_unmanaged_occupied_slots(
     matter_lock_simple: MatterLock,
 ) -> None:
     """Test get_usercodes returns unmanaged occupied slots as UNREADABLE_CODE."""
-    register_mock_service(
-        hass,
-        MATTER_DOMAIN,
-        "get_lock_users",
-        AsyncMock(
-            return_value={
-                LOCK_ENTITY_ID: {
-                    "users": [
-                        {
-                            "credentials": [
-                                {
-                                    "type": "pin",
-                                    "index": 5,
-                                },
-                                {
-                                    "type": "pin",
-                                    "index": 8,
-                                },
-                            ]
-                        }
+    mock_get_lock_users = AsyncMock(
+        return_value={
+            "users": [
+                {
+                    "credentials": [
+                        {"type": "pin", "index": 5},
+                        {"type": "pin", "index": 8},
                     ]
                 }
-            }
-        ),
+            ]
+        }
     )
-    codes = await matter_lock_simple.async_get_usercodes()
+    with (
+        patch.object(
+            matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+        ),
+        patch.object(matter_lock_simple, "_get_matter_node", return_value=MagicMock()),
+        patch(f"{_PROVIDER_MODULE}.get_lock_users", mock_get_lock_users),
+    ):
+        codes = await matter_lock_simple.async_get_usercodes()
     assert codes == {5: SlotCode.UNREADABLE_CODE, 8: SlotCode.UNREADABLE_CODE}
 
 
@@ -269,26 +293,26 @@ async def test_get_usercodes_invalid_credential_index_skipped(
     matter_lock_simple: MatterLock,
 ) -> None:
     """Test that invalid credential_index values are skipped with a warning."""
-    register_mock_service(
-        hass,
-        MATTER_DOMAIN,
-        "get_lock_users",
-        AsyncMock(
-            return_value={
-                LOCK_ENTITY_ID: {
-                    "users": [
-                        {
-                            "credentials": [
-                                {"type": "pin", "index": "bad"},
-                                {"type": "pin", "index": 3},
-                            ]
-                        }
+    mock_get_lock_users = AsyncMock(
+        return_value={
+            "users": [
+                {
+                    "credentials": [
+                        {"type": "pin", "index": "bad"},
+                        {"type": "pin", "index": 3},
                     ]
                 }
-            }
-        ),
+            ]
+        }
     )
-    codes = await matter_lock_simple.async_get_usercodes()
+    with (
+        patch.object(
+            matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+        ),
+        patch.object(matter_lock_simple, "_get_matter_node", return_value=MagicMock()),
+        patch(f"{_PROVIDER_MODULE}.get_lock_users", mock_get_lock_users),
+    ):
+        codes = await matter_lock_simple.async_get_usercodes()
     # Only slot 3 should appear; "bad" index is skipped
     assert codes == {3: SlotCode.UNREADABLE_CODE}
 
@@ -302,46 +326,44 @@ async def test_set_usercode_no_name(
     hass: HomeAssistant, matter_lock_simple: MatterLock
 ) -> None:
     """Test set_usercode without a name only calls set_lock_credential."""
-    calls: list[str] = []
-
-    async def _capture_call(call):
-        calls.append(call.service)
-        return {LOCK_ENTITY_ID: {"credential_index": 3, "user_index": 3}}
-
-    register_mock_service(
-        hass, MATTER_DOMAIN, "set_lock_credential", AsyncMock(side_effect=_capture_call)
+    mock_set_credential = AsyncMock(
+        return_value={"credential_index": 3, "user_index": 3}
     )
-    register_mock_service(
-        hass, MATTER_DOMAIN, "set_lock_user", AsyncMock(side_effect=_capture_call)
-    )
-
-    result = await matter_lock_simple.async_set_usercode(3, "9999")
+    mock_set_user = AsyncMock(return_value={})
+    with (
+        patch.object(
+            matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+        ),
+        patch.object(matter_lock_simple, "_get_matter_node", return_value=MagicMock()),
+        patch(f"{_PROVIDER_MODULE}.set_lock_credential", mock_set_credential),
+        patch(f"{_PROVIDER_MODULE}.set_lock_user", mock_set_user),
+    ):
+        result = await matter_lock_simple.async_set_usercode(3, "9999")
 
     assert result is True
-    assert calls == ["set_lock_credential"]
+    assert mock_set_credential.call_count == 1
+    assert mock_set_user.call_count == 0
 
 
 async def test_set_usercode_skips_name_when_no_user_index(
     hass: HomeAssistant, matter_lock_simple: MatterLock
 ) -> None:
     """Test set_usercode skips set_lock_user when response has no user_index."""
-    calls: list[str] = []
-
-    async def _capture_call(call):
-        calls.append(call.service)
-        return {LOCK_ENTITY_ID: {}}
-
-    register_mock_service(
-        hass, MATTER_DOMAIN, "set_lock_credential", AsyncMock(side_effect=_capture_call)
-    )
-    register_mock_service(
-        hass, MATTER_DOMAIN, "set_lock_user", AsyncMock(side_effect=_capture_call)
-    )
-
-    result = await matter_lock_simple.async_set_usercode(1, "1234", "User One")
+    mock_set_credential = AsyncMock(return_value={})
+    mock_set_user = AsyncMock(return_value={})
+    with (
+        patch.object(
+            matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+        ),
+        patch.object(matter_lock_simple, "_get_matter_node", return_value=MagicMock()),
+        patch(f"{_PROVIDER_MODULE}.set_lock_credential", mock_set_credential),
+        patch(f"{_PROVIDER_MODULE}.set_lock_user", mock_set_user),
+    ):
+        result = await matter_lock_simple.async_set_usercode(1, "1234", "User One")
 
     assert result is True
-    assert calls == ["set_lock_credential"]
+    assert mock_set_credential.call_count == 1
+    assert mock_set_user.call_count == 0
 
 
 # ---------------------------------------------------------------------------
@@ -353,22 +375,22 @@ async def test_clear_usercode_already_empty(
     hass: HomeAssistant, matter_lock_simple: MatterLock
 ) -> None:
     """Test clear_usercode returns False when the credential does not exist."""
-    credential_status_response = {
-        LOCK_ENTITY_ID: {"credential_exists": False},
-    }
-    handler_status = AsyncMock(return_value=credential_status_response)
-    handler_clear = AsyncMock(return_value={LOCK_ENTITY_ID: {}})
-    register_mock_service(
-        hass, MATTER_DOMAIN, "get_lock_credential_status", handler_status
-    )
-    register_mock_service(hass, MATTER_DOMAIN, "clear_lock_credential", handler_clear)
-
-    result = await matter_lock_simple.async_clear_usercode(2)
+    mock_get_status = AsyncMock(return_value={"credential_exists": False})
+    mock_clear = AsyncMock(return_value={})
+    with (
+        patch.object(
+            matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+        ),
+        patch.object(matter_lock_simple, "_get_matter_node", return_value=MagicMock()),
+        patch(f"{_PROVIDER_MODULE}.get_lock_credential_status", mock_get_status),
+        patch(f"{_PROVIDER_MODULE}.clear_lock_credential", mock_clear),
+    ):
+        result = await matter_lock_simple.async_clear_usercode(2)
 
     assert result is False
     # Only the credential status check should have been called
-    assert handler_status.call_count == 1
-    assert handler_clear.call_count == 0
+    assert mock_get_status.call_count == 1
+    assert mock_clear.call_count == 0
 
 
 # ---------------------------------------------------------------------------
@@ -382,8 +404,8 @@ async def test_hard_refresh_codes(
     simple_lcm_config_entry: MockConfigEntry,
 ) -> None:
     """Test hard_refresh_codes returns same result as get_usercodes."""
-    mock_response = {
-        LOCK_ENTITY_ID: {
+    mock_get_lock_users = AsyncMock(
+        return_value={
             "max_users": 10,
             "users": [
                 {
@@ -393,66 +415,77 @@ async def test_hard_refresh_codes(
                     ],
                 }
             ],
-        },
-    }
-    handler = AsyncMock(return_value=mock_response)
-    register_mock_service(hass, MATTER_DOMAIN, "get_lock_users", handler)
-
-    codes = await matter_lock_simple.async_hard_refresh_codes()
+        }
+    )
+    with (
+        patch.object(
+            matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+        ),
+        patch.object(matter_lock_simple, "_get_matter_node", return_value=MagicMock()),
+        patch(f"{_PROVIDER_MODULE}.get_lock_users", mock_get_lock_users),
+    ):
+        codes = await matter_lock_simple.async_hard_refresh_codes()
 
     assert codes[1] is SlotCode.EMPTY
     assert codes[2] is SlotCode.UNREADABLE_CODE
 
 
 # ---------------------------------------------------------------------------
-# Service error tests
+# Error tests
 # ---------------------------------------------------------------------------
 
 
-async def test_service_call_failure_raises_lock_disconnected(
+async def test_helper_failure_raises_lock_disconnected(
     hass: HomeAssistant, matter_lock_simple: MatterLock
 ) -> None:
-    """Test that Matter service failures raise LockDisconnected."""
-    handler = AsyncMock(side_effect=HomeAssistantError("connection lost"))
-    register_mock_service(hass, MATTER_DOMAIN, "set_lock_credential", handler)
-
-    with pytest.raises(LockDisconnected, match="connection lost"):
-        await matter_lock_simple.async_set_usercode(1, "1234")
+    """Test that Matter helper failures raise LockDisconnected."""
+    mock_set_credential = AsyncMock(side_effect=HomeAssistantError("connection lost"))
+    with (
+        patch.object(
+            matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+        ),
+        patch.object(matter_lock_simple, "_get_matter_node", return_value=MagicMock()),
+        patch(f"{_PROVIDER_MODULE}.set_lock_credential", mock_set_credential),
+    ):
+        with pytest.raises(LockDisconnected, match="connection lost"):
+            await matter_lock_simple.async_set_usercode(1, "1234")
 
 
 async def test_service_validation_error_raises_provider_error(
     hass: HomeAssistant, matter_lock_simple: MatterLock
 ) -> None:
     """Test that ServiceValidationError raises LockCodeManagerProviderError, not LockDisconnected."""
-    handler = AsyncMock(side_effect=ServiceValidationError("invalid data"))
-    register_mock_service(hass, MATTER_DOMAIN, "set_lock_credential", handler)
-
-    with pytest.raises(LockCodeManagerProviderError, match="rejected input"):
-        await matter_lock_simple.async_set_usercode(1, "1234")
+    mock_set_credential = AsyncMock(side_effect=ServiceValidationError("invalid data"))
+    with (
+        patch.object(
+            matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+        ),
+        patch.object(matter_lock_simple, "_get_matter_node", return_value=MagicMock()),
+        patch(f"{_PROVIDER_MODULE}.set_lock_credential", mock_set_credential),
+    ):
+        with pytest.raises(LockCodeManagerProviderError, match="rejected input"):
+            await matter_lock_simple.async_set_usercode(1, "1234")
 
 
 async def test_set_usercode_user_name_failure_does_not_propagate(
     hass: HomeAssistant, matter_lock_simple: MatterLock
 ) -> None:
     """Test that a user name set failure does not propagate when credential set succeeds."""
-    register_mock_service(
-        hass,
-        MATTER_DOMAIN,
-        "set_lock_credential",
-        AsyncMock(
-            return_value={
-                LOCK_ENTITY_ID: {"credential_index": 1, "user_index": 1},
-            }
+    mock_set_credential = AsyncMock(
+        return_value={"credential_index": 1, "user_index": 1}
+    )
+    mock_set_user = AsyncMock(
+        side_effect=HomeAssistantError("500 Internal Server Error")
+    )
+    with (
+        patch.object(
+            matter_lock_simple, "_get_matter_client", return_value=MagicMock()
         ),
-    )
-    register_mock_service(
-        hass,
-        MATTER_DOMAIN,
-        "set_lock_user",
-        AsyncMock(side_effect=HomeAssistantError("500 Internal Server Error")),
-    )
-
-    result = await matter_lock_simple.async_set_usercode(1, "1234", name="Test")
+        patch.object(matter_lock_simple, "_get_matter_node", return_value=MagicMock()),
+        patch(f"{_PROVIDER_MODULE}.set_lock_credential", mock_set_credential),
+        patch(f"{_PROVIDER_MODULE}.set_lock_user", mock_set_user),
+    ):
+        result = await matter_lock_simple.async_set_usercode(1, "1234", name="Test")
 
     assert result is True
 
@@ -461,92 +494,92 @@ async def test_set_usercode_duplicate_direct_raises_immediately(
     hass: HomeAssistant, matter_lock_simple: MatterLock
 ) -> None:
     """Test that a duplicate on a direct (user-initiated) call raises immediately."""
-    handler = AsyncMock(
-        side_effect=HomeAssistantError(
-            "Failed to set credential: lock returned status `duplicate`"
-        )
+    mock_set_credential = AsyncMock(
+        side_effect=_make_set_credential_failed_error("duplicate")
     )
-    register_mock_service(hass, MATTER_DOMAIN, "set_lock_credential", handler)
-
-    with pytest.raises(DuplicateCodeError) as exc_info:
-        await matter_lock_simple.async_set_usercode(1, "1234")
+    with (
+        patch.object(
+            matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+        ),
+        patch.object(matter_lock_simple, "_get_matter_node", return_value=MagicMock()),
+        patch(f"{_PROVIDER_MODULE}.set_lock_credential", mock_set_credential),
+    ):
+        with pytest.raises(DuplicateCodeError) as exc_info:
+            await matter_lock_simple.async_set_usercode(1, "1234")
     assert exc_info.value.code_slot == 1
     assert exc_info.value.lock_entity_id == LOCK_ENTITY_ID
     # Only one set attempt, no clear-and-retry for direct calls
-    assert handler.call_count == 1
+    assert mock_set_credential.call_count == 1
 
 
 async def test_set_usercode_duplicate_sync_retries_after_clear(
     hass: HomeAssistant, matter_lock_simple: MatterLock
 ) -> None:
     """Test that a duplicate during sync clears and retries successfully."""
-    set_handler = AsyncMock(
+    mock_set_credential = AsyncMock(
         side_effect=[
-            HomeAssistantError(
-                "Failed to set credential: lock returned status `duplicate`"
-            ),
-            {LOCK_ENTITY_ID: {"credential_index": 1, "user_index": 1}},
+            _make_set_credential_failed_error("duplicate"),
+            {"credential_index": 1, "user_index": 1},
         ]
     )
-    clear_handler = AsyncMock(return_value={LOCK_ENTITY_ID: {}})
-    register_mock_service(hass, MATTER_DOMAIN, "set_lock_credential", set_handler)
-    register_mock_service(hass, MATTER_DOMAIN, "clear_lock_credential", clear_handler)
-
-    result = await matter_lock_simple.async_set_usercode(1, "1234", source="sync")
+    mock_clear = AsyncMock(return_value={})
+    with (
+        patch.object(
+            matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+        ),
+        patch.object(matter_lock_simple, "_get_matter_node", return_value=MagicMock()),
+        patch(f"{_PROVIDER_MODULE}.set_lock_credential", mock_set_credential),
+        patch(f"{_PROVIDER_MODULE}.clear_lock_credential", mock_clear),
+    ):
+        result = await matter_lock_simple.async_set_usercode(1, "1234", source="sync")
 
     assert result is True
-    assert set_handler.call_count == 2
-    assert clear_handler.call_count == 1
+    assert mock_set_credential.call_count == 2
+    assert mock_clear.call_count == 1
 
 
 async def test_set_usercode_duplicate_sync_persistent_raises(
     hass: HomeAssistant, matter_lock_simple: MatterLock
 ) -> None:
     """Test that a persistent duplicate during sync raises after retry."""
-    set_handler = AsyncMock(
-        side_effect=HomeAssistantError(
-            "Failed to set credential: lock returned status `duplicate`"
-        )
+    mock_set_credential = AsyncMock(
+        side_effect=_make_set_credential_failed_error("duplicate")
     )
-    clear_handler = AsyncMock(return_value={LOCK_ENTITY_ID: {}})
-    register_mock_service(hass, MATTER_DOMAIN, "set_lock_credential", set_handler)
-    register_mock_service(hass, MATTER_DOMAIN, "clear_lock_credential", clear_handler)
-
-    with pytest.raises(DuplicateCodeError) as exc_info:
-        await matter_lock_simple.async_set_usercode(1, "1234", source="sync")
+    mock_clear = AsyncMock(return_value={})
+    with (
+        patch.object(
+            matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+        ),
+        patch.object(matter_lock_simple, "_get_matter_node", return_value=MagicMock()),
+        patch(f"{_PROVIDER_MODULE}.set_lock_credential", mock_set_credential),
+        patch(f"{_PROVIDER_MODULE}.clear_lock_credential", mock_clear),
+    ):
+        with pytest.raises(DuplicateCodeError) as exc_info:
+            await matter_lock_simple.async_set_usercode(1, "1234", source="sync")
     assert exc_info.value.code_slot == 1
     assert exc_info.value.lock_entity_id == LOCK_ENTITY_ID
-    assert set_handler.call_count == 2
-    assert clear_handler.call_count == 1
+    assert mock_set_credential.call_count == 2
+    assert mock_clear.call_count == 1
 
 
-async def test_async_call_service_void_service(
+async def test_set_credential_failed_non_duplicate_raises_code_rejected(
     hass: HomeAssistant, matter_lock_simple: MatterLock
 ) -> None:
-    """Test _async_call_service works with void services that do not return responses.
-
-    Void services (SupportsResponse.NONE) should be called without
-    return_response=True and return an empty dict without raising
-    LockCodeManagerProviderError.
-    """
-    handler = AsyncMock(return_value=None)
-
-    async def _service_handler(call):
-        return await handler(call)
-
-    hass.services.async_register(
-        MATTER_DOMAIN,
-        "void_service",
-        _service_handler,
-        supports_response=SupportsResponse.NONE,
+    """Test that SetCredentialFailedError with non-duplicate status raises CodeRejectedError."""
+    mock_set_credential = AsyncMock(
+        side_effect=_make_set_credential_failed_error("occupied")
     )
-
-    result = await matter_lock_simple._async_call_service(
-        "void_service", {"entity_id": matter_lock_simple.lock.entity_id}
-    )
-
-    assert result == {}
-    assert handler.call_count == 1
+    with (
+        patch.object(
+            matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+        ),
+        patch.object(matter_lock_simple, "_get_matter_node", return_value=MagicMock()),
+        patch(f"{_PROVIDER_MODULE}.set_lock_credential", mock_set_credential),
+    ):
+        with pytest.raises(CodeRejectedError) as exc_info:
+            await matter_lock_simple.async_set_usercode(1, "1234")
+    assert exc_info.value.code_slot == 1
+    assert exc_info.value.lock_entity_id == LOCK_ENTITY_ID
 
 
 async def test_get_usercodes_multiple_credential_types(
@@ -555,8 +588,8 @@ async def test_get_usercodes_multiple_credential_types(
     simple_lcm_config_entry: MockConfigEntry,
 ) -> None:
     """Test that only PIN credentials are considered, not other types like RFID."""
-    mock_response = {
-        LOCK_ENTITY_ID: {
+    mock_get_lock_users = AsyncMock(
+        return_value={
             "max_users": 10,
             "users": [
                 {
@@ -567,17 +600,44 @@ async def test_get_usercodes_multiple_credential_types(
                     ],
                 },
             ],
-        },
-    }
-    handler = AsyncMock(return_value=mock_response)
-    register_mock_service(hass, MATTER_DOMAIN, "get_lock_users", handler)
-
-    codes = await matter_lock_simple.async_get_usercodes()
+        }
+    )
+    with (
+        patch.object(
+            matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+        ),
+        patch.object(matter_lock_simple, "_get_matter_node", return_value=MagicMock()),
+        patch(f"{_PROVIDER_MODULE}.get_lock_users", mock_get_lock_users),
+    ):
+        codes = await matter_lock_simple.async_get_usercodes()
 
     # Slot 1 has only RFID credential, not PIN
     assert codes[1] is SlotCode.EMPTY
     # Slot 2 has a PIN credential
     assert codes[2] is SlotCode.UNREADABLE_CODE
+
+
+async def test_require_client_and_node_no_client(
+    hass: HomeAssistant, matter_lock_simple: MatterLock
+) -> None:
+    """Test _require_client_and_node raises LockDisconnected when client is None."""
+    with patch.object(matter_lock_simple, "_get_matter_client", return_value=None):
+        with pytest.raises(LockDisconnected, match="client or node unavailable"):
+            matter_lock_simple._require_client_and_node()
+
+
+async def test_require_client_and_node_no_node(
+    hass: HomeAssistant, matter_lock_simple: MatterLock
+) -> None:
+    """Test _require_client_and_node raises LockDisconnected when node is None."""
+    with (
+        patch.object(
+            matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+        ),
+        patch.object(matter_lock_simple, "_get_matter_node", return_value=None),
+    ):
+        with pytest.raises(LockDisconnected, match="client or node unavailable"):
+            matter_lock_simple._require_client_and_node()
 
 
 # =============================================================================
@@ -1093,18 +1153,21 @@ class TestOptimisticPushUpdates:
         hass: HomeAssistant,
         matter_lock_simple: MatterLock,
     ) -> None:
-        """async_set_usercode pushes SlotCode.UNREADABLE_CODE after service call."""
+        """async_set_usercode pushes SlotCode.UNREADABLE_CODE after helper call."""
         mock_coordinator = MagicMock()
         matter_lock_simple.coordinator = mock_coordinator
 
-        register_mock_service(
-            hass,
-            MATTER_DOMAIN,
-            "set_lock_credential",
-            AsyncMock(return_value={LOCK_ENTITY_ID: {}}),
-        )
-
-        result = await matter_lock_simple.async_set_usercode(3, "1234")
+        mock_set_credential = AsyncMock(return_value={})
+        with (
+            patch.object(
+                matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+            ),
+            patch.object(
+                matter_lock_simple, "_get_matter_node", return_value=MagicMock()
+            ),
+            patch(f"{_PROVIDER_MODULE}.set_lock_credential", mock_set_credential),
+        ):
+            result = await matter_lock_simple.async_set_usercode(3, "1234")
 
         assert result is True
         mock_coordinator.push_update.assert_called_once_with(
@@ -1119,14 +1182,17 @@ class TestOptimisticPushUpdates:
         """async_set_usercode without coordinator does not crash."""
         matter_lock_simple.coordinator = None
 
-        register_mock_service(
-            hass,
-            MATTER_DOMAIN,
-            "set_lock_credential",
-            AsyncMock(return_value={LOCK_ENTITY_ID: {}}),
-        )
-
-        result = await matter_lock_simple.async_set_usercode(3, "1234")
+        mock_set_credential = AsyncMock(return_value={})
+        with (
+            patch.object(
+                matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+            ),
+            patch.object(
+                matter_lock_simple, "_get_matter_node", return_value=MagicMock()
+            ),
+            patch(f"{_PROVIDER_MODULE}.set_lock_credential", mock_set_credential),
+        ):
+            result = await matter_lock_simple.async_set_usercode(3, "1234")
         assert result is True
 
     async def test_clear_usercode_pushes_empty(
@@ -1138,20 +1204,19 @@ class TestOptimisticPushUpdates:
         mock_coordinator = MagicMock()
         matter_lock_simple.coordinator = mock_coordinator
 
-        register_mock_service(
-            hass,
-            MATTER_DOMAIN,
-            "get_lock_credential_status",
-            AsyncMock(return_value={LOCK_ENTITY_ID: {"credential_exists": True}}),
-        )
-        register_mock_service(
-            hass,
-            MATTER_DOMAIN,
-            "clear_lock_credential",
-            AsyncMock(return_value={LOCK_ENTITY_ID: {}}),
-        )
-
-        result = await matter_lock_simple.async_clear_usercode(5)
+        mock_get_status = AsyncMock(return_value={"credential_exists": True})
+        mock_clear = AsyncMock(return_value={})
+        with (
+            patch.object(
+                matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+            ),
+            patch.object(
+                matter_lock_simple, "_get_matter_node", return_value=MagicMock()
+            ),
+            patch(f"{_PROVIDER_MODULE}.get_lock_credential_status", mock_get_status),
+            patch(f"{_PROVIDER_MODULE}.clear_lock_credential", mock_clear),
+        ):
+            result = await matter_lock_simple.async_clear_usercode(5)
 
         assert result is True
         mock_coordinator.push_update.assert_called_once_with({5: SlotCode.EMPTY})
@@ -1165,14 +1230,17 @@ class TestOptimisticPushUpdates:
         mock_coordinator = MagicMock()
         matter_lock_simple.coordinator = mock_coordinator
 
-        register_mock_service(
-            hass,
-            MATTER_DOMAIN,
-            "get_lock_credential_status",
-            AsyncMock(return_value={LOCK_ENTITY_ID: {"credential_exists": False}}),
-        )
-
-        result = await matter_lock_simple.async_clear_usercode(5)
+        mock_get_status = AsyncMock(return_value={"credential_exists": False})
+        with (
+            patch.object(
+                matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+            ),
+            patch.object(
+                matter_lock_simple, "_get_matter_node", return_value=MagicMock()
+            ),
+            patch(f"{_PROVIDER_MODULE}.get_lock_credential_status", mock_get_status),
+        ):
+            result = await matter_lock_simple.async_clear_usercode(5)
 
         assert result is False
         mock_coordinator.push_update.assert_not_called()
@@ -1182,19 +1250,22 @@ class TestOptimisticPushUpdates:
         hass: HomeAssistant,
         matter_lock_simple: MatterLock,
     ) -> None:
-        """async_set_usercode does not push when service call fails."""
+        """async_set_usercode does not push when helper call fails."""
         mock_coordinator = MagicMock()
         matter_lock_simple.coordinator = mock_coordinator
 
-        register_mock_service(
-            hass,
-            MATTER_DOMAIN,
-            "set_lock_credential",
-            AsyncMock(side_effect=HomeAssistantError("timeout")),
-        )
-
-        with pytest.raises(LockDisconnected):
-            await matter_lock_simple.async_set_usercode(3, "1234")
+        mock_set_credential = AsyncMock(side_effect=HomeAssistantError("timeout"))
+        with (
+            patch.object(
+                matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+            ),
+            patch.object(
+                matter_lock_simple, "_get_matter_node", return_value=MagicMock()
+            ),
+            patch(f"{_PROVIDER_MODULE}.set_lock_credential", mock_set_credential),
+        ):
+            with pytest.raises(LockDisconnected):
+                await matter_lock_simple.async_set_usercode(3, "1234")
 
         mock_coordinator.push_update.assert_not_called()
 
@@ -1203,24 +1274,23 @@ class TestOptimisticPushUpdates:
         hass: HomeAssistant,
         matter_lock_simple: MatterLock,
     ) -> None:
-        """async_clear_usercode does not push when clear service fails."""
+        """async_clear_usercode does not push when clear helper fails."""
         mock_coordinator = MagicMock()
         matter_lock_simple.coordinator = mock_coordinator
 
-        register_mock_service(
-            hass,
-            MATTER_DOMAIN,
-            "get_lock_credential_status",
-            AsyncMock(return_value={LOCK_ENTITY_ID: {"credential_exists": True}}),
-        )
-        register_mock_service(
-            hass,
-            MATTER_DOMAIN,
-            "clear_lock_credential",
-            AsyncMock(side_effect=HomeAssistantError("timeout")),
-        )
-
-        with pytest.raises(LockDisconnected):
-            await matter_lock_simple.async_clear_usercode(5)
+        mock_get_status = AsyncMock(return_value={"credential_exists": True})
+        mock_clear = AsyncMock(side_effect=HomeAssistantError("timeout"))
+        with (
+            patch.object(
+                matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+            ),
+            patch.object(
+                matter_lock_simple, "_get_matter_node", return_value=MagicMock()
+            ),
+            patch(f"{_PROVIDER_MODULE}.get_lock_credential_status", mock_get_status),
+            patch(f"{_PROVIDER_MODULE}.clear_lock_credential", mock_clear),
+        ):
+            with pytest.raises(LockDisconnected):
+                await matter_lock_simple.async_clear_usercode(5)
 
         mock_coordinator.push_update.assert_not_called()

--- a/tests/providers/matter/test_provider.py
+++ b/tests/providers/matter/test_provider.py
@@ -288,6 +288,35 @@ async def test_get_usercodes_unmanaged_occupied_slots(
     assert codes == {5: SlotCode.UNREADABLE_CODE, 8: SlotCode.UNREADABLE_CODE}
 
 
+async def test_get_usercodes_none_credential_index_skipped(
+    hass: HomeAssistant,
+    matter_lock_simple: MatterLock,
+) -> None:
+    """Test that PIN credentials with a None index are skipped."""
+    mock_get_lock_users = AsyncMock(
+        return_value={
+            "users": [
+                {
+                    "credentials": [
+                        {"type": "pin"},  # no "index" key → cred_index is None
+                        {"type": "pin", "index": 4},
+                    ]
+                }
+            ]
+        }
+    )
+    with (
+        patch.object(
+            matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+        ),
+        patch.object(matter_lock_simple, "_get_matter_node", return_value=MagicMock()),
+        patch(f"{_PROVIDER_MODULE}.get_lock_users", mock_get_lock_users),
+    ):
+        codes = await matter_lock_simple.async_get_usercodes()
+    # Only slot 4 should appear; the credential with no index is skipped
+    assert codes == {4: SlotCode.UNREADABLE_CODE}
+
+
 async def test_get_usercodes_invalid_credential_index_skipped(
     hass: HomeAssistant,
     matter_lock_simple: MatterLock,
@@ -582,6 +611,158 @@ async def test_set_credential_failed_non_duplicate_raises_code_rejected(
     assert exc_info.value.lock_entity_id == LOCK_ENTITY_ID
 
 
+async def test_clear_lock_credential_service_validation_error(
+    hass: HomeAssistant, matter_lock_simple: MatterLock
+) -> None:
+    """Test _clear_lock_credential raises LockCodeManagerProviderError on ServiceValidationError."""
+    mock_clear = AsyncMock(side_effect=ServiceValidationError("bad slot"))
+    with (
+        patch.object(
+            matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+        ),
+        patch.object(matter_lock_simple, "_get_matter_node", return_value=MagicMock()),
+        patch(f"{_PROVIDER_MODULE}.clear_lock_credential", mock_clear),
+    ):
+        with pytest.raises(LockCodeManagerProviderError, match="rejected input"):
+            await matter_lock_simple._clear_lock_credential(1)
+
+
+async def test_clear_lock_credential_communication_error(
+    hass: HomeAssistant, matter_lock_simple: MatterLock
+) -> None:
+    """Test _clear_lock_credential raises LockDisconnected on HomeAssistantError."""
+    mock_clear = AsyncMock(side_effect=HomeAssistantError("connection lost"))
+    with (
+        patch.object(
+            matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+        ),
+        patch.object(matter_lock_simple, "_get_matter_node", return_value=MagicMock()),
+        patch(f"{_PROVIDER_MODULE}.clear_lock_credential", mock_clear),
+    ):
+        with pytest.raises(LockDisconnected, match="clear_lock_credential failed"):
+            await matter_lock_simple._clear_lock_credential(1)
+
+
+async def test_get_usercodes_client_unavailable(
+    hass: HomeAssistant, matter_lock_simple: MatterLock
+) -> None:
+    """Test async_get_usercodes raises LockDisconnected when client/node unavailable."""
+    with patch.object(matter_lock_simple, "_get_matter_client", return_value=None):
+        with pytest.raises(LockDisconnected, match="client or node unavailable"):
+            await matter_lock_simple.async_get_usercodes()
+
+
+async def test_get_usercodes_get_lock_users_service_validation_error(
+    hass: HomeAssistant, matter_lock_simple: MatterLock
+) -> None:
+    """Test async_get_usercodes raises LockCodeManagerProviderError on ServiceValidationError from get_lock_users."""
+    mock_get_lock_users = AsyncMock(side_effect=ServiceValidationError("bad request"))
+    with (
+        patch.object(
+            matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+        ),
+        patch.object(matter_lock_simple, "_get_matter_node", return_value=MagicMock()),
+        patch(f"{_PROVIDER_MODULE}.get_lock_users", mock_get_lock_users),
+    ):
+        with pytest.raises(LockCodeManagerProviderError, match="rejected input"):
+            await matter_lock_simple.async_get_usercodes()
+
+
+async def test_get_usercodes_get_lock_users_communication_error(
+    hass: HomeAssistant, matter_lock_simple: MatterLock
+) -> None:
+    """Test async_get_usercodes raises LockDisconnected on HomeAssistantError from get_lock_users."""
+    mock_get_lock_users = AsyncMock(side_effect=HomeAssistantError("connection lost"))
+    with (
+        patch.object(
+            matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+        ),
+        patch.object(matter_lock_simple, "_get_matter_node", return_value=MagicMock()),
+        patch(f"{_PROVIDER_MODULE}.get_lock_users", mock_get_lock_users),
+    ):
+        with pytest.raises(LockDisconnected, match="get_lock_users failed"):
+            await matter_lock_simple.async_get_usercodes()
+
+
+async def test_get_usercodes_invalid_users_type(
+    hass: HomeAssistant, matter_lock_simple: MatterLock
+) -> None:
+    """Test async_get_usercodes raises LockCodeManagerProviderError when users is not a list."""
+    mock_get_lock_users = AsyncMock(return_value={"users": "not-a-list"})
+    with (
+        patch.object(
+            matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+        ),
+        patch.object(matter_lock_simple, "_get_matter_node", return_value=MagicMock()),
+        patch(f"{_PROVIDER_MODULE}.get_lock_users", mock_get_lock_users),
+    ):
+        with pytest.raises(
+            LockCodeManagerProviderError, match="unexpected 'users' value"
+        ):
+            await matter_lock_simple.async_get_usercodes()
+
+
+async def test_set_credential_failed_non_duplicate_on_retry_raises_code_rejected(
+    hass: HomeAssistant, matter_lock_simple: MatterLock
+) -> None:
+    """Test that non-duplicate SetCredentialFailedError on retry raises CodeRejectedError."""
+    mock_set_credential = AsyncMock(
+        side_effect=[
+            _make_set_credential_failed_error("duplicate"),
+            _make_set_credential_failed_error("occupied"),
+        ]
+    )
+    mock_clear = AsyncMock(return_value={})
+    with (
+        patch.object(
+            matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+        ),
+        patch.object(matter_lock_simple, "_get_matter_node", return_value=MagicMock()),
+        patch(f"{_PROVIDER_MODULE}.set_lock_credential", mock_set_credential),
+        patch(f"{_PROVIDER_MODULE}.clear_lock_credential", mock_clear),
+    ):
+        with pytest.raises(CodeRejectedError) as exc_info:
+            await matter_lock_simple.async_set_usercode(1, "1234", source="sync")
+    assert exc_info.value.code_slot == 1
+    assert exc_info.value.lock_entity_id == LOCK_ENTITY_ID
+    assert mock_set_credential.call_count == 2
+    assert mock_clear.call_count == 1
+
+
+async def test_clear_usercode_get_status_service_validation_error(
+    hass: HomeAssistant, matter_lock_simple: MatterLock
+) -> None:
+    """Test async_clear_usercode raises LockCodeManagerProviderError on ServiceValidationError."""
+    mock_get_status = AsyncMock(side_effect=ServiceValidationError("bad index"))
+    with (
+        patch.object(
+            matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+        ),
+        patch.object(matter_lock_simple, "_get_matter_node", return_value=MagicMock()),
+        patch(f"{_PROVIDER_MODULE}.get_lock_credential_status", mock_get_status),
+    ):
+        with pytest.raises(
+            LockCodeManagerProviderError, match="get_lock_credential_status rejected"
+        ):
+            await matter_lock_simple.async_clear_usercode(1)
+
+
+async def test_clear_usercode_get_status_communication_error(
+    hass: HomeAssistant, matter_lock_simple: MatterLock
+) -> None:
+    """Test async_clear_usercode raises LockDisconnected on HomeAssistantError from status check."""
+    mock_get_status = AsyncMock(side_effect=HomeAssistantError("connection lost"))
+    with (
+        patch.object(
+            matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+        ),
+        patch.object(matter_lock_simple, "_get_matter_node", return_value=MagicMock()),
+        patch(f"{_PROVIDER_MODULE}.get_lock_credential_status", mock_get_status),
+    ):
+        with pytest.raises(LockDisconnected, match="get_lock_credential_status failed"):
+            await matter_lock_simple.async_clear_usercode(1)
+
+
 async def test_get_usercodes_multiple_credential_types(
     hass: HomeAssistant,
     matter_lock_simple: MatterLock,
@@ -615,6 +796,67 @@ async def test_get_usercodes_multiple_credential_types(
     assert codes[1] is SlotCode.EMPTY
     # Slot 2 has a PIN credential
     assert codes[2] is SlotCode.UNREADABLE_CODE
+
+
+async def test_get_matter_node_exception_returns_none(
+    hass: HomeAssistant, matter_lock_simple: MatterLock
+) -> None:
+    """Test _get_matter_node returns None when get_node_from_device_entry raises."""
+    # Give the lock a fake device entry so the device_entry guard is bypassed
+    matter_lock_simple.device_entry = MagicMock()
+    with patch(
+        f"{_PROVIDER_MODULE}.get_node_from_device_entry",
+        side_effect=Exception("node lookup failed"),
+    ):
+        result = matter_lock_simple._get_matter_node()
+    assert result is None
+
+
+async def test_setup_client_unavailable(
+    hass: HomeAssistant,
+    matter_lock_simple: MatterLock,
+    simple_lcm_config_entry: MockConfigEntry,
+) -> None:
+    """Test async_setup raises LockDisconnected when _require_client_and_node fails."""
+    with patch.object(matter_lock_simple, "_get_matter_client", return_value=None):
+        with pytest.raises(LockDisconnected, match="client or node unavailable"):
+            await matter_lock_simple.async_setup(simple_lcm_config_entry)
+
+
+async def test_setup_get_lock_info_service_validation_error(
+    hass: HomeAssistant,
+    matter_lock_simple: MatterLock,
+    simple_lcm_config_entry: MockConfigEntry,
+) -> None:
+    """Test async_setup raises LockCodeManagerProviderError on ServiceValidationError."""
+    mock_get_lock_info = AsyncMock(side_effect=ServiceValidationError("bad input"))
+    with (
+        patch.object(
+            matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+        ),
+        patch.object(matter_lock_simple, "_get_matter_node", return_value=MagicMock()),
+        patch(f"{_PROVIDER_MODULE}.get_lock_info", mock_get_lock_info),
+    ):
+        with pytest.raises(LockCodeManagerProviderError, match="rejected input"):
+            await matter_lock_simple.async_setup(simple_lcm_config_entry)
+
+
+async def test_setup_get_lock_info_communication_error(
+    hass: HomeAssistant,
+    matter_lock_simple: MatterLock,
+    simple_lcm_config_entry: MockConfigEntry,
+) -> None:
+    """Test async_setup raises LockDisconnected on HomeAssistantError from get_lock_info."""
+    mock_get_lock_info = AsyncMock(side_effect=HomeAssistantError("connection lost"))
+    with (
+        patch.object(
+            matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+        ),
+        patch.object(matter_lock_simple, "_get_matter_node", return_value=MagicMock()),
+        patch(f"{_PROVIDER_MODULE}.get_lock_info", mock_get_lock_info),
+    ):
+        with pytest.raises(LockDisconnected, match="get_lock_info failed"):
+            await matter_lock_simple.async_setup(simple_lcm_config_entry)
 
 
 async def test_require_client_and_node_no_client(

--- a/tests/providers/zigbee2mqtt/conftest.py
+++ b/tests/providers/zigbee2mqtt/conftest.py
@@ -30,16 +30,7 @@ Z2M_TOPIC_NAME = "TestLockZ2M"
 Z2M_FULL_TOPIC = f"zigbee2mqtt/{Z2M_TOPIC_NAME}"
 Z2M_GET_TOPIC = f"{Z2M_FULL_TOPIC}/get"
 Z2M_SET_TOPIC = f"{Z2M_FULL_TOPIC}/set"
-Z2M_LOCK_ENTITY_ID = "lock.mqtt_test_z2m"
-
-# LCM config: one lock, two slots
-Z2M_LCM_CONFIG = {
-    CONF_LOCKS: [Z2M_LOCK_ENTITY_ID],
-    CONF_SLOTS: {
-        1: {"name": "slot1", "pin": "1234", "enabled": True},
-        2: {"name": "slot2", "pin": "5678", "enabled": True},
-    },
-}
+Z2M_LOCK_UNIQUE_ID = "test_z2m"
 
 
 @dataclass
@@ -142,7 +133,7 @@ def mqtt_patches(mqtt_bus: MqttMessageBus):
                             }
                         },
                     )
-            except (json.JSONDecodeError, TypeError):
+            except json.JSONDecodeError, TypeError:
                 pass
 
     with (
@@ -208,9 +199,15 @@ async def lcm_config_entry(
     lock entity is from the mqtt platform, instantiates Zigbee2MQTTLock,
     creates the coordinator, entities, and sync managers.
     """
-    lcm_entry = MockConfigEntry(
-        domain=DOMAIN, data=Z2M_LCM_CONFIG, unique_id="test_z2m_e2e"
-    )
+    entity_id = mqtt_lock_entity.entity_id
+    config = {
+        CONF_LOCKS: [entity_id],
+        CONF_SLOTS: {
+            1: {"name": "slot1", "pin": "1234", "enabled": True},
+            2: {"name": "slot2", "pin": "5678", "enabled": True},
+        },
+    }
+    lcm_entry = MockConfigEntry(domain=DOMAIN, data=config, unique_id="test_z2m_e2e")
     lcm_entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(lcm_entry.entry_id)
     await hass.async_block_till_done()
@@ -220,10 +217,11 @@ async def lcm_config_entry(
     await hass.config_entries.async_unload(lcm_entry.entry_id)
 
 
-def get_z2m_lock(hass: HomeAssistant, lcm_entry: MockConfigEntry) -> Zigbee2MQTTLock:
+def get_z2m_lock(lcm_entry: MockConfigEntry) -> Zigbee2MQTTLock:
     """Extract the Zigbee2MQTTLock from a loaded LCM config entry."""
-    lock = lcm_entry.runtime_data.locks.get(Z2M_LOCK_ENTITY_ID)
-    assert lock is not None, f"Lock {Z2M_LOCK_ENTITY_ID} not found in runtime data"
+    locks = lcm_entry.runtime_data.locks
+    assert len(locks) == 1, f"Expected 1 lock, found {len(locks)}"
+    lock = next(iter(locks.values()))
     assert isinstance(lock, Zigbee2MQTTLock)
     return lock
 
@@ -231,7 +229,7 @@ def get_z2m_lock(hass: HomeAssistant, lcm_entry: MockConfigEntry) -> Zigbee2MQTT
 @pytest.fixture
 def z2m_lock(hass, lcm_config_entry):
     """Extract the Z2M lock from the LCM config entry."""
-    return get_z2m_lock(hass, lcm_config_entry)
+    return get_z2m_lock(lcm_config_entry)
 
 
 @pytest.fixture

--- a/tests/providers/zigbee2mqtt/test_e2e.py
+++ b/tests/providers/zigbee2mqtt/test_e2e.py
@@ -14,9 +14,9 @@ from custom_components.lock_code_manager.providers.zigbee2mqtt import (
 from .conftest import (
     Z2M_FULL_TOPIC,
     Z2M_GET_TOPIC,
-    Z2M_LOCK_ENTITY_ID,
     Z2M_SET_TOPIC,
     MqttMessageBus,
+    get_z2m_lock,
 )
 
 
@@ -29,8 +29,7 @@ class TestFullSetupLifecycle:
         lcm_config_entry,
     ) -> None:
         """Verify LCM discovers the MQTT lock and creates a Zigbee2MQTTLock."""
-        lock = lcm_config_entry.runtime_data.locks.get(Z2M_LOCK_ENTITY_ID)
-        assert lock is not None
+        lock = get_z2m_lock(lcm_config_entry)
         assert isinstance(lock, Zigbee2MQTTLock)
 
     async def test_coordinator_created(


### PR DESCRIPTION
## Proposed change

Migrates the Matter provider from HA service calls to direct `lock_helpers` function calls, fixes two bugs, and upgrades the project to Python 3.14.

### Matter provider migration
- **Replace all service calls with direct `lock_helpers` imports** — `get_lock_info`, `get_lock_users`, `set_lock_credential`, `clear_lock_credential`, `get_lock_credential_status`, `set_lock_user`
- **Delete `_async_call_service`** — no longer needed; eliminates 35 lines of response validation boilerplate
- **Delete `_is_duplicate_error`** — replaced by direct `SetCredentialFailedError` check with typed `translation_placeholders["status"]`
- **Add `_require_client_and_node` helper** — shared client/node resolution with `LockDisconnected` on failure
- **Correct exception mapping**:
  - `SetCredentialFailedError` status=`"duplicate"` → `DuplicateCodeError`
  - `SetCredentialFailedError` other status → `CodeRejectedError` (lock is reachable but rejected the credential)
  - `ServiceValidationError` subclasses → `LockCodeManagerProviderError`
  - Other `HomeAssistantError` → `LockDisconnected`

### Bug fixes
- **Fix wrong credential keys in `async_get_usercodes`**: `credential_type`/`credential_index` → `type`/`index`
- **Flatten nested try blocks** in `async_set_usercode` — extracted `_set_credential_with_duplicate_handling` and `_set_user_name` helpers

### Infrastructure
- Bump Python requirement from 3.13 to 3.14
- Bump `pytest-homeassistant-custom-component` to 0.13.324 (HA 2026.4.3)
- Bump `homeassistant` dev dependency to >=2026.4.0b0
- Set ruff `target-version = "py314"`
- Update CI to test Python 3.14 (target)

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue:
- This PR is related to issue: