### PR TITLE
feat: refresh devcontainer with Python 3.14, Claude Code, Rust

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,39 @@
+FROM mcr.microsoft.com/vscode/devcontainers/base:debian
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# System dependencies needed by HA and lock integrations
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        libudev-dev \
+        libpcap-dev \
+        libyaml-dev \
+        libxml2 \
+        git \
+        cmake \
+        autoconf \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# uv for fast Python/pip operations
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+USER vscode
+
+# Install Python 3.14 via uv and create venv
+ENV VIRTUAL_ENV="/home/vscode/.local/ha-venv"
+RUN uv python install 3.14 \
+    && uv venv --python 3.14 $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+# Claude Code
+RUN curl -fsSL https://claude.ai/install.sh | bash
+ENV PATH="/home/vscode/.claude/local/bin:$PATH"
+
+# Rust (needed for pyo3-ffi build deps and prek)
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/home/vscode/.cargo/bin:$PATH"
+
+WORKDIR /workspaces
+
+ENV SHELL=/bin/bash

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -34,9 +34,6 @@ ENV PATH="/home/vscode/.claude/local/bin:$PATH"
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/home/vscode/.cargo/bin:$PATH"
 
-# Enable corepack so yarn runs without interactive prompts
-RUN corepack enable
-
 WORKDIR /workspaces
 
 ENV SHELL=/bin/bash

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -34,6 +34,9 @@ ENV PATH="/home/vscode/.claude/local/bin:$PATH"
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/home/vscode/.cargo/bin:$PATH"
 
+# Enable corepack so yarn runs without interactive prompts
+RUN corepack enable
+
 WORKDIR /workspaces
 
 ENV SHELL=/bin/bash

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -30,9 +30,10 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN curl -fsSL https://claude.ai/install.sh | bash
 ENV PATH="/home/vscode/.claude/local/bin:$PATH"
 
-# Rust (needed for pyo3-ffi build deps and prek)
+# Rust (needed for pyo3-ffi build deps) + prek (pre-commit replacement)
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/home/vscode/.cargo/bin:$PATH"
+RUN cargo install prek
 
 WORKDIR /workspaces
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,7 @@
         }
     },
     "containerEnv": {
-        "COREPACK_ENABLE_AUTO_PIN": "0",
+        "COREPACK_ENABLE_DOWNLOAD_PROMPT": "0",
         "DEVCONTAINER": "1"
     },
     "postCreateCommand": "scripts/setup-devcontainer",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,6 +12,7 @@
         }
     },
     "containerEnv": {
+        "COREPACK_ENABLE_AUTO_PIN": "0",
         "DEVCONTAINER": "1"
     },
     "postCreateCommand": "scripts/setup-devcontainer",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,21 +1,21 @@
 {
     "name": "lock_code_manager Dev",
-    "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+    "build": {
+        "dockerfile": "Dockerfile",
+        "context": ".."
+    },
     "forwardPorts": [8123],
     "features": {
+        "ghcr.io/devcontainers/features/github-cli:1": {},
         "ghcr.io/devcontainers/features/node:1": {
             "version": "lts"
-        },
-        "ghcr.io/devcontainers/features/python:1": {
-            "version": "3.13",
-            "installTools": false
         }
     },
     "containerEnv": {
-        "DEVCONTAINER": "1",
-        "PIP_BREAK_SYSTEM_PACKAGES": "1"
+        "DEVCONTAINER": "1"
     },
     "postCreateCommand": "scripts/setup-devcontainer",
+    "postStartCommand": "scripts/setup-devcontainer",
     "customizations": {
         "vscode": {
             "extensions": [
@@ -29,7 +29,10 @@
                 "rvest.vs-code-prettier-eslint",
                 "visualstudioexptteam.vscodeintellicode",
                 "GitHub.vscode-pull-request-github"
-            ]
+            ],
+            "settings": {
+                "python.defaultInterpreterPath": "/home/vscode/.local/ha-venv/bin/python"
+            }
         }
     }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,7 +16,7 @@
         "DEVCONTAINER": "1"
     },
     "postCreateCommand": "scripts/setup-devcontainer",
-    "postStartCommand": "scripts/setup-devcontainer",
+    "postStartCommand": "scripts/bootstrap-devcontainer",
     "customizations": {
         "vscode": {
             "extensions": [

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -256,6 +256,13 @@ yarn build                     # Build frontend strategy module
 yarn watch                     # Watch mode for development
 ```
 
+**Important:** After modifying any TypeScript files in `ts/`, the JavaScript
+bundle must be rebuilt before testing in the browser. Use `yarn watch` during
+development for automatic rebuilds, or run `yarn build` manually. The compiled
+output is `custom_components/lock_code_manager/www/lock-code-manager-strategy.js`.
+If you test with stale JavaScript, the Lovelace strategy will fail with:
+`Timeout waiting for strategy element ll-strategy-dashboard-lock-code-manager to be registered`
+
 ## Code Style
 
 - Python: Ruff for linting/formatting (line length: 88)

--- a/requirements_lint.txt
+++ b/requirements_lint.txt
@@ -1,3 +1,2 @@
 mypy==1.20.2
-pre-commit==4.6.0
 ruff==0.15.12

--- a/scripts/bootstrap-devcontainer
+++ b/scripts/bootstrap-devcontainer
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Lightweight bootstrap for container restarts (postStartCommand).
+# Only syncs dependencies — hook installation and first-time setup
+# are handled by scripts/setup-devcontainer (postCreateCommand).
+
+set -e
+cd "$(dirname "$0")/.."
+
+export DEVCONTAINER=1
+
+# Sync Python deps (fast no-op if already up to date)
+uv pip install -r requirements_dev.txt
+
+# Sync frontend deps
+if command -v corepack &> /dev/null; then
+    corepack enable 2>/dev/null || true
+fi
+yarn install

--- a/scripts/setup
+++ b/scripts/setup
@@ -53,16 +53,12 @@ fi
 pip install --upgrade uv
 uv pip install -r requirements_dev.txt
 
-# Install git hooks. Prefer prek (fast Rust-based replacement).
-# If prek is unavailable, use a uv-managed pre-commit pinned to Python 3.13
-# instead of whatever pre-commit binary may already be on PATH (a Homebrew
-# install linked against Python 3.14 fails on macOS).
-if command -v prek &> /dev/null; then
-  prek install
-else
-  uv tool install --force --python 3.13 pre-commit
-  pre-commit install
+# Install git hooks via prek (fast Rust-based pre-commit replacement).
+# Install prek if not available: https://github.com/j178/prek
+if ! command -v prek &> /dev/null; then
+  cargo install prek 2>/dev/null || uv tool install prek
 fi
+prek install --overwrite
 yarn install
 
 # Setup directories for HA and linking

--- a/scripts/setup-devcontainer
+++ b/scripts/setup-devcontainer
@@ -52,9 +52,11 @@ if ! python3 -c "import aiousbwatcher" 2>/dev/null; then
     pip install aiousbwatcher
 fi
 
-# Install git hooks (unset core.hooksPath first — Codespaces sets it and
-# both prek and pre-commit refuse to install alongside it)
+# Install git hooks. Clean up Codespaces-managed hooks first — it sets
+# core.hooksPath and installs its own pre-commit hook, both of which
+# interfere with prek/pre-commit.
 git config --unset-all core.hooksPath 2>/dev/null || true
+rm -f .git/hooks/pre-commit .git/hooks/pre-commit.legacy
 if command -v prek &> /dev/null; then
     prek install
 else

--- a/scripts/setup-devcontainer
+++ b/scripts/setup-devcontainer
@@ -70,14 +70,10 @@ yarn install
 # Setup .ha directory with config and custom components
 mkdir -p "${PWD}/.ha/custom_components"
 
-# Copy dev config files (makes .ha self-contained).
-# Remove stale symlinks first (left over from older setup scripts that
-# used symlinks instead of copies).
+# Symlink dev config files into .ha so edits in dev/ are reflected immediately
 for yaml_file in "${PWD}"/dev/*.yaml; do
     if [ -f "$yaml_file" ]; then
-        dest="${PWD}/.ha/$(basename "$yaml_file")"
-        [ -L "$dest" ] && rm "$dest"
-        cp "$yaml_file" "$dest"
+        ensure_link "$yaml_file" "${PWD}/.ha/$(basename "$yaml_file")"
     fi
 done
 

--- a/scripts/setup-devcontainer
+++ b/scripts/setup-devcontainer
@@ -55,9 +55,6 @@ fi
 # Install git hooks via prek (clean up Codespaces-managed hooks first)
 git config --unset-all core.hooksPath 2>/dev/null || true
 rm -f .git/hooks/pre-commit .git/hooks/pre-commit.legacy
-if ! command -v prek &> /dev/null; then
-    cargo install prek
-fi
 prek install
 
 # Frontend dependencies

--- a/scripts/setup-devcontainer
+++ b/scripts/setup-devcontainer
@@ -66,7 +66,8 @@ else
     pre-commit install
 fi
 
-# Frontend dependencies
+# Frontend dependencies (corepack enable avoids interactive yarn download prompts)
+corepack enable 2>/dev/null || true
 yarn install
 
 # Setup .ha directory with config and custom components

--- a/scripts/setup-devcontainer
+++ b/scripts/setup-devcontainer
@@ -52,7 +52,9 @@ if ! python3 -c "import aiousbwatcher" 2>/dev/null; then
     pip install aiousbwatcher
 fi
 
-# Install git hooks
+# Install git hooks (unset core.hooksPath first — Codespaces sets it and
+# both prek and pre-commit refuse to install alongside it)
+git config --unset-all core.hooksPath 2>/dev/null || true
 if command -v prek &> /dev/null; then
     prek install
 else

--- a/scripts/setup-devcontainer
+++ b/scripts/setup-devcontainer
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 
-# Script setup
+# Setup script for the devcontainer environment.
+# Runs on both postCreateCommand and postStartCommand so it must be
+# idempotent — safe to run multiple times without side effects.
+
 set -e
 cd "$(dirname "$0")/.."
 
@@ -41,40 +44,38 @@ ensure_link() {
     ln -s "$target" "$link"
 }
 
-# Install dependencies into the container's system Python environment.
-if command -v dpkg >/dev/null 2>&1; then
-    if ! dpkg -s libudev-dev >/dev/null 2>&1; then
-        sudo apt-get update
-        sudo apt-get install -y libudev-dev
-    fi
+# Install Python dependencies into the venv
+uv pip install -r requirements_dev.txt
+
+# Ensure aiousbwatcher is available (pyo3 wheel may not be pre-built)
+if ! python3 -c "import aiousbwatcher" 2>/dev/null; then
+    pip install aiousbwatcher
 fi
 
-python3 -m pip install --upgrade uv
-uv pip install --system -r requirements_dev.txt
-
-if ! python3 - <<'PY'
-try:
-    import aiousbwatcher  # noqa: F401
-except ImportError:
-    raise SystemExit(1)
-PY
-then
-    python3 -m pip install aiousbwatcher==1.1.1
-fi
-
+# Install git hooks
 if command -v prek &> /dev/null; then
-  prek install
+    prek install
 else
-  if ! command -v pre-commit &> /dev/null; then
-    python3 -m pip install pre-commit
-  fi
-  pre-commit install
+    if ! command -v pre-commit &> /dev/null; then
+        pip install pre-commit
+    fi
+    pre-commit install
 fi
+
+# Frontend dependencies
 yarn install
 
-# Setup directories for HA and linking
-ensure_link "${PWD}/dev/configuration.yaml" "${PWD}/.ha/configuration.yaml"
-ensure_link "${PWD}/dev/virtual.yaml" "${PWD}/.ha/virtual.yaml"
+# Setup .ha directory with config and custom components
+mkdir -p "${PWD}/.ha/custom_components"
+
+# Copy dev config files (makes .ha self-contained)
+for yaml_file in "${PWD}"/dev/*.yaml; do
+    if [ -f "$yaml_file" ]; then
+        cp "$yaml_file" "${PWD}/.ha/"
+    fi
+done
+
+# Link the component being developed — changes are reflected immediately
 ensure_link "${PWD}/custom_components/lock_code_manager" "${PWD}/.ha/custom_components/lock_code_manager"
 
 # Download and extract Virtual component if not already present
@@ -82,8 +83,10 @@ if [[ ! -d "${PWD}/.ha/custom_components/virtual" ]]; then
     virtual_tag="$(get_virtual_release_tag)"
     curl -L -o virtual.zip "https://github.com/twrecked/hass-virtual/archive/refs/tags/${virtual_tag}.zip"
     unzip -j virtual.zip "*/custom_components/virtual/*" -d "${PWD}/.ha/custom_components/virtual/"
-
     rm virtual.zip
 fi
 
-hass --config "${PWD}/.ha" --script ensure_config
+# Validate HA config on first run
+if [ ! -f "${PWD}/.ha/.storage/core.config" ]; then
+    hass --config "${PWD}/.ha" --script ensure_config
+fi

--- a/scripts/setup-devcontainer
+++ b/scripts/setup-devcontainer
@@ -70,10 +70,14 @@ yarn install
 # Setup .ha directory with config and custom components
 mkdir -p "${PWD}/.ha/custom_components"
 
-# Copy dev config files (makes .ha self-contained)
+# Copy dev config files (makes .ha self-contained).
+# Remove stale symlinks first (left over from older setup scripts that
+# used symlinks instead of copies).
 for yaml_file in "${PWD}"/dev/*.yaml; do
     if [ -f "$yaml_file" ]; then
-        cp "$yaml_file" "${PWD}/.ha/"
+        dest="${PWD}/.ha/$(basename "$yaml_file")"
+        [ -L "$dest" ] && rm "$dest"
+        cp "$yaml_file" "$dest"
     fi
 done
 

--- a/scripts/setup-devcontainer
+++ b/scripts/setup-devcontainer
@@ -52,22 +52,31 @@ if ! python3 -c "import aiousbwatcher" 2>/dev/null; then
     pip install aiousbwatcher
 fi
 
-# Install git hooks. Clean up Codespaces-managed hooks first — it sets
-# core.hooksPath and installs its own pre-commit hook, both of which
-# interfere with prek/pre-commit.
+# Install git hooks. Skip if already installed (the script is idempotent
+# and runs on both postCreate and postStart).
 git config --unset-all core.hooksPath 2>/dev/null || true
-rm -f .git/hooks/pre-commit .git/hooks/pre-commit.legacy
-if command -v prek &> /dev/null; then
-    prek install
+if [ -f .git/hooks/pre-commit ] && grep -q -e prek -e pre-commit .git/hooks/pre-commit 2>/dev/null; then
+    # Our hook is already in place — clean up any legacy file and move on
+    rm -f .git/hooks/pre-commit.legacy
 else
-    if ! command -v pre-commit &> /dev/null; then
-        pip install pre-commit
+    # Remove Codespaces-managed hook before installing ours
+    rm -f .git/hooks/pre-commit .git/hooks/pre-commit.legacy
+    if command -v prek &> /dev/null; then
+        prek install
+    else
+        if ! command -v pre-commit &> /dev/null; then
+            pip install pre-commit
+        fi
+        pre-commit install
     fi
-    pre-commit install
 fi
 
-# Frontend dependencies (corepack enable avoids interactive yarn download prompts)
-corepack enable 2>/dev/null || true
+# Frontend dependencies — pre-download yarn via corepack to avoid
+# interactive "Do you want to continue?" prompts
+if command -v corepack &> /dev/null; then
+    corepack enable
+    corepack prepare yarn@stable --activate 2>/dev/null || true
+fi
 yarn install
 
 # Setup .ha directory with config and custom components

--- a/scripts/setup-devcontainer
+++ b/scripts/setup-devcontainer
@@ -52,30 +52,21 @@ if ! python3 -c "import aiousbwatcher" 2>/dev/null; then
     pip install aiousbwatcher
 fi
 
-# Install git hooks. Skip if already installed (the script is idempotent
-# and runs on both postCreate and postStart).
+# Install git hooks (clean up Codespaces-managed hooks first)
 git config --unset-all core.hooksPath 2>/dev/null || true
-if [ -f .git/hooks/pre-commit ] && grep -q -e prek -e pre-commit .git/hooks/pre-commit 2>/dev/null; then
-    # Our hook is already in place — clean up any legacy file and move on
-    rm -f .git/hooks/pre-commit.legacy
+rm -f .git/hooks/pre-commit .git/hooks/pre-commit.legacy
+if command -v prek &> /dev/null; then
+    prek install
 else
-    # Remove Codespaces-managed hook before installing ours
-    rm -f .git/hooks/pre-commit .git/hooks/pre-commit.legacy
-    if command -v prek &> /dev/null; then
-        prek install
-    else
-        if ! command -v pre-commit &> /dev/null; then
-            pip install pre-commit
-        fi
-        pre-commit install
+    if ! command -v pre-commit &> /dev/null; then
+        pip install pre-commit
     fi
+    pre-commit install
 fi
 
-# Frontend dependencies — pre-download yarn via corepack to avoid
-# interactive "Do you want to continue?" prompts
+# Frontend dependencies
 if command -v corepack &> /dev/null; then
-    corepack enable
-    corepack prepare yarn@stable --activate 2>/dev/null || true
+    corepack enable 2>/dev/null || true
 fi
 yarn install
 

--- a/scripts/setup-devcontainer
+++ b/scripts/setup-devcontainer
@@ -52,17 +52,13 @@ if ! python3 -c "import aiousbwatcher" 2>/dev/null; then
     pip install aiousbwatcher
 fi
 
-# Install git hooks (clean up Codespaces-managed hooks first)
+# Install git hooks via prek (clean up Codespaces-managed hooks first)
 git config --unset-all core.hooksPath 2>/dev/null || true
 rm -f .git/hooks/pre-commit .git/hooks/pre-commit.legacy
-if command -v prek &> /dev/null; then
-    prek install
-else
-    if ! command -v pre-commit &> /dev/null; then
-        pip install pre-commit
-    fi
-    pre-commit install
+if ! command -v prek &> /dev/null; then
+    cargo install prek
 fi
+prek install
 
 # Frontend dependencies
 if command -v corepack &> /dev/null; then


### PR DESCRIPTION
## Proposed change

Rebuilds the devcontainer setup from scratch, replacing the stale PR #707 (244 commits behind). Follows the same pattern as HA Core's own devcontainer (custom Dockerfile with uv venv, separate setup/bootstrap scripts).

### What's in the container

| Tool | Purpose |
|------|---------|
| Python 3.14 | Matches project target (`requires-python = ">=3.14"`) |
| Claude Code | AI-assisted development |
| Rust toolchain | pyo3-ffi build deps, prek |
| GitHub CLI | PR/issue management |
| Node LTS | Frontend TypeScript build (yarn) |
| System libs | libudev-dev, libpcap-dev, etc. for HA lock integrations |

### Development workflow

- `custom_components/lock_code_manager` is **symlinked** into `.ha/custom_components/` — Python changes are reflected immediately, just restart HA
- Dev config files (`dev/*.yaml`) are symlinked to `.ha/` so edits are committed
- Debug logging for `custom_components.lock_code_manager` is pre-configured
- `yarn watch` for automatic frontend rebuilds during development
- VS Code debug launch config runs HA from the venv

### Setup / bootstrap split

Following HA Core's pattern:
- **`postCreateCommand`** → `scripts/setup-devcontainer`: full first-time setup (deps, hooks, config, virtual component)
- **`postStartCommand`** → `scripts/bootstrap-devcontainer`: lightweight dep sync only (no hook reinstallation)

This avoids the Codespaces issue where re-running hook installation on every start caused legacy hook migration loops.

### Standardize on prek

Both local (`scripts/setup`) and devcontainer (`scripts/setup-devcontainer`) now use prek exclusively for git hooks, replacing the pre-commit fallback. prek is a Rust-based drop-in replacement that reads the same `.pre-commit-config.yaml` — no config changes needed. pre-commit.ci continues to work in GitHub CI using the same config file.

This fixes the recurring broken Python 3.7 shebang issue from a stale pre-commit installation.

### Also included

- AGENTS.md note about TypeScript rebuild requirement
- `COREPACK_ENABLE_AUTO_PIN=0` env var to suppress yarn download prompts

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #707
- This PR is related to issue: