### PR TITLE
ci: speed up Python checks by running ruff/mypy without waiting for setup

### DIFF
--- a/.github/workflows/python-checks.yml
+++ b/.github/workflows/python-checks.yml
@@ -30,14 +30,13 @@ jobs:
 
   ruff:
     name: Ruff
-    needs: setup
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: ${{ needs.setup.outputs.target-python }}
+          python-version: ${{ env.TARGET_PYTHON }}
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
@@ -51,14 +50,13 @@ jobs:
 
   mypy:
     name: Mypy
-    needs: setup
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: ${{ needs.setup.outputs.target-python }}
+          python-version: ${{ env.TARGET_PYTHON }}
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
@@ -88,16 +86,11 @@ jobs:
         with:
           enable-cache: true
       - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install libudev-dev
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libudev-dev
       - name: Install dependencies
-        run: uv pip install --system -r requirements_dev.txt
+        run: uv pip install --system -r requirements_dev.txt pytest-cov pytest-github-actions-annotate-failures
       - name: Run tests and generate coverage report
-        # CI-only deps installed separately to keep requirements_dev.txt lightweight
-        run: |
-          uv pip install --system pytest-cov pytest-github-actions-annotate-failures
-          pytest ./tests/ --cov=custom_components/lock_code_manager/ --cov-report=xml --junitxml=junit.xml
+        run: pytest ./tests/ --cov=custom_components/lock_code_manager/ --cov-report=xml --junitxml=junit.xml
       - name: Upload coverage to Codecov
         if: matrix.python-version == needs.setup.outputs.target-python
         uses: codecov/codecov-action@v6


### PR DESCRIPTION
## Proposed change

Removes the `needs: setup` dependency from the ruff and mypy jobs so they start immediately in parallel with setup, instead of waiting ~30s for the version matrix computation they don't need.

Also:
- Merge CI-only pip installs (pytest-cov, pytest-github-actions-annotate-failures) into the main install step
- Optimize apt-get with `--no-install-recommends`

Before: `setup` → (`ruff` | `mypy` | `pytest`) — ruff/mypy waited for setup
After: (`ruff` | `mypy` | `setup`) → `pytest` — ruff/mypy start immediately

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue:
- This PR is related to issue: