### PR TITLE
fix: Schlage sync loop and uncaught ReadTimeout

### DIFF
--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -830,10 +830,12 @@ class BaseLock:
                 blocking=blocking,
                 return_response=return_response,
             )
-        except HomeAssistantError as err:
-            # ServiceValidationError is a subclass of HomeAssistantError so
-            # it's covered here. CancelledError and programming bugs (TypeError,
-            # KeyError) deliberately propagate.
+        except (HomeAssistantError, OSError) as err:
+            # HomeAssistantError covers ServiceValidationError and HA-wrapped
+            # failures. OSError covers transient network errors (ReadTimeout,
+            # ConnectionError) from integrations that don't wrap them in
+            # HomeAssistantError. CancelledError and programming bugs
+            # (TypeError, KeyError) deliberately propagate.
             LOGGER.error(
                 "Error calling %s.%s service call: %s", domain, service, str(err)
             )

--- a/custom_components/lock_code_manager/providers/schlage.py
+++ b/custom_components/lock_code_manager/providers/schlage.py
@@ -315,26 +315,17 @@ class SchlageLock(BaseLock):
         effective_name = name or existing_friendly_name
         tagged_name = _make_tagged_name(code_slot, effective_name)
 
-        if existing_full_name:
-            # Code exists: delete first, then re-add. Schlage rejects add_code
-            # with a duplicate name, so we always delete-then-add for existing codes.
-            await self._async_delete_code(existing_full_name)
+        # Clear any existing code on this slot before adding. Schlage rejects
+        # add_code with a duplicate name, and eventual consistency in the cloud
+        # API means get_codes may not reflect a recently-added code.
+        names_to_delete = {n for n in (existing_full_name, tagged_name) if n}
+        for code_name in names_to_delete:
+            try:
+                await self._async_delete_code(code_name)
+            except LockDisconnected:
+                pass  # code may not exist — that's fine
 
-        try:
-            await self._async_add_code(tagged_name, usercode)
-        except LockDisconnected as err:
-            if "already exists" not in str(err).lower():
-                raise
-            # Schlage API eventual consistency: get_codes didn't return the code
-            # but add_code says it already exists. Fall back to delete-then-add.
-            LOGGER.debug(
-                "Lock %s: code '%s' already exists (eventual consistency), "
-                "deleting and re-adding",
-                self.lock.entity_id,
-                tagged_name,
-            )
-            await self._async_delete_code(tagged_name)
-            await self._async_add_code(tagged_name, usercode)
+        await self._async_add_code(tagged_name, usercode)
 
         LOGGER.debug(
             "Lock %s: set usercode on slot %s",

--- a/custom_components/lock_code_manager/providers/schlage.py
+++ b/custom_components/lock_code_manager/providers/schlage.py
@@ -315,25 +315,25 @@ class SchlageLock(BaseLock):
         effective_name = name or existing_friendly_name
         tagged_name = _make_tagged_name(code_slot, effective_name)
 
-        if existing_full_name and existing_full_name == tagged_name:
-            # Same name (PIN-only update): Schlage rejects add_code with a
-            # duplicate name, so delete the old code first then re-add.
+        if existing_full_name:
+            # Code exists: delete first, then re-add. Schlage rejects add_code
+            # with a duplicate name, so we always delete-then-add for existing codes.
             await self._async_delete_code(existing_full_name)
+
+        try:
             await self._async_add_code(tagged_name, usercode)
-        elif existing_full_name:
-            # Different name: add new first (safe, different name) then delete old.
-            await self._async_add_code(tagged_name, usercode)
-            try:
-                await self._async_delete_code(existing_full_name)
-            except LockDisconnected:
-                LOGGER.warning(
-                    "Lock %s: code set on slot %s but failed to remove old entry '%s'",
-                    self.lock.entity_id,
-                    code_slot,
-                    existing_full_name,
-                )
-        else:
-            # No existing code: just add.
+        except LockDisconnected as err:
+            if "already exists" not in str(err).lower():
+                raise
+            # Schlage API eventual consistency: get_codes didn't return the code
+            # but add_code says it already exists. Fall back to delete-then-add.
+            LOGGER.debug(
+                "Lock %s: code '%s' already exists (eventual consistency), "
+                "deleting and re-adding",
+                self.lock.entity_id,
+                tagged_name,
+            )
+            await self._async_delete_code(tagged_name)
             await self._async_add_code(tagged_name, usercode)
 
         LOGGER.debug(

--- a/tests/providers/schlage/test_provider.py
+++ b/tests/providers/schlage/test_provider.py
@@ -327,9 +327,10 @@ async def test_set_usercode_replaces_existing(
     add_call = add_handler.call_args[0][0]
     assert add_call.data["name"] == "[LCM:1] New Name"
     assert add_call.data["code"] == "5678"
-    # old code deleted
-    delete_call = delete_handler.call_args[0][0]
-    assert delete_call.data["name"] == "[LCM:1] Old Name"
+    # Both old name and new tagged name deleted (eventual consistency guard)
+    assert delete_handler.call_count == 2
+    deleted_names = {call[0][0].data["name"] for call in delete_handler.call_args_list}
+    assert deleted_names == {"[LCM:1] Old Name", "[LCM:1] New Name"}
 
 
 async def test_set_usercode_preserves_existing_name(
@@ -360,7 +361,7 @@ async def test_set_usercode_preserves_existing_name(
     result = await schlage_lock.async_set_usercode(1, "9999")
 
     assert result is True
-    # Old code deleted first, then new code added with same tagged name
+    # Name unchanged so existing_full_name == tagged_name, deduplicated to 1 delete
     assert delete_handler.call_count == 1
     delete_call = delete_handler.call_args[0][0]
     assert delete_call.data["name"] == "[LCM:1] Guest"

--- a/tests/providers/test_base.py
+++ b/tests/providers/test_base.py
@@ -383,6 +383,33 @@ async def test_async_call_service_propagates_non_ha_exceptions(
     hass.services.async_remove("test_domain", "buggy_service")
 
 
+async def test_async_call_service_wraps_os_error_as_lock_disconnected(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """Test that async_call_service wraps OSError (e.g. ReadTimeout) as LockDisconnected.
+
+    Integrations that don't wrap network errors in HomeAssistantError raise raw
+    OSError subclasses (TimeoutError, ConnectionError).  These are transient and
+    should be routed through the retry/backoff path, not treated as programming
+    errors.
+    """
+    lock_provider = lock_code_manager_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
+
+    async def timeout_service(call):
+        raise TimeoutError("Read timed out")
+
+    hass.services.async_register("test_domain", "timeout_service", timeout_service)
+
+    with pytest.raises(
+        LockDisconnected, match="Service call test_domain.timeout_service failed"
+    ):
+        await lock_provider.async_call_service("test_domain", "timeout_service", {})
+
+    hass.services.async_remove("test_domain", "timeout_service")
+
+
 async def test_set_usercode_refreshes_coordinator_on_change(
     hass: HomeAssistant,
     mock_lock_config_entry,


### PR DESCRIPTION
## Proposed change

Fixes two bugs causing Schlage locks to repeatedly re-set codes every sync cycle:

### 1. Schlage set_usercode sync loop from eventual consistency
Schlage's cloud API has eventual consistency — `get_codes` may not return a code that `add_code` knows about. This caused `async_set_usercode` to attempt `add_code` for a code that already existed, getting "already exists" error → `LockOperationFailed` → retry → same error → infinite loop.

**Fix:** Simplified `async_set_usercode` to always delete-then-add. Before adding a code, both the existing tagged name and the new tagged name are speculatively deleted (deduplicated via set when names match). `LockDisconnected` on delete is swallowed since the code may not exist. This eliminates the "already exists" error entirely rather than handling it reactively.

### 2. Catch OSError in BaseLock async_call_service
`ReadTimeout` from `requests`/`urllib3` extends `OSError`, not `HomeAssistantError`. When Schlage's cloud API timed out during a set operation, the error leaked past `async_call_service` to the sync manager's generic `except Exception` handler, which suspended the lock instead of retrying.

**Fix:** `async_call_service` now catches `(HomeAssistantError, OSError)` — covering both HA-wrapped errors and raw network errors from integrations that don't wrap them. Added test coverage for this behavior.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #1083
- This PR is related to issue: