### PR TITLE
feat: add ZHA (Zigbee Home Automation) lock provider

### DIFF
--- a/custom_components/lock_code_manager/manifest.json
+++ b/custom_components/lock_code_manager/manifest.json
@@ -13,6 +13,7 @@
     "schedule",
     "template",
     "virtual",
+    "zha",
     "zwave_js"
   ],
   "codeowners": [

--- a/custom_components/lock_code_manager/providers/__init__.py
+++ b/custom_components/lock_code_manager/providers/__init__.py
@@ -7,6 +7,7 @@ from .akuvox import AkuvoxLock
 from .matter import MatterLock
 from .schlage import SchlageLock
 from .virtual import VirtualLock
+from .zha import ZHALock
 from .zigbee2mqtt import Zigbee2MQTTLock
 from .zwave_js import ZWaveJSLock
 
@@ -16,5 +17,6 @@ INTEGRATIONS_CLASS_MAP: dict[str, type[BaseLock]] = {
     "mqtt": Zigbee2MQTTLock,
     "schlage": SchlageLock,
     "virtual": VirtualLock,
+    "zha": ZHALock,
     "zwave_js": ZWaveJSLock,
 }

--- a/custom_components/lock_code_manager/providers/zha.py
+++ b/custom_components/lock_code_manager/providers/zha.py
@@ -21,6 +21,7 @@ from homeassistant.components.zha.const import DOMAIN as ZHA_DOMAIN
 from homeassistant.components.zha.helpers import (
     get_zha_gateway_proxy as _get_zha_gateway_proxy,
 )
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import callback
 
 from ..exceptions import LockDisconnected
@@ -109,6 +110,25 @@ class ZHALock(BaseLock):
     def connection_check_interval(self) -> timedelta | None:
         """Return interval for connection checks."""
         return timedelta(seconds=30)
+
+    # -- Setup ---------------------------------------------------------------
+
+    async def async_setup(self, config_entry: ConfigEntry) -> None:
+        """Detect programming event support before coordinator creation.
+
+        The coordinator reads ``hard_refresh_interval`` during init, so we
+        must know whether the lock supports programming events before that.
+        """
+        await super().async_setup(config_entry)
+        self._supports_programming_events = (
+            await self._async_check_programming_event_support()
+        )
+        if not self._supports_programming_events:
+            _LOGGER.info(
+                "Lock %s: programming event notifications not supported, "
+                "enabling drift detection (1 hour interval)",
+                self.lock.entity_id,
+            )
 
     # -- Cluster access ------------------------------------------------------
 
@@ -214,12 +234,12 @@ class ZHALock(BaseLock):
                 raise
             except Exception:
                 _LOGGER.debug(
-                    "Lock %s: failed to read slot %s, assuming empty",
+                    "Lock %s: failed to read slot %s, marking unreadable",
                     self.lock.entity_id,
                     slot_num,
                     exc_info=True,
                 )
-                data[slot_num] = SlotCode.EMPTY
+                data[slot_num] = SlotCode.UNREADABLE_CODE
         return data
 
     async def async_set_usercode(
@@ -304,12 +324,6 @@ class ZHALock(BaseLock):
         if not cluster:
             raise LockDisconnected(
                 "DoorLock cluster not available for push subscription"
-            )
-
-        if self._supports_programming_events is None:
-            self.hass.async_create_task(
-                self._async_detect_programming_support(),
-                f"Detect programming event support for {self.lock.entity_id}",
             )
 
         cluster.add_listener(self)
@@ -426,18 +440,6 @@ class ZHALock(BaseLock):
 
     # -- Programming event support detection ---------------------------------
 
-    async def _async_detect_programming_support(self) -> None:
-        """Detect programming event support and update the property."""
-        self._supports_programming_events = (
-            await self._async_check_programming_event_support()
-        )
-        if not self._supports_programming_events:
-            _LOGGER.info(
-                "Lock %s: programming event notifications not supported, "
-                "enabling drift detection (1 hour interval)",
-                self.lock.entity_id,
-            )
-
     async def _async_check_programming_event_support(self) -> bool:
         """Check if the lock supports programming event notifications.
 
@@ -453,27 +455,36 @@ class ZHALock(BaseLock):
             DoorLock.AttributeDefs.rf_programming_event_mask,
             DoorLock.AttributeDefs.rfid_programming_event_mask,
         )
+
+        try:
+            result = await cluster.read_attributes(
+                [attr.id for attr in mask_attrs],
+                allow_cache=False,
+                only_cache=False,
+            )
+        except Exception:
+            _LOGGER.debug(
+                "Lock %s: could not read programming event mask attributes",
+                self.lock.entity_id,
+                exc_info=True,
+            )
+            return False
+
+        values = result[0] if isinstance(result, tuple) else result
+
         for attr in mask_attrs:
-            try:
-                if hasattr(cluster, "get"):
-                    value = cluster.get(attr.name)
-                    if value is not None and value != 0:
-                        _LOGGER.debug(
-                            "Lock %s: supports programming events (%s [0x%04x]=0x%04x)",
-                            self.lock.entity_id,
-                            attr.name,
-                            attr.id,
-                            value,
-                        )
-                        return True
-            except Exception:
+            value = None
+            if isinstance(values, dict):
+                value = values.get(attr.id, values.get(attr.name))
+            if value is not None and value != 0:
                 _LOGGER.debug(
-                    "Lock %s: could not read %s [0x%04x]",
+                    "Lock %s: supports programming events (%s [0x%04x]=0x%04x)",
                     self.lock.entity_id,
                     attr.name,
                     attr.id,
-                    exc_info=True,
+                    value,
                 )
+                return True
 
         _LOGGER.debug(
             "Lock %s: no programming event mask attributes found, "

--- a/custom_components/lock_code_manager/providers/zha.py
+++ b/custom_components/lock_code_manager/providers/zha.py
@@ -1,0 +1,483 @@
+"""ZHA (Zigbee Home Automation) lock provider.
+
+Communicates with Zigbee locks via the zigpy DoorLock cluster through ZHA.
+Supports push updates via cluster listeners for operation events (lock/unlock
+with user ID) and programming events (PIN code changes).  When the lock does
+not support programming event notifications, falls back to drift detection
+polling.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import timedelta
+import logging
+from typing import Any, Literal
+
+from zigpy.zcl.clusters.closures import DoorLock
+
+from homeassistant.components.zha.const import DOMAIN as ZHA_DOMAIN
+from homeassistant.components.zha.helpers import (
+    get_zha_gateway_proxy as _get_zha_gateway_proxy,
+)
+from homeassistant.core import callback
+
+from ..exceptions import LockDisconnected
+from ..models import SlotCode
+from ._base import BaseLock
+
+_LOGGER = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# ZCL DoorLock event mappings
+# ---------------------------------------------------------------------------
+
+OPERATION_TO_LOCKED: dict[int, bool] = {
+    DoorLock.OperationEvent.Lock: True,
+    DoorLock.OperationEvent.KeyLock: True,
+    DoorLock.OperationEvent.AutoLock: True,
+    DoorLock.OperationEvent.Manual_Lock: True,
+    DoorLock.OperationEvent.ScheduleLock: True,
+    DoorLock.OperationEvent.OnTouchLock: True,
+    DoorLock.OperationEvent.Unlock: False,
+    DoorLock.OperationEvent.KeyUnlock: False,
+    DoorLock.OperationEvent.Manual_Unlock: False,
+    DoorLock.OperationEvent.ScheduleUnlock: False,
+}
+
+OPERATION_SOURCE_NAMES: dict[int, str] = {
+    DoorLock.OperationEventSource.Keypad: "Keypad",
+    DoorLock.OperationEventSource.RF: "RF",
+    DoorLock.OperationEventSource.Manual: "Manual",
+    DoorLock.OperationEventSource.RFID: "RFID",
+    DoorLock.OperationEventSource.Indeterminate: "Unknown",
+}
+
+
+# ---------------------------------------------------------------------------
+# Provider
+# ---------------------------------------------------------------------------
+
+
+@dataclass(repr=False, eq=False)
+class ZHALock(BaseLock):
+    """ZHA lock provider.
+
+    Push updates come from zigpy cluster listeners:
+    - ``programming_event_notification`` (0x21): PIN added/deleted/changed
+    - ``operation_event_notification`` (0x20): lock/unlock with user ID
+
+    If the lock does not support programming event notifications (detected via
+    event mask attributes), falls back to hourly drift detection polling.
+    """
+
+    _door_lock_cluster: DoorLock | None = field(init=False, default=None)
+    _endpoint_id: int | None = field(init=False, default=None)
+    _cluster_listener_unsub: Callable[[], None] | None = field(init=False, default=None)
+    _supports_programming_events: bool | None = field(init=False, default=None)
+
+    # -- Properties ----------------------------------------------------------
+
+    @property
+    def domain(self) -> str:
+        """Return integration domain."""
+        return ZHA_DOMAIN
+
+    @property
+    def supports_push(self) -> bool:
+        """Return whether this lock supports push-based updates.
+
+        Always True — we subscribe to cluster events for operation
+        notifications (lock/unlock with user ID).  Programming event support
+        is checked separately to decide whether drift detection is needed.
+        """
+        return True
+
+    @property
+    def hard_refresh_interval(self) -> timedelta | None:
+        """Return interval for drift detection.
+
+        One hour if the lock lacks programming event notifications, otherwise
+        None (push handles code changes).
+        """
+        if self._supports_programming_events is False:
+            return timedelta(hours=1)
+        return None
+
+    @property
+    def connection_check_interval(self) -> timedelta | None:
+        """Return interval for connection checks."""
+        return timedelta(seconds=30)
+
+    # -- Cluster access ------------------------------------------------------
+
+    def _get_door_lock_cluster(self) -> DoorLock | None:
+        """Return the DoorLock cluster for this device, caching the result."""
+        if self._door_lock_cluster is not None:
+            return self._door_lock_cluster
+
+        gateway = self._get_gateway()
+        if not gateway:
+            return None
+
+        entity_ref = gateway.get_entity_reference(self.lock.entity_id)
+        if not entity_ref:
+            _LOGGER.debug("Could not find entity reference for %s", self.lock.entity_id)
+            return None
+
+        device_proxy = entity_ref.entity_data.device_proxy
+        if not device_proxy:
+            _LOGGER.debug("Could not find device proxy for %s", self.lock.entity_id)
+            return None
+
+        zigpy_device = device_proxy.device.device
+        if not zigpy_device:
+            _LOGGER.debug("Could not find zigpy device for %s", self.lock.entity_id)
+            return None
+
+        for endpoint_id, endpoint in zigpy_device.endpoints.items():
+            if endpoint_id == 0:
+                continue
+            for cluster in endpoint.in_clusters.values():
+                if cluster.cluster_id == DoorLock.cluster_id:
+                    self._door_lock_cluster = cluster
+                    self._endpoint_id = endpoint_id
+                    _LOGGER.debug(
+                        "Found DoorLock cluster on endpoint %s for %s",
+                        endpoint_id,
+                        self.lock.entity_id,
+                    )
+                    return cluster
+
+        _LOGGER.warning("Could not find DoorLock cluster for %s", self.lock.entity_id)
+        return None
+
+    async def _get_connected_cluster(self) -> DoorLock:
+        """Return a connected DoorLock cluster or raise LockDisconnected."""
+        cluster = self._get_door_lock_cluster()
+        if not cluster:
+            raise LockDisconnected("DoorLock cluster not available")
+        if not await self.async_is_integration_connected():
+            raise LockDisconnected("Lock not connected")
+        return cluster
+
+    # -- Helpers -------------------------------------------------------------
+
+    def _get_gateway(self) -> Any | None:
+        """Return the ZHA gateway proxy, or None if unavailable."""
+        try:
+            return _get_zha_gateway_proxy(self.hass)
+        except KeyError, ValueError:
+            return None
+
+    # -- Connection ----------------------------------------------------------
+
+    async def async_is_integration_connected(self) -> bool:
+        """Return whether ZHA is loaded and the device is available."""
+        gateway = self._get_gateway()
+        if not gateway:
+            return False
+        entity_ref = gateway.get_entity_reference(self.lock.entity_id)
+        if not entity_ref:
+            return False
+        device_proxy = entity_ref.entity_data.device_proxy
+        if not device_proxy:
+            return False
+        return device_proxy.device.available
+
+    # -- Usercode operations -------------------------------------------------
+
+    async def async_get_usercodes(self) -> dict[int, str | SlotCode]:
+        """Read PIN codes from all managed slots."""
+        cluster = await self._get_connected_cluster()
+        managed = self.managed_slots
+        if not managed:
+            return {}
+
+        data: dict[int, str | SlotCode] = {}
+        for slot_num in managed:
+            try:
+                result = await cluster.get_pin_code(slot_num)
+                _LOGGER.debug(
+                    "Lock %s slot %s get_pin_code: %s",
+                    self.lock.entity_id,
+                    slot_num,
+                    result,
+                )
+                user_status, pin_code = self._parse_pin_response(result)
+                if user_status == DoorLock.UserStatus.Enabled and pin_code:
+                    data[slot_num] = pin_code
+                else:
+                    data[slot_num] = SlotCode.EMPTY
+            except LockDisconnected:
+                raise
+            except Exception:
+                _LOGGER.debug(
+                    "Lock %s: failed to read slot %s, assuming empty",
+                    self.lock.entity_id,
+                    slot_num,
+                    exc_info=True,
+                )
+                data[slot_num] = SlotCode.EMPTY
+        return data
+
+    async def async_set_usercode(
+        self,
+        code_slot: int,
+        usercode: str,
+        name: str | None = None,
+        source: Literal["sync", "direct"] = "direct",
+    ) -> bool:
+        """Set a PIN code on a slot."""
+        cluster = await self._get_connected_cluster()
+        try:
+            result = await cluster.set_pin_code(
+                code_slot,
+                DoorLock.UserStatus.Enabled,
+                DoorLock.UserType.Unrestricted,
+                str(usercode),
+            )
+            _LOGGER.debug(
+                "Lock %s slot %s set_pin_code: %s",
+                self.lock.entity_id,
+                code_slot,
+                result,
+            )
+            if hasattr(result, "status") and result.status != 0:
+                raise LockDisconnected(f"set_pin_code failed: status {result.status}")
+            return True
+        except LockDisconnected:
+            raise
+        except Exception as err:
+            raise LockDisconnected(f"Failed to set PIN: {err}") from err
+
+    async def async_clear_usercode(self, code_slot: int) -> bool:
+        """Clear a PIN code from a slot."""
+        cluster = await self._get_connected_cluster()
+        try:
+            result = await cluster.clear_pin_code(code_slot)
+            _LOGGER.debug(
+                "Lock %s slot %s clear_pin_code: %s",
+                self.lock.entity_id,
+                code_slot,
+                result,
+            )
+            if hasattr(result, "status") and result.status != 0:
+                raise LockDisconnected(f"clear_pin_code failed: status {result.status}")
+            return True
+        except LockDisconnected:
+            raise
+        except Exception as err:
+            raise LockDisconnected(f"Failed to clear PIN: {err}") from err
+
+    async def async_hard_refresh_codes(self) -> dict[int, str | SlotCode]:
+        """Re-read all codes from the lock (no cache to invalidate)."""
+        return await self.async_get_usercodes()
+
+    # -- Response parsing ----------------------------------------------------
+
+    @staticmethod
+    def _parse_pin_response(result: Any) -> tuple[int, str]:
+        """Extract (user_status, pin_code) from a get_pin_code response."""
+        if hasattr(result, "user_status"):
+            pin = getattr(result, "code", "") or ""
+            if isinstance(pin, bytes):
+                pin = pin.decode("utf-8", errors="ignore")
+            return result.user_status, str(pin)
+        if isinstance(result, (list, tuple)) and len(result) >= 4:
+            pin = result[3]
+            if isinstance(pin, bytes):
+                pin = pin.decode("utf-8", errors="ignore")
+            return result[1], str(pin) if pin else ""
+        return DoorLock.UserStatus.Available, ""
+
+    # -- Push updates --------------------------------------------------------
+
+    @callback
+    def setup_push_subscription(self) -> None:
+        """Subscribe to DoorLock cluster events."""
+        if self._cluster_listener_unsub is not None:
+            return
+
+        cluster = self._get_door_lock_cluster()
+        if not cluster:
+            raise LockDisconnected(
+                "DoorLock cluster not available for push subscription"
+            )
+
+        if self._supports_programming_events is None:
+            self.hass.async_create_task(
+                self._async_detect_programming_support(),
+                f"Detect programming event support for {self.lock.entity_id}",
+            )
+
+        cluster.add_listener(self)
+        self._cluster_listener_unsub = lambda: cluster.remove_listener(self)
+        _LOGGER.debug(
+            "Lock %s: subscribed to DoorLock cluster events",
+            self.lock.entity_id,
+        )
+
+    @callback
+    def teardown_push_subscription(self) -> None:
+        """Unsubscribe from DoorLock cluster events."""
+        if self._cluster_listener_unsub is not None:
+            self._cluster_listener_unsub()
+            self._cluster_listener_unsub = None
+            _LOGGER.debug(
+                "Lock %s: unsubscribed from DoorLock cluster events",
+                self.lock.entity_id,
+            )
+
+    # -- Cluster listener callbacks ------------------------------------------
+
+    def cluster_command(
+        self,
+        tsn: int,
+        command_id: int,
+        args: Any,
+    ) -> None:
+        """Handle incoming cluster commands from the lock (zigpy listener)."""
+        if command_id == DoorLock.ClientCommandDefs.programming_event_notification.id:
+            self._handle_programming_event(args)
+        elif command_id == DoorLock.ClientCommandDefs.operation_event_notification.id:
+            self._handle_operation_event(args)
+
+    def _handle_programming_event(self, args: Any) -> None:
+        """Handle programming event (PIN added/deleted/changed).
+
+        Triggers a coordinator refresh to pick up the new code state.
+        """
+        try:
+            event_code = (
+                args.program_event_code
+                if hasattr(args, "program_event_code")
+                else args[1]
+            )
+            user_id = args.user_id if hasattr(args, "user_id") else args[2]
+        except AttributeError, IndexError, TypeError:
+            _LOGGER.debug(
+                "Lock %s: could not parse programming event: %s",
+                self.lock.entity_id,
+                args,
+            )
+            return
+
+        _LOGGER.debug(
+            "Lock %s: programming event code=%s user_id=%s",
+            self.lock.entity_id,
+            event_code,
+            user_id,
+        )
+        if self.coordinator:
+            self.hass.async_create_task(
+                self.coordinator.async_request_refresh(),
+                f"Refresh {self.lock.entity_id} after programming event",
+            )
+
+    def _handle_operation_event(self, args: Any) -> None:
+        """Handle operation event (lock/unlock with user ID).
+
+        Fires a code slot event so automations can react to lock usage.
+        """
+        try:
+            source = (
+                args.operation_event_source
+                if hasattr(args, "operation_event_source")
+                else args[0]
+            )
+            event_code = (
+                args.operation_event_code
+                if hasattr(args, "operation_event_code")
+                else args[1]
+            )
+            user_id = args.user_id if hasattr(args, "user_id") else args[2]
+        except AttributeError, IndexError, TypeError:
+            _LOGGER.debug(
+                "Lock %s: could not parse operation event: %s",
+                self.lock.entity_id,
+                args,
+            )
+            return
+
+        _LOGGER.debug(
+            "Lock %s: operation event source=%s code=%s user_id=%s",
+            self.lock.entity_id,
+            source,
+            event_code,
+            user_id,
+        )
+
+        to_locked = OPERATION_TO_LOCKED.get(event_code)
+        source_name = OPERATION_SOURCE_NAMES.get(source, f"Source {source}")
+        action = "lock" if to_locked else "unlock" if to_locked is False else "event"
+
+        self.async_fire_code_slot_event(
+            code_slot=user_id if user_id > 0 else None,
+            to_locked=to_locked,
+            action_text=f"{source_name} {action} operation",
+            source_data={
+                "source": source,
+                "event_code": event_code,
+                "user_id": user_id,
+            },
+        )
+
+    # -- Programming event support detection ---------------------------------
+
+    async def _async_detect_programming_support(self) -> None:
+        """Detect programming event support and update the property."""
+        self._supports_programming_events = (
+            await self._async_check_programming_event_support()
+        )
+        if not self._supports_programming_events:
+            _LOGGER.info(
+                "Lock %s: programming event notifications not supported, "
+                "enabling drift detection (1 hour interval)",
+                self.lock.entity_id,
+            )
+
+    async def _async_check_programming_event_support(self) -> bool:
+        """Check if the lock supports programming event notifications.
+
+        Reads event mask attributes to determine if the lock will send
+        programming_event_notification when codes change.
+        """
+        cluster = self._get_door_lock_cluster()
+        if not cluster:
+            return False
+
+        mask_attrs = (
+            DoorLock.AttributeDefs.keypad_programming_event_mask,
+            DoorLock.AttributeDefs.rf_programming_event_mask,
+            DoorLock.AttributeDefs.rfid_programming_event_mask,
+        )
+        for attr in mask_attrs:
+            try:
+                if hasattr(cluster, "get"):
+                    value = cluster.get(attr.name)
+                    if value is not None and value != 0:
+                        _LOGGER.debug(
+                            "Lock %s: supports programming events (%s [0x%04x]=0x%04x)",
+                            self.lock.entity_id,
+                            attr.name,
+                            attr.id,
+                            value,
+                        )
+                        return True
+            except Exception:
+                _LOGGER.debug(
+                    "Lock %s: could not read %s [0x%04x]",
+                    self.lock.entity_id,
+                    attr.name,
+                    attr.id,
+                    exc_info=True,
+                )
+
+        _LOGGER.debug(
+            "Lock %s: no programming event mask attributes found, "
+            "will use drift detection fallback",
+            self.lock.entity_id,
+        )
+        return False

--- a/custom_components/lock_code_manager/providers/zha.py
+++ b/custom_components/lock_code_manager/providers/zha.py
@@ -114,11 +114,16 @@ class ZHALock(BaseLock):
     # -- Setup ---------------------------------------------------------------
 
     async def async_setup(self, config_entry: ConfigEntry) -> None:
-        """Detect programming event support before coordinator creation.
+        """Initialize provider state and detect programming event support.
 
-        The coordinator reads ``hard_refresh_interval`` during init, so we
-        must know whether the lock supports programming events before that.
+        Called on initial setup AND on integration reconnect, so we clear
+        cached cluster references (which may be stale after a ZHA reload)
+        and re-detect programming event support.  The coordinator reads
+        ``hard_refresh_interval`` during init, so detection must complete
+        before coordinator creation.
         """
+        self._door_lock_cluster = None
+        self._endpoint_id = None
         await super().async_setup(config_entry)
         self._supports_programming_events = (
             await self._async_check_programming_event_support()
@@ -266,6 +271,8 @@ class ZHALock(BaseLock):
             )
             if hasattr(result, "status") and result.status != 0:
                 raise LockDisconnected(f"set_pin_code failed: status {result.status}")
+            if self.coordinator:
+                self.coordinator.push_update({code_slot: usercode})
             return True
         except LockDisconnected:
             raise
@@ -285,6 +292,8 @@ class ZHALock(BaseLock):
             )
             if hasattr(result, "status") and result.status != 0:
                 raise LockDisconnected(f"clear_pin_code failed: status {result.status}")
+            if self.coordinator:
+                self.coordinator.push_update({code_slot: SlotCode.EMPTY})
             return True
         except LockDisconnected:
             raise

--- a/custom_components/lock_code_manager/providers/zha.py
+++ b/custom_components/lock_code_manager/providers/zha.py
@@ -24,7 +24,7 @@ from homeassistant.components.zha.helpers import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import callback
 
-from ..exceptions import LockDisconnected
+from ..exceptions import CodeRejectedError, LockDisconnected
 from ..models import SlotCode
 from ._base import BaseLock
 
@@ -122,6 +122,7 @@ class ZHALock(BaseLock):
         ``hard_refresh_interval`` during init, so detection must complete
         before coordinator creation.
         """
+        self.teardown_push_subscription()
         self._door_lock_cluster = None
         self._endpoint_id = None
         await super().async_setup(config_entry)
@@ -193,7 +194,14 @@ class ZHALock(BaseLock):
         """Return the ZHA gateway proxy, or None if unavailable."""
         try:
             return _get_zha_gateway_proxy(self.hass)
-        except KeyError, ValueError:
+        except KeyError:
+            return None
+        except ValueError:
+            _LOGGER.warning(
+                "Lock %s: unexpected ValueError getting ZHA gateway",
+                self.lock.entity_id,
+                exc_info=True,
+            )
             return None
 
     # -- Connection ----------------------------------------------------------
@@ -270,11 +278,15 @@ class ZHALock(BaseLock):
                 result,
             )
             if hasattr(result, "status") and result.status != 0:
-                raise LockDisconnected(f"set_pin_code failed: status {result.status}")
+                raise CodeRejectedError(
+                    code_slot=code_slot,
+                    lock_entity_id=self.lock.entity_id,
+                    reason=f"set_pin_code rejected: status {result.status}",
+                )
             if self.coordinator:
                 self.coordinator.push_update({code_slot: usercode})
             return True
-        except LockDisconnected:
+        except CodeRejectedError, LockDisconnected:
             raise
         except Exception as err:
             raise LockDisconnected(f"Failed to set PIN: {err}") from err
@@ -291,11 +303,15 @@ class ZHALock(BaseLock):
                 result,
             )
             if hasattr(result, "status") and result.status != 0:
-                raise LockDisconnected(f"clear_pin_code failed: status {result.status}")
+                raise CodeRejectedError(
+                    code_slot=code_slot,
+                    lock_entity_id=self.lock.entity_id,
+                    reason=f"clear_pin_code rejected: status {result.status}",
+                )
             if self.coordinator:
                 self.coordinator.push_update({code_slot: SlotCode.EMPTY})
             return True
-        except LockDisconnected:
+        except CodeRejectedError, LockDisconnected:
             raise
         except Exception as err:
             raise LockDisconnected(f"Failed to clear PIN: {err}") from err
@@ -380,11 +396,18 @@ class ZHALock(BaseLock):
             )
             user_id = args.user_id if hasattr(args, "user_id") else args[2]
         except AttributeError, IndexError, TypeError:
-            _LOGGER.debug(
-                "Lock %s: could not parse programming event: %s",
+            _LOGGER.warning(
+                "Lock %s: could not parse programming event, "
+                "triggering refresh as safety net: %s",
                 self.lock.entity_id,
                 args,
             )
+            # Refresh anyway — we know something changed on the lock
+            if self.coordinator:
+                self.hass.async_create_task(
+                    self.coordinator.async_request_refresh(),
+                    f"Refresh {self.lock.entity_id} after unparseable programming event",
+                )
             return
 
         _LOGGER.debug(
@@ -417,7 +440,7 @@ class ZHALock(BaseLock):
             )
             user_id = args.user_id if hasattr(args, "user_id") else args[2]
         except AttributeError, IndexError, TypeError:
-            _LOGGER.debug(
+            _LOGGER.warning(
                 "Lock %s: could not parse operation event: %s",
                 self.lock.entity_id,
                 args,

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,10 +4,15 @@ aiofiles==25.1.0
 aiousbwatcher==1.1.2
 colorlog==6.10.1
 debugpy==1.8.20
+ha-silabs-firmware-client>=0.3.0
 homeassistant>=2026.4.3
 pyserial==3.5
 python-matter-server==8.1.2
 pyudev==0.24.4
+universal-silabs-flasher>=0.1.0
+usb-devices>=0.4.5
 uv
 zeroconf==0.148.0
+zha>=0.0.81
+zigpy>=0.60.0
 zwave-js-server-python==0.69.0

--- a/tests/providers/zha/__init__.py
+++ b/tests/providers/zha/__init__.py
@@ -1,0 +1,1 @@
+"""ZHA provider tests."""

--- a/tests/providers/zha/conftest.py
+++ b/tests/providers/zha/conftest.py
@@ -1,0 +1,436 @@
+"""ZHA provider test fixtures."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Generator
+import itertools
+import sys
+import time
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, create_autospec, patch
+import warnings
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+from zigpy.application import ControllerApplication
+import zigpy.config
+import zigpy.device
+from zigpy.profiles import zha as zha_profile
+import zigpy.quirks
+import zigpy.state
+import zigpy.types
+from zigpy.zcl.clusters import closures, general
+from zigpy.zcl.foundation import Status
+import zigpy.zdo.types as zdo_t
+
+from homeassistant.components.zha import const as zha_const
+from homeassistant.components.zha.helpers import get_zha_gateway
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.setup import async_setup_component
+
+from custom_components.lock_code_manager.const import (
+    CONF_ENABLED,
+    CONF_LOCKS,
+    CONF_NAME,
+    CONF_PIN,
+    CONF_SLOTS,
+    DOMAIN,
+)
+from custom_components.lock_code_manager.providers.zha import ZHALock
+
+# ZHA endpoint signature constants
+SIG_EP_INPUT = 1
+SIG_EP_OUTPUT = 2
+SIG_EP_PROFILE = 3
+SIG_EP_TYPE = 4
+
+ZHA_LCM_CONFIG_SLOTS = {
+    1: {CONF_NAME: "slot1", CONF_PIN: "1234", CONF_ENABLED: True},
+    2: {CONF_NAME: "slot2", CONF_PIN: "5678", CONF_ENABLED: True},
+}
+
+
+# ---------------------------------------------------------------------------
+# Zigpy / ZHA infrastructure fixtures
+# ---------------------------------------------------------------------------
+
+
+class _FakeZigbeeApp(ControllerApplication):
+    """Fake Zigbee application controller for testing."""
+
+    async def add_endpoint(self, descriptor: zdo_t.SimpleDescriptor):
+        """Add endpoint."""
+
+    async def connect(self):
+        """Connect."""
+
+    async def disconnect(self):
+        """Disconnect."""
+
+    async def force_remove(self, dev: zigpy.device.Device):
+        """Force remove device."""
+
+    async def load_network_info(self, *, load_devices: bool = False):
+        """Load network info."""
+
+    async def permit_ncp(self, time_s: int = 60):
+        """Permit NCP."""
+
+    async def permit_with_link_key(
+        self,
+        node: zigpy.types.EUI64,
+        link_key: zigpy.types.KeyData,
+        time_s: int = 60,
+    ):
+        """Permit with link key."""
+
+    async def reset_network_info(self):
+        """Reset network info."""
+
+    async def send_packet(self, packet: zigpy.types.ZigbeePacket):
+        """Send packet."""
+
+    async def start_network(self):
+        """Start network."""
+
+    async def write_network_info(
+        self,
+        *,
+        network_info: zigpy.state.NetworkInfo,
+        node_info: zigpy.state.NodeInfo,
+    ) -> None:
+        """Write network info."""
+
+    async def request(
+        self,
+        device: zigpy.device.Device,
+        profile: zigpy.types.uint16_t,
+        cluster: zigpy.types.uint16_t,
+        src_ep: zigpy.types.uint8_t,
+        dst_ep: zigpy.types.uint8_t,
+        sequence: zigpy.types.uint8_t,
+        data: bytes,
+        *,
+        expect_reply: bool = True,
+        use_ieee: bool = False,
+        extended_timeout: bool = False,
+    ):
+        """Request."""
+
+    async def move_network_to_channel(
+        self, new_channel: int, *, num_broadcasts: int = 5
+    ) -> None:
+        """Move network to channel."""
+
+    def _persist_coordinator_model_strings_in_db(self) -> None:
+        """Persist coordinator model strings."""
+
+
+def _wrap_mock_instance(obj: Any) -> MagicMock:
+    """Auto-mock every attribute and method in an object."""
+    mock = create_autospec(obj, spec_set=True, instance=True)
+    for attr_name in dir(obj):
+        if attr_name.startswith("__") and attr_name not in {"__getitem__"}:
+            continue
+        real_attr = getattr(obj, attr_name)
+        mock_attr = getattr(mock, attr_name)
+        if callable(real_attr) and not hasattr(real_attr, "__aenter__"):
+            mock_attr.side_effect = real_attr
+        else:
+            setattr(mock, attr_name, real_attr)
+    return mock
+
+
+def _patch_zha_cluster(cluster):
+    """Patch a ZHA cluster for testing."""
+    cluster.PLUGGED_ATTR_READS = {}
+    cluster.bind = AsyncMock(return_value=[0])
+    cluster.configure_reporting = AsyncMock(return_value=[[]])
+    cluster.configure_reporting_multiple = AsyncMock(return_value=[])
+    cluster.handle_cluster_request = MagicMock()
+    cluster.read_attributes = AsyncMock(return_value=[{}, {}])
+    cluster.read_attributes_raw = AsyncMock(return_value=[])
+    cluster.unbind = AsyncMock(return_value=[0])
+    cluster.write_attributes = AsyncMock(return_value=[])
+    cluster._write_attributes = AsyncMock(return_value=[])
+
+
+@pytest.fixture
+def mock_zha_radio_delays() -> Generator[None]:
+    """Mock ZHA radio manager delays to speed up tests."""
+    with (
+        patch(
+            "homeassistant.components.zha.radio_manager.CONNECT_DELAY_S",
+            0,
+        ),
+        patch(
+            "homeassistant.components.zha.radio_manager.RETRY_DELAY_S",
+            0,
+        ),
+    ):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def mock_usb() -> Generator[None]:
+    """Mock the USB component to avoid aiousbwatcher dependency."""
+    if "aiousbwatcher" not in sys.modules:
+        mock_mod = MagicMock()
+        mock_mod.AIOUSBWatcher = MagicMock()
+        mock_mod.InotifyNotAvailableError = Exception
+        sys.modules["aiousbwatcher"] = mock_mod
+    yield
+
+
+@pytest.fixture
+async def zigpy_app_controller():
+    """Zigpy ApplicationController fixture."""
+    app = _FakeZigbeeApp(
+        {
+            zigpy.config.CONF_DATABASE: None,
+            zigpy.config.CONF_DEVICE: {zigpy.config.CONF_DEVICE_PATH: "/dev/null"},
+            zigpy.config.CONF_STARTUP_ENERGY_SCAN: False,
+            zigpy.config.CONF_NWK_BACKUP_ENABLED: False,
+            zigpy.config.CONF_TOPO_SCAN_ENABLED: False,
+            zigpy.config.CONF_OTA: {zigpy.config.CONF_OTA_ENABLED: False},
+        }
+    )
+
+    app.state.node_info.nwk = 0x0000
+    app.state.node_info.ieee = zigpy.types.EUI64.convert("00:15:8d:00:02:32:4f:32")
+    app.state.node_info.manufacturer = "Coordinator Manufacturer"
+    app.state.node_info.model = "Coordinator Model"
+    app.state.network_info.pan_id = 0x1234
+    app.state.network_info.extended_pan_id = app.state.node_info.ieee
+    app.state.network_info.channel = 15
+    app.state.network_info.network_key.key = zigpy.types.KeyData(range(16))
+    app.state.counters = zigpy.state.CounterGroups()
+
+    dev = app.add_device(nwk=app.state.node_info.nwk, ieee=app.state.node_info.ieee)
+    dev.node_desc = zdo_t.NodeDescriptor()
+    dev.node_desc.logical_type = zdo_t.LogicalType.Coordinator
+    dev.manufacturer = "Coordinator Manufacturer"
+    dev.model = "Coordinator Model"
+
+    ep = dev.add_endpoint(1)
+    ep.profile_id = zha_profile.PROFILE_ID
+    ep.add_input_cluster(general.Basic.cluster_id)
+    ep.add_input_cluster(general.Groups.cluster_id)
+
+    with patch("zigpy.device.Device.request", return_value=[Status.SUCCESS]):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            mock_app = _wrap_mock_instance(app)
+            mock_app.backups = _wrap_mock_instance(app.backups)
+
+            class MockSemaphore:
+                max_value = 8
+                max_concurrency = 8
+
+            mock_app._concurrent_requests_semaphore = MockSemaphore()
+
+        yield mock_app
+
+
+@pytest.fixture(name="zha_config_entry")
+async def zha_config_entry_fixture() -> MockConfigEntry:
+    """Fixture representing a ZHA config entry."""
+    return MockConfigEntry(
+        version=5,
+        domain=zha_const.DOMAIN,
+        data={
+            zigpy.config.CONF_DEVICE: {
+                zigpy.config.CONF_DEVICE_PATH: "/dev/ttyUSB0",
+                zigpy.config.CONF_DEVICE_BAUDRATE: 115200,
+                zigpy.config.CONF_DEVICE_FLOW_CONTROL: "hardware",
+            },
+            zha_const.CONF_RADIO_TYPE: "ezsp",
+        },
+        options={},
+    )
+
+
+@pytest.fixture
+def mock_zigpy_connect(
+    zigpy_app_controller: ControllerApplication,
+) -> Generator[ControllerApplication]:
+    """Patch the zigpy radio connection with our mock application."""
+    with (
+        patch(
+            "bellows.zigbee.application.ControllerApplication.new",
+            return_value=zigpy_app_controller,
+        ),
+        patch(
+            "bellows.zigbee.application.ControllerApplication",
+            return_value=zigpy_app_controller,
+        ),
+    ):
+        yield zigpy_app_controller
+
+
+@pytest.fixture
+def setup_zha(
+    hass: HomeAssistant,
+    zha_config_entry: MockConfigEntry,
+    mock_zigpy_connect: ControllerApplication,
+    mock_zha_radio_delays: None,
+) -> Callable[..., Awaitable[None]]:
+    """Set up ZHA component."""
+
+    async def _setup(config=None) -> None:
+        zha_config_entry.add_to_hass(hass)
+        config = config or {}
+        with patch(
+            "homeassistant.components.zha.PLATFORMS",
+            (Platform.DEVICE_TRACKER, Platform.LOCK, Platform.SENSOR),
+        ):
+            status = await async_setup_component(
+                hass,
+                zha_const.DOMAIN,
+                {
+                    zha_const.DOMAIN: {
+                        zha_const.CONF_ENABLE_QUIRKS: False,
+                        **config,
+                    }
+                },
+            )
+            assert status is True
+            await hass.async_block_till_done()
+
+    return _setup
+
+
+@pytest.fixture
+def zigpy_device_mock(
+    zigpy_app_controller,
+) -> Callable[..., zigpy.device.Device]:
+    """Make a fake device using the specified cluster classes."""
+
+    def _mock_dev(
+        endpoints,
+        ieee="00:0d:6f:00:0a:90:69:e7",
+        manufacturer="FakeManufacturer",
+        model="FakeModel",
+        node_descriptor=b"\x02@\x807\x10\x7fd\x00\x00*d\x00\x00",
+        nwk=0xB79C,
+        patch_cluster_flag=True,
+    ):
+        device = zigpy.device.Device(
+            zigpy_app_controller, zigpy.types.EUI64.convert(ieee), nwk
+        )
+        device.manufacturer = manufacturer
+        device.model = model
+        device.node_desc = zdo_t.NodeDescriptor.deserialize(node_descriptor)[0]
+        device.last_seen = time.time()
+
+        for epid, ep in endpoints.items():
+            endpoint = device.add_endpoint(epid)
+            endpoint.device_type = ep[SIG_EP_TYPE]
+            endpoint.profile_id = ep.get(SIG_EP_PROFILE, 0x0104)
+            endpoint.request = AsyncMock()
+
+            for cluster_id in ep.get(SIG_EP_INPUT, []):
+                endpoint.add_input_cluster(cluster_id)
+
+            for cluster_id in ep.get(SIG_EP_OUTPUT, []):
+                endpoint.add_output_cluster(cluster_id)
+
+        device.status = zigpy.device.Status.ENDPOINTS_INIT
+        device = zigpy.quirks.get_device(device)
+
+        if patch_cluster_flag:
+            for endpoint in (ep for epid, ep in device.endpoints.items() if epid):
+                endpoint.request = AsyncMock(return_value=[0])
+                for cluster in itertools.chain(
+                    endpoint.in_clusters.values(),
+                    endpoint.out_clusters.values(),
+                ):
+                    _patch_zha_cluster(cluster)
+
+        return device
+
+    return _mock_dev
+
+
+@pytest.fixture
+def zigpy_lock_device(
+    zigpy_device_mock: Callable[..., zigpy.device.Device],
+) -> zigpy.device.Device:
+    """Create a mock Zigbee lock device."""
+    return zigpy_device_mock(
+        {
+            1: {
+                SIG_EP_INPUT: [
+                    closures.DoorLock.cluster_id,
+                    general.Basic.cluster_id,
+                ],
+                SIG_EP_OUTPUT: [],
+                SIG_EP_TYPE: zha_profile.DeviceType.DOOR_LOCK,
+                SIG_EP_PROFILE: zha_profile.PROFILE_ID,
+            }
+        },
+        ieee="01:2d:6f:00:0a:90:69:e8",
+        manufacturer="Yale",
+        model="YRD256",
+    )
+
+
+@pytest.fixture
+async def zha_lock_entity(
+    hass: HomeAssistant,
+    setup_zha: Callable[..., Awaitable[None]],
+    zigpy_lock_device: zigpy.device.Device,
+    zha_config_entry: MockConfigEntry,
+) -> er.RegistryEntry:
+    """Set up ZHA with a lock device and return the lock entity."""
+    await setup_zha()
+    gateway = get_zha_gateway(hass)
+
+    gateway.get_or_create_device(zigpy_lock_device)
+    await gateway.async_device_initialized(zigpy_lock_device)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    ent_reg = er.async_get(hass)
+    entries = list(
+        er.async_entries_for_config_entry(ent_reg, zha_config_entry.entry_id)
+    )
+    lock_entries = [e for e in entries if e.domain == "lock"]
+    assert len(lock_entries) == 1, f"Expected 1 lock entity, found {len(lock_entries)}"
+    return lock_entries[0]
+
+
+# ---------------------------------------------------------------------------
+# ZHALock fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(name="zha_lock")
+async def zha_lock_fixture(
+    hass: HomeAssistant,
+    zha_lock_entity: er.RegistryEntry,
+    zha_config_entry: MockConfigEntry,
+) -> ZHALock:
+    """Create a ZHALock instance for testing."""
+    return ZHALock(
+        hass=hass,
+        dev_reg=dr.async_get(hass),
+        ent_reg=er.async_get(hass),
+        lock_config_entry=zha_config_entry,
+        lock=zha_lock_entity,
+    )
+
+
+@pytest.fixture
+async def simple_lcm_config_entry(
+    hass: HomeAssistant, zha_lock_entity: er.RegistryEntry
+) -> MockConfigEntry:
+    """Lightweight LCM config entry for unit tests (no full setup)."""
+    config = {
+        CONF_LOCKS: [zha_lock_entity.entity_id],
+        CONF_SLOTS: ZHA_LCM_CONFIG_SLOTS,
+    }
+    entry = MockConfigEntry(domain=DOMAIN, data=config, unique_id="test_zha_lcm")
+    entry.add_to_hass(hass)
+    return entry

--- a/tests/providers/zha/test_provider.py
+++ b/tests/providers/zha/test_provider.py
@@ -531,6 +531,25 @@ async def test_async_setup_clears_cached_state(
     assert zha_lock._endpoint_id is not None
 
 
+async def test_async_setup_is_idempotent(
+    hass: HomeAssistant, zha_lock: ZHALock, simple_lcm_config_entry: MockConfigEntry
+) -> None:
+    """Test calling async_setup twice does not accumulate cluster listeners."""
+    cluster = zha_lock._get_door_lock_cluster()
+    assert cluster is not None
+    cluster.read_attributes = AsyncMock(return_value=({}, {}))
+
+    await zha_lock.async_setup(simple_lcm_config_entry)
+    zha_lock.setup_push_subscription()
+    assert zha_lock._cluster_listener_unsub is not None
+
+    # Simulate ZHA reload — async_setup tears down and re-initializes
+    await zha_lock.async_setup(simple_lcm_config_entry)
+
+    # Listener torn down by async_setup's teardown call
+    assert zha_lock._cluster_listener_unsub is None
+
+
 async def test_check_programming_support_no_cluster(
     hass: HomeAssistant, zha_lock: ZHALock
 ) -> None:

--- a/tests/providers/zha/test_provider.py
+++ b/tests/providers/zha/test_provider.py
@@ -1,0 +1,244 @@
+"""Test the ZHA lock provider."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest.mock import AsyncMock
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+from zigpy.zcl.clusters.closures import DoorLock
+
+from homeassistant.components.zha.const import DOMAIN as ZHA_DOMAIN
+from homeassistant.core import HomeAssistant
+
+from custom_components.lock_code_manager.exceptions import LockDisconnected
+from custom_components.lock_code_manager.models import SlotCode
+from custom_components.lock_code_manager.providers.zha import ZHALock
+
+# ---------------------------------------------------------------------------
+# Property tests
+# ---------------------------------------------------------------------------
+
+
+async def test_domain(zha_lock: ZHALock) -> None:
+    """Test domain property returns zha."""
+    assert zha_lock.domain == ZHA_DOMAIN
+
+
+async def test_supports_push(zha_lock: ZHALock) -> None:
+    """Test that ZHA locks support push updates."""
+    assert zha_lock.supports_push is True
+
+
+async def test_connection_check_interval(zha_lock: ZHALock) -> None:
+    """Test connection check interval is 30 seconds."""
+    assert zha_lock.connection_check_interval == timedelta(seconds=30)
+
+
+async def test_hard_refresh_with_programming_events(zha_lock: ZHALock) -> None:
+    """Test hard refresh interval is None when programming events supported."""
+    zha_lock._supports_programming_events = True
+    assert zha_lock.hard_refresh_interval is None
+
+
+async def test_hard_refresh_without_programming_events(zha_lock: ZHALock) -> None:
+    """Test hard refresh interval is 1 hour when programming events not supported."""
+    zha_lock._supports_programming_events = False
+    assert zha_lock.hard_refresh_interval == timedelta(hours=1)
+
+
+# ---------------------------------------------------------------------------
+# Connection tests
+# ---------------------------------------------------------------------------
+
+
+async def test_is_integration_connected(hass: HomeAssistant, zha_lock: ZHALock) -> None:
+    """Test connection is up when device is available."""
+    assert await zha_lock.async_is_integration_connected() is True
+
+
+# ---------------------------------------------------------------------------
+# Cluster access tests
+# ---------------------------------------------------------------------------
+
+
+async def test_get_door_lock_cluster(hass: HomeAssistant, zha_lock: ZHALock) -> None:
+    """Test getting the DoorLock cluster."""
+    cluster = zha_lock._get_door_lock_cluster()
+    assert cluster is not None
+    assert cluster.cluster_id == DoorLock.cluster_id
+
+
+async def test_get_door_lock_cluster_caches_result(
+    hass: HomeAssistant, zha_lock: ZHALock
+) -> None:
+    """Test that the cluster is cached after first access."""
+    cluster1 = zha_lock._get_door_lock_cluster()
+    cluster2 = zha_lock._get_door_lock_cluster()
+    assert cluster1 is cluster2
+
+
+# ---------------------------------------------------------------------------
+# Usercode tests
+# ---------------------------------------------------------------------------
+
+
+async def test_get_usercodes(
+    hass: HomeAssistant,
+    zha_lock: ZHALock,
+    simple_lcm_config_entry: MockConfigEntry,
+) -> None:
+    """Test reading usercodes from the lock."""
+    cluster = zha_lock._get_door_lock_cluster()
+    assert cluster is not None
+
+    async def mock_get_pin_code(slot_num):
+        if slot_num == 1:
+            return type(
+                "Response",
+                (),
+                {"user_status": DoorLock.UserStatus.Enabled, "code": "1234"},
+            )()
+        return type(
+            "Response",
+            (),
+            {"user_status": DoorLock.UserStatus.Available, "code": ""},
+        )()
+
+    cluster.get_pin_code = AsyncMock(side_effect=mock_get_pin_code)
+
+    codes = await zha_lock.async_get_usercodes()
+
+    assert codes[1] == "1234"
+    assert codes[2] is SlotCode.EMPTY
+
+
+async def test_set_usercode(
+    hass: HomeAssistant,
+    zha_lock: ZHALock,
+    simple_lcm_config_entry: MockConfigEntry,
+) -> None:
+    """Test set_usercode calls the cluster correctly."""
+    cluster = zha_lock._get_door_lock_cluster()
+    assert cluster is not None
+    cluster.set_pin_code = AsyncMock(return_value=type("Response", (), {"status": 0})())
+
+    result = await zha_lock.async_set_usercode(3, "5678", "Test User")
+
+    assert result is True
+    cluster.set_pin_code.assert_called_once_with(
+        3,
+        DoorLock.UserStatus.Enabled,
+        DoorLock.UserType.Unrestricted,
+        "5678",
+    )
+
+
+async def test_set_usercode_failure(
+    hass: HomeAssistant,
+    zha_lock: ZHALock,
+    simple_lcm_config_entry: MockConfigEntry,
+) -> None:
+    """Test set_usercode raises LockDisconnected on failure."""
+    cluster = zha_lock._get_door_lock_cluster()
+    assert cluster is not None
+    cluster.set_pin_code = AsyncMock(return_value=type("Response", (), {"status": 1})())
+
+    with pytest.raises(LockDisconnected, match="set_pin_code failed"):
+        await zha_lock.async_set_usercode(3, "5678")
+
+
+async def test_clear_usercode(
+    hass: HomeAssistant,
+    zha_lock: ZHALock,
+    simple_lcm_config_entry: MockConfigEntry,
+) -> None:
+    """Test clear_usercode calls the cluster correctly."""
+    cluster = zha_lock._get_door_lock_cluster()
+    assert cluster is not None
+    cluster.clear_pin_code = AsyncMock(
+        return_value=type("Response", (), {"status": 0})()
+    )
+
+    result = await zha_lock.async_clear_usercode(3)
+
+    assert result is True
+    cluster.clear_pin_code.assert_called_once_with(3)
+
+
+async def test_clear_usercode_failure(
+    hass: HomeAssistant,
+    zha_lock: ZHALock,
+    simple_lcm_config_entry: MockConfigEntry,
+) -> None:
+    """Test clear_usercode raises LockDisconnected on failure."""
+    cluster = zha_lock._get_door_lock_cluster()
+    assert cluster is not None
+    cluster.clear_pin_code = AsyncMock(
+        return_value=type("Response", (), {"status": 1})()
+    )
+
+    with pytest.raises(LockDisconnected, match="clear_pin_code failed"):
+        await zha_lock.async_clear_usercode(3)
+
+
+# ---------------------------------------------------------------------------
+# Push update tests
+# ---------------------------------------------------------------------------
+
+
+async def test_subscribe_push_updates(hass: HomeAssistant, zha_lock: ZHALock) -> None:
+    """Test subscribing to push updates."""
+    zha_lock.setup_push_subscription()
+    assert zha_lock._cluster_listener_unsub is not None
+
+    zha_lock.teardown_push_subscription()
+    assert zha_lock._cluster_listener_unsub is None
+
+
+async def test_subscribe_is_idempotent(hass: HomeAssistant, zha_lock: ZHALock) -> None:
+    """Test that calling subscribe multiple times is safe."""
+    zha_lock.setup_push_subscription()
+    first_unsub = zha_lock._cluster_listener_unsub
+
+    zha_lock.setup_push_subscription()
+    assert zha_lock._cluster_listener_unsub is first_unsub
+
+    zha_lock.teardown_push_subscription()
+
+
+# ---------------------------------------------------------------------------
+# Programming event support detection
+# ---------------------------------------------------------------------------
+
+
+async def test_programming_event_support_with_mask(
+    hass: HomeAssistant, zha_lock: ZHALock
+) -> None:
+    """Test detecting programming event support via mask attributes."""
+    cluster = zha_lock._get_door_lock_cluster()
+    assert cluster is not None
+
+    def mock_get(attr_name):
+        if attr_name == "keypad_programming_event_mask":
+            return 0x0001
+        return None
+
+    cluster.get = mock_get
+
+    result = await zha_lock._async_check_programming_event_support()
+    assert result is True
+
+
+async def test_programming_event_support_without_mask(
+    hass: HomeAssistant, zha_lock: ZHALock
+) -> None:
+    """Test programming events not supported when no mask attributes."""
+    cluster = zha_lock._get_door_lock_cluster()
+    assert cluster is not None
+
+    cluster.get = lambda attr_name: None
+
+    result = await zha_lock._async_check_programming_event_support()
+    assert result is False

--- a/tests/providers/zha/test_provider.py
+++ b/tests/providers/zha/test_provider.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -14,7 +14,9 @@ from homeassistant.core import HomeAssistant
 
 from custom_components.lock_code_manager.exceptions import LockDisconnected
 from custom_components.lock_code_manager.models import SlotCode
-from custom_components.lock_code_manager.providers.zha import ZHALock
+from custom_components.lock_code_manager.providers.zha import (
+    ZHALock,
+)
 
 # ---------------------------------------------------------------------------
 # Property tests
@@ -242,3 +244,347 @@ async def test_programming_event_support_without_mask(
 
     result = await zha_lock._async_check_programming_event_support()
     assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Connection failure paths
+# ---------------------------------------------------------------------------
+
+
+async def test_is_integration_connected_no_gateway(
+    hass: HomeAssistant, zha_lock: ZHALock
+) -> None:
+    """Test connection returns False when gateway is unavailable."""
+    with patch.object(zha_lock, "_get_gateway", return_value=None):
+        assert await zha_lock.async_is_integration_connected() is False
+
+
+async def test_is_integration_connected_no_entity_ref(
+    hass: HomeAssistant, zha_lock: ZHALock
+) -> None:
+    """Test connection returns False when entity reference not found."""
+    gateway = MagicMock()
+    gateway.get_entity_reference.return_value = None
+    with patch.object(zha_lock, "_get_gateway", return_value=gateway):
+        assert await zha_lock.async_is_integration_connected() is False
+
+
+async def test_is_integration_connected_no_device_proxy(
+    hass: HomeAssistant, zha_lock: ZHALock
+) -> None:
+    """Test connection returns False when device proxy is missing."""
+    entity_ref = MagicMock()
+    entity_ref.entity_data.device_proxy = None
+    gateway = MagicMock()
+    gateway.get_entity_reference.return_value = entity_ref
+    with patch.object(zha_lock, "_get_gateway", return_value=gateway):
+        assert await zha_lock.async_is_integration_connected() is False
+
+
+# ---------------------------------------------------------------------------
+# Cluster access failure paths
+# ---------------------------------------------------------------------------
+
+
+async def test_get_door_lock_cluster_no_gateway(
+    hass: HomeAssistant, zha_lock: ZHALock
+) -> None:
+    """Test cluster lookup returns None when gateway unavailable."""
+    zha_lock._door_lock_cluster = None
+    with patch.object(zha_lock, "_get_gateway", return_value=None):
+        assert zha_lock._get_door_lock_cluster() is None
+
+
+async def test_get_door_lock_cluster_no_entity_ref(
+    hass: HomeAssistant, zha_lock: ZHALock
+) -> None:
+    """Test cluster lookup returns None when entity ref not found."""
+    zha_lock._door_lock_cluster = None
+    gateway = MagicMock()
+    gateway.get_entity_reference.return_value = None
+    with patch.object(zha_lock, "_get_gateway", return_value=gateway):
+        assert zha_lock._get_door_lock_cluster() is None
+
+
+async def test_get_connected_cluster_raises_when_no_cluster(
+    hass: HomeAssistant, zha_lock: ZHALock
+) -> None:
+    """Test _get_connected_cluster raises LockDisconnected without cluster."""
+    with patch.object(zha_lock, "_get_door_lock_cluster", return_value=None):
+        with pytest.raises(LockDisconnected, match="cluster not available"):
+            await zha_lock._get_connected_cluster()
+
+
+async def test_get_connected_cluster_raises_when_disconnected(
+    hass: HomeAssistant, zha_lock: ZHALock
+) -> None:
+    """Test _get_connected_cluster raises LockDisconnected when not connected."""
+    with patch.object(zha_lock, "async_is_integration_connected", return_value=False):
+        with pytest.raises(LockDisconnected, match="not connected"):
+            await zha_lock._get_connected_cluster()
+
+
+async def test_get_gateway_handles_exceptions(
+    hass: HomeAssistant, zha_lock: ZHALock
+) -> None:
+    """Test _get_gateway returns None on KeyError/ValueError."""
+    with patch(
+        "custom_components.lock_code_manager.providers.zha._get_zha_gateway_proxy",
+        side_effect=KeyError("not loaded"),
+    ):
+        assert zha_lock._get_gateway() is None
+
+
+# ---------------------------------------------------------------------------
+# Parse PIN response edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_parse_pin_response_bytes() -> None:
+    """Test parsing PIN response with bytes code."""
+    result = type(
+        "Response",
+        (),
+        {"user_status": DoorLock.UserStatus.Enabled, "code": b"1234"},
+    )()
+    status, pin = ZHALock._parse_pin_response(result)
+    assert status == DoorLock.UserStatus.Enabled
+    assert pin == "1234"
+
+
+def test_parse_pin_response_list_format() -> None:
+    """Test parsing PIN response in list format."""
+    result = [0, DoorLock.UserStatus.Enabled, 0, "5678"]
+    status, pin = ZHALock._parse_pin_response(result)
+    assert status == DoorLock.UserStatus.Enabled
+    assert pin == "5678"
+
+
+def test_parse_pin_response_list_bytes() -> None:
+    """Test parsing list-format response with bytes PIN."""
+    result = [0, DoorLock.UserStatus.Enabled, 0, b"5678"]
+    status, pin = ZHALock._parse_pin_response(result)
+    assert status == DoorLock.UserStatus.Enabled
+    assert pin == "5678"
+
+
+def test_parse_pin_response_unknown_format() -> None:
+    """Test parsing unknown response format returns Available/empty."""
+    status, pin = ZHALock._parse_pin_response("unexpected")
+    assert status == DoorLock.UserStatus.Available
+    assert pin == ""
+
+
+# ---------------------------------------------------------------------------
+# Cluster command / event handling
+# ---------------------------------------------------------------------------
+
+
+async def test_cluster_command_programming_event(
+    hass: HomeAssistant, zha_lock: ZHALock
+) -> None:
+    """Test cluster_command dispatches programming events."""
+    zha_lock.coordinator = MagicMock()
+    zha_lock.coordinator.async_request_refresh = AsyncMock()
+
+    args = type("Args", (), {"program_event_code": 1, "user_id": 2})()
+    cmd_id = DoorLock.ClientCommandDefs.programming_event_notification.id
+    zha_lock.cluster_command(0, cmd_id, args)
+    await hass.async_block_till_done()
+
+    zha_lock.coordinator.async_request_refresh.assert_called_once()
+
+
+async def test_cluster_command_operation_event(
+    hass: HomeAssistant, zha_lock: ZHALock
+) -> None:
+    """Test cluster_command dispatches operation events and fires code slot event."""
+    with patch.object(zha_lock, "async_fire_code_slot_event") as mock_fire:
+        args = type(
+            "Args",
+            (),
+            {
+                "operation_event_source": DoorLock.OperationEventSource.Keypad,
+                "operation_event_code": DoorLock.OperationEvent.Unlock,
+                "user_id": 3,
+            },
+        )()
+        cmd_id = DoorLock.ClientCommandDefs.operation_event_notification.id
+        zha_lock.cluster_command(0, cmd_id, args)
+
+        mock_fire.assert_called_once_with(
+            code_slot=3,
+            to_locked=False,
+            action_text="Keypad unlock operation",
+            source_data={
+                "source": DoorLock.OperationEventSource.Keypad,
+                "event_code": DoorLock.OperationEvent.Unlock,
+                "user_id": 3,
+            },
+        )
+
+
+async def test_operation_event_zero_user_id(
+    hass: HomeAssistant, zha_lock: ZHALock
+) -> None:
+    """Test operation event with user_id=0 passes code_slot=None."""
+    with patch.object(zha_lock, "async_fire_code_slot_event") as mock_fire:
+        args = type(
+            "Args",
+            (),
+            {
+                "operation_event_source": DoorLock.OperationEventSource.Manual,
+                "operation_event_code": DoorLock.OperationEvent.Lock,
+                "user_id": 0,
+            },
+        )()
+        cmd_id = DoorLock.ClientCommandDefs.operation_event_notification.id
+        zha_lock.cluster_command(0, cmd_id, args)
+
+        mock_fire.assert_called_once()
+        assert mock_fire.call_args.kwargs["code_slot"] is None
+        assert mock_fire.call_args.kwargs["to_locked"] is True
+
+
+async def test_cluster_command_unknown_ignored(
+    hass: HomeAssistant, zha_lock: ZHALock
+) -> None:
+    """Test unknown command IDs are silently ignored."""
+    zha_lock.cluster_command(0, 999, None)
+
+
+async def test_programming_event_unparseable(
+    hass: HomeAssistant, zha_lock: ZHALock
+) -> None:
+    """Test programming event with unparseable args is handled gracefully."""
+    zha_lock._handle_programming_event(None)
+
+
+async def test_operation_event_unparseable(
+    hass: HomeAssistant, zha_lock: ZHALock
+) -> None:
+    """Test operation event with unparseable args is handled gracefully."""
+    zha_lock._handle_operation_event(None)
+
+
+# ---------------------------------------------------------------------------
+# Push subscription edge cases
+# ---------------------------------------------------------------------------
+
+
+async def test_setup_push_no_cluster_raises(
+    hass: HomeAssistant, zha_lock: ZHALock
+) -> None:
+    """Test setup_push_subscription raises when cluster unavailable."""
+    with patch.object(zha_lock, "_get_door_lock_cluster", return_value=None):
+        with pytest.raises(LockDisconnected, match="not available"):
+            zha_lock.setup_push_subscription()
+
+
+async def test_teardown_push_when_not_subscribed(
+    hass: HomeAssistant, zha_lock: ZHALock
+) -> None:
+    """Test teardown when not subscribed is a no-op."""
+    assert zha_lock._cluster_listener_unsub is None
+    zha_lock.teardown_push_subscription()
+    assert zha_lock._cluster_listener_unsub is None
+
+
+# ---------------------------------------------------------------------------
+# Detect programming support
+# ---------------------------------------------------------------------------
+
+
+async def test_detect_programming_support_logs_fallback(
+    hass: HomeAssistant, zha_lock: ZHALock, caplog
+) -> None:
+    """Test _async_detect_programming_support sets flag and logs when unsupported."""
+    cluster = zha_lock._get_door_lock_cluster()
+    assert cluster is not None
+    cluster.get = lambda attr_name: None
+
+    await zha_lock._async_detect_programming_support()
+
+    assert zha_lock._supports_programming_events is False
+    assert "drift detection" in caplog.text
+
+
+async def test_check_programming_support_no_cluster(
+    hass: HomeAssistant, zha_lock: ZHALock
+) -> None:
+    """Test programming support check returns False without cluster."""
+    with patch.object(zha_lock, "_get_door_lock_cluster", return_value=None):
+        assert await zha_lock._async_check_programming_event_support() is False
+
+
+async def test_check_programming_support_exception_in_get(
+    hass: HomeAssistant, zha_lock: ZHALock
+) -> None:
+    """Test programming support check handles exceptions reading attributes."""
+    cluster = zha_lock._get_door_lock_cluster()
+    assert cluster is not None
+
+    def exploding_get(attr_name):
+        raise RuntimeError("read failed")
+
+    cluster.get = exploding_get
+
+    result = await zha_lock._async_check_programming_event_support()
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# get_usercodes error handling
+# ---------------------------------------------------------------------------
+
+
+async def test_get_usercodes_slot_read_failure(
+    hass: HomeAssistant,
+    zha_lock: ZHALock,
+    simple_lcm_config_entry: MockConfigEntry,
+) -> None:
+    """Test get_usercodes returns EMPTY for slots that fail to read."""
+    cluster = zha_lock._get_door_lock_cluster()
+    assert cluster is not None
+    cluster.get_pin_code = AsyncMock(side_effect=RuntimeError("zigpy timeout"))
+
+    codes = await zha_lock.async_get_usercodes()
+
+    assert codes[1] is SlotCode.EMPTY
+    assert codes[2] is SlotCode.EMPTY
+
+
+async def test_get_usercodes_no_managed_slots(
+    hass: HomeAssistant, zha_lock: ZHALock
+) -> None:
+    """Test get_usercodes returns empty dict with no managed slots."""
+    codes = await zha_lock.async_get_usercodes()
+    assert codes == {}
+
+
+async def test_set_usercode_generic_exception(
+    hass: HomeAssistant,
+    zha_lock: ZHALock,
+    simple_lcm_config_entry: MockConfigEntry,
+) -> None:
+    """Test set_usercode wraps generic exceptions as LockDisconnected."""
+    cluster = zha_lock._get_door_lock_cluster()
+    assert cluster is not None
+    cluster.set_pin_code = AsyncMock(side_effect=RuntimeError("zigpy error"))
+
+    with pytest.raises(LockDisconnected, match="Failed to set PIN"):
+        await zha_lock.async_set_usercode(1, "1234")
+
+
+async def test_clear_usercode_generic_exception(
+    hass: HomeAssistant,
+    zha_lock: ZHALock,
+    simple_lcm_config_entry: MockConfigEntry,
+) -> None:
+    """Test clear_usercode wraps generic exceptions as LockDisconnected."""
+    cluster = zha_lock._get_door_lock_cluster()
+    assert cluster is not None
+    cluster.clear_pin_code = AsyncMock(side_effect=RuntimeError("zigpy error"))
+
+    with pytest.raises(LockDisconnected, match="Failed to clear PIN"):
+        await zha_lock.async_clear_usercode(1)

--- a/tests/providers/zha/test_provider.py
+++ b/tests/providers/zha/test_provider.py
@@ -222,12 +222,8 @@ async def test_programming_event_support_with_mask(
     cluster = zha_lock._get_door_lock_cluster()
     assert cluster is not None
 
-    def mock_get(attr_name):
-        if attr_name == "keypad_programming_event_mask":
-            return 0x0001
-        return None
-
-    cluster.get = mock_get
+    mask_attr = DoorLock.AttributeDefs.keypad_programming_event_mask
+    cluster.read_attributes = AsyncMock(return_value=({mask_attr.id: 0x0001}, {}))
 
     result = await zha_lock._async_check_programming_event_support()
     assert result is True
@@ -240,7 +236,7 @@ async def test_programming_event_support_without_mask(
     cluster = zha_lock._get_door_lock_cluster()
     assert cluster is not None
 
-    cluster.get = lambda attr_name: None
+    cluster.read_attributes = AsyncMock(return_value=({}, {}))
 
     result = await zha_lock._async_check_programming_event_support()
     assert result is False
@@ -495,18 +491,18 @@ async def test_teardown_push_when_not_subscribed(
 # ---------------------------------------------------------------------------
 
 
-async def test_detect_programming_support_logs_fallback(
-    hass: HomeAssistant, zha_lock: ZHALock, caplog
+async def test_async_setup_detects_programming_support(
+    hass: HomeAssistant, zha_lock: ZHALock, simple_lcm_config_entry: MockConfigEntry
 ) -> None:
-    """Test _async_detect_programming_support sets flag and logs when unsupported."""
+    """Test async_setup detects programming event support before coordinator."""
     cluster = zha_lock._get_door_lock_cluster()
     assert cluster is not None
-    cluster.get = lambda attr_name: None
+    cluster.read_attributes = AsyncMock(return_value=({}, {}))
 
-    await zha_lock._async_detect_programming_support()
+    await zha_lock.async_setup(simple_lcm_config_entry)
 
     assert zha_lock._supports_programming_events is False
-    assert "drift detection" in caplog.text
+    assert zha_lock.hard_refresh_interval == timedelta(hours=1)
 
 
 async def test_check_programming_support_no_cluster(
@@ -517,17 +513,14 @@ async def test_check_programming_support_no_cluster(
         assert await zha_lock._async_check_programming_event_support() is False
 
 
-async def test_check_programming_support_exception_in_get(
+async def test_check_programming_support_read_failure(
     hass: HomeAssistant, zha_lock: ZHALock
 ) -> None:
-    """Test programming support check handles exceptions reading attributes."""
+    """Test programming support check handles read_attributes failure."""
     cluster = zha_lock._get_door_lock_cluster()
     assert cluster is not None
 
-    def exploding_get(attr_name):
-        raise RuntimeError("read failed")
-
-    cluster.get = exploding_get
+    cluster.read_attributes = AsyncMock(side_effect=RuntimeError("read failed"))
 
     result = await zha_lock._async_check_programming_event_support()
     assert result is False
@@ -543,15 +536,15 @@ async def test_get_usercodes_slot_read_failure(
     zha_lock: ZHALock,
     simple_lcm_config_entry: MockConfigEntry,
 ) -> None:
-    """Test get_usercodes returns EMPTY for slots that fail to read."""
+    """Test get_usercodes returns UNREADABLE_CODE for slots that fail to read."""
     cluster = zha_lock._get_door_lock_cluster()
     assert cluster is not None
     cluster.get_pin_code = AsyncMock(side_effect=RuntimeError("zigpy timeout"))
 
     codes = await zha_lock.async_get_usercodes()
 
-    assert codes[1] is SlotCode.EMPTY
-    assert codes[2] is SlotCode.EMPTY
+    assert codes[1] is SlotCode.UNREADABLE_CODE
+    assert codes[2] is SlotCode.UNREADABLE_CODE
 
 
 async def test_get_usercodes_no_managed_slots(

--- a/tests/providers/zha/test_provider.py
+++ b/tests/providers/zha/test_provider.py
@@ -12,7 +12,10 @@ from zigpy.zcl.clusters.closures import DoorLock
 from homeassistant.components.zha.const import DOMAIN as ZHA_DOMAIN
 from homeassistant.core import HomeAssistant
 
-from custom_components.lock_code_manager.exceptions import LockDisconnected
+from custom_components.lock_code_manager.exceptions import (
+    CodeRejectedError,
+    LockDisconnected,
+)
 from custom_components.lock_code_manager.models import SlotCode
 from custom_components.lock_code_manager.providers.zha import (
     ZHALock,
@@ -144,12 +147,12 @@ async def test_set_usercode_failure(
     zha_lock: ZHALock,
     simple_lcm_config_entry: MockConfigEntry,
 ) -> None:
-    """Test set_usercode raises LockDisconnected on failure."""
+    """Test set_usercode raises CodeRejectedError on non-zero status."""
     cluster = zha_lock._get_door_lock_cluster()
     assert cluster is not None
     cluster.set_pin_code = AsyncMock(return_value=type("Response", (), {"status": 1})())
 
-    with pytest.raises(LockDisconnected, match="set_pin_code failed"):
+    with pytest.raises(CodeRejectedError, match="set_pin_code rejected"):
         await zha_lock.async_set_usercode(3, "5678")
 
 
@@ -178,14 +181,14 @@ async def test_clear_usercode_failure(
     zha_lock: ZHALock,
     simple_lcm_config_entry: MockConfigEntry,
 ) -> None:
-    """Test clear_usercode raises LockDisconnected on failure."""
+    """Test clear_usercode raises CodeRejectedError on non-zero status."""
     cluster = zha_lock._get_door_lock_cluster()
     assert cluster is not None
     cluster.clear_pin_code = AsyncMock(
         return_value=type("Response", (), {"status": 1})()
     )
 
-    with pytest.raises(LockDisconnected, match="clear_pin_code failed"):
+    with pytest.raises(CodeRejectedError, match="clear_pin_code rejected"):
         await zha_lock.async_clear_usercode(3)
 
 

--- a/tests/providers/zha/test_provider.py
+++ b/tests/providers/zha/test_provider.py
@@ -121,10 +121,11 @@ async def test_set_usercode(
     zha_lock: ZHALock,
     simple_lcm_config_entry: MockConfigEntry,
 ) -> None:
-    """Test set_usercode calls the cluster correctly."""
+    """Test set_usercode calls the cluster and pushes optimistic update."""
     cluster = zha_lock._get_door_lock_cluster()
     assert cluster is not None
     cluster.set_pin_code = AsyncMock(return_value=type("Response", (), {"status": 0})())
+    zha_lock.coordinator = MagicMock()
 
     result = await zha_lock.async_set_usercode(3, "5678", "Test User")
 
@@ -135,6 +136,7 @@ async def test_set_usercode(
         DoorLock.UserType.Unrestricted,
         "5678",
     )
+    zha_lock.coordinator.push_update.assert_called_once_with({3: "5678"})
 
 
 async def test_set_usercode_failure(
@@ -156,17 +158,19 @@ async def test_clear_usercode(
     zha_lock: ZHALock,
     simple_lcm_config_entry: MockConfigEntry,
 ) -> None:
-    """Test clear_usercode calls the cluster correctly."""
+    """Test clear_usercode calls the cluster and pushes optimistic update."""
     cluster = zha_lock._get_door_lock_cluster()
     assert cluster is not None
     cluster.clear_pin_code = AsyncMock(
         return_value=type("Response", (), {"status": 0})()
     )
+    zha_lock.coordinator = MagicMock()
 
     result = await zha_lock.async_clear_usercode(3)
 
     assert result is True
     cluster.clear_pin_code.assert_called_once_with(3)
+    zha_lock.coordinator.push_update.assert_called_once_with({3: SlotCode.EMPTY})
 
 
 async def test_clear_usercode_failure(
@@ -503,6 +507,25 @@ async def test_async_setup_detects_programming_support(
 
     assert zha_lock._supports_programming_events is False
     assert zha_lock.hard_refresh_interval == timedelta(hours=1)
+
+
+async def test_async_setup_clears_cached_state(
+    hass: HomeAssistant, zha_lock: ZHALock, simple_lcm_config_entry: MockConfigEntry
+) -> None:
+    """Test async_setup clears cached cluster on reconnect."""
+    # Prime the cache
+    cluster = zha_lock._get_door_lock_cluster()
+    assert cluster is not None
+    assert zha_lock._door_lock_cluster is not None
+
+    cluster.read_attributes = AsyncMock(return_value=({}, {}))
+
+    # async_setup should clear the cache so a stale reference isn't kept
+    await zha_lock.async_setup(simple_lcm_config_entry)
+
+    # The cluster was re-discovered (cache cleared then re-populated)
+    # Verify the cache was cleared by checking it went through discovery again
+    assert zha_lock._endpoint_id is not None
 
 
 async def test_check_programming_support_no_cluster(


### PR DESCRIPTION
## Proposed change

Adds support for Zigbee locks connected via ZHA. This is a complete rebuild of #739 against the current codebase (the old branch was 116 commits behind main with significant API changes).

### What it does

Communicates with Zigbee locks through the zigpy DoorLock cluster for PIN code get/set/clear operations.

- **Push updates** via cluster listeners for operation events (lock/unlock with user ID) and programming events (PIN code changes)
- **Programming event detection** via event mask attributes, with hourly drift detection fallback when unsupported
- **Code slot events** for automations (keypad unlock → fire event with user ID)

### Architecture

Single-module provider (`providers/zha.py`) following the same pattern as other providers. Uses `managed_slots` property, `source` parameter on `async_set_usercode`, and the current `BaseLock` interface.

### Test coverage

17 unit tests covering properties, connection checks, cluster access, usercode operations, push subscription lifecycle, and programming event support detection.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: closes #739
- This PR is related to issue: