### PR TITLE
tune: reduce sync tick interval from 5s to 2s

### DIFF
--- a/custom_components/lock_code_manager/const.py
+++ b/custom_components/lock_code_manager/const.py
@@ -117,7 +117,7 @@ BACKOFF_MAX_SECONDS: int = 1800  # 30 minutes
 POLL_FAILURE_ALERT_THRESHOLD: int = 12
 
 # Sync timing
-TICK_INTERVAL = timedelta(seconds=5)
+TICK_INTERVAL = timedelta(seconds=2)
 MAX_SYNC_ATTEMPTS = 3
 SYNC_ATTEMPT_WINDOW = timedelta(minutes=5)
 

--- a/custom_components/lock_code_manager/sync.py
+++ b/custom_components/lock_code_manager/sync.py
@@ -5,7 +5,7 @@ code) and drives set/clear operations to reconcile. Uses a state machine
 (SyncState enum) with periodic tick for retries and per-lock suspension on
 repeated failures.
 
-Tick interval: 5 seconds (TICK_INTERVAL)
+Tick interval: 2 seconds (TICK_INTERVAL)
 Circuit breaker: 3 attempts within 5 minutes (MAX_SYNC_ATTEMPTS, SYNC_ATTEMPT_WINDOW)
 """
 


### PR DESCRIPTION
## Proposed change

Reduces the sync manager tick interval from 5 seconds to 2 seconds for snappier state transitions.

The tick is lightweight when idle — immediate return for IN_SYNC, SYNCING, and SUSPENDED states. Lock operations are separately rate-limited at 2 seconds minimum between calls, so a faster tick doesn't increase lock traffic. It just reduces the latency between detecting a state change and starting the sync operation.

Observed during live testing with a Kwikset 914 (ZHA): the SYNCING indicator was visible for a noticeable period after a PIN change. Reducing the tick makes transitions feel more responsive.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue:
- This PR is related to issue: