### PR TITLE
ci: group pytest and zeroconf with homeassistant in dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -26,7 +26,9 @@ updates:
       homeassistant:
         patterns:
           - "homeassistant"
+          - "pytest"
           - "pytest-homeassistant-custom-component"
+          - "zeroconf"
   - package-ecosystem: npm
     directory: "/" # Location of package manifests
     schedule:

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -26,9 +26,11 @@ updates:
       homeassistant:
         patterns:
           - "homeassistant"
+          - "python-matter-server"
           - "pytest"
           - "pytest-homeassistant-custom-component"
           - "zeroconf"
+          - "zwave-js-server-python"
   - package-ecosystem: npm
     directory: "/" # Location of package manifests
     schedule:


### PR DESCRIPTION
## Proposed change

Groups `pytest` and `zeroconf` with `homeassistant` and `pytest-homeassistant-custom-component` in the dependabot config so they're bumped together in a single PR.

**Why:**
- `pytest` is pinned by `pytest-homeassistant-custom-component` (currently requires `==9.0.0`). An independent bump to `>=9.0.3` caused #1081 to fail.
- `zeroconf` is pinned by `homeassistant`. We also pin it exactly (`==0.148.0`). An independent bump could cause version conflicts.

Grouping ensures these interdependent packages are always updated together, preventing CI failures from version mismatches.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue:
- This PR is related to issue: #1081