### PR TITLE
fix: sync manager stuck in LOADING for disabled slots

### DIFF
--- a/custom_components/lock_code_manager/sync.py
+++ b/custom_components/lock_code_manager/sync.py
@@ -238,8 +238,13 @@ class SlotSyncManager:
         """Ensure all dependent entities exist with valid states.
 
         The name entity (CONF_NAME) is optional — STATE_UNKNOWN is its
-        normal state when no name is configured, so we only block on
-        STATE_UNAVAILABLE for it.
+        normal state when no name is configured.
+
+        When the slot is inactive (active entity is OFF), PIN and code
+        sensor entities are allowed to be STATE_UNKNOWN since the sync
+        manager only needs to know the slot is off to proceed (clear or
+        confirm already cleared). This prevents disabled slots from
+        being stuck in LOADING forever.
         """
         for key in (CONF_PIN, CONF_NAME, ATTR_ACTIVE, ATTR_CODE):
             if key not in self._entity_id_map:
@@ -248,11 +253,23 @@ class SlotSyncManager:
             if state is None or state == STATE_UNAVAILABLE:
                 _LOGGER.debug("%s: Waiting for %s state", self._log_prefix, key)
                 return False
-            # Name is optional — STATE_UNKNOWN is valid (no name configured).
-            # All other entities must have a definite state.
-            if key != CONF_NAME and state == STATE_UNKNOWN:
-                _LOGGER.debug("%s: Waiting for %s state", self._log_prefix, key)
-                return False
+
+        active_state = self._get_entity_state(ATTR_ACTIVE)
+
+        for key in (CONF_PIN, CONF_NAME, ATTR_ACTIVE, ATTR_CODE):
+            state = self._get_entity_state(key)
+            if state == STATE_UNKNOWN:
+                # Name is always optional
+                if key == CONF_NAME:
+                    continue
+                # Active entity must always have a definite state
+                if key == ATTR_ACTIVE:
+                    _LOGGER.debug("%s: Waiting for %s state", self._log_prefix, key)
+                    return False
+                # PIN and code sensor can be unknown when slot is inactive
+                if active_state != STATE_OFF:
+                    _LOGGER.debug("%s: Waiting for %s state", self._log_prefix, key)
+                    return False
         return True
 
     def _resolve_slot_state(self) -> SlotState | None:

--- a/custom_components/lock_code_manager/sync.py
+++ b/custom_components/lock_code_manager/sync.py
@@ -246,6 +246,8 @@ class SlotSyncManager:
         confirm already cleared). This prevents disabled slots from
         being stuck in LOADING forever.
         """
+        # Collect all states in a single pass
+        states: dict[str, str | None] = {}
         for key in (CONF_PIN, CONF_NAME, ATTR_ACTIVE, ATTR_CODE):
             if key not in self._entity_id_map:
                 return False
@@ -253,23 +255,21 @@ class SlotSyncManager:
             if state is None or state == STATE_UNAVAILABLE:
                 _LOGGER.debug("%s: Waiting for %s state", self._log_prefix, key)
                 return False
+            states[key] = state
 
-        active_state = self._get_entity_state(ATTR_ACTIVE)
+        # Active entity must always have a definite state
+        if states[ATTR_ACTIVE] == STATE_UNKNOWN:
+            _LOGGER.debug("%s: Waiting for %s state", self._log_prefix, ATTR_ACTIVE)
+            return False
 
-        for key in (CONF_PIN, CONF_NAME, ATTR_ACTIVE, ATTR_CODE):
-            state = self._get_entity_state(key)
-            if state == STATE_UNKNOWN:
-                # Name is always optional
-                if key == CONF_NAME:
-                    continue
-                # Active entity must always have a definite state
-                if key == ATTR_ACTIVE:
-                    _LOGGER.debug("%s: Waiting for %s state", self._log_prefix, key)
-                    return False
-                # PIN and code sensor can be unknown when slot is inactive
-                if active_state != STATE_OFF:
-                    _LOGGER.debug("%s: Waiting for %s state", self._log_prefix, key)
-                    return False
+        # Name is always optional (STATE_UNKNOWN = no name configured)
+        # PIN and code sensor can be unknown when the slot is inactive
+        slot_inactive = states[ATTR_ACTIVE] == STATE_OFF
+        for key in (CONF_PIN, ATTR_CODE):
+            if states[key] == STATE_UNKNOWN and not slot_inactive:
+                _LOGGER.debug("%s: Waiting for %s state", self._log_prefix, key)
+                return False
+
         return True
 
     def _resolve_slot_state(self) -> SlotState | None:

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.issue_registry import (
     IssueSeverity,
@@ -25,7 +25,7 @@ from custom_components.lock_code_manager.exceptions import (
 from custom_components.lock_code_manager.models import SlotCode, SyncState
 from custom_components.lock_code_manager.sync import SlotState, SlotSyncManager
 
-from .common import SLOT_1_IN_SYNC_ENTITY
+from .common import SLOT_1_ACTIVE_ENTITY, SLOT_1_IN_SYNC_ENTITY, SLOT_1_PIN_ENTITY
 from .conftest import async_trigger_sync_tick, get_in_sync_entity_obj
 
 
@@ -425,6 +425,28 @@ class TestSyncStateMachine:
         manager._coordinator.data[1] = SlotCode.EMPTY
         await async_trigger_sync_tick(hass, SLOT_1_IN_SYNC_ENTITY, set_dirty=False)
         assert manager._state is SyncState.OUT_OF_SYNC
+
+    async def test_disabled_slot_with_unknown_pin_exits_loading(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """Disabled slot with unknown PIN/code transitions out of LOADING."""
+        entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
+        manager = entity_obj._sync_manager
+        manager._state = SyncState.LOADING
+
+        # Simulate disabled slot: active=off, PIN unknown
+        hass.states.async_set(SLOT_1_ACTIVE_ENTITY, STATE_OFF)
+        hass.states.async_set(SLOT_1_PIN_ENTITY, STATE_UNKNOWN)
+        # Coordinator has slot as EMPTY (no code on lock)
+        manager._coordinator.data[1] = SlotCode.EMPTY
+
+        await async_trigger_sync_tick(hass, SLOT_1_IN_SYNC_ENTITY, set_dirty=False)
+
+        # Should transition to IN_SYNC (slot off, code empty = in sync)
+        assert manager._state is SyncState.IN_SYNC
 
     async def test_loading_to_synced(
         self,

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -448,6 +448,42 @@ class TestSyncStateMachine:
         # Should transition to IN_SYNC (slot off, code empty = in sync)
         assert manager._state is SyncState.IN_SYNC
 
+    async def test_active_unknown_stays_in_loading(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """Slot stays in LOADING when active entity is STATE_UNKNOWN."""
+        entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
+        manager = entity_obj._sync_manager
+        manager._state = SyncState.LOADING
+
+        hass.states.async_set(SLOT_1_ACTIVE_ENTITY, STATE_UNKNOWN)
+        manager._coordinator.data[1] = SlotCode.EMPTY
+
+        await async_trigger_sync_tick(hass, SLOT_1_IN_SYNC_ENTITY, set_dirty=False)
+        assert manager._state is SyncState.LOADING
+
+    async def test_enabled_slot_with_unknown_pin_stays_in_loading(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """Enabled slot with unknown PIN stays in LOADING (needs PIN to sync)."""
+        entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
+        manager = entity_obj._sync_manager
+        manager._state = SyncState.LOADING
+
+        # Active=on but PIN unknown — can't sync without knowing what PIN to set
+        hass.states.async_set(SLOT_1_ACTIVE_ENTITY, STATE_ON)
+        hass.states.async_set(SLOT_1_PIN_ENTITY, STATE_UNKNOWN)
+        manager._coordinator.data[1] = SlotCode.EMPTY
+
+        await async_trigger_sync_tick(hass, SLOT_1_IN_SYNC_ENTITY, set_dirty=False)
+        assert manager._state is SyncState.LOADING
+
     async def test_loading_to_synced(
         self,
         hass: HomeAssistant,


### PR DESCRIPTION
## Proposed change

Fixes the sync manager getting permanently stuck in LOADING state for disabled slots that have no PIN configured.

**Root cause:** `_ensure_entities_ready` required ALL four entities (PIN, name, active, code sensor) to have definite states (not `STATE_UNKNOWN`). When a slot is disabled with no PIN set, both the PIN text entity and code sensor entity are `STATE_UNKNOWN`. The sync manager blocked on them forever.

**Fix:** When the active entity is `STATE_OFF` (slot disabled), allow PIN and code sensor to be `STATE_UNKNOWN`. The sync manager only needs to know the slot is inactive to proceed — it will confirm the slot is already cleared or clear it.

Entities that must always have definite state:
- `ATTR_ACTIVE` — always required (determines sync behavior)

Entities allowed to be `STATE_UNKNOWN` conditionally:
- `CONF_NAME` — always allowed (name is optional)
- `CONF_PIN` — allowed when slot is inactive
- `ATTR_CODE` — allowed when slot is inactive

This is the companion fix to the name entity fix from #1077. Both were found via live smoke testing.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #1083
- This PR is related to issue: