### PR TITLE
fix: Schlage sync loop from stale reads and already-exists errors

### DIFF
--- a/custom_components/lock_code_manager/providers/schlage.py
+++ b/custom_components/lock_code_manager/providers/schlage.py
@@ -325,7 +325,23 @@ class SchlageLock(BaseLock):
             except LockDisconnected:
                 pass  # code may not exist — that's fine
 
-        await self._async_add_code(tagged_name, usercode)
+        try:
+            await self._async_add_code(tagged_name, usercode)
+        except LockDisconnected as err:
+            # Schlage's cloud API has eventual consistency: a delete may not
+            # propagate before the add, causing "already exists".  Since PINs
+            # are write-only we can't verify the value, but the code IS on the
+            # lock — treat it as success so _last_set_pin gets recorded and the
+            # sync manager doesn't loop.
+            if "already exists" not in str(err).lower():
+                raise
+
+            LOGGER.debug(
+                "Lock %s: code for slot %s already exists on lock "
+                "(eventual consistency), treating as successful set",
+                self.lock.entity_id,
+                code_slot,
+            )
 
         LOGGER.debug(
             "Lock %s: set usercode on slot %s",

--- a/custom_components/lock_code_manager/sync.py
+++ b/custom_components/lock_code_manager/sync.py
@@ -330,6 +330,14 @@ class SlotSyncManager:
             if lock_code is SlotCode.UNREADABLE_CODE:
                 return slot_state.pin_state == self._last_set_pin
             if lock_code is SlotCode.EMPTY:
+                # If we recently set a PIN on this slot and it matches the
+                # configured PIN, trust the set — the provider may not have
+                # caught up yet (eventual consistency, e.g. Schlage cloud API).
+                if (
+                    self._last_set_pin is not None
+                    and slot_state.pin_state == self._last_set_pin
+                ):
+                    return True
                 return False  # need to set
             return slot_state.pin_state == lock_code
         # active_state == STATE_OFF: slot should be cleared

--- a/tests/providers/schlage/test_provider.py
+++ b/tests/providers/schlage/test_provider.py
@@ -372,6 +372,48 @@ async def test_set_usercode_preserves_existing_name(
     assert call_order == ["delete", "add"]
 
 
+async def test_set_usercode_already_exists_treated_as_success(
+    hass: HomeAssistant, schlage_lock: SchlageLock
+) -> None:
+    """Test that 'already exists' on add_code is treated as success.
+
+    Schlage's cloud API has eventual consistency: a delete may not propagate
+    before the add, causing 'already exists'.  Since PINs are write-only,
+    we can't verify the value but the code IS on the lock.
+    """
+    get_response = {LOCK_ENTITY_ID: {}}
+    get_handler = AsyncMock(return_value=get_response)
+    add_handler = AsyncMock(
+        side_effect=HomeAssistantError(
+            'A PIN code with the name "[LCM:1] Guest" already exists on the lock'
+        )
+    )
+    delete_handler = AsyncMock(return_value=None)
+    register_mock_service(hass, SCHLAGE_DOMAIN, "get_codes", get_handler)
+    register_mock_service(hass, SCHLAGE_DOMAIN, "add_code", add_handler)
+    register_mock_service(hass, SCHLAGE_DOMAIN, "delete_code", delete_handler)
+
+    result = await schlage_lock.async_set_usercode(1, "1234", "Guest")
+
+    assert result is True
+
+
+async def test_set_usercode_non_exists_error_still_raises(
+    hass: HomeAssistant, schlage_lock: SchlageLock
+) -> None:
+    """Test that add_code errors other than 'already exists' still raise."""
+    get_response = {LOCK_ENTITY_ID: {}}
+    get_handler = AsyncMock(return_value=get_response)
+    add_handler = AsyncMock(side_effect=HomeAssistantError("connection lost"))
+    delete_handler = AsyncMock(return_value=None)
+    register_mock_service(hass, SCHLAGE_DOMAIN, "get_codes", get_handler)
+    register_mock_service(hass, SCHLAGE_DOMAIN, "add_code", add_handler)
+    register_mock_service(hass, SCHLAGE_DOMAIN, "delete_code", delete_handler)
+
+    with pytest.raises(LockDisconnected, match="connection lost"):
+        await schlage_lock.async_set_usercode(1, "1234")
+
+
 async def test_set_usercode_service_failure(
     hass: HomeAssistant, schlage_lock: SchlageLock
 ) -> None:

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -114,6 +114,26 @@ class TestCalculateInSync:
                 id="active-empty-code",
             ),
             pytest.param(
+                "1234",
+                {
+                    "active": STATE_ON,
+                    "pin": "1234",
+                    "coordinator_code": SlotCode.EMPTY,
+                },
+                True,
+                id="active-empty-code-matching-last-set",
+            ),
+            pytest.param(
+                "5678",
+                {
+                    "active": STATE_ON,
+                    "pin": "1234",
+                    "coordinator_code": SlotCode.EMPTY,
+                },
+                False,
+                id="active-empty-code-mismatched-last-set",
+            ),
+            pytest.param(
                 None,
                 {
                     "active": STATE_ON,


### PR DESCRIPTION
## Proposed change

Follow-up to #1089 — user still experiencing the sync loop on 2.3.3. Analysis of the new debug log revealed two remaining issues that cause the sync manager to endlessly re-set codes on Schlage locks.

### 1. Stale coordinator reads after successful set

After `async_set_usercode` succeeds, the sync calls `async_refresh()` to verify. Schlage's cloud API has eventual consistency — `get_codes` may return stale data showing the slot as **EMPTY** even though the code was just added. `calculate_in_sync` sees `EMPTY` → returns `False` → `OUT_OF_SYNC` → re-set on next tick.

**Fix:** When `lock_code` is `EMPTY` but `_last_set_pin` is set and matches the configured PIN, trust the write — the provider hasn't caught up yet. This prevents unnecessary re-sets after successful writes while still correctly detecting genuinely empty slots (where `_last_set_pin` is `None` or doesn't match).

### 2. "Already exists" treated as transient failure

With delete-then-add from #1089, the delete may succeed but Schlage's eventual consistency means `add_code` can still see the old entry and reject with "already exists". This is wrapped as `LockDisconnected` → retry on next tick → same error → loop.

**Fix:** In Schlage's `async_set_usercode`, catch `LockDisconnected` where the message contains "already exists" and treat it as success. Since PINs are write-only, we can't verify the value, but the code IS on the lock. This allows `_last_set_pin` to be recorded, which combined with fix 1 prevents the read-side from triggering another re-set.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #1083
- This PR is related to issue: #1089