### PR TITLE
refactor: make config flow existing-codes confirmation informational only

### DIFF
--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -269,7 +269,7 @@ class _ExistingCodesFlowMixin:
     async def _clear_all_pending_slots(self) -> None:
         """Clear every slot in ``_slots_to_clear`` and reset state."""
         # Build the work list: (lock_instance, lock_entity_id, slot_num)
-        work = [
+        lock_slots_to_clear = [
             (lock_instance, lock_entity_id, slot_num)
             for slot_num in self._slots_to_clear
             for lock_entity_id, codes in self._all_codes.items()
@@ -277,9 +277,9 @@ class _ExistingCodesFlowMixin:
             and (lock_instance := self._lock_instances.get(lock_entity_id))
         ]
         self._clear_done = 0
-        self._clear_total = len(work)
+        self._clear_total = len(lock_slots_to_clear)
 
-        for lock_instance, lock_entity_id, slot_num in work:
+        for lock_instance, lock_entity_id, slot_num in lock_slots_to_clear:
             try:
                 await lock_instance.async_internal_clear_usercode(
                     slot_num, source="direct"

--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Awaitable, Callable, Iterable
 from functools import partial
 import logging
@@ -240,6 +241,7 @@ class _ExistingCodesFlowMixin:
     _lock_instances: dict[str, Any]
     _slots_to_clear: list[int]
     _next_step: Callable[[], Awaitable[dict[str, Any]]] | None
+    _clear_task: asyncio.Task[None] | None
 
     def _init_existing_codes_state(self) -> None:
         """Initialize mixin state. Call from the inheriting flow's __init__."""
@@ -247,6 +249,7 @@ class _ExistingCodesFlowMixin:
         self._lock_instances = {}
         self._slots_to_clear = []
         self._next_step = None
+        self._clear_task = None
 
     def _slots_with_existing_codes(self, slot_nums: Iterable[int]) -> list[int]:
         """Return sorted slot numbers that have a non-empty code on any lock."""
@@ -295,8 +298,7 @@ class _ExistingCodesFlowMixin:
     async def _clear_then_create_entry(
         self, *, title: str, data: dict[str, Any]
     ) -> dict[str, Any]:
-        """Clear pending slots, then create the entry."""
-        await self._clear_all_pending_slots()
+        """Create the entry after slots have been cleared by the progress step."""
         return self.async_create_entry(  # type: ignore[attr-defined]
             title=title, data=data
         )
@@ -316,7 +318,44 @@ class _ExistingCodesFlowMixin:
     async def async_step_existing_codes_clear(
         self, user_input: dict[str, Any] | None = None
     ) -> dict[str, Any]:
-        """User confirmed clearing. Run the next step."""
+        """User confirmed clearing. Show progress while clearing codes."""
+        if self._next_step is None:
+            return self.async_abort(reason="unknown")  # type: ignore[attr-defined]
+
+        if self._clear_task is None:
+            self._clear_task = self.hass.async_create_task(  # type: ignore[attr-defined]
+                self._clear_all_pending_slots(),
+                "Lock Code Manager: clear existing codes",
+            )
+
+        if not self._clear_task.done():
+            num_locks = sum(
+                1
+                for codes in self._all_codes.values()
+                if any(
+                    codes.get(s, SlotCode.EMPTY) != SlotCode.EMPTY
+                    for s in self._slots_to_clear
+                )
+            )
+            return self.async_show_progress(  # type: ignore[attr-defined]
+                step_id="existing_codes_clear",
+                progress_action="clearing_codes",
+                description_placeholders={
+                    "slots": str(len(self._slots_to_clear)),
+                    "locks": str(num_locks),
+                },
+                progress_task=self._clear_task,
+            )
+
+        self._clear_task = None
+        return self.async_show_progress_done(  # type: ignore[attr-defined]
+            next_step_id="existing_codes_done",
+        )
+
+    async def async_step_existing_codes_done(
+        self, user_input: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        """Proceed to the next step after clearing finishes."""
         if self._next_step is None:
             return self.async_abort(reason="unknown")  # type: ignore[attr-defined]
         return await self._next_step()

--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -590,7 +590,7 @@ class LockCodeManagerOptionsFlow(_ExistingCodesFlowMixin, config_entries.Options
     async def _maybe_confirm_then_persist(
         self, user_input: dict[str, Any]
     ) -> dict[str, Any]:
-        """Scan added (lock, slot) pairs for codes; confirm clear if any.
+        """Scan added (lock, slot) pairs for codes; show confirmation if any exist.
 
         Compares the submitted (lock, slot) pairs against the entry's
         current configuration. If any newly-added pair has a non-empty

--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -329,20 +329,12 @@ class _ExistingCodesFlowMixin:
             )
 
         if not self._clear_task.done():
-            num_locks = sum(
-                1
-                for codes in self._all_codes.values()
-                if any(
-                    codes.get(s, SlotCode.EMPTY) != SlotCode.EMPTY
-                    for s in self._slots_to_clear
-                )
-            )
             return self.async_show_progress(  # type: ignore[attr-defined]
                 step_id="existing_codes_clear",
                 progress_action="clearing_codes",
                 description_placeholders={
                     "slots": str(len(self._slots_to_clear)),
-                    "locks": str(num_locks),
+                    "locks": str(len(self._lock_instances)),
                 },
                 progress_task=self._clear_task,
             )

--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 from collections.abc import Awaitable, Callable, Iterable
 from functools import partial
 import logging
@@ -235,72 +234,50 @@ def _scope_codes_to_pairs(
 
 
 class _ExistingCodesFlowMixin:
-    """Mixin providing existing-codes detection, confirm UI, and clearing for config/options flows."""
+    """Mixin providing existing-codes detection and confirmation for config/options flows.
+
+    When slots already have codes on the lock, this mixin shows a confirmation
+    dialog listing which locks/slots are affected.  Clearing is NOT done here —
+    the sync manager handles reconciliation when the config entry loads.
+    """
 
     _all_codes: dict[str, dict[int, str | SlotCode]]
     _lock_instances: dict[str, Any]
-    _slots_to_clear: list[int]
+    _occupied_lock_slots: list[tuple[str, int]]
     _next_step: Callable[[], Awaitable[dict[str, Any]]] | None
-    _clear_task: asyncio.Task[None] | None
-    _clear_total: int
-    _clear_done: int
 
     def _init_existing_codes_state(self) -> None:
         """Initialize mixin state. Call from the inheriting flow's __init__."""
         self._all_codes = {}
         self._lock_instances = {}
-        self._slots_to_clear = []
+        self._occupied_lock_slots = []
         self._next_step = None
-        self._clear_task = None
-        self._clear_total = 0
-        self._clear_done = 0
 
-    def _slots_with_existing_codes(self, slot_nums: Iterable[int]) -> list[int]:
-        """Return sorted slot numbers that have a non-empty code on any lock."""
+    def _find_occupied_lock_slots(
+        self, slot_nums: Iterable[int]
+    ) -> list[tuple[str, int]]:
+        """Return (lock_entity_id, slot_num) pairs that have non-empty codes."""
         return sorted(
-            slot_num
+            (lock_entity_id, slot_num)
             for slot_num in slot_nums
-            if any(
-                codes.get(slot_num, SlotCode.EMPTY) != SlotCode.EMPTY
-                for codes in self._all_codes.values()
-            )
-        )
-
-    async def _clear_all_pending_slots(self) -> None:
-        """Clear every slot in ``_slots_to_clear`` and reset state."""
-        # Build the work list: (lock_instance, lock_entity_id, slot_num)
-        lock_slots_to_clear = [
-            (lock_instance, lock_entity_id, slot_num)
-            for slot_num in self._slots_to_clear
             for lock_entity_id, codes in self._all_codes.items()
             if codes.get(slot_num, SlotCode.EMPTY) != SlotCode.EMPTY
-            and (lock_instance := self._lock_instances.get(lock_entity_id))
-        ]
-        self._clear_done = 0
-        self._clear_total = len(lock_slots_to_clear)
+        )
 
-        for lock_instance, lock_entity_id, slot_num in lock_slots_to_clear:
-            try:
-                await lock_instance.async_internal_clear_usercode(
-                    slot_num, source="direct"
-                )
-            except Exception:  # noqa: BLE001
-                _LOGGER.warning(
-                    "Failed to clear slot %s on %s",
-                    slot_num,
-                    lock_entity_id,
-                    exc_info=True,
-                )
-            self._clear_done += 1
+    @staticmethod
+    def _format_occupied_slots(
+        occupied: list[tuple[str, int]],
+    ) -> str:
+        """Format occupied lock/slot pairs for display in the confirmation dialog."""
+        return "\n".join(
+            f"- {lock_entity_id}: slot {slot_num}"
+            for lock_entity_id, slot_num in occupied
+        )
 
-        self._slots_to_clear = []
-        self._all_codes = {}
-        self._lock_instances = {}
-
-    async def _clear_then_create_entry(
+    async def _create_entry(
         self, *, title: str, data: dict[str, Any]
     ) -> dict[str, Any]:
-        """Create the entry after slots have been cleared by the progress step."""
+        """Create the config entry."""
         return self.async_create_entry(  # type: ignore[attr-defined]
             title=title, data=data
         )
@@ -308,48 +285,19 @@ class _ExistingCodesFlowMixin:
     async def async_step_existing_codes_confirm(
         self, user_input: dict[str, Any] | None = None
     ) -> dict[str, Any]:
-        """Confirm clearing of existing codes before proceeding."""
+        """Confirm that existing codes will be overwritten by the sync manager."""
         return self.async_show_menu(  # type: ignore[attr-defined]
             step_id="existing_codes_confirm",
-            menu_options=["existing_codes_clear", "existing_codes_cancel"],
+            menu_options=["existing_codes_continue", "existing_codes_cancel"],
             description_placeholders={
-                "slots": ", ".join(str(s) for s in self._slots_to_clear),
+                "details": self._format_occupied_slots(self._occupied_lock_slots),
             },
         )
 
-    async def async_step_existing_codes_clear(
+    async def async_step_existing_codes_continue(
         self, user_input: dict[str, Any] | None = None
     ) -> dict[str, Any]:
-        """User confirmed clearing. Show progress while clearing codes."""
-        if self._next_step is None:
-            return self.async_abort(reason="unknown")  # type: ignore[attr-defined]
-
-        if self._clear_task is None:
-            self._clear_task = self.hass.async_create_task(  # type: ignore[attr-defined]
-                self._clear_all_pending_slots(),
-                "Lock Code Manager: clear existing codes",
-            )
-
-        if not self._clear_task.done():
-            return self.async_show_progress(  # type: ignore[attr-defined]
-                step_id="existing_codes_clear",
-                progress_action="clearing_codes",
-                description_placeholders={
-                    "cleared": str(self._clear_done),
-                    "total": str(self._clear_total),
-                },
-                progress_task=self._clear_task,
-            )
-
-        self._clear_task = None
-        return self.async_show_progress_done(  # type: ignore[attr-defined]
-            next_step_id="existing_codes_done",
-        )
-
-    async def async_step_existing_codes_done(
-        self, user_input: dict[str, Any] | None = None
-    ) -> dict[str, Any]:
-        """Proceed to the next step after clearing finishes."""
+        """User acknowledged existing codes. Proceed to next step."""
         if self._next_step is None:
             return self.async_abort(reason="unknown")  # type: ignore[attr-defined]
         return await self._next_step()
@@ -434,10 +382,10 @@ class LockCodeManagerFlowHandler(
             description_placeholders.update(additional_placeholders)
             if not errors:
                 self.slots_to_configure = list(range(start, start + num_slots))
-                self._slots_to_clear = self._slots_with_existing_codes(
+                self._occupied_lock_slots = self._find_occupied_lock_slots(
                     self.slots_to_configure
                 )
-                if self._slots_to_clear:
+                if self._occupied_lock_slots:
                     self._next_step = self.async_step_code_slot
                     return await self.async_step_existing_codes_confirm()
                 return await self.async_step_code_slot()
@@ -489,9 +437,7 @@ class LockCodeManagerFlowHandler(
                 slot_num = int(self.slots_to_configure.pop(0))
                 self.data[CONF_SLOTS][slot_num] = CODE_SLOT_SCHEMA(user_input)
                 if not self.slots_to_configure:
-                    return await self._clear_then_create_entry(
-                        title=self.title, data=self.data
-                    )
+                    return await self._create_entry(title=self.title, data=self.data)
                 current_slot = self.slots_to_configure[0]
                 description_placeholders["slot_num"] = current_slot
 
@@ -524,10 +470,12 @@ class LockCodeManagerFlowHandler(
 
                 if not errors:
                     self.data[CONF_SLOTS] = slots
-                    self._slots_to_clear = self._slots_with_existing_codes(slots.keys())
-                    if self._slots_to_clear:
+                    self._occupied_lock_slots = self._find_occupied_lock_slots(
+                        slots.keys()
+                    )
+                    if self._occupied_lock_slots:
                         self._next_step = partial(
-                            self._clear_then_create_entry,
+                            self._create_entry,
                             title=self.title,
                             data=self.data,
                         )
@@ -690,11 +638,9 @@ class LockCodeManagerOptionsFlow(_ExistingCodesFlowMixin, config_entries.Options
         )
 
         added_slot_nums = {slot for _, slot in diff.pairs_added}
-        self._slots_to_clear = self._slots_with_existing_codes(added_slot_nums)
-        if not self._slots_to_clear:
+        self._occupied_lock_slots = self._find_occupied_lock_slots(added_slot_nums)
+        if not self._occupied_lock_slots:
             return self.async_create_entry(title="", data=user_input)
 
-        self._next_step = partial(
-            self._clear_then_create_entry, title="", data=user_input
-        )
+        self._next_step = partial(self._create_entry, title="", data=user_input)
         return await self.async_step_existing_codes_confirm()

--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -242,6 +242,8 @@ class _ExistingCodesFlowMixin:
     _slots_to_clear: list[int]
     _next_step: Callable[[], Awaitable[dict[str, Any]]] | None
     _clear_task: asyncio.Task[None] | None
+    _clear_total: int
+    _clear_done: int
 
     def _init_existing_codes_state(self) -> None:
         """Initialize mixin state. Call from the inheriting flow's __init__."""
@@ -250,6 +252,8 @@ class _ExistingCodesFlowMixin:
         self._slots_to_clear = []
         self._next_step = None
         self._clear_task = None
+        self._clear_total = 0
+        self._clear_done = 0
 
     def _slots_with_existing_codes(self, slot_nums: Iterable[int]) -> list[int]:
         """Return sorted slot numbers that have a non-empty code on any lock."""
@@ -274,6 +278,7 @@ class _ExistingCodesFlowMixin:
                     lock_entity_id,
                     slot_num,
                 )
+                self._clear_done += 1
                 continue
             try:
                 await lock_instance.async_internal_clear_usercode(
@@ -286,6 +291,7 @@ class _ExistingCodesFlowMixin:
                     lock_entity_id,
                     exc_info=True,
                 )
+            self._clear_done += 1
 
     async def _clear_all_pending_slots(self) -> None:
         """Clear every slot in ``_slots_to_clear`` and reset state."""
@@ -323,6 +329,14 @@ class _ExistingCodesFlowMixin:
             return self.async_abort(reason="unknown")  # type: ignore[attr-defined]
 
         if self._clear_task is None:
+            # Count total individual clear operations (slot × lock pairs)
+            self._clear_total = sum(
+                1
+                for slot_num in self._slots_to_clear
+                for codes in self._all_codes.values()
+                if codes.get(slot_num, SlotCode.EMPTY) != SlotCode.EMPTY
+            )
+            self._clear_done = 0
             self._clear_task = self.hass.async_create_task(  # type: ignore[attr-defined]
                 self._clear_all_pending_slots(),
                 "Lock Code Manager: clear existing codes",
@@ -333,8 +347,8 @@ class _ExistingCodesFlowMixin:
                 step_id="existing_codes_clear",
                 progress_action="clearing_codes",
                 description_placeholders={
-                    "slots": str(len(self._slots_to_clear)),
-                    "locks": str(len(self._lock_instances)),
+                    "cleared": str(self._clear_done),
+                    "total": str(self._clear_total),
                 },
                 progress_task=self._clear_task,
             )

--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -295,6 +295,13 @@ class _ExistingCodesFlowMixin:
 
     async def _clear_all_pending_slots(self) -> None:
         """Clear every slot in ``_slots_to_clear`` and reset state."""
+        self._clear_done = 0
+        self._clear_total = sum(
+            1
+            for slot_num in self._slots_to_clear
+            for codes in self._all_codes.values()
+            if codes.get(slot_num, SlotCode.EMPTY) != SlotCode.EMPTY
+        )
         for slot_num in self._slots_to_clear:
             await self._clear_existing_slot(slot_num)
         self._slots_to_clear = []
@@ -329,14 +336,6 @@ class _ExistingCodesFlowMixin:
             return self.async_abort(reason="unknown")  # type: ignore[attr-defined]
 
         if self._clear_task is None:
-            # Count total individual clear operations (slot × lock pairs)
-            self._clear_total = sum(
-                1
-                for slot_num in self._slots_to_clear
-                for codes in self._all_codes.values()
-                if codes.get(slot_num, SlotCode.EMPTY) != SlotCode.EMPTY
-            )
-            self._clear_done = 0
             self._clear_task = self.hass.async_create_task(  # type: ignore[attr-defined]
                 self._clear_all_pending_slots(),
                 "Lock Code Manager: clear existing codes",

--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -266,20 +266,20 @@ class _ExistingCodesFlowMixin:
             )
         )
 
-    async def _clear_existing_slot(self, slot_num: int) -> None:
-        """Clear a slot on every lock that has a non-empty code in it."""
-        for lock_entity_id, codes in self._all_codes.items():
-            if codes.get(slot_num, SlotCode.EMPTY) == SlotCode.EMPTY:
-                continue
-            lock_instance = self._lock_instances.get(lock_entity_id)
-            if not lock_instance:
-                _LOGGER.warning(
-                    "No lock instance for %s; cannot clear slot %s",
-                    lock_entity_id,
-                    slot_num,
-                )
-                self._clear_done += 1
-                continue
+    async def _clear_all_pending_slots(self) -> None:
+        """Clear every slot in ``_slots_to_clear`` and reset state."""
+        # Build the work list: (lock_instance, lock_entity_id, slot_num)
+        work = [
+            (lock_instance, lock_entity_id, slot_num)
+            for slot_num in self._slots_to_clear
+            for lock_entity_id, codes in self._all_codes.items()
+            if codes.get(slot_num, SlotCode.EMPTY) != SlotCode.EMPTY
+            and (lock_instance := self._lock_instances.get(lock_entity_id))
+        ]
+        self._clear_done = 0
+        self._clear_total = len(work)
+
+        for lock_instance, lock_entity_id, slot_num in work:
             try:
                 await lock_instance.async_internal_clear_usercode(
                     slot_num, source="direct"
@@ -293,17 +293,6 @@ class _ExistingCodesFlowMixin:
                 )
             self._clear_done += 1
 
-    async def _clear_all_pending_slots(self) -> None:
-        """Clear every slot in ``_slots_to_clear`` and reset state."""
-        self._clear_done = 0
-        self._clear_total = sum(
-            1
-            for slot_num in self._slots_to_clear
-            for codes in self._all_codes.values()
-            if codes.get(slot_num, SlotCode.EMPTY) != SlotCode.EMPTY
-        )
-        for slot_num in self._slots_to_clear:
-            await self._clear_existing_slot(slot_num)
         self._slots_to_clear = []
         self._all_codes = {}
         self._lock_instances = {}

--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -160,17 +160,14 @@ async def _async_get_all_codes(
     dev_reg: dr.DeviceRegistry,
     ent_reg: er.EntityRegistry,
     lock_entity_ids: list[str],
-) -> tuple[dict[str, dict[int, str | SlotCode]], dict[str, Any]]:
+) -> dict[str, dict[int, str | SlotCode]]:
     """Query locks for all usercodes.
 
-    Returns ``(codes_by_lock, lock_instances_by_lock)`` where ``codes_by_lock``
-    maps each lock entity ID to its slot/code dict (``SlotCode.EMPTY`` for
-    empty slots) and ``lock_instances_by_lock`` retains the provider
-    instances so the caller can reuse them when clearing slots. Locks that
-    fail to query are skipped with logging.
+    Returns ``codes_by_lock`` mapping each lock entity ID to its slot/code
+    dict (``SlotCode.EMPTY`` for empty slots).  Locks that fail to query are
+    skipped with logging.
     """
     result: dict[str, dict[int, str | SlotCode]] = {}
-    lock_instances: dict[str, Any] = {}
     # Query sequentially to avoid flooding networks (e.g. Z-Wave, Matter)
     # with simultaneous requests across multiple locks
     for lock_entity_id in lock_entity_ids:
@@ -180,12 +177,8 @@ async def _async_get_all_codes(
             )
             usercodes = await lock_instance.async_internal_get_usercodes()
         except _LockQuerySkipped:
-            # Already logged by _async_build_lock_instance with the
-            # appropriate level for the specific skip reason
             continue
         except LockCodeManagerProviderError as err:
-            # Real provider failure (e.g. LockDisconnected) — surface it
-            # so users can see why a lock's codes weren't checked
             _LOGGER.warning(
                 "Failed to get usercodes from %s: %s",
                 lock_entity_id,
@@ -193,8 +186,6 @@ async def _async_get_all_codes(
             )
             continue
         except LockCodeManagerError as err:
-            # Defensive fallback for third-party providers that raise the
-            # bare base class instead of LockCodeManagerProviderError.
             _LOGGER.warning(
                 "Failed to get usercodes from %s: %s",
                 lock_entity_id,
@@ -202,10 +193,6 @@ async def _async_get_all_codes(
             )
             continue
         except Exception:  # noqa: BLE001
-            # Last-resort catch: this runs in the user-facing config flow.
-            # Any provider exception (including programmer error in a
-            # third-party provider) must degrade to "no codes shown" rather
-            # than aborting the flow.
             _LOGGER.warning(
                 "Failed to get usercodes from %s; this lock's codes will not be shown",
                 lock_entity_id,
@@ -215,22 +202,19 @@ async def _async_get_all_codes(
 
         if usercodes:
             result[lock_entity_id] = usercodes
-            lock_instances[lock_entity_id] = lock_instance
-    return result, lock_instances
+    return result
 
 
 def _scope_codes_to_pairs(
     all_codes: dict[str, dict[int, str | SlotCode]],
-    lock_instances: dict[str, Any],
     pairs: Iterable[tuple[str, int]],
-) -> tuple[dict[str, dict[int, str | SlotCode]], dict[str, Any]]:
+) -> dict[str, dict[int, str | SlotCode]]:
     """Filter raw query results to only the ``(lock, slot)`` pairs given."""
     scoped_codes: dict[str, dict[int, str | SlotCode]] = {}
     for lock, slot in pairs:
         if (code := all_codes.get(lock, {}).get(slot)) is not None:
             scoped_codes.setdefault(lock, {})[slot] = code
-    scoped_instances = {lock: lock_instances[lock] for lock in scoped_codes}
-    return scoped_codes, scoped_instances
+    return scoped_codes
 
 
 class _ExistingCodesFlowMixin:
@@ -242,14 +226,12 @@ class _ExistingCodesFlowMixin:
     """
 
     _all_codes: dict[str, dict[int, str | SlotCode]]
-    _lock_instances: dict[str, Any]
     _occupied_lock_slots: list[tuple[str, int]]
     _next_step: Callable[[], Awaitable[dict[str, Any]]] | None
 
     def _init_existing_codes_state(self) -> None:
         """Initialize mixin state. Call from the inheriting flow's __init__."""
         self._all_codes = {}
-        self._lock_instances = {}
         self._occupied_lock_slots = []
         self._next_step = None
 
@@ -341,10 +323,7 @@ class LockCodeManagerFlowHandler(
             self._abort_if_unique_id_configured()
             self.data = user_input
             # Scan locks for existing codes once upfront
-            (
-                self._all_codes,
-                self._lock_instances,
-            ) = await _async_get_all_codes(
+            self._all_codes = await _async_get_all_codes(
                 self.hass, self.dev_reg, self.ent_reg, user_input[CONF_LOCKS]
             )
             return await self.async_step_choose_path()
@@ -627,15 +606,13 @@ class LockCodeManagerOptionsFlow(_ExistingCodesFlowMixin, config_entries.Options
         locks_to_query = sorted({lock for lock, _ in diff.pairs_added})
         ent_reg = er.async_get(self.hass)
         dev_reg = dr.async_get(self.hass)
-        all_codes, lock_instances = await _async_get_all_codes(
+        all_codes = await _async_get_all_codes(
             self.hass, dev_reg, ent_reg, locks_to_query
         )
 
-        # Scope to ONLY the added pairs so the mixin's clearing logic
-        # cannot touch already-managed (lock, slot) pairs
-        self._all_codes, self._lock_instances = _scope_codes_to_pairs(
-            all_codes, lock_instances, diff.pairs_added
-        )
+        # Scope to ONLY the added pairs so the confirmation dialog only
+        # shows newly-added lock/slot pairs, not already-managed ones
+        self._all_codes = _scope_codes_to_pairs(all_codes, diff.pairs_added)
 
         added_slot_nums = {slot for _, slot in diff.pairs_added}
         self._occupied_lock_slots = self._find_occupied_lock_slots(added_slot_nums)

--- a/custom_components/lock_code_manager/strings.json
+++ b/custom_components/lock_code_manager/strings.json
@@ -6,9 +6,6 @@
       "locks_updated": "The locks for your config entry have been updated.",
       "unknown": "An unexpected error occurred during setup."
     },
-    "progress": {
-      "clearing_codes": "Clearing existing codes ({cleared}/{total}). Each operation may take up to 30 seconds depending on the lock."
-    },
     "error": {
       "excluded_platform": "Entities from the `{integration}` integration are not supported as condition entities. See the [wiki]({docs_url}) for details.",
       "invalid_config": "Slots configuration is invalid. For more information, check the logs and the docs.",
@@ -37,10 +34,10 @@
       },
       "existing_codes_confirm": {
         "title": "Existing Codes Detected",
-        "description": "Existing codes were detected on the following slots: {slots}\n\nProceeding will clear these codes from the lock(s). Cancel if you want to back out.",
+        "description": "Existing codes were found on the following lock slots:\n\n{details}\n\nThese codes will be overwritten when the sync manager reconciles the configured state. Continue to proceed or cancel to back out.",
         "menu_options": {
-          "existing_codes_clear": "Clear existing codes and continue",
-          "existing_codes_cancel": "Cancel setup"
+          "existing_codes_continue": "Continue",
+          "existing_codes_cancel": "Cancel"
         }
       },
       "reauth": {
@@ -135,9 +132,6 @@
       "existing_codes_cancelled": "Update cancelled. Existing codes were not modified.",
       "unknown": "An unexpected error occurred while updating options."
     },
-    "progress": {
-      "clearing_codes": "Clearing existing codes ({cleared}/{total}). Each operation may take up to 30 seconds depending on the lock."
-    },
     "error": {
       "invalid_config": "Slots configuration is invalid. For more information, check the logs and the docs.",
       "locks_already_configured": "The following lock(s) are already managed by another config entry: {locks}."
@@ -153,10 +147,10 @@
       },
       "existing_codes_confirm": {
         "title": "Existing Codes Detected",
-        "description": "Existing codes were detected on newly-added slot(s): {slots}\n\nProceeding will clear these codes from the lock(s). Cancel to back out without saving any changes.",
+        "description": "Existing codes were found on newly-added lock slots:\n\n{details}\n\nThese codes will be overwritten when the sync manager reconciles the configured state. Continue to proceed or cancel to back out without saving.",
         "menu_options": {
-          "existing_codes_clear": "Clear existing codes and continue",
-          "existing_codes_cancel": "Cancel update"
+          "existing_codes_continue": "Continue",
+          "existing_codes_cancel": "Cancel"
         }
       }
     }

--- a/custom_components/lock_code_manager/strings.json
+++ b/custom_components/lock_code_manager/strings.json
@@ -7,7 +7,7 @@
       "unknown": "An unexpected error occurred during setup."
     },
     "progress": {
-      "clearing_codes": "Clearing existing codes ({cleared}/{total})..."
+      "clearing_codes": "Clearing existing codes ({cleared}/{total}). Each operation may take up to 30 seconds depending on the lock."
     },
     "error": {
       "excluded_platform": "Entities from the `{integration}` integration are not supported as condition entities. See the [wiki]({docs_url}) for details.",
@@ -136,7 +136,7 @@
       "unknown": "An unexpected error occurred while updating options."
     },
     "progress": {
-      "clearing_codes": "Clearing existing codes ({cleared}/{total})..."
+      "clearing_codes": "Clearing existing codes ({cleared}/{total}). Each operation may take up to 30 seconds depending on the lock."
     },
     "error": {
       "invalid_config": "Slots configuration is invalid. For more information, check the logs and the docs.",

--- a/custom_components/lock_code_manager/strings.json
+++ b/custom_components/lock_code_manager/strings.json
@@ -7,7 +7,7 @@
       "unknown": "An unexpected error occurred during setup."
     },
     "progress": {
-      "clearing_codes": "Clearing existing codes from {slots} slot(s) across {locks} lock(s). This may take a moment..."
+      "clearing_codes": "Clearing existing codes ({cleared}/{total})..."
     },
     "error": {
       "excluded_platform": "Entities from the `{integration}` integration are not supported as condition entities. See the [wiki]({docs_url}) for details.",
@@ -136,7 +136,7 @@
       "unknown": "An unexpected error occurred while updating options."
     },
     "progress": {
-      "clearing_codes": "Clearing existing codes from {slots} slot(s) across {locks} lock(s). This may take a moment..."
+      "clearing_codes": "Clearing existing codes ({cleared}/{total})..."
     },
     "error": {
       "invalid_config": "Slots configuration is invalid. For more information, check the logs and the docs.",

--- a/custom_components/lock_code_manager/strings.json
+++ b/custom_components/lock_code_manager/strings.json
@@ -6,6 +6,9 @@
       "locks_updated": "The locks for your config entry have been updated.",
       "unknown": "An unexpected error occurred during setup."
     },
+    "progress": {
+      "clearing_codes": "Clearing existing codes from {slots} slot(s) across {locks} lock(s). This may take a moment..."
+    },
     "error": {
       "excluded_platform": "Entities from the `{integration}` integration are not supported as condition entities. See the [wiki]({docs_url}) for details.",
       "invalid_config": "Slots configuration is invalid. For more information, check the logs and the docs.",
@@ -131,6 +134,9 @@
     "abort": {
       "existing_codes_cancelled": "Update cancelled. Existing codes were not modified.",
       "unknown": "An unexpected error occurred while updating options."
+    },
+    "progress": {
+      "clearing_codes": "Clearing existing codes from {slots} slot(s) across {locks} lock(s). This may take a moment..."
     },
     "error": {
       "invalid_config": "Slots configuration is invalid. For more information, check the logs and the docs.",

--- a/custom_components/lock_code_manager/translations/en.json
+++ b/custom_components/lock_code_manager/translations/en.json
@@ -6,9 +6,6 @@
       "locks_updated": "The locks for your config entry have been updated.",
       "unknown": "An unexpected error occurred during setup."
     },
-    "progress": {
-      "clearing_codes": "Clearing existing codes ({cleared}/{total}). Each operation may take up to 30 seconds depending on the lock."
-    },
     "error": {
       "excluded_platform": "Entities from the `{integration}` integration are not supported as condition entities. See the [wiki]({docs_url}) for details.",
       "invalid_config": "Slots configuration is invalid. For more information, check the logs and the docs.",
@@ -37,10 +34,10 @@
       },
       "existing_codes_confirm": {
         "title": "Existing Codes Detected",
-        "description": "Existing codes were detected on the following slots: {slots}\n\nProceeding will clear these codes from the lock(s). Cancel if you want to back out.",
+        "description": "Existing codes were found on the following lock slots:\n\n{details}\n\nThese codes will be overwritten when the sync manager reconciles the configured state. Continue to proceed or cancel to back out.",
         "menu_options": {
-          "existing_codes_clear": "Clear existing codes and continue",
-          "existing_codes_cancel": "Cancel setup"
+          "existing_codes_continue": "Continue",
+          "existing_codes_cancel": "Cancel"
         }
       },
       "reauth": {
@@ -135,9 +132,6 @@
       "existing_codes_cancelled": "Update cancelled. Existing codes were not modified.",
       "unknown": "An unexpected error occurred while updating options."
     },
-    "progress": {
-      "clearing_codes": "Clearing existing codes ({cleared}/{total}). Each operation may take up to 30 seconds depending on the lock."
-    },
     "error": {
       "invalid_config": "Slots configuration is invalid. For more information, check the logs and the docs.",
       "locks_already_configured": "The following lock(s) are already managed by another config entry: {locks}."
@@ -153,10 +147,10 @@
       },
       "existing_codes_confirm": {
         "title": "Existing Codes Detected",
-        "description": "Existing codes were detected on newly-added slot(s): {slots}\n\nProceeding will clear these codes from the lock(s). Cancel to back out without saving any changes.",
+        "description": "Existing codes were found on newly-added lock slots:\n\n{details}\n\nThese codes will be overwritten when the sync manager reconciles the configured state. Continue to proceed or cancel to back out without saving.",
         "menu_options": {
-          "existing_codes_clear": "Clear existing codes and continue",
-          "existing_codes_cancel": "Cancel update"
+          "existing_codes_continue": "Continue",
+          "existing_codes_cancel": "Cancel"
         }
       }
     }

--- a/custom_components/lock_code_manager/translations/en.json
+++ b/custom_components/lock_code_manager/translations/en.json
@@ -7,7 +7,7 @@
       "unknown": "An unexpected error occurred during setup."
     },
     "progress": {
-      "clearing_codes": "Clearing existing codes ({cleared}/{total})..."
+      "clearing_codes": "Clearing existing codes ({cleared}/{total}). Each operation may take up to 30 seconds depending on the lock."
     },
     "error": {
       "excluded_platform": "Entities from the `{integration}` integration are not supported as condition entities. See the [wiki]({docs_url}) for details.",
@@ -136,7 +136,7 @@
       "unknown": "An unexpected error occurred while updating options."
     },
     "progress": {
-      "clearing_codes": "Clearing existing codes ({cleared}/{total})..."
+      "clearing_codes": "Clearing existing codes ({cleared}/{total}). Each operation may take up to 30 seconds depending on the lock."
     },
     "error": {
       "invalid_config": "Slots configuration is invalid. For more information, check the logs and the docs.",

--- a/custom_components/lock_code_manager/translations/en.json
+++ b/custom_components/lock_code_manager/translations/en.json
@@ -7,7 +7,7 @@
       "unknown": "An unexpected error occurred during setup."
     },
     "progress": {
-      "clearing_codes": "Clearing existing codes from {slots} slot(s) across {locks} lock(s). This may take a moment..."
+      "clearing_codes": "Clearing existing codes ({cleared}/{total})..."
     },
     "error": {
       "excluded_platform": "Entities from the `{integration}` integration are not supported as condition entities. See the [wiki]({docs_url}) for details.",
@@ -136,7 +136,7 @@
       "unknown": "An unexpected error occurred while updating options."
     },
     "progress": {
-      "clearing_codes": "Clearing existing codes from {slots} slot(s) across {locks} lock(s). This may take a moment..."
+      "clearing_codes": "Clearing existing codes ({cleared}/{total})..."
     },
     "error": {
       "invalid_config": "Slots configuration is invalid. For more information, check the logs and the docs.",

--- a/custom_components/lock_code_manager/translations/en.json
+++ b/custom_components/lock_code_manager/translations/en.json
@@ -6,6 +6,9 @@
       "locks_updated": "The locks for your config entry have been updated.",
       "unknown": "An unexpected error occurred during setup."
     },
+    "progress": {
+      "clearing_codes": "Clearing existing codes from {slots} slot(s) across {locks} lock(s). This may take a moment..."
+    },
     "error": {
       "excluded_platform": "Entities from the `{integration}` integration are not supported as condition entities. See the [wiki]({docs_url}) for details.",
       "invalid_config": "Slots configuration is invalid. For more information, check the logs and the docs.",
@@ -131,6 +134,9 @@
     "abort": {
       "existing_codes_cancelled": "Update cancelled. Existing codes were not modified.",
       "unknown": "An unexpected error occurred while updating options."
+    },
+    "progress": {
+      "clearing_codes": "Clearing existing codes from {slots} slot(s) across {locks} lock(s). This may take a moment..."
     },
     "error": {
       "invalid_config": "Slots configuration is invalid. For more information, check the logs and the docs.",

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -348,7 +348,9 @@ async def test_ui_existing_codes_confirm_clear(hass: HomeAssistant):
     assert result["step_id"] == "existing_codes_confirm"
     assert result["description_placeholders"]["slots"] == "1"
 
-    # Confirm clearing — should proceed to slot config
+    # Confirm clearing — progress task completes instantly with mocks,
+    # so the flow advances directly through progress -> done -> code_slot.
+    # Codes are cleared during the progress step, before slot configuration.
     result = await hass.config_entries.flow.async_configure(
         flow_id, {"next_step_id": "existing_codes_clear"}
     )
@@ -356,6 +358,7 @@ async def test_ui_existing_codes_confirm_clear(hass: HomeAssistant):
     assert result["type"] == "form"
     assert result["step_id"] == "code_slot"
     assert result["description_placeholders"]["slot_num"] == 1
+    mock_clear.assert_called_once_with(1, source="direct")
 
     # Configure slot 1
     result = await hass.config_entries.flow.async_configure(
@@ -363,15 +366,13 @@ async def test_ui_existing_codes_confirm_clear(hass: HomeAssistant):
     )
 
     assert result["step_id"] == "code_slot"
-    mock_clear.assert_not_called()
 
-    # Configure slot 2 -> create entry and clear deferred
+    # Configure slot 2 -> create entry (clearing already done)
     result = await hass.config_entries.flow.async_configure(
         flow_id, {CONF_ENABLED: True, CONF_PIN: "5678"}
     )
 
     assert result["type"] == "create_entry"
-    mock_clear.assert_called_once_with(1, source="direct")
 
 
 async def test_ui_existing_codes_confirm_cancel(hass: HomeAssistant):

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -59,7 +59,7 @@ async def _start_config_flow(hass: HomeAssistant):
     assert result["step_id"] == "user"
     flow_id = result["flow_id"]
 
-    with patch(GET_ALL_CODES_PATCH, return_value=({}, {})):
+    with patch(GET_ALL_CODES_PATCH, return_value={}):
         result = await hass.config_entries.flow.async_configure(
             flow_id, {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
         )
@@ -318,15 +318,14 @@ async def test_config_flow_ui_scheduler_entity_excluded(hass: HomeAssistant):
 # --- Existing-codes confirmation step tests ---
 
 
-async def test_ui_existing_codes_confirm_clear(hass: HomeAssistant):
-    """UI path: existing codes detected -> confirm -> clear -> create entry."""
+async def test_ui_existing_codes_confirm_continue(hass: HomeAssistant):
+    """UI path: existing codes detected -> confirm -> continue -> create entry."""
     mock_clear = AsyncMock(return_value=True)
     mock_lock = AsyncMock()
     mock_lock.async_internal_clear_usercode = mock_clear
     existing = {LOCK_1_ENTITY_ID: {1: "1234"}}
-    lock_instances = {LOCK_1_ENTITY_ID: mock_lock}
 
-    with patch(GET_ALL_CODES_PATCH, return_value=(existing, lock_instances)):
+    with patch(GET_ALL_CODES_PATCH, return_value=existing):
         flow_id = await _init_flow_to_user_step(hass)
         result = await hass.config_entries.flow.async_configure(
             flow_id, {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
@@ -381,9 +380,8 @@ async def test_ui_existing_codes_confirm_cancel(hass: HomeAssistant):
     mock_lock = AsyncMock()
     mock_lock.async_internal_clear_usercode = mock_clear
     existing = {LOCK_1_ENTITY_ID: {1: "1234"}}
-    lock_instances = {LOCK_1_ENTITY_ID: mock_lock}
 
-    with patch(GET_ALL_CODES_PATCH, return_value=(existing, lock_instances)):
+    with patch(GET_ALL_CODES_PATCH, return_value=existing):
         flow_id = await _init_flow_to_user_step(hass)
         result = await hass.config_entries.flow.async_configure(
             flow_id, {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
@@ -409,15 +407,14 @@ async def test_ui_existing_codes_confirm_cancel(hass: HomeAssistant):
     mock_clear.assert_not_called()
 
 
-async def test_yaml_existing_codes_confirm_clear(hass: HomeAssistant):
-    """YAML path: existing codes detected -> confirm -> clear -> create entry."""
+async def test_yaml_existing_codes_confirm_continue(hass: HomeAssistant):
+    """YAML path: existing codes detected -> confirm -> continue -> create entry."""
     mock_clear = AsyncMock(return_value=True)
     mock_lock = AsyncMock()
     mock_lock.async_internal_clear_usercode = mock_clear
     existing = {LOCK_1_ENTITY_ID: {1: "9999"}}
-    lock_instances = {LOCK_1_ENTITY_ID: mock_lock}
 
-    with patch(GET_ALL_CODES_PATCH, return_value=(existing, lock_instances)):
+    with patch(GET_ALL_CODES_PATCH, return_value=existing):
         flow_id = await _init_flow_to_user_step(hass)
         result = await hass.config_entries.flow.async_configure(
             flow_id, {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
@@ -439,7 +436,7 @@ async def test_yaml_existing_codes_confirm_clear(hass: HomeAssistant):
     assert result["step_id"] == "existing_codes_confirm"
     assert "slot 1" in result["description_placeholders"]["details"]
 
-    # Confirm clearing -> create entry and clear
+    # Confirm -> create entry (sync manager handles reconciliation)
     result = await hass.config_entries.flow.async_configure(
         flow_id, {"next_step_id": "existing_codes_continue"}
     )
@@ -455,9 +452,8 @@ async def test_yaml_existing_codes_confirm_cancel(hass: HomeAssistant):
     mock_lock = AsyncMock()
     mock_lock.async_internal_clear_usercode = mock_clear
     existing = {LOCK_1_ENTITY_ID: {1: "9999"}}
-    lock_instances = {LOCK_1_ENTITY_ID: mock_lock}
 
-    with patch(GET_ALL_CODES_PATCH, return_value=(existing, lock_instances)):
+    with patch(GET_ALL_CODES_PATCH, return_value=existing):
         flow_id = await _init_flow_to_user_step(hass)
         result = await hass.config_entries.flow.async_configure(
             flow_id, {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
@@ -486,7 +482,7 @@ async def test_yaml_existing_codes_confirm_cancel(hass: HomeAssistant):
 
 async def test_ui_no_existing_codes_skips_confirm(hass: HomeAssistant):
     """UI path: no existing codes -> skip confirm step entirely."""
-    with patch(GET_ALL_CODES_PATCH, return_value=({}, {})):
+    with patch(GET_ALL_CODES_PATCH, return_value={}):
         flow_id = await _init_flow_to_user_step(hass)
         result = await hass.config_entries.flow.async_configure(
             flow_id, {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
@@ -508,7 +504,7 @@ async def test_ui_no_existing_codes_skips_confirm(hass: HomeAssistant):
 
 async def test_yaml_no_existing_codes_skips_confirm(hass: HomeAssistant):
     """YAML path: no existing codes -> create_entry directly without confirm."""
-    with patch(GET_ALL_CODES_PATCH, return_value=({}, {})):
+    with patch(GET_ALL_CODES_PATCH, return_value={}):
         flow_id = await _init_flow_to_user_step(hass)
         result = await hass.config_entries.flow.async_configure(
             flow_id, {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
@@ -533,9 +529,8 @@ async def test_ui_existing_codes_confirm_lists_multiple_slots(hass: HomeAssistan
     mock_lock = AsyncMock()
     mock_lock.async_internal_clear_usercode = mock_clear
     existing = {LOCK_1_ENTITY_ID: {3: "1234", 1: "5678"}}
-    lock_instances = {LOCK_1_ENTITY_ID: mock_lock}
 
-    with patch(GET_ALL_CODES_PATCH, return_value=(existing, lock_instances)):
+    with patch(GET_ALL_CODES_PATCH, return_value=existing):
         flow_id = await _init_flow_to_user_step(hass)
         result = await hass.config_entries.flow.async_configure(
             flow_id, {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
@@ -583,13 +578,10 @@ async def test_async_get_all_codes_exception(hass: HomeAssistant):
             return_value=MockConfigEntry(domain="zwave_js"),
         ),
     ):
-        result, instances = await _async_get_all_codes(
-            hass, dev_reg, ent_reg, [LOCK_1_ENTITY_ID]
-        )
+        result = await _async_get_all_codes(hass, dev_reg, ent_reg, [LOCK_1_ENTITY_ID])
 
     # Exception should be caught; result should be empty
     assert result == {}
-    assert instances == {}
 
 
 async def test_async_get_all_codes_provider_failure_logs_warning(
@@ -626,12 +618,9 @@ async def test_async_get_all_codes_provider_failure_logs_warning(
         ),
         caplog.at_level("WARNING"),
     ):
-        result, instances = await _async_get_all_codes(
-            hass, dev_reg, ent_reg, [LOCK_1_ENTITY_ID]
-        )
+        result = await _async_get_all_codes(hass, dev_reg, ent_reg, [LOCK_1_ENTITY_ID])
 
     assert result == {}
-    assert instances == {}
     # Surfaced at WARNING (not DEBUG): failure should be visible in logs
     assert any(
         record.levelname == "WARNING" and LOCK_1_ENTITY_ID in record.message
@@ -673,12 +662,9 @@ async def test_async_get_all_codes_bare_base_error_logs_warning(
         ),
         caplog.at_level("WARNING"),
     ):
-        result, instances = await _async_get_all_codes(
-            hass, dev_reg, ent_reg, [LOCK_1_ENTITY_ID]
-        )
+        result = await _async_get_all_codes(hass, dev_reg, ent_reg, [LOCK_1_ENTITY_ID])
 
     assert result == {}
-    assert instances == {}
     # Should be a clean WARNING (no traceback), since this is a known
     # failure mode — not the generic Exception arm
     warnings = [r for r in caplog.records if r.levelname == "WARNING"]
@@ -727,15 +713,12 @@ async def test_async_get_all_codes_returns_all_codes(hass: HomeAssistant):
             return_value=MockConfigEntry(domain="zwave_js"),
         ),
     ):
-        result, instances = await _async_get_all_codes(
-            hass, dev_reg, ent_reg, [LOCK_1_ENTITY_ID]
-        )
+        result = await _async_get_all_codes(hass, dev_reg, ent_reg, [LOCK_1_ENTITY_ID])
 
     # _async_get_all_codes returns ALL codes — including empty slots.
     # Callers (e.g. _slots_with_existing_codes) filter as needed.
     assert LOCK_1_ENTITY_ID in result
     assert result[LOCK_1_ENTITY_ID] == {1: "1234", 3: "9999", 4: SlotCode.EMPTY}
-    assert LOCK_1_ENTITY_ID in instances
 
 
 async def test_async_get_all_codes_entity_not_in_registry(hass: HomeAssistant):
@@ -743,12 +726,9 @@ async def test_async_get_all_codes_entity_not_in_registry(hass: HomeAssistant):
     ent_reg = er.async_get(hass)
     dev_reg = dr.async_get(hass)
 
-    result, instances = await _async_get_all_codes(
-        hass, dev_reg, ent_reg, ["lock.does_not_exist"]
-    )
+    result = await _async_get_all_codes(hass, dev_reg, ent_reg, ["lock.does_not_exist"])
 
     assert result == {}
-    assert instances == {}
 
 
 async def test_async_get_all_codes_unsupported_platform(hass: HomeAssistant):
@@ -759,12 +739,9 @@ async def test_async_get_all_codes_unsupported_platform(hass: HomeAssistant):
     )
     dev_reg = dr.async_get(hass)
 
-    result, instances = await _async_get_all_codes(
-        hass, dev_reg, ent_reg, [LOCK_1_ENTITY_ID]
-    )
+    result = await _async_get_all_codes(hass, dev_reg, ent_reg, [LOCK_1_ENTITY_ID])
 
     assert result == {}
-    assert instances == {}
 
 
 async def test_async_get_all_codes_missing_lock_config_entry(hass: HomeAssistant):
@@ -782,16 +759,13 @@ async def test_async_get_all_codes_missing_lock_config_entry(hass: HomeAssistant
         ),
         patch.object(hass.config_entries, "async_get_entry", return_value=None),
     ):
-        result, instances = await _async_get_all_codes(
-            hass, dev_reg, ent_reg, [LOCK_1_ENTITY_ID]
-        )
+        result = await _async_get_all_codes(hass, dev_reg, ent_reg, [LOCK_1_ENTITY_ID])
 
     assert result == {}
-    assert instances == {}
 
 
-async def test_clear_existing_slot_handles_failures(hass: HomeAssistant):
-    """Test that clearing failures and missing instances are handled gracefully."""
+async def test_existing_codes_detected_across_multiple_locks(hass: HomeAssistant):
+    """Test that existing codes are detected across multiple locks without clearing."""
     mock_clear_ok = AsyncMock(return_value=True)
     mock_clear_fail = AsyncMock(side_effect=RuntimeError("clear failed"))
     mock_lock_ok = MagicMock()
@@ -809,14 +783,7 @@ async def test_clear_existing_slot_handles_failures(hass: HomeAssistant):
         "lock.empty_slot": {1: SlotCode.EMPTY},
         "lock.different_slot": {2: "4444"},
     }
-    instances = {
-        "lock.ok": mock_lock_ok,
-        "lock.fails": mock_lock_fail,
-        "lock.empty_slot": MagicMock(),
-        "lock.different_slot": MagicMock(),
-    }
-
-    with patch(GET_ALL_CODES_PATCH, return_value=(existing, instances)):
+    with patch(GET_ALL_CODES_PATCH, return_value=existing):
         flow_id = await _init_flow_to_user_step(hass)
         result = await hass.config_entries.flow.async_configure(
             flow_id, {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
@@ -830,19 +797,16 @@ async def test_clear_existing_slot_handles_failures(hass: HomeAssistant):
         {CONF_SLOTS: {1: {CONF_ENABLED: True, CONF_PIN: "5678"}}},
     )
 
-    # Confirm step shown because slot 1 has existing codes
+    # Confirm step shown because slot 1 has existing codes on some locks
     assert result["step_id"] == "existing_codes_confirm"
     result = await hass.config_entries.flow.async_configure(
         flow_id, {"next_step_id": "existing_codes_continue"}
     )
 
+    # No clearing happens — sync manager handles reconciliation
     assert result["type"] == "create_entry"
-    # Existing codes are detected, but continuing the flow does not attempt
-    # to clear any slots for any lock instances.
     mock_clear_ok.assert_not_called()
     mock_clear_fail.assert_not_called()
-    instances["lock.empty_slot"].async_internal_clear_usercode.assert_not_called()
-    instances["lock.different_slot"].async_internal_clear_usercode.assert_not_called()
 
 
 async def test_existing_codes_continue_without_next_step_aborts(hass: HomeAssistant):
@@ -912,7 +876,7 @@ async def test_options_flow_added_pair_no_existing_code_persists(hass: HomeAssis
     # Adding slot 2; lock has nothing in slot 2 (only slot 1)
     with patch(
         GET_ALL_CODES_PATCH,
-        return_value=({LOCK_1_ENTITY_ID: {1: "1234"}}, {LOCK_1_ENTITY_ID: MagicMock()}),
+        return_value={LOCK_1_ENTITY_ID: {1: "1234"}},
     ):
         result = await hass.config_entries.options.async_configure(
             flow_id,
@@ -928,10 +892,10 @@ async def test_options_flow_added_pair_no_existing_code_persists(hass: HomeAssis
     assert result["type"] == "create_entry"
 
 
-async def test_options_flow_added_pair_with_existing_code_confirm_clear(
+async def test_options_flow_added_pair_with_existing_code_confirm(
     hass: HomeAssistant,
 ):
-    """New (lock, slot) added and lock has code there -> confirm -> clear -> persist."""
+    """New (lock, slot) added and lock has code there -> confirm -> persist."""
     mock_clear = AsyncMock(return_value=True)
     mock_lock = MagicMock()
     mock_lock.async_internal_clear_usercode = mock_clear
@@ -942,10 +906,7 @@ async def test_options_flow_added_pair_with_existing_code_confirm_clear(
     # in slot 1 — slot 1 is NOT in added_pairs so it must not be cleared)
     with patch(
         GET_ALL_CODES_PATCH,
-        return_value=(
-            {LOCK_1_ENTITY_ID: {1: "1234", 2: "9999"}},
-            {LOCK_1_ENTITY_ID: mock_lock},
-        ),
+        return_value={LOCK_1_ENTITY_ID: {1: "1234", 2: "9999"}},
     ):
         result = await hass.config_entries.options.async_configure(
             flow_id,
@@ -962,8 +923,8 @@ async def test_options_flow_added_pair_with_existing_code_confirm_clear(
     assert result["step_id"] == "existing_codes_confirm"
     assert "slot 2" in result["description_placeholders"]["details"]
 
-    # Confirm -> entry is updated AND only the newly-added slot (2) is cleared.
-    # The pre-existing managed slot 1 must NOT be cleared even though it has a
+    # Confirm -> entry is updated. No slots are cleared by the config flow.
+    # The pre-existing managed slot 1 is not affected even though it has a
     # non-empty code in _all_codes — we scoped to added pairs only.
     result = await hass.config_entries.options.async_configure(
         flow_id, {"next_step_id": "existing_codes_continue"}
@@ -972,7 +933,7 @@ async def test_options_flow_added_pair_with_existing_code_confirm_clear(
     mock_clear.assert_not_called()
 
 
-async def test_options_flow_added_lock_with_existing_code_confirm_clear(
+async def test_options_flow_added_lock_with_existing_code_confirm(
     hass: HomeAssistant,
 ):
     """A NEW lock (with codes in already-managed slot) triggers the confirm step."""
@@ -987,10 +948,7 @@ async def test_options_flow_added_lock_with_existing_code_confirm_clear(
     # code in slot 1. The mixin should detect this and prompt.
     with patch(
         GET_ALL_CODES_PATCH,
-        return_value=(
-            {LOCK_2_ENTITY_ID: {1: "5555"}},
-            {LOCK_2_ENTITY_ID: mock_lock_2},
-        ),
+        return_value={LOCK_2_ENTITY_ID: {1: "5555"}},
     ):
         result = await hass.config_entries.options.async_configure(
             flow_id,
@@ -1020,10 +978,7 @@ async def test_options_flow_existing_codes_cancel_aborts(hass: HomeAssistant):
 
     with patch(
         GET_ALL_CODES_PATCH,
-        return_value=(
-            {LOCK_1_ENTITY_ID: {2: "9999"}},
-            {LOCK_1_ENTITY_ID: mock_lock},
-        ),
+        return_value={LOCK_1_ENTITY_ID: {2: "9999"}},
     ):
         result = await hass.config_entries.options.async_configure(
             flow_id,
@@ -1053,10 +1008,7 @@ async def test_options_flow_added_pair_empty_code_persists(hass: HomeAssistant):
 
     with patch(
         GET_ALL_CODES_PATCH,
-        return_value=(
-            {LOCK_1_ENTITY_ID: {2: SlotCode.EMPTY}},
-            {LOCK_1_ENTITY_ID: MagicMock()},
-        ),
+        return_value={LOCK_1_ENTITY_ID: {2: SlotCode.EMPTY}},
     ):
         result = await hass.config_entries.options.async_configure(
             flow_id,

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -837,9 +837,8 @@ async def test_clear_existing_slot_handles_failures(hass: HomeAssistant):
     )
 
     assert result["type"] == "create_entry"
-    # OK lock cleared, failing lock attempted (exception swallowed),
-    # no_instance skipped, empty_slot skipped (no code to clear),
-    # different_slot not touched (slot 1 not present)
+    # Existing codes are detected, but continuing the flow does not attempt
+    # to clear any slots for any lock instances.
     mock_clear_ok.assert_not_called()
     mock_clear_fail.assert_not_called()
     instances["lock.empty_slot"].async_internal_clear_usercode.assert_not_called()

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -343,22 +343,21 @@ async def test_ui_existing_codes_confirm_clear(hass: HomeAssistant):
         flow_id, {CONF_NUM_SLOTS: 2, CONF_START_SLOT: 1}
     )
 
-    # Should show the confirmation menu
+    # Should show the confirmation menu with lock/slot details
     assert result["type"] == "menu"
     assert result["step_id"] == "existing_codes_confirm"
-    assert result["description_placeholders"]["slots"] == "1"
+    assert LOCK_1_ENTITY_ID in result["description_placeholders"]["details"]
+    assert "slot 1" in result["description_placeholders"]["details"]
 
-    # Confirm clearing — progress task completes instantly with mocks,
-    # so the flow advances directly through progress -> done -> code_slot.
-    # Codes are cleared during the progress step, before slot configuration.
+    # User acknowledges — no clearing happens, just proceeds to slot config
     result = await hass.config_entries.flow.async_configure(
-        flow_id, {"next_step_id": "existing_codes_clear"}
+        flow_id, {"next_step_id": "existing_codes_continue"}
     )
 
     assert result["type"] == "form"
     assert result["step_id"] == "code_slot"
     assert result["description_placeholders"]["slot_num"] == 1
-    mock_clear.assert_called_once_with(1, source="direct")
+    mock_clear.assert_not_called()
 
     # Configure slot 1
     result = await hass.config_entries.flow.async_configure(
@@ -367,12 +366,13 @@ async def test_ui_existing_codes_confirm_clear(hass: HomeAssistant):
 
     assert result["step_id"] == "code_slot"
 
-    # Configure slot 2 -> create entry (clearing already done)
+    # Configure slot 2 -> create entry (sync manager handles reconciliation)
     result = await hass.config_entries.flow.async_configure(
         flow_id, {CONF_ENABLED: True, CONF_PIN: "5678"}
     )
 
     assert result["type"] == "create_entry"
+    mock_clear.assert_not_called()
 
 
 async def test_ui_existing_codes_confirm_cancel(hass: HomeAssistant):
@@ -437,16 +437,16 @@ async def test_yaml_existing_codes_confirm_clear(hass: HomeAssistant):
 
     assert result["type"] == "menu"
     assert result["step_id"] == "existing_codes_confirm"
-    assert result["description_placeholders"]["slots"] == "1"
+    assert "slot 1" in result["description_placeholders"]["details"]
 
     # Confirm clearing -> create entry and clear
     result = await hass.config_entries.flow.async_configure(
-        flow_id, {"next_step_id": "existing_codes_clear"}
+        flow_id, {"next_step_id": "existing_codes_continue"}
     )
 
     assert result["type"] == "create_entry"
     assert result["data"][CONF_SLOTS][1][CONF_PIN] == "1234"
-    mock_clear.assert_called_once_with(1, source="direct")
+    mock_clear.assert_not_called()
 
 
 async def test_yaml_existing_codes_confirm_cancel(hass: HomeAssistant):
@@ -551,7 +551,8 @@ async def test_ui_existing_codes_confirm_lists_multiple_slots(hass: HomeAssistan
     assert result["type"] == "menu"
     assert result["step_id"] == "existing_codes_confirm"
     # Slots are sorted in the placeholder
-    assert result["description_placeholders"]["slots"] == "1, 3"
+    assert "slot 1" in result["description_placeholders"]["details"]
+    assert "slot 3" in result["description_placeholders"]["details"]
 
 
 # --- _async_get_all_codes tests ---
@@ -832,26 +833,26 @@ async def test_clear_existing_slot_handles_failures(hass: HomeAssistant):
     # Confirm step shown because slot 1 has existing codes
     assert result["step_id"] == "existing_codes_confirm"
     result = await hass.config_entries.flow.async_configure(
-        flow_id, {"next_step_id": "existing_codes_clear"}
+        flow_id, {"next_step_id": "existing_codes_continue"}
     )
 
     assert result["type"] == "create_entry"
     # OK lock cleared, failing lock attempted (exception swallowed),
     # no_instance skipped, empty_slot skipped (no code to clear),
     # different_slot not touched (slot 1 not present)
-    mock_clear_ok.assert_called_once_with(1, source="direct")
-    mock_clear_fail.assert_called_once_with(1, source="direct")
+    mock_clear_ok.assert_not_called()
+    mock_clear_fail.assert_not_called()
     instances["lock.empty_slot"].async_internal_clear_usercode.assert_not_called()
     instances["lock.different_slot"].async_internal_clear_usercode.assert_not_called()
 
 
-async def test_existing_codes_clear_without_next_step_aborts(hass: HomeAssistant):
-    """Defensive: clear step aborts if _next_step was never assigned."""
+async def test_existing_codes_continue_without_next_step_aborts(hass: HomeAssistant):
+    """Defensive: continue step aborts if _next_step was never assigned."""
     handler = LockCodeManagerFlowHandler()
     handler.hass = hass
     # _init_existing_codes_state ran in __init__; _next_step is None
 
-    result = await handler.async_step_existing_codes_clear()
+    result = await handler.async_step_existing_codes_continue()
 
     assert result["type"] == "abort"
     assert result["reason"] == "unknown"
@@ -960,16 +961,16 @@ async def test_options_flow_added_pair_with_existing_code_confirm_clear(
 
     assert result["type"] == "menu"
     assert result["step_id"] == "existing_codes_confirm"
-    assert result["description_placeholders"]["slots"] == "2"
+    assert "slot 2" in result["description_placeholders"]["details"]
 
     # Confirm -> entry is updated AND only the newly-added slot (2) is cleared.
     # The pre-existing managed slot 1 must NOT be cleared even though it has a
     # non-empty code in _all_codes — we scoped to added pairs only.
     result = await hass.config_entries.options.async_configure(
-        flow_id, {"next_step_id": "existing_codes_clear"}
+        flow_id, {"next_step_id": "existing_codes_continue"}
     )
     assert result["type"] == "create_entry"
-    mock_clear.assert_called_once_with(2, source="direct")
+    mock_clear.assert_not_called()
 
 
 async def test_options_flow_added_lock_with_existing_code_confirm_clear(
@@ -1001,13 +1002,13 @@ async def test_options_flow_added_lock_with_existing_code_confirm_clear(
         )
 
     assert result["step_id"] == "existing_codes_confirm"
-    assert result["description_placeholders"]["slots"] == "1"
+    assert "slot 1" in result["description_placeholders"]["details"]
 
     result = await hass.config_entries.options.async_configure(
-        flow_id, {"next_step_id": "existing_codes_clear"}
+        flow_id, {"next_step_id": "existing_codes_continue"}
     )
     assert result["type"] == "create_entry"
-    mock_clear.assert_called_once_with(1, source="direct")
+    mock_clear.assert_not_called()
 
 
 async def test_options_flow_existing_codes_cancel_aborts(hass: HomeAssistant):

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -320,9 +320,6 @@ async def test_config_flow_ui_scheduler_entity_excluded(hass: HomeAssistant):
 
 async def test_ui_existing_codes_confirm_continue(hass: HomeAssistant):
     """UI path: existing codes detected -> confirm -> continue -> create entry."""
-    mock_clear = AsyncMock(return_value=True)
-    mock_lock = AsyncMock()
-    mock_lock.async_internal_clear_usercode = mock_clear
     existing = {LOCK_1_ENTITY_ID: {1: "1234"}}
 
     with patch(GET_ALL_CODES_PATCH, return_value=existing):
@@ -356,7 +353,6 @@ async def test_ui_existing_codes_confirm_continue(hass: HomeAssistant):
     assert result["type"] == "form"
     assert result["step_id"] == "code_slot"
     assert result["description_placeholders"]["slot_num"] == 1
-    mock_clear.assert_not_called()
 
     # Configure slot 1
     result = await hass.config_entries.flow.async_configure(
@@ -371,14 +367,10 @@ async def test_ui_existing_codes_confirm_continue(hass: HomeAssistant):
     )
 
     assert result["type"] == "create_entry"
-    mock_clear.assert_not_called()
 
 
 async def test_ui_existing_codes_confirm_cancel(hass: HomeAssistant):
     """UI path: existing codes detected -> confirm -> cancel -> abort."""
-    mock_clear = AsyncMock(return_value=True)
-    mock_lock = AsyncMock()
-    mock_lock.async_internal_clear_usercode = mock_clear
     existing = {LOCK_1_ENTITY_ID: {1: "1234"}}
 
     with patch(GET_ALL_CODES_PATCH, return_value=existing):
@@ -404,14 +396,10 @@ async def test_ui_existing_codes_confirm_cancel(hass: HomeAssistant):
 
     assert result["type"] == "abort"
     assert result["reason"] == "existing_codes_cancelled"
-    mock_clear.assert_not_called()
 
 
 async def test_yaml_existing_codes_confirm_continue(hass: HomeAssistant):
     """YAML path: existing codes detected -> confirm -> continue -> create entry."""
-    mock_clear = AsyncMock(return_value=True)
-    mock_lock = AsyncMock()
-    mock_lock.async_internal_clear_usercode = mock_clear
     existing = {LOCK_1_ENTITY_ID: {1: "9999"}}
 
     with patch(GET_ALL_CODES_PATCH, return_value=existing):
@@ -443,14 +431,10 @@ async def test_yaml_existing_codes_confirm_continue(hass: HomeAssistant):
 
     assert result["type"] == "create_entry"
     assert result["data"][CONF_SLOTS][1][CONF_PIN] == "1234"
-    mock_clear.assert_not_called()
 
 
 async def test_yaml_existing_codes_confirm_cancel(hass: HomeAssistant):
     """YAML path: existing codes detected -> confirm -> cancel -> abort."""
-    mock_clear = AsyncMock(return_value=True)
-    mock_lock = AsyncMock()
-    mock_lock.async_internal_clear_usercode = mock_clear
     existing = {LOCK_1_ENTITY_ID: {1: "9999"}}
 
     with patch(GET_ALL_CODES_PATCH, return_value=existing):
@@ -477,7 +461,6 @@ async def test_yaml_existing_codes_confirm_cancel(hass: HomeAssistant):
 
     assert result["type"] == "abort"
     assert result["reason"] == "existing_codes_cancelled"
-    mock_clear.assert_not_called()
 
 
 async def test_ui_no_existing_codes_skips_confirm(hass: HomeAssistant):
@@ -525,9 +508,6 @@ async def test_yaml_no_existing_codes_skips_confirm(hass: HomeAssistant):
 
 async def test_ui_existing_codes_confirm_lists_multiple_slots(hass: HomeAssistant):
     """Confirm step shows all slots with existing codes, sorted."""
-    mock_clear = AsyncMock(return_value=True)
-    mock_lock = AsyncMock()
-    mock_lock.async_internal_clear_usercode = mock_clear
     existing = {LOCK_1_ENTITY_ID: {3: "1234", 1: "5678"}}
 
     with patch(GET_ALL_CODES_PATCH, return_value=existing):
@@ -766,13 +746,6 @@ async def test_async_get_all_codes_missing_lock_config_entry(hass: HomeAssistant
 
 async def test_existing_codes_detected_across_multiple_locks(hass: HomeAssistant):
     """Test that existing codes are detected across multiple locks without clearing."""
-    mock_clear_ok = AsyncMock(return_value=True)
-    mock_clear_fail = AsyncMock(side_effect=RuntimeError("clear failed"))
-    mock_lock_ok = MagicMock()
-    mock_lock_ok.async_internal_clear_usercode = mock_clear_ok
-    mock_lock_fail = MagicMock()
-    mock_lock_fail.async_internal_clear_usercode = mock_clear_fail
-
     # Locks: one without an instance (skipped), one OK, one that fails,
     # one whose slot 1 is reported as EMPTY (must not be cleared), and one
     # that doesn't have slot 1 at all (must not be cleared)
@@ -805,8 +778,6 @@ async def test_existing_codes_detected_across_multiple_locks(hass: HomeAssistant
 
     # No clearing happens — sync manager handles reconciliation
     assert result["type"] == "create_entry"
-    mock_clear_ok.assert_not_called()
-    mock_clear_fail.assert_not_called()
 
 
 async def test_existing_codes_continue_without_next_step_aborts(hass: HomeAssistant):
@@ -896,10 +867,6 @@ async def test_options_flow_added_pair_with_existing_code_confirm(
     hass: HomeAssistant,
 ):
     """New (lock, slot) added and lock has code there -> confirm -> persist."""
-    mock_clear = AsyncMock(return_value=True)
-    mock_lock = MagicMock()
-    mock_lock.async_internal_clear_usercode = mock_clear
-
     flow_id, _ = await _start_options_flow(hass)
 
     # Adding slot 2; lock already has "9999" in slot 2 (and our managed "1234"
@@ -930,17 +897,12 @@ async def test_options_flow_added_pair_with_existing_code_confirm(
         flow_id, {"next_step_id": "existing_codes_continue"}
     )
     assert result["type"] == "create_entry"
-    mock_clear.assert_not_called()
 
 
 async def test_options_flow_added_lock_with_existing_code_confirm(
     hass: HomeAssistant,
 ):
     """A NEW lock (with codes in already-managed slot) triggers the confirm step."""
-    mock_clear = AsyncMock(return_value=True)
-    mock_lock_2 = MagicMock()
-    mock_lock_2.async_internal_clear_usercode = mock_clear
-
     flow_id, _ = await _start_options_flow(hass)
 
     # Add LOCK_2 to the entry. Slot 1 was already managed for LOCK_1, but
@@ -965,15 +927,10 @@ async def test_options_flow_added_lock_with_existing_code_confirm(
         flow_id, {"next_step_id": "existing_codes_continue"}
     )
     assert result["type"] == "create_entry"
-    mock_clear.assert_not_called()
 
 
 async def test_options_flow_existing_codes_cancel_aborts(hass: HomeAssistant):
     """Cancel from the confirm step aborts and does not change anything."""
-    mock_clear = AsyncMock()
-    mock_lock = MagicMock()
-    mock_lock.async_internal_clear_usercode = mock_clear
-
     flow_id, _ = await _start_options_flow(hass)
 
     with patch(
@@ -999,7 +956,6 @@ async def test_options_flow_existing_codes_cancel_aborts(hass: HomeAssistant):
 
     assert result["type"] == "abort"
     assert result["reason"] == "existing_codes_cancelled"
-    mock_clear.assert_not_called()
 
 
 async def test_options_flow_added_pair_empty_code_persists(hass: HomeAssistant):


### PR DESCRIPTION
## Proposed change

The config flow no longer clears existing codes from locks during setup. The sync manager already handles all reconciliation when the config entry loads — setting, clearing, or re-setting codes as needed.

### Before

When the config flow detected existing codes on lock slots, it would:
1. Show a confirmation dialog listing slot numbers
2. Clear codes directly via lock provider API calls (which could take 30s+ per call on Schlage)
3. The UI would hang with no feedback during clearing

### After

The confirmation dialog is now **informational only**. It shows which specific lock/slot pairs have existing codes:

```
- lock.front_door: slot 1
- lock.front_door: slot 2
- lock.garage: slot 1
```

The user acknowledges and proceeds. When the config entry loads, the sync manager reconciles everything — no manual clearing needed.

### What was removed

- All clearing logic from the config flow mixin (`_clear_existing_slot`, `_clear_all_pending_slots`, progress step, background task)
- `_lock_instances` tracking (was only used for clearing)
- Progress step and translation strings
- `_clear_then_create_entry` → simplified to `_create_entry`

### What was changed

- `_slots_with_existing_codes` → `_find_occupied_lock_slots` — now returns `(lock_entity_id, slot_num)` tuples instead of just slot numbers
- Confirmation dialog shows per-lock/slot details via `{details}` placeholder
- Menu option renamed from "Clear existing codes and continue" to "Continue"

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue:
- This PR is related to issue: