### PR TITLE
chore(lint): expand ruff rule set + enforce D213 docstring style

### DIFF
--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -140,7 +140,8 @@ async def async_migrate_entry(
 
 @callback
 def _async_notify_lovelace_dashboards(hass: HomeAssistant) -> None:
-    """Fire lovelace_updated for each registered dashboard.
+    """
+    Fire lovelace_updated for each registered dashboard.
 
     This triggers the "Configuration changed" toast in the Home Assistant
     frontend, prompting users to refresh the dashboard so the strategy

--- a/custom_components/lock_code_manager/callbacks.py
+++ b/custom_components/lock_code_manager/callbacks.py
@@ -1,4 +1,5 @@
-"""Typed callback registry for entity lifecycle management.
+"""
+Typed callback registry for entity lifecycle management.
 
 Platforms register entity-creation callbacks; entities register
 their own removal callbacks.
@@ -63,7 +64,8 @@ UnregisterFunc = Callable[[], None]
 
 @dataclass
 class EntityCallbackRegistry:
-    """Registry of entity lifecycle callbacks.
+    """
+    Registry of entity lifecycle callbacks.
 
     Entity Types:
         Standard: Entities created once per slot (e.g., enabled switch, name/PIN
@@ -260,7 +262,8 @@ class EntityCallbackRegistry:
 
     @callback
     def invoke_lock_removed_handlers(self, lock_entity_id: str) -> None:
-        """Invoke lock-removed callbacks.
+        """
+        Invoke lock-removed callbacks.
 
         Iterates a snapshot of the handler list because handlers may
         unregister themselves (or other handlers) during invocation.

--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -122,7 +122,8 @@ def _async_build_lock_instance(
     ent_reg: er.EntityRegistry,
     lock_entity_id: str,
 ) -> Any:
-    """Build a temporary lock provider instance for ``lock_entity_id``.
+    """
+    Build a temporary lock provider instance for ``lock_entity_id``.
 
     Performs setup-time checks (entity in registry, supported platform,
     parent config entry exists) and instantiates the provider class.
@@ -161,7 +162,8 @@ async def _async_get_all_codes(
     ent_reg: er.EntityRegistry,
     lock_entity_ids: list[str],
 ) -> tuple[dict[str, dict[int, str | SlotCode]], dict[str, Any]]:
-    """Query locks for all usercodes.
+    """
+    Query locks for all usercodes.
 
     Returns ``(codes_by_lock, lock_instances_by_lock)`` where ``codes_by_lock``
     maps each lock entity ID to its slot/code dict (``SlotCode.EMPTY`` for
@@ -201,7 +203,7 @@ async def _async_get_all_codes(
                 err,
             )
             continue
-        except Exception:  # noqa: BLE001
+        except Exception:
             # Last-resort catch: this runs in the user-facing config flow.
             # Any provider exception (including programmer error in a
             # third-party provider) must degrade to "no codes shown" rather
@@ -276,7 +278,7 @@ class _ExistingCodesFlowMixin:
                 await lock_instance.async_internal_clear_usercode(
                     slot_num, source="direct"
                 )
-            except Exception:  # noqa: BLE001
+            except Exception:
                 _LOGGER.warning(
                     "Failed to clear slot %s on %s",
                     slot_num,
@@ -630,7 +632,8 @@ class LockCodeManagerOptionsFlow(_ExistingCodesFlowMixin, config_entries.Options
     async def _maybe_confirm_then_persist(
         self, user_input: dict[str, Any]
     ) -> dict[str, Any]:
-        """Scan added (lock, slot) pairs for codes; confirm clear if any.
+        """
+        Scan added (lock, slot) pairs for codes; confirm clear if any.
 
         Compares the submitted (lock, slot) pairs against the entry's
         current configuration. If any newly-added pair has a non-empty

--- a/custom_components/lock_code_manager/coordinator.py
+++ b/custom_components/lock_code_manager/coordinator.py
@@ -1,4 +1,5 @@
-"""Manages the slot->code mapping for a single lock.
+"""
+Manages the slot->code mapping for a single lock.
 
 Stores ALL slots (managed and unmanaged). See ARCHITECTURE.md for the full data flow.
 """
@@ -167,7 +168,8 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator[dict[int, str | SlotCo
         return self._slot_sync_mgrs_suspended
 
     def suspend_slot_sync_mgrs(self) -> None:
-        """Suspend slot sync managers for this lock.
+        """
+        Suspend slot sync managers for this lock.
 
         Called by any SlotSyncManager that hits a circuit breaker or
         unexpected error. All sync managers for this lock will see the

--- a/custom_components/lock_code_manager/data.py
+++ b/custom_components/lock_code_manager/data.py
@@ -17,7 +17,8 @@ _EMPTY_SLOTS: Mapping[int, Mapping[str, Any]] = MappingProxyType({})
 
 @dataclass(frozen=True, slots=True)
 class EntryConfig:
-    """Typed, normalized view of an LCM entry's configuration.
+    """
+    Typed, normalized view of an LCM entry's configuration.
 
     Slot keys are normalized to ``int`` at construction (the on-disk
     JSON representation uses ``str``; voluptuous-validated user input
@@ -37,7 +38,8 @@ class EntryConfig:
 
     @classmethod
     def empty(cls) -> EntryConfig:
-        """Return a config representing an entry with no locks or slots.
+        """
+        Return a config representing an entry with no locks or slots.
 
         Used as the initial value for ``runtime_data.config`` before the
         entry's data has been read.
@@ -46,7 +48,8 @@ class EntryConfig:
 
     @classmethod
     def from_entry(cls, entry: ConfigEntry) -> EntryConfig:
-        """Build EntryConfig from a config entry, options-preferred.
+        """
+        Build EntryConfig from a config entry, options-preferred.
 
         Uses options-preferred precedence: during options-flow updates
         the new config is in ``options`` while ``data`` still holds the
@@ -65,7 +68,8 @@ class EntryConfig:
 
     @classmethod
     def from_mapping(cls, mapping: Mapping[str, Any]) -> EntryConfig:
-        """Build EntryConfig from a raw config mapping (data, options, or input).
+        """
+        Build EntryConfig from a raw config mapping (data, options, or input).
 
         Slot keys are normalized to ``int`` regardless of source. Inner
         slot config dicts are wrapped in ``MappingProxyType`` so the
@@ -85,7 +89,8 @@ class EntryConfig:
         return lock_entity_id in self.locks
 
     def has_slot(self, slot_num: int | str) -> bool:
-        """Return True if this entry manages the given slot number.
+        """
+        Return True if this entry manages the given slot number.
 
         Accepts ``int`` or ``str`` to absorb the slot-key type variance
         in the codebase (entities created during the listener may carry
@@ -95,7 +100,8 @@ class EntryConfig:
         return int(slot_num) in self.slots
 
     def slot(self, slot_num: int | str) -> Mapping[str, Any]:
-        """Return the slot config dict, or an empty mapping if absent.
+        """
+        Return the slot config dict, or an empty mapping if absent.
 
         Like :meth:`has_slot`, accepts ``int`` or ``str`` so callers
         don't need to cast at every read site.
@@ -103,7 +109,8 @@ class EntryConfig:
         return self.slots.get(int(slot_num), {})
 
     def __sub__(self, other: EntryConfig) -> EntryConfigDiff:
-        """Return the diff from ``self`` (old) to ``other`` (new).
+        """
+        Return the diff from ``self`` (old) to ``other`` (new).
 
         Sugar for ``EntryConfigDiff(old=self, new=other)``. Reads as
         ``old_config - new_config`` — note this is a *delta* (both adds
@@ -122,7 +129,8 @@ class EntryConfig:
     def with_slot_field_set(
         self, slot_num: int | str, key: str, value: Any
     ) -> EntryConfig:
-        """Return a new EntryConfig with one slot's field set to ``value``.
+        """
+        Return a new EntryConfig with one slot's field set to ``value``.
 
         Creates the slot if it doesn't already exist. Used by writer
         paths (entity field updates, condition entity set service) to
@@ -142,7 +150,8 @@ class EntryConfig:
         )
 
     def with_slot_field_removed(self, slot_num: int | str, key: str) -> EntryConfig:
-        """Return a new EntryConfig with one slot's field removed.
+        """
+        Return a new EntryConfig with one slot's field removed.
 
         No-op (returns ``self``) if the slot or key is already absent.
         """
@@ -161,7 +170,8 @@ class EntryConfig:
         )
 
     def to_dict(self) -> dict[str, Any]:
-        """Return a plain mutable dict suitable for ``async_update_entry``.
+        """
+        Return a plain mutable dict suitable for ``async_update_entry``.
 
         Only includes the keys EntryConfig knows about (CONF_LOCKS and
         CONF_SLOTS). Inner slot dicts are plain ``dict`` (not
@@ -179,7 +189,8 @@ class EntryConfig:
 
 
 def get_entry_config(entry: ConfigEntry) -> EntryConfig:
-    """Return the EntryConfig view of ``entry``.
+    """
+    Return the EntryConfig view of ``entry``.
 
     Prefers the cached instance on ``entry.runtime_data.config`` (set by
     the listener during setup and on every update) and falls back to
@@ -207,7 +218,8 @@ def get_managed_slots(hass: HomeAssistant, lock_entity_id: str) -> set[int]:
 def find_entry_for_lock_slot(
     hass: HomeAssistant, lock_entity_id: str, code_slot: int | str
 ) -> ConfigEntry | None:
-    """Find the config entry that manages a specific lock + slot combination.
+    """
+    Find the config entry that manages a specific lock + slot combination.
 
     Returns None if no entry manages this lock/slot. There can be at most one
     due to the config entry uniqueness constraint.
@@ -225,7 +237,8 @@ def find_entry_for_lock_slot(
 
 @dataclass(frozen=True, slots=True)
 class EntryConfigDiff:
-    """Diff between two LCM entry configurations.
+    """
+    Diff between two LCM entry configurations.
 
     Constructed directly from the two configs being compared:
 
@@ -339,7 +352,8 @@ def build_slot_unique_id(
     key: str,
     lock_entity_id: str | None = None,
 ) -> str:
-    """Build the unique ID for a slot entity.
+    """
+    Build the unique ID for a slot entity.
 
     Standard: {entry_id}|{slot_num}|{key}
     Per-lock:  {entry_id}|{slot_num}|{key}|{lock_entity_id}

--- a/custom_components/lock_code_manager/diagnostics.py
+++ b/custom_components/lock_code_manager/diagnostics.py
@@ -49,7 +49,8 @@ def _entity_states_for_device(
     ent_reg: er.EntityRegistry,
     device_id: str,
 ) -> list[dict[str, Any]]:
-    """Return entity states for all entities on a device.
+    """
+    Return entity states for all entities on a device.
 
     Sensitive entities (PIN text, code sensor) have their state and
     attributes redacted to avoid leaking PINs in diagnostics output.

--- a/custom_components/lock_code_manager/entity.py
+++ b/custom_components/lock_code_manager/entity.py
@@ -222,8 +222,8 @@ class BaseLockCodeManagerEntity(Entity):
         ):
             return
 
-        if (from_state and STATE_UNAVAILABLE != from_state.state) and (
-            to_state and STATE_UNAVAILABLE != to_state.state
+        if (from_state and from_state.state != STATE_UNAVAILABLE) and (
+            to_state and to_state.state != STATE_UNAVAILABLE
         ):
             return
 

--- a/custom_components/lock_code_manager/exceptions.py
+++ b/custom_components/lock_code_manager/exceptions.py
@@ -15,7 +15,8 @@ class LockCodeManagerError(HomeAssistantError):
 
 
 class LockCodeManagerProviderError(LockCodeManagerError):
-    """Base class for exceptions raised by lock providers.
+    """
+    Base class for exceptions raised by lock providers.
 
     Subclasses cover real provider-side failures: communication problems
     (``LockDisconnected``), the lock rejecting a code (``CodeRejectedError``,
@@ -84,7 +85,8 @@ class LockDisconnected(LockCodeManagerProviderError):
 
 
 class LockOperationFailed(LockCodeManagerProviderError):
-    """Raised when the lock is reachable but the operation failed.
+    """
+    Raised when the lock is reachable but the operation failed.
 
     This covers cases like the lock not supporting a requested operation
     or the provider rejecting the command for a lock-side reason. Unlike

--- a/custom_components/lock_code_manager/models.py
+++ b/custom_components/lock_code_manager/models.py
@@ -1,4 +1,5 @@
-"""Data model types for lock_code_manager.
+"""
+Data model types for lock_code_manager.
 
 Canonical home for dataclasses, type aliases, enums, and structured data types
 used across the integration.
@@ -22,7 +23,8 @@ if TYPE_CHECKING:
 
 
 class SyncState(StrEnum):
-    """State machine for slot sync reconciliation.
+    """
+    State machine for slot sync reconciliation.
 
     LOADING: initial state, waiting for entity states to resolve.
     IN_SYNC: desired state matches actual state on the lock.
@@ -40,7 +42,8 @@ class SyncState(StrEnum):
 
 
 class SlotCode(StrEnum):
-    """Sentinel values for slot codes in coordinator data.
+    """
+    Sentinel values for slot codes in coordinator data.
 
     Used alongside str values: a readable code is a plain string,
     while EMPTY and UNREADABLE_CODE represent non-string slot states.

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -1,4 +1,5 @@
-"""Abstract base for lock providers.
+"""
+Abstract base for lock providers.
 
 Handles rate limiting, connection checking, and coordinator refresh after operations.
 See ARCHITECTURE.md for the provider interface contract.
@@ -8,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Awaitable, Callable
+import contextlib
 from dataclasses import dataclass, field
 from datetime import timedelta
 import logging
@@ -189,7 +191,8 @@ class BaseLock:
         pre_execute: Callable[[], None] | None = None,
         **kwargs: Any,
     ) -> Any:
-        """Execute operation with connection check, serialization, and delay.
+        """
+        Execute operation with connection check, serialization, and delay.
 
         pre_execute runs inside the lock before the operation, for checks
         that must be atomic with the operation (e.g., duplicate detection).
@@ -379,7 +382,8 @@ class BaseLock:
     @final
     @callback
     def subscribe_push_updates(self) -> None:
-        """Subscribe to push-based value updates.
+        """
+        Subscribe to push-based value updates.
 
         Idempotent: safe to call when already subscribed (delegates to
         ``setup_push_subscription`` which must be idempotent).
@@ -398,7 +402,7 @@ class BaseLock:
                 self.lock.entity_id,
                 err,
             )
-        except Exception as err:  # noqa: BLE001
+        except Exception as err:
             LOGGER.warning(
                 "Lock %s: push subscription failed unexpectedly: %s",
                 self.lock.entity_id,
@@ -407,7 +411,8 @@ class BaseLock:
 
     @callback
     def setup_push_subscription(self) -> None:
-        """Subscribe to push-based value updates.
+        """
+        Subscribe to push-based value updates.
 
         Override in subclasses that support push. Raise on failure;
         the caller will log and retry on the next reconnect event.
@@ -426,14 +431,13 @@ class BaseLock:
     @callback
     def unsubscribe_push_updates(self) -> None:
         """Unsubscribe from push-based value updates."""
-        try:
+        with contextlib.suppress(ProviderNotImplementedError):
             self.teardown_push_subscription()
-        except ProviderNotImplementedError:
-            pass
 
     @callback
     def teardown_push_subscription(self) -> None:
-        """Unsubscribe from push-based value updates.
+        """
+        Unsubscribe from push-based value updates.
 
         Override in subclasses that support push.
         Implementations MUST be idempotent (no-op if already unsubscribed).
@@ -473,7 +477,8 @@ class BaseLock:
             self._setup_complete.set()
 
     async def _async_on_integration_loaded(self) -> None:
-        """Handle provider integration LOADED transition.
+        """
+        Handle provider integration LOADED transition.
 
         Re-runs ``async_setup`` to re-initialize provider state (e.g.
         re-register event listeners after an integration reload), then
@@ -566,7 +571,8 @@ class BaseLock:
                 self.subscribe_push_updates()
 
     async def async_setup(self, config_entry: ConfigEntry) -> None:
-        """Set up lock by provider.
+        """
+        Set up lock by provider.
 
         Default is a no-op; providers override for provider-specific setup
         (e.g. registering event listeners, validating capabilities).
@@ -627,7 +633,8 @@ class BaseLock:
         )
 
     async def async_is_integration_connected(self) -> bool:
-        """Return True iff the lock's parent config entry is loaded.
+        """
+        Return True iff the lock's parent config entry is loaded.
 
         Providers override for integration-specific connection signals.
         Raises ``LockCodeManagerError`` if ``lock_config_entry`` is None —
@@ -692,7 +699,8 @@ class BaseLock:
         name: str | None = None,
         source: Literal["sync", "direct"] = "direct",
     ) -> bool:
-        """Set a usercode on a code slot.
+        """
+        Set a usercode on a code slot.
 
         Returns True if the value was changed, False if already set to this
         value. If the provider cannot determine whether a change occurred,
@@ -724,7 +732,8 @@ class BaseLock:
         )
 
         def _pre_execute_checks() -> None:
-            """Run pre-execution checks atomically inside the operation lock.
+            """
+            Run pre-execution checks atomically inside the operation lock.
 
             Checks for duplicate PINs (from coordinator data) and for codes
             previously rejected by the lock firmware (from event 15).
@@ -758,7 +767,8 @@ class BaseLock:
             await self.coordinator.async_request_refresh()
 
     async def async_clear_usercode(self, code_slot: int) -> bool:
-        """Clear a usercode on a code slot.
+        """
+        Clear a usercode on a code slot.
 
         Returns True if the value was changed, False if already cleared.
         If the provider cannot determine whether a change occurred, return
@@ -798,7 +808,8 @@ class BaseLock:
 
     @final
     async def async_internal_get_usercodes(self) -> dict[int, str | SlotCode]:
-        """Rate-limited wrapper around async_get_usercodes().
+        """
+        Rate-limited wrapper around async_get_usercodes().
 
         Slot keys are int; values are usercode strings or SlotCode sentinels.
         """
@@ -814,7 +825,8 @@ class BaseLock:
         blocking: bool = True,
         return_response: bool = False,
     ) -> dict[str, Any] | None:
-        """Call a hass service and re-raise failures as LockDisconnected.
+        """
+        Call a hass service and re-raise failures as LockDisconnected.
 
         When ``return_response=True``, returns the service response (as a
         dict) so callers don't have to write their own service-call wrapper

--- a/custom_components/lock_code_manager/providers/_util.py
+++ b/custom_components/lock_code_manager/providers/_util.py
@@ -1,4 +1,5 @@
-"""Shared helpers for provider implementations.
+"""
+Shared helpers for provider implementations.
 
 Provider-internal utilities that don't belong in the integration-wide
 ``util.py``. Currently: slot-tagging used by providers whose lock APIs
@@ -22,7 +23,8 @@ def make_tagged_name(slot_num: int, name: str | None = None) -> str:
 
 
 def parse_tag(name: str) -> tuple[int | None, str]:
-    """Parse a Lock Code Manager slot tag from a code name.
+    """
+    Parse a Lock Code Manager slot tag from a code name.
 
     Returns ``(slot_num, friendly_name)`` when a tag is present, or
     ``(None, original_name)`` when no tag is found.

--- a/custom_components/lock_code_manager/providers/akuvox.py
+++ b/custom_components/lock_code_manager/providers/akuvox.py
@@ -1,4 +1,5 @@
-"""Local Akuvox lock provider.
+"""
+Local Akuvox lock provider.
 
 Akuvox door controllers manage access codes as *users* identified by an
 internal device ID, not by numeric slot numbers. This provider bridges
@@ -51,7 +52,8 @@ def _is_local_user(user: dict[str, Any]) -> bool:
 
 @dataclass(repr=False, eq=False)
 class AkuvoxLock(BaseLock):
-    """Local Akuvox lock provider implementation.
+    """
+    Local Akuvox lock provider implementation.
 
     Users on Akuvox controllers are identified by a device-internal ID
     and a name, not by slot numbers. This provider assigns virtual slot
@@ -77,7 +79,8 @@ class AkuvoxLock(BaseLock):
         return timedelta(minutes=2)
 
     async def _async_list_users(self) -> list[dict[str, Any]]:
-        """Call ``local_akuvox.list_users`` and return the user list.
+        """
+        Call ``local_akuvox.list_users`` and return the user list.
 
         Returns a list of user dicts with keys: id, name, user_id,
         private_pin, card_code, schedule_relay, lift_floor_num, etc.
@@ -163,7 +166,8 @@ class AkuvoxLock(BaseLock):
         return await self.async_get_usercodes()
 
     async def _async_tag_unmanaged_users(self) -> None:
-        """Discover untagged local users and tag them with a slot number.
+        """
+        Discover untagged local users and tag them with a slot number.
 
         Untagged local users that have a PIN are assigned to the next
         available managed slot and their names are updated on the device
@@ -227,7 +231,8 @@ class AkuvoxLock(BaseLock):
             )
 
     async def async_get_usercodes(self) -> dict[int, str | SlotCode]:
-        """Get dictionary of code slots and usercodes.
+        """
+        Get dictionary of code slots and usercodes.
 
         Users already bearing a ``[LCM:<slot>]`` tag in their name are
         mapped to the embedded slot number. Only reads and classifies;
@@ -243,9 +248,7 @@ class AkuvoxLock(BaseLock):
         users = await self._async_list_users()
 
         # Start with all managed slots empty
-        result: dict[int, str | SlotCode] = {
-            slot: SlotCode.EMPTY for slot in managed_slots
-        }
+        result: dict[int, str | SlotCode] = dict.fromkeys(managed_slots, SlotCode.EMPTY)
 
         for user in users:
             if not _is_local_user(user):
@@ -272,7 +275,8 @@ class AkuvoxLock(BaseLock):
         name: str | None = None,
         source: Literal["sync", "direct"] = "direct",
     ) -> bool:
-        """Set user code on a virtual slot.
+        """
+        Set user code on a virtual slot.
 
         If a user already exists for the given slot, the PIN (and
         optionally the name) is updated via ``modify_user``. Otherwise
@@ -313,7 +317,8 @@ class AkuvoxLock(BaseLock):
         return True
 
     async def async_clear_usercode(self, code_slot: int) -> bool:
-        """Clear user code from a virtual slot by deleting the user.
+        """
+        Clear user code from a virtual slot by deleting the user.
 
         Returns True if a user was deleted, False if the slot was already empty.
         """

--- a/custom_components/lock_code_manager/providers/matter.py
+++ b/custom_components/lock_code_manager/providers/matter.py
@@ -1,4 +1,5 @@
-"""Matter lock provider.
+"""
+Matter lock provider.
 
 Handles PIN credential management via Matter lock helpers.
 PINs are write-only: occupied slots report SlotCode.UNREADABLE_CODE, cleared slots report
@@ -73,7 +74,8 @@ class MatterLock(BaseLock):
 
     @property
     def supports_push(self) -> bool:
-        """Return whether this lock supports push-based updates.
+        """
+        Return whether this lock supports push-based updates.
 
         Matter locks push occupancy changes via LockUserChange events.
         PINs are still write-only (values are never pushed), but slot
@@ -88,7 +90,8 @@ class MatterLock(BaseLock):
 
     @property
     def hard_refresh_interval(self) -> timedelta | None:
-        """Return interval between hard refreshes for drift detection.
+        """
+        Return interval between hard refreshes for drift detection.
 
         Matter locks support push events for local changes, but API-initiated
         changes bypass push notifications. Periodic hard refresh catches drift
@@ -97,7 +100,8 @@ class MatterLock(BaseLock):
         return timedelta(hours=1)
 
     def _get_matter_node(self) -> Any | None:
-        """Get the MatterNode for this lock from the Matter integration.
+        """
+        Get the MatterNode for this lock from the Matter integration.
 
         Uses the Matter integration's helper to resolve the node from the
         device entry, which correctly handles the device identifier format.
@@ -107,7 +111,7 @@ class MatterLock(BaseLock):
             return None
         try:
             return get_node_from_device_entry(self.hass, self.device_entry)
-        except Exception as err:  # noqa: BLE001
+        except Exception as err:
             LOGGER.debug(
                 "Failed to resolve Matter node for %s: %s",
                 self.lock.entity_id,
@@ -125,7 +129,7 @@ class MatterLock(BaseLock):
         """Get the MatterClient via the Matter integration helper."""
         try:
             return get_matter(self.hass).matter_client
-        except Exception as err:  # noqa: BLE001
+        except Exception as err:
             LOGGER.debug(
                 "Failed to get Matter client for %s: %s",
                 self.lock.entity_id,
@@ -188,7 +192,8 @@ class MatterLock(BaseLock):
 
     @callback
     def setup_push_subscription(self) -> None:
-        """Subscribe to Matter DoorLock cluster events.
+        """
+        Subscribe to Matter DoorLock cluster events.
 
         Handles two event types:
         - LockOperation (event 2): fires code slot events when a PIN is used
@@ -246,7 +251,8 @@ class MatterLock(BaseLock):
 
     @callback
     def _handle_lock_operation(self, node_event: Any) -> None:
-        """Handle LockOperation events (event ID 2).
+        """
+        Handle LockOperation events (event ID 2).
 
         Fires a code slot event when a PIN credential is used to lock/unlock.
         Only PIN credentials (credentialType=1) trigger the event — other
@@ -300,7 +306,8 @@ class MatterLock(BaseLock):
 
     @callback
     def _handle_lock_user_change(self, node_event: Any) -> None:
-        """Handle LockUserChange events (event ID 4).
+        """
+        Handle LockUserChange events (event ID 4).
 
         Pushes occupancy updates to the coordinator when a PIN credential is
         added, modified, or cleared. This provides real-time change detection
@@ -357,7 +364,8 @@ class MatterLock(BaseLock):
     # -- Credential helpers --------------------------------------------------
 
     async def _set_lock_credential(self, code_slot: int, usercode: str) -> int | None:
-        """Send set_lock_credential to the lock and return the user_index.
+        """
+        Send set_lock_credential to the lock and return the user_index.
 
         Raises SetCredentialFailedError on lock rejection,
         LockCodeManagerProviderError on invalid input,
@@ -386,7 +394,8 @@ class MatterLock(BaseLock):
         return result.get("user_index")
 
     async def _clear_lock_credential(self, code_slot: int) -> None:
-        """Send clear_lock_credential to the lock.
+        """
+        Send clear_lock_credential to the lock.
 
         Raises LockCodeManagerProviderError on invalid input,
         LockDisconnected on communication failure.
@@ -412,7 +421,8 @@ class MatterLock(BaseLock):
     # -- Usercode CRUD -------------------------------------------------------
 
     async def async_get_usercodes(self) -> dict[int, str | SlotCode]:
-        """Get dictionary of code slots and usercodes.
+        """
+        Get dictionary of code slots and usercodes.
 
         Returns all occupied PIN credential slots as SlotCode.UNREADABLE_CODE (PINs are
         write-only) and managed empty slots as SlotCode.EMPTY. Unmanaged
@@ -478,7 +488,8 @@ class MatterLock(BaseLock):
         usercode: str,
         source: Literal["sync", "direct"],
     ) -> int | None:
-        """Set a credential, handling duplicate status.
+        """
+        Set a credential, handling duplicate status.
 
         For sync operations, clears the slot and retries on duplicate (handles
         the restart case where _last_set_pin is lost). For direct operations,
@@ -550,7 +561,8 @@ class MatterLock(BaseLock):
         name: str | None = None,
         source: Literal["sync", "direct"] = "direct",
     ) -> bool:
-        """Set a usercode on a code slot.
+        """
+        Set a usercode on a code slot.
 
         Returns True unconditionally because Matter does not reveal whether
         the credential value actually changed. Pushes SlotCode.UNREADABLE_CODE
@@ -570,7 +582,8 @@ class MatterLock(BaseLock):
         return True
 
     async def async_clear_usercode(self, code_slot: int) -> bool:
-        """Clear a usercode on a code slot.
+        """
+        Clear a usercode on a code slot.
 
         Returns True if a credential was cleared, False if the slot was already
         empty. Pushes SlotCode.EMPTY to the coordinator immediately on success.
@@ -605,7 +618,8 @@ class MatterLock(BaseLock):
         return True
 
     async def async_hard_refresh_codes(self) -> dict[int, str | SlotCode]:
-        """Perform hard refresh and return all codes.
+        """
+        Perform hard refresh and return all codes.
 
         Matter has no cache to invalidate, so this is identical to async_get_usercodes.
         """

--- a/custom_components/lock_code_manager/providers/schlage.py
+++ b/custom_components/lock_code_manager/providers/schlage.py
@@ -1,4 +1,5 @@
-"""Schlage WiFi lock provider.
+"""
+Schlage WiFi lock provider.
 
 Schlage locks manage access codes by name rather than numeric slot numbers.
 This provider bridges that gap by tagging code names with a slot prefix
@@ -17,6 +18,7 @@ SlotCode.UNREADABLE_CODE and cleared slots report SlotCode.EMPTY.
 
 from __future__ import annotations
 
+import contextlib
 from dataclasses import dataclass
 from datetime import timedelta
 from typing import Literal
@@ -34,7 +36,8 @@ SCHLAGE_DOMAIN = "schlage"
 
 @dataclass(repr=False, eq=False)
 class SchlageLock(BaseLock):
-    """Schlage WiFi lock provider implementation.
+    """
+    Schlage WiFi lock provider implementation.
 
     Codes on Schlage locks are identified by friendly name, not by slot
     number.  This provider assigns virtual slot numbers by embedding a
@@ -61,7 +64,8 @@ class SchlageLock(BaseLock):
         return timedelta(minutes=5)
 
     async def _async_get_codes(self) -> dict[str, dict[str, str]]:
-        """Call ``schlage.get_codes`` and return the response dict.
+        """
+        Call ``schlage.get_codes`` and return the response dict.
 
         Returns a dict mapping access-code IDs to ``{"name": ..., "code": ...}``.
         """
@@ -125,7 +129,8 @@ class SchlageLock(BaseLock):
         await self._async_tag_unmanaged_codes()
 
     async def _async_tag_unmanaged_codes(self) -> None:
-        """Tag unmanaged codes on the lock with Lock Code Manager slot numbers.
+        """
+        Tag unmanaged codes on the lock with Lock Code Manager slot numbers.
 
         Discovers untagged codes and assigns them to the next available managed
         slot by renaming (add tagged, delete original).
@@ -231,7 +236,8 @@ class SchlageLock(BaseLock):
             )
 
     async def async_get_usercodes(self) -> dict[int, str | SlotCode]:
-        """Get dictionary of code slots and usercodes.
+        """
+        Get dictionary of code slots and usercodes.
 
         Schlage PINs are write-only (returned as masked values), so occupied
         slots return SlotCode.UNREADABLE_CODE and cleared slots return SlotCode.EMPTY.
@@ -292,7 +298,8 @@ class SchlageLock(BaseLock):
         name: str | None = None,
         source: Literal["sync", "direct"] = "direct",
     ) -> bool:
-        """Set user code on a virtual slot.
+        """
+        Set user code on a virtual slot.
 
         If a code already exists for the given slot it is replaced.
         Returns True unconditionally because Schlage PINs are write-only
@@ -320,10 +327,9 @@ class SchlageLock(BaseLock):
         # API means get_codes may not reflect a recently-added code.
         names_to_delete = {n for n in (existing_full_name, tagged_name) if n}
         for code_name in names_to_delete:
-            try:
+            # code may not exist — that's fine
+            with contextlib.suppress(LockDisconnected):
                 await self._async_delete_code(code_name)
-            except LockDisconnected:
-                pass  # code may not exist — that's fine
 
         try:
             await self._async_add_code(tagged_name, usercode)
@@ -351,7 +357,8 @@ class SchlageLock(BaseLock):
         return True
 
     async def async_clear_usercode(self, code_slot: int) -> bool:
-        """Clear user code from a virtual slot.
+        """
+        Clear user code from a virtual slot.
 
         Returns True if a code was deleted, False if the slot was already empty.
         """
@@ -381,7 +388,8 @@ class SchlageLock(BaseLock):
         return True
 
     async def async_hard_refresh_codes(self) -> dict[int, str | SlotCode]:
-        """Perform hard refresh and return all codes.
+        """
+        Perform hard refresh and return all codes.
 
         Schlage has no cache to invalidate; re-tags unmanaged codes and then
         reads the current state.

--- a/custom_components/lock_code_manager/providers/virtual.py
+++ b/custom_components/lock_code_manager/providers/virtual.py
@@ -95,7 +95,8 @@ class VirtualLock(BaseLock):
         return True
 
     async def async_get_usercodes(self) -> dict[int, str | SlotCode]:
-        """Get dictionary of code slots and usercodes.
+        """
+        Get dictionary of code slots and usercodes.
 
         Returns all slots with data plus managed empty slots. Unmanaged
         occupied slots are included so callers like the lock reset config

--- a/custom_components/lock_code_manager/providers/zha.py
+++ b/custom_components/lock_code_manager/providers/zha.py
@@ -1,4 +1,5 @@
-"""ZHA (Zigbee Home Automation) lock provider.
+"""
+ZHA (Zigbee Home Automation) lock provider.
 
 Communicates with Zigbee locks via the zigpy DoorLock cluster through ZHA.
 Supports push updates via cluster listeners for operation events (lock/unlock
@@ -63,7 +64,8 @@ OPERATION_SOURCE_NAMES: dict[int, str] = {
 
 @dataclass(repr=False, eq=False)
 class ZHALock(BaseLock):
-    """ZHA lock provider.
+    """
+    ZHA lock provider.
 
     Push updates come from zigpy cluster listeners:
     - ``programming_event_notification`` (0x21): PIN added/deleted/changed
@@ -87,7 +89,8 @@ class ZHALock(BaseLock):
 
     @property
     def supports_push(self) -> bool:
-        """Return whether this lock supports push-based updates.
+        """
+        Return whether this lock supports push-based updates.
 
         Always True — we subscribe to cluster events for operation
         notifications (lock/unlock with user ID).  Programming event support
@@ -97,7 +100,8 @@ class ZHALock(BaseLock):
 
     @property
     def hard_refresh_interval(self) -> timedelta | None:
-        """Return interval for drift detection.
+        """
+        Return interval for drift detection.
 
         One hour if the lock lacks programming event notifications, otherwise
         None (push handles code changes).
@@ -114,7 +118,8 @@ class ZHALock(BaseLock):
     # -- Setup ---------------------------------------------------------------
 
     async def async_setup(self, config_entry: ConfigEntry) -> None:
-        """Initialize provider state and detect programming event support.
+        """
+        Initialize provider state and detect programming event support.
 
         Called on initial setup AND on integration reconnect, so we clear
         cached cluster references (which may be stale after a ZHA reload)
@@ -384,7 +389,8 @@ class ZHALock(BaseLock):
             self._handle_operation_event(args)
 
     def _handle_programming_event(self, args: Any) -> None:
-        """Handle programming event (PIN added/deleted/changed).
+        """
+        Handle programming event (PIN added/deleted/changed).
 
         Triggers a coordinator refresh to pick up the new code state.
         """
@@ -423,7 +429,8 @@ class ZHALock(BaseLock):
             )
 
     def _handle_operation_event(self, args: Any) -> None:
-        """Handle operation event (lock/unlock with user ID).
+        """
+        Handle operation event (lock/unlock with user ID).
 
         Fires a code slot event so automations can react to lock usage.
         """
@@ -473,7 +480,8 @@ class ZHALock(BaseLock):
     # -- Programming event support detection ---------------------------------
 
     async def _async_check_programming_event_support(self) -> bool:
-        """Check if the lock supports programming event notifications.
+        """
+        Check if the lock supports programming event notifications.
 
         Reads event mask attributes to determine if the lock will send
         programming_event_notification when codes change.

--- a/custom_components/lock_code_manager/providers/zigbee2mqtt.py
+++ b/custom_components/lock_code_manager/providers/zigbee2mqtt.py
@@ -51,7 +51,8 @@ _Z2M_LOCK_ACTIONS = _Z2M_LOCK_ACTIONS_LOCKED | _Z2M_LOCK_ACTIONS_UNLOCKED
 
 
 def _mqtt_payload_pin_has_code_value(pin_raw: Any) -> bool:
-    """Return True when MQTT exposes a usable PIN value (including numeric zero).
+    """
+    Return True when MQTT exposes a usable PIN value (including numeric zero).
 
     Plain truthiness is unsafe: ``0`` is a valid digit and must not be treated as
     absent. Boolean JSON values are ignored because they are not PIN payloads.
@@ -93,7 +94,8 @@ class Zigbee2MQTTLock(BaseLock):
 
     @property
     def usercode_scan_interval(self) -> timedelta:
-        """Return scan interval for usercodes.
+        """
+        Return scan interval for usercodes.
 
         With push updates, we only need polling as a fallback.
         """
@@ -114,7 +116,8 @@ class Zigbee2MQTTLock(BaseLock):
         await self._async_ensure_device_subscription()
 
     def _get_friendly_name(self) -> str | None:
-        """Get the Zigbee2MQTT friendly name for this device.
+        """
+        Get the Zigbee2MQTT friendly name for this device.
 
         Reads ``device_registry`` name on each call so renames stay aligned with the
         Zigbee2MQTT friendly name (cached value alone would go stale).
@@ -176,9 +179,7 @@ class Zigbee2MQTTLock(BaseLock):
     async def async_is_device_available(self) -> bool:
         """Return whether the lock entity reports an operational state."""
         state = self.hass.states.get(self.lock.entity_id)
-        if state is None or state.state == "unavailable":
-            return False
-        return True
+        return not (state is None or state.state == "unavailable")
 
     @callback
     def _process_z2m_device_payload(self, payload: dict[str, Any]) -> None:
@@ -353,7 +354,8 @@ class Zigbee2MQTTLock(BaseLock):
 
     @callback
     def setup_push_subscription(self) -> None:
-        """Subscribe via background task when still unsubscribed (e.g. reconnect).
+        """
+        Subscribe via background task when still unsubscribed (e.g. reconnect).
 
         Primary subscribe is ``await`` in ``async_setup``.
         """
@@ -378,7 +380,8 @@ class Zigbee2MQTTLock(BaseLock):
             return
 
         async def _subscribe_or_log() -> None:
-            """Run ``_async_ensure_device_subscription`` from the reconnect task path.
+            """
+            Run ``_async_ensure_device_subscription`` from the reconnect task path.
 
             Log errors only; sync ``setup_push_subscription`` cannot raise.
             """
@@ -469,7 +472,7 @@ class Zigbee2MQTTLock(BaseLock):
                     slot_num,
                 )
                 data[slot_num] = SlotCode.UNREADABLE_CODE
-            except Exception as err:  # noqa: BLE001
+            except Exception as err:
                 # Broad catch is intentional: the future is resolved by the MQTT
                 # callback, and any exception from resolution (InvalidStateError,
                 # data processing errors) should not crash the entire refresh.

--- a/custom_components/lock_code_manager/providers/zwave_js.py
+++ b/custom_components/lock_code_manager/providers/zwave_js.py
@@ -1,4 +1,5 @@
-"""Z-Wave JS lock provider.
+"""
+Z-Wave JS lock provider.
 
 Handles push updates, duplicate code detection, and rate-limited set/clear operations.
 See ARCHITECTURE.md for the provider's role in the data flow.
@@ -355,7 +356,8 @@ class ZWaveJSLock(BaseLock):
         self._listeners.clear()
 
     async def async_setup(self, config_entry: ConfigEntry) -> None:
-        """Set up lock by provider.
+        """
+        Set up lock by provider.
 
         Idempotent: clears existing listeners before re-registering.
         """
@@ -382,7 +384,7 @@ class ZWaveJSLock(BaseLock):
         """Return whether the Z-Wave node is available for commands."""
         try:
             return self.node.status != NodeStatus.DEAD
-        except Exception as err:  # noqa: BLE001
+        except Exception as err:
             _LOGGER.debug(
                 "Lock %s: failed to check device availability: %s",
                 self.lock.entity_id,
@@ -420,7 +422,7 @@ class ZWaveJSLock(BaseLock):
                         code_slot,
                     )
                     return False
-        except Exception:  # noqa: BLE001
+        except Exception:
             pass
 
         self._set_in_progress_code_slot = code_slot
@@ -470,7 +472,7 @@ class ZWaveJSLock(BaseLock):
                     code_slot,
                 )
                 return False
-        except Exception:  # noqa: BLE001
+        except Exception:
             pass
 
         service_data = {

--- a/custom_components/lock_code_manager/repairs.py
+++ b/custom_components/lock_code_manager/repairs.py
@@ -22,7 +22,8 @@ class AcknowledgeRepairFlow(RepairsFlow):
 
 
 class NumberOfUsesDeprecatedFlow(RepairsFlow):
-    """Handler for the number_of_uses deprecation repair.
+    """
+    Handler for the number_of_uses deprecation repair.
 
     When the user confirms, strips number_of_uses from all slot configs
     in the config entry.

--- a/custom_components/lock_code_manager/sync.py
+++ b/custom_components/lock_code_manager/sync.py
@@ -1,4 +1,5 @@
-"""Slot sync manager — owns desired vs actual reconciliation.
+"""
+Slot sync manager — owns desired vs actual reconciliation.
 
 Compares entity states (active, PIN, name) against coordinator data (actual lock
 code) and drives set/clear operations to reconcile. Uses a state machine
@@ -66,7 +67,8 @@ _LOGGER = logging.getLogger(__name__)
 
 @dataclass(frozen=True)
 class SlotState:
-    """Snapshot of entity states for a slot on a specific lock.
+    """
+    Snapshot of entity states for a slot on a specific lock.
 
     Used by SlotSyncManager to compare desired (entity) vs actual
     (coordinator) state. Includes raw HA state strings (rather than
@@ -83,7 +85,8 @@ class SlotState:
 
 
 class SlotSyncManager:
-    """Manage sync state for a single lock x slot combination.
+    """
+    Manage sync state for a single lock x slot combination.
 
     Compares desired state (from entity states: active, PIN) against actual
     state (from coordinator data) and drives set/clear operations to reconcile.
@@ -235,7 +238,8 @@ class SlotSyncManager:
         return not missing
 
     def _ensure_entities_ready(self) -> bool:
-        """Ensure all dependent entities exist with valid states.
+        """
+        Ensure all dependent entities exist with valid states.
 
         The name entity (CONF_NAME) is optional — STATE_UNKNOWN is its
         normal state when no name is configured.
@@ -273,7 +277,8 @@ class SlotSyncManager:
         return True
 
     def _resolve_slot_state(self) -> SlotState | None:
-        """Resolve slot state from current entity and coordinator data.
+        """
+        Resolve slot state from current entity and coordinator data.
 
         All state reads are sync (hass.states.get) with no awaits between them,
         ensuring atomicity on Home Assistant's single-threaded event loop.
@@ -311,7 +316,8 @@ class SlotSyncManager:
     # -- Sync calculation ----------------------------------------------------
 
     def calculate_in_sync(self, slot_state: SlotState) -> bool:
-        """Calculate whether slot should be in sync.
+        """
+        Calculate whether slot should be in sync.
 
         Active (state=ON): PIN should match code on lock.
         Inactive (state=OFF): Code on lock should be empty.
@@ -333,12 +339,10 @@ class SlotSyncManager:
                 # If we recently set a PIN on this slot and it matches the
                 # configured PIN, trust the set — the provider may not have
                 # caught up yet (eventual consistency, e.g. Schlage cloud API).
-                if (
+                return (
                     self._last_set_pin is not None
                     and slot_state.pin_state == self._last_set_pin
-                ):
-                    return True
-                return False  # need to set
+                )
             return slot_state.pin_state == lock_code
         # active_state == STATE_OFF: slot should be cleared
         # The "" check covers the fallback path where coordinator_code is None
@@ -349,7 +353,8 @@ class SlotSyncManager:
     # -- Sync execution ------------------------------------------------------
 
     async def _perform_sync(self, slot_state: SlotState) -> None:
-        """Execute sync operation (set or clear usercode).
+        """
+        Execute sync operation (set or clear usercode).
 
         Raises CodeRejectedError, LockDisconnected, or propagates any exception.
         Error handling is done by the caller (_async_tick).
@@ -441,7 +446,8 @@ class SlotSyncManager:
         self._sync_attempt_first = None
 
     def _record_sync_attempt(self) -> None:
-        """Record a sync attempt toward circuit breaker counter.
+        """
+        Record a sync attempt toward circuit breaker counter.
 
         Called for set operations. Successful clear operations and transient
         LockDisconnected errors are not tracked since they represent
@@ -475,7 +481,8 @@ class SlotSyncManager:
 
     @callback
     def _request_sync_check(self, *_args: Any) -> None:
-        """Request a sync check on the next tick.
+        """
+        Request a sync check on the next tick.
 
         Transitions IN_SYNC -> OUT_OF_SYNC if calculate_in_sync returns False
         (also resets circuit breaker since the sync target changed).
@@ -497,7 +504,8 @@ class SlotSyncManager:
     def _request_sync_check_if_relevant(
         self, event: Event[EventStateChangedData]
     ) -> None:
-        """Request sync check only if the state change is for a tracked entity.
+        """
+        Request sync check only if the state change is for a tracked entity.
 
         Used by the catch-all state tracking fallback to avoid unnecessary
         checks on every HA state change. Falls back to always-checking if
@@ -523,7 +531,8 @@ class SlotSyncManager:
         await self._async_tick_impl()
 
     async def _async_tick_impl(self) -> None:
-        """Core tick logic — called from _async_tick for LOADING and OUT_OF_SYNC states.
+        """
+        Core tick logic — called from _async_tick for LOADING and OUT_OF_SYNC states.
 
         This is the single authoritative place for all sync state mutations:
         circuit breaker tracking, sync operations, and ``_last_set_pin``
@@ -669,7 +678,7 @@ class SlotSyncManager:
             if not self._lock.supports_push:
                 try:
                     await self._coordinator.async_refresh()
-                except Exception:  # noqa: BLE001
+                except Exception:
                     _LOGGER.exception(
                         "%s: Coordinator refresh failed after sync operation. "
                         "Sync may have succeeded but verification failed. "
@@ -719,7 +728,8 @@ class SlotSyncManager:
 
     @callback
     def _try_upgrade_state_tracking(self) -> None:
-        """Upgrade catch-all state tracking to targeted if entities are now available.
+        """
+        Upgrade catch-all state tracking to targeted if entities are now available.
 
         Called at the start of each tick (outside any callback), so it is safe
         to modify subscriptions here without timing issues.
@@ -742,7 +752,8 @@ class SlotSyncManager:
 
     @callback
     def _setup_state_tracking(self) -> None:
-        """Set up state change tracking for dependent entities.
+        """
+        Set up state change tracking for dependent entities.
 
         If all entity IDs are available, tracks only those specific entities.
         Otherwise, tracks all state changes via a catch-all subscription that

--- a/custom_components/lock_code_manager/util.py
+++ b/custom_components/lock_code_manager/util.py
@@ -22,7 +22,8 @@ def mask_pin(
     slot_num: int | str,
     instance_id: str,
 ) -> str:
-    """Return a deterministic masked representation of a PIN for logging.
+    """
+    Return a deterministic masked representation of a PIN for logging.
 
     Uses CRC32 salted with the HA instance ID and slot number so the same
     PIN on the same slot always produces the same 8-char hex token regardless
@@ -45,7 +46,8 @@ async def async_disable_slot(
     lock_name: str | None = None,
     lock_entity_id: str | None = None,
 ) -> bool:
-    """Disable a slot via the enabled switch and optionally create a repair issue.
+    """
+    Disable a slot via the enabled switch and optionally create a repair issue.
 
     Returns True if the switch was found and turned off, False otherwise.
     When reason is provided, a repair issue is created so the user can

--- a/custom_components/lock_code_manager/websocket.py
+++ b/custom_components/lock_code_manager/websocket.py
@@ -126,9 +126,16 @@ def _get_text_state(hass: HomeAssistant, entity_id: str | None) -> str | None:
     """Get text state from an entity, returning None if unavailable."""
     if not entity_id:
         return None
-    if state := hass.states.get(entity_id):
-        if state.state and state.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
-            return state.state
+    if (
+        (state := hass.states.get(entity_id))
+        and state.state
+        and state.state
+        not in (
+            STATE_UNKNOWN,
+            STATE_UNAVAILABLE,
+        )
+    ):
+        return state.state
     return None
 
 
@@ -148,12 +155,19 @@ def _get_number_state(hass: HomeAssistant, entity_id: str | None) -> int | None:
     """Get integer state from a number entity, returning None if unavailable."""
     if not entity_id:
         return None
-    if state := hass.states.get(entity_id):
-        if state.state and state.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
-            try:
-                return int(float(state.state))
-            except ValueError, TypeError:
-                return None
+    if (
+        (state := hass.states.get(entity_id))
+        and state.state
+        and state.state
+        not in (
+            STATE_UNKNOWN,
+            STATE_UNAVAILABLE,
+        )
+    ):
+        try:
+            return int(float(state.state))
+        except ValueError, TypeError:
+            return None
     return None
 
 
@@ -470,9 +484,10 @@ def _get_slot_state_entity_ids(hass: HomeAssistant, lock_entity_id: str) -> list
 def _get_lock_friendly_name(hass: HomeAssistant, lock: BaseLock) -> str:
     """Get the friendly name for a lock, using state attributes as primary source."""
     # Prefer the friendly_name from state (what HA displays in the UI)
-    if state := hass.states.get(lock.lock.entity_id):
-        if friendly_name := state.attributes.get(ATTR_FRIENDLY_NAME):
-            return friendly_name
+    if (state := hass.states.get(lock.lock.entity_id)) and (
+        friendly_name := state.attributes.get(ATTR_FRIENDLY_NAME)
+    ):
+        return friendly_name
     # Fall back to entity registry name/original_name
     return lock.display_name
 
@@ -732,11 +747,12 @@ def _get_last_used_info(
         return None, None
     last_used = event_state.state
     last_used_lock_name: str | None = None
-    if last_used_lock_id := event_state.attributes.get("event_type"):
-        if lock_state := hass.states.get(last_used_lock_id):
-            last_used_lock_name = lock_state.attributes.get(
-                ATTR_FRIENDLY_NAME, last_used_lock_id
-            )
+    if (last_used_lock_id := event_state.attributes.get("event_type")) and (
+        lock_state := hass.states.get(last_used_lock_id)
+    ):
+        last_used_lock_name = lock_state.attributes.get(
+            ATTR_FRIENDLY_NAME, last_used_lock_id
+        )
     return last_used, last_used_lock_name
 
 
@@ -842,7 +858,7 @@ async def _get_next_calendar_event(
 
         return next_event_data if next_event_data else None
 
-    except Exception:  # noqa: BLE001 - Catch-all: calendar fetch is best-effort
+    except Exception:
         _LOGGER.debug("Failed to fetch next calendar event for %s", calendar_entity_id)
         return None
 
@@ -929,17 +945,18 @@ def _serialize_slot_card_data(
     # Conditions
     if number_of_uses is not None:
         result[CONF_CONDITIONS][CONF_NUMBER_OF_USES] = number_of_uses
-    if condition_entity_id:
-        # Include condition entity data (handles both calendar and non-calendar entities)
-        if condition_data := _get_condition_entity_data(hass, condition_entity_id):
-            result[CONF_CONDITIONS][ATTR_CONDITION_ENTITY] = condition_data
-            # Add next calendar event if available (for inactive calendar conditions)
-            if (
-                calendar_next_event
-                and condition_data.get(ATTR_CONDITION_ENTITY_DOMAIN) == CALENDAR_DOMAIN
-                and condition_data.get(ATTR_CONDITION_ENTITY_STATE) != STATE_ON
-            ):
-                condition_data[ATTR_CALENDAR_NEXT] = calendar_next_event
+    # Include condition entity data (handles both calendar and non-calendar entities)
+    if condition_entity_id and (
+        condition_data := _get_condition_entity_data(hass, condition_entity_id)
+    ):
+        result[CONF_CONDITIONS][ATTR_CONDITION_ENTITY] = condition_data
+        # Add next calendar event if available (for inactive calendar conditions)
+        if (
+            calendar_next_event
+            and condition_data.get(ATTR_CONDITION_ENTITY_DOMAIN) == CALENDAR_DOMAIN
+            and condition_data.get(ATTR_CONDITION_ENTITY_STATE) != STATE_ON
+        ):
+            condition_data[ATTR_CALENDAR_NEXT] = calendar_next_event
 
     return result
 
@@ -1124,7 +1141,8 @@ async def ws_set_usercode(
     connection: websocket_api.ActiveConnection,
     msg: dict[str, Any],
 ) -> None:
-    """Set a usercode on a lock slot.
+    """
+    Set a usercode on a lock slot.
 
     This is intended for managing unmanaged slots directly on the lock.
     For LCM-managed slots, use the entity services instead.
@@ -1136,7 +1154,7 @@ async def ws_set_usercode(
         connection.send_result(msg["id"], {"success": True})
     except ServiceValidationError as err:
         connection.send_error(msg["id"], websocket_api.const.ERR_NOT_FOUND, str(err))
-    except Exception as err:  # noqa: BLE001 - WS handler must catch all to send error response
+    except Exception as err:
         connection.send_error(
             msg["id"],
             websocket_api.const.ERR_UNKNOWN_ERROR,
@@ -1157,7 +1175,8 @@ async def ws_clear_usercode(
     connection: websocket_api.ActiveConnection,
     msg: dict[str, Any],
 ) -> None:
-    """Clear a usercode from a lock slot.
+    """
+    Clear a usercode from a lock slot.
 
     This is intended for managing unmanaged slots directly on the lock.
     For LCM-managed slots, use the entity services instead.
@@ -1167,7 +1186,7 @@ async def ws_clear_usercode(
         connection.send_result(msg["id"], {"success": True})
     except ServiceValidationError as err:
         connection.send_error(msg["id"], websocket_api.const.ERR_NOT_FOUND, str(err))
-    except Exception as err:  # noqa: BLE001 - WS handler must catch all to send error response
+    except Exception as err:
         connection.send_error(
             msg["id"],
             websocket_api.const.ERR_UNKNOWN_ERROR,
@@ -1192,7 +1211,8 @@ async def ws_set_slot_condition(
     msg: dict[str, Any],
     config_entry: ConfigEntry,
 ) -> None:
-    """Set a condition entity for a slot.
+    """
+    Set a condition entity for a slot.
 
     The condition entity must exist in hass.states and must not belong to an
     excluded platform (for example, the scheduler integration).

--- a/custom_components/lock_code_manager/websocket.py
+++ b/custom_components/lock_code_manager/websocket.py
@@ -166,7 +166,7 @@ def _get_number_state(hass: HomeAssistant, entity_id: str | None) -> int | None:
     ):
         try:
             return int(float(state.state))
-        except (ValueError, TypeError):
+        except ValueError, TypeError:
             return None
     return None
 

--- a/custom_components/lock_code_manager/websocket.py
+++ b/custom_components/lock_code_manager/websocket.py
@@ -166,7 +166,7 @@ def _get_number_state(hass: HomeAssistant, entity_id: str | None) -> int | None:
     ):
         try:
             return int(float(state.state))
-        except ValueError, TypeError:
+        except (ValueError, TypeError):
             return None
     return None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,17 +5,40 @@ requires-python = ">=3.14"
 
 [tool.ruff]
 target-version = "py314"
-lint.select = ["D", "E", "F", "G", "I", "PLC", "PLE", "PLR", "PLW", "UP", "W"]
+lint.select = [
+    "B",   # flake8-bugbear
+    "C4",  # flake8-comprehensions
+    "D",   # pydocstyle
+    "E",   # pycodestyle errors
+    "F",   # pyflakes
+    "G",   # flake8-logging-format
+    "I",   # isort
+    "PLC", # pylint conventions
+    "PLE", # pylint errors
+    "PLR", # pylint refactor
+    "PLW", # pylint warnings
+    "PTH", # flake8-use-pathlib
+    "RET", # flake8-return
+    "RUF", # ruff-specific
+    "SIM", # flake8-simplify
+    "UP",  # pyupgrade
+    "W",   # pycodestyle warnings
+]
+lint.extend-select = [
+    # Docstring style: summary on the line *below* opening ``"""``, with
+    # closing ``"""`` on its own line below the body. Single-line docstrings
+    # remain on one line.
+    "D213",
+]
 lint.ignore = [
     "D203",    # 1 blank line required before class docstring (conflicts with D211)
-    "D212",    # Multi-line docstring summary should start at the first line (conflicts with D213)
-    "D213",    # Multi-line docstring summary should start at the second line (conflicts with D212)
+    "D212",    # Multi-line summary on first line (conflicts with D213)
     "E501",    # Line too long
-    "PLR0911", # Too many return statements ({returns} > {max_returns})
-    "PLR0912", # Too many branches ({branches} > {max_branches})
-    "PLR0913", # Too many arguments to function call ({c_args} > {max_args})
-    "PLR0915", # Too many statements ({statements} > {max_statements})
-    "PLR2004", # Magic value used in comparison, consider replacing {value} with a constant variable
+    "PLR0911", # Too many return statements
+    "PLR0912", # Too many branches
+    "PLR0913", # Too many arguments
+    "PLR0915", # Too many statements
+    "PLR2004", # Magic value used in comparison
 ]
 exclude = [
     ".venv",
@@ -45,6 +68,12 @@ combine-as-imports = true
 
 [tool.ruff.lint.isort.sections]
 "homeassistant" = ["homeassistant"]
+
+[tool.ruff.lint.per-file-ignores]
+# Tests use nested with/if for fixture readability; SIM117/SIM102 don't
+# improve clarity there. RUF043 (regex match=) and bugbear are also too
+# noisy on test scaffolding.
+"tests/**/*.py" = ["B", "RUF", "D", "PLR", "SIM117", "SIM102", "SIM105"]
 
 
 [tool.pylint.MASTER]

--- a/scripts/setup
+++ b/scripts/setup
@@ -46,7 +46,7 @@ if [ -n "$DEVCONTAINER" ]; then
 fi
 
 if [ ! -n "$VIRTUAL_ENV" ];then
-  python3.13 -m venv venv
+  python3.14 -m venv venv
   source venv/bin/activate
 fi
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -97,7 +97,8 @@ class MockLCMLock(BaseLock):
         name: str | None = None,
         source: Literal["sync", "direct"] = "direct",
     ) -> bool:
-        """Set a usercode on a code slot.
+        """
+        Set a usercode on a code slot.
 
         Returns True if the value was changed, False if already set.
         """
@@ -108,7 +109,8 @@ class MockLCMLock(BaseLock):
         return True
 
     async def async_clear_usercode(self, code_slot: int) -> bool:
-        """Clear a usercode on a code slot.
+        """
+        Clear a usercode on a code slot.
 
         Returns True if the value was changed, False if already cleared.
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -199,7 +199,8 @@ def mock_calendars_fixture(
 
 
 def get_in_sync_entity_obj(hass: HomeAssistant, entity_id: str):
-    """Get the in-sync entity object for a given entity ID.
+    """
+    Get the in-sync entity object for a given entity ID.
 
     Returns the entity object from the entity component registry.
     """
@@ -212,7 +213,8 @@ def get_in_sync_entity_obj(hass: HomeAssistant, entity_id: str):
 async def async_trigger_sync_tick(
     hass: HomeAssistant, entity_id: str, set_dirty: bool = True
 ) -> None:
-    """Manually trigger a sync tick for an in-sync entity.
+    """
+    Manually trigger a sync tick for an in-sync entity.
 
     Encapsulates the pattern of forcing an entity into a tickable state and
     triggering an immediate tick, useful for testing tick-based sync behavior
@@ -229,7 +231,8 @@ async def async_trigger_sync_tick(
 
 
 async def async_initial_tick(hass: HomeAssistant, entity_id: str) -> None:
-    """Trigger initial tick for entity setup.
+    """
+    Trigger initial tick for entity setup.
 
     During entity setup, the initial tick in async_start may fail if dependent
     entities (active, code sensor) are not yet registered. This helper triggers
@@ -245,7 +248,8 @@ async def async_initial_tick(hass: HomeAssistant, entity_id: str) -> None:
 async def async_trigger_sync_tick_for_manager(
     hass: HomeAssistant, sync_manager, set_dirty: bool = True
 ) -> None:
-    """Manually trigger a sync tick for a sync manager object.
+    """
+    Manually trigger a sync tick for a sync manager object.
 
     Useful when you already have the entity object or need to trigger
     ticks on multiple managers in a loop.

--- a/tests/providers/akuvox/conftest.py
+++ b/tests/providers/akuvox/conftest.py
@@ -133,7 +133,8 @@ AKUVOX_LCM_CONFIG_SLOTS = {
 
 @pytest.fixture
 async def akuvox_lock_entity(hass: HomeAssistant) -> er.RegistryEntry:
-    """Create an Akuvox config entry (LOADED), device, and lock entity.
+    """
+    Create an Akuvox config entry (LOADED), device, and lock entity.
 
     Sets the config entry to LOADED state so the provider's
     async_is_integration_connected check passes.
@@ -170,7 +171,8 @@ def akuvox_mock_services(
     hass: HomeAssistant,
     akuvox_lock_entity: er.RegistryEntry,
 ) -> dict[str, AsyncMock]:
-    """Register mock Akuvox services needed for the full LCM setup path.
+    """
+    Register mock Akuvox services needed for the full LCM setup path.
 
     Returns a dict of service name to handler so E2E tests can inspect
     call counts or swap side effects.
@@ -206,7 +208,8 @@ async def e2e_lcm_config_entry(
     akuvox_lock_entity: er.RegistryEntry,
     akuvox_mock_services: dict[str, AsyncMock],
 ) -> AsyncGenerator[MockConfigEntry]:
-    """Set up a full LCM config entry managing the Akuvox lock.
+    """
+    Set up a full LCM config entry managing the Akuvox lock.
 
     This goes through the real async_setup_entry path: LCM discovers the
     lock entity is from the local_akuvox platform and instantiates AkuvoxLock.

--- a/tests/providers/akuvox/test_e2e.py
+++ b/tests/providers/akuvox/test_e2e.py
@@ -125,7 +125,8 @@ class TestGetUsercodes:
         akuvox_lock_entity: er.RegistryEntry,
         akuvox_mock_services: dict[str, AsyncMock],
     ) -> None:
-        """Get usercodes returns mapped slot data from Akuvox.
+        """
+        Get usercodes returns mapped slot data from Akuvox.
 
         After initial setup with empty users, both managed slots should
         be EMPTY. When the mock reports a tagged user with a PIN on

--- a/tests/providers/akuvox/test_provider.py
+++ b/tests/providers/akuvox/test_provider.py
@@ -395,7 +395,8 @@ class TestListUsersErrors:
         akuvox_lock: AkuvoxLock,
         lcm_config_entry: MockConfigEntry,
     ) -> None:
-        """Test that a non-dict service response raises LockDisconnected.
+        """
+        Test that a non-dict service response raises LockDisconnected.
 
         Home Assistant's service layer rejects non-dict return values when
         return_response=True, so the service call itself raises HomeAssistantError

--- a/tests/providers/helpers.py
+++ b/tests/providers/helpers.py
@@ -1,4 +1,5 @@
-"""Shared test mixins and helpers for service-based lock providers.
+"""
+Shared test mixins and helpers for service-based lock providers.
 
 Service-based providers (Matter, Schlage, Akuvox) communicate with their
 respective integrations via Home Assistant services. They share common
@@ -36,7 +37,8 @@ def register_mock_service(
     service_name: str,
     handler: AsyncMock,
 ) -> None:
-    """Register a mock service that supports responses.
+    """
+    Register a mock service that supports responses.
 
     Replaces the per-provider _register_<provider>_service helpers that were
     identical except for the domain string.
@@ -54,7 +56,8 @@ def register_mock_service(
 
 
 class ServiceProviderConnectionTests:
-    """Shared connection tests for service-based providers.
+    """
+    Shared connection tests for service-based providers.
 
     Service-based providers (Matter, Schlage, Akuvox) all use the same pattern
     for async_is_integration_connected: check that the lock's config entry exists
@@ -103,7 +106,8 @@ class ServiceProviderConnectionTests:
 
 
 class ServiceProviderDeviceAvailabilityTests:
-    """Shared device availability tests for providers that use service calls.
+    """
+    Shared device availability tests for providers that use service calls.
 
     Subclasses must define a class attribute:
         availability_service: str - the service name used to check availability

--- a/tests/providers/matter/conftest.py
+++ b/tests/providers/matter/conftest.py
@@ -128,7 +128,8 @@ async def matter_lock_simple(
 
 @pytest.fixture
 async def simple_lcm_config_entry(hass: HomeAssistant) -> MockConfigEntry:
-    """Create a Lock Code Manager config entry that manages slots 1 and 2.
+    """
+    Create a Lock Code Manager config entry that manages slots 1 and 2.
 
     This is a lightweight entry for unit tests that don't need the full LCM
     setup path. It only adds slot configuration data so that managed_slots
@@ -180,7 +181,8 @@ async def lock_entity(hass: HomeAssistant, matter_node: MatterNode) -> er.Regist
 
 @pytest.fixture
 def matter_mock_helpers() -> dict[str, AsyncMock]:
-    """Provide mock lock_helpers functions and patch them into the provider module.
+    """
+    Provide mock lock_helpers functions and patch them into the provider module.
 
     Returns a dict of helper name to AsyncMock so E2E tests can inspect
     call counts or swap side effects.
@@ -229,7 +231,8 @@ async def lcm_config_entry(
     lock_entity: er.RegistryEntry,
     matter_mock_helpers: dict[str, AsyncMock],
 ) -> MockConfigEntry:
-    """Set up a full LCM config entry managing the Matter lock.
+    """
+    Set up a full LCM config entry managing the Matter lock.
 
     This goes through the real async_setup_entry path: LCM discovers the
     lock entity is from the matter platform and instantiates MatterLock.

--- a/tests/providers/matter/test_e2e.py
+++ b/tests/providers/matter/test_e2e.py
@@ -94,7 +94,8 @@ class TestSetAndClearUsercodes:
         e2e_matter_lock: MatterLock,
         matter_mock_helpers: dict[str, AsyncMock],
     ) -> None:
-        """After set, the coordinator has the optimistic UNREADABLE_CODE value.
+        """
+        After set, the coordinator has the optimistic UNREADABLE_CODE value.
 
         Matter PINs are write-only so optimistic updates use UNREADABLE_CODE
         instead of the actual PIN value.
@@ -145,7 +146,8 @@ class TestGetUsercodes:
         lock_entity: er.RegistryEntry,
         matter_mock_helpers: dict[str, AsyncMock],
     ) -> None:
-        """Get usercodes returns slot occupancy from Matter.
+        """
+        Get usercodes returns slot occupancy from Matter.
 
         After initial setup with empty users, both managed slots should
         be EMPTY. When the mock reports a user with a PIN credential on

--- a/tests/providers/matter/test_provider.py
+++ b/tests/providers/matter/test_provider.py
@@ -186,11 +186,9 @@ async def test_setup_unsupported_lock(
         ),
         patch.object(matter_lock_simple, "_get_matter_node", return_value=MagicMock()),
         patch(f"{_PROVIDER_MODULE}.get_lock_info", mock_get_lock_info),
+        pytest.raises(LockCodeManagerError, match="does not support user management"),
     ):
-        with pytest.raises(
-            LockCodeManagerError, match="does not support user management"
-        ):
-            await matter_lock_simple.async_setup(simple_lcm_config_entry)
+        await matter_lock_simple.async_setup(simple_lcm_config_entry)
 
 
 async def test_setup_no_pin_support(
@@ -211,11 +209,9 @@ async def test_setup_no_pin_support(
         ),
         patch.object(matter_lock_simple, "_get_matter_node", return_value=MagicMock()),
         patch(f"{_PROVIDER_MODULE}.get_lock_info", mock_get_lock_info),
+        pytest.raises(LockCodeManagerError, match="does not support PIN credentials"),
     ):
-        with pytest.raises(
-            LockCodeManagerError, match="does not support PIN credentials"
-        ):
-            await matter_lock_simple.async_setup(simple_lcm_config_entry)
+        await matter_lock_simple.async_setup(simple_lcm_config_entry)
 
 
 # ---------------------------------------------------------------------------
@@ -695,11 +691,9 @@ async def test_get_usercodes_invalid_users_type(
         ),
         patch.object(matter_lock_simple, "_get_matter_node", return_value=MagicMock()),
         patch(f"{_PROVIDER_MODULE}.get_lock_users", mock_get_lock_users),
+        pytest.raises(LockCodeManagerProviderError, match="unexpected 'users' value"),
     ):
-        with pytest.raises(
-            LockCodeManagerProviderError, match="unexpected 'users' value"
-        ):
-            await matter_lock_simple.async_get_usercodes()
+        await matter_lock_simple.async_get_usercodes()
 
 
 async def test_set_credential_failed_non_duplicate_on_retry_raises_code_rejected(

--- a/tests/providers/schlage/conftest.py
+++ b/tests/providers/schlage/conftest.py
@@ -65,7 +65,8 @@ async def schlage_lock(
 
 @pytest.fixture
 async def simple_lcm_config_entry(hass: HomeAssistant) -> MockConfigEntry:
-    """Create a Lock Code Manager config entry that manages slots 1 and 2.
+    """
+    Create a Lock Code Manager config entry that manages slots 1 and 2.
 
     This is a lightweight entry for unit tests that don't need the full LCM
     setup path. It only adds slot configuration data so that managed_slots
@@ -116,7 +117,8 @@ def provider_lock_class() -> type[SchlageLock]:
 
 @pytest.fixture
 async def schlage_lock_entity(hass: HomeAssistant) -> er.RegistryEntry:
-    """Create a Schlage config entry (LOADED state) and lock entity.
+    """
+    Create a Schlage config entry (LOADED state) and lock entity.
 
     The lock entity is registered under the "schlage" platform so that
     LCM's INTEGRATIONS_CLASS_MAP lookup finds it as a SchlageLock.
@@ -142,7 +144,8 @@ def schlage_mock_services(
     hass: HomeAssistant,
     schlage_lock_entity: er.RegistryEntry,
 ) -> dict[str, AsyncMock]:
-    """Register mock Schlage services needed for the full LCM setup path.
+    """
+    Register mock Schlage services needed for the full LCM setup path.
 
     Returns a dict of service name to handler so E2E tests can inspect
     call counts or swap side effects.
@@ -171,7 +174,8 @@ async def lcm_config_entry(
     schlage_lock_entity: er.RegistryEntry,
     schlage_mock_services: dict[str, AsyncMock],
 ) -> MockConfigEntry:
-    """Set up a full LCM config entry managing the Schlage lock.
+    """
+    Set up a full LCM config entry managing the Schlage lock.
 
     This goes through the real async_setup_entry path: LCM discovers the
     lock entity is from the schlage platform and instantiates SchlageLock.

--- a/tests/providers/schlage/test_e2e.py
+++ b/tests/providers/schlage/test_e2e.py
@@ -94,7 +94,8 @@ class TestSetAndClearUsercodes:
         schlage_lock_entity: er.RegistryEntry,
         schlage_mock_services: dict[str, AsyncMock],
     ) -> None:
-        """After a coordinator refresh, data reflects the lock state.
+        """
+        After a coordinator refresh, data reflects the lock state.
 
         Schlage is not a push provider, so the coordinator reads state
         from the lock via get_codes. When the mock reports a tagged code
@@ -150,7 +151,8 @@ class TestGetUsercodes:
         schlage_lock_entity: er.RegistryEntry,
         schlage_mock_services: dict[str, AsyncMock],
     ) -> None:
-        """Get usercodes returns slot occupancy from Schlage.
+        """
+        Get usercodes returns slot occupancy from Schlage.
 
         After initial setup with empty codes, both managed slots should
         be EMPTY. When the mock reports a tagged code on slot 1, that

--- a/tests/providers/schlage/test_provider.py
+++ b/tests/providers/schlage/test_provider.py
@@ -336,7 +336,8 @@ async def test_set_usercode_replaces_existing(
 async def test_set_usercode_preserves_existing_name(
     hass: HomeAssistant, schlage_lock: SchlageLock
 ) -> None:
-    """Test set_usercode preserves the existing friendly name when no name is provided.
+    """
+    Test set_usercode preserves the existing friendly name when no name is provided.
 
     When the name does not change (PIN-only update), the old code must be deleted
     first because Schlage rejects add_code with a duplicate name.
@@ -375,7 +376,8 @@ async def test_set_usercode_preserves_existing_name(
 async def test_set_usercode_already_exists_treated_as_success(
     hass: HomeAssistant, schlage_lock: SchlageLock
 ) -> None:
-    """Test that 'already exists' on add_code is treated as success.
+    """
+    Test that 'already exists' on add_code is treated as success.
 
     Schlage's cloud API has eventual consistency: a delete may not propagate
     before the add, causing 'already exists'.  Since PINs are write-only,

--- a/tests/providers/test_base.py
+++ b/tests/providers/test_base.py
@@ -364,7 +364,8 @@ async def test_async_call_service_propagates_non_ha_exceptions(
     mock_lock_config_entry,
     lock_code_manager_config_entry,
 ):
-    """Non-HomeAssistantError exceptions must propagate, not become LockDisconnected.
+    """
+    Non-HomeAssistantError exceptions must propagate, not become LockDisconnected.
 
     Wrapping programming errors (TypeError) or shutdown signals
     (asyncio.CancelledError) as LockDisconnected would trigger false
@@ -388,7 +389,8 @@ async def test_async_call_service_wraps_os_error_as_lock_disconnected(
     mock_lock_config_entry,
     lock_code_manager_config_entry,
 ):
-    """Test that async_call_service wraps OSError (e.g. ReadTimeout) as LockDisconnected.
+    """
+    Test that async_call_service wraps OSError (e.g. ReadTimeout) as LockDisconnected.
 
     Integrations that don't wrap network errors in HomeAssistantError raise raw
     OSError subclasses (TimeoutError, ConnectionError).  These are transient and

--- a/tests/providers/virtual/conftest.py
+++ b/tests/providers/virtual/conftest.py
@@ -93,7 +93,8 @@ async def virtual_lock_with_slots(hass: HomeAssistant) -> VirtualLock:
 
 @pytest.fixture
 async def virtual_lock_entity(hass: HomeAssistant) -> er.RegistryEntry:
-    """Create a virtual config entry and lock entity.
+    """
+    Create a virtual config entry and lock entity.
 
     The lock entity is registered under the "virtual" platform so that
     LCM's INTEGRATIONS_CLASS_MAP lookup finds it as a VirtualLock.
@@ -119,7 +120,8 @@ async def lcm_config_entry(
     hass: HomeAssistant,
     virtual_lock_entity: er.RegistryEntry,
 ) -> MockConfigEntry:
-    """Set up a full LCM config entry managing the virtual lock.
+    """
+    Set up a full LCM config entry managing the virtual lock.
 
     This goes through the real async_setup_entry path: LCM discovers the
     lock entity is from the virtual platform and instantiates VirtualLock.

--- a/tests/providers/zigbee2mqtt/conftest.py
+++ b/tests/providers/zigbee2mqtt/conftest.py
@@ -35,7 +35,8 @@ Z2M_LOCK_UNIQUE_ID = "test_z2m"
 
 @dataclass
 class MqttMessageBus:
-    """Lightweight MQTT message bus for E2E testing.
+    """
+    Lightweight MQTT message bus for E2E testing.
 
     Tracks subscriptions and publishes so tests can fire incoming messages
     and verify outgoing publishes without a real Paho client.
@@ -64,7 +65,8 @@ class MqttMessageBus:
         self.publishes.append((topic, payload))
 
     def fire_message(self, topic: str, payload: dict[str, Any]) -> None:
-        """Simulate an incoming MQTT message on a topic.
+        """
+        Simulate an incoming MQTT message on a topic.
 
         Creates a ReceiveMessage-like object and dispatches to all
         registered callbacks for the topic.
@@ -104,7 +106,8 @@ def mqtt_bus() -> MqttMessageBus:
 
 @pytest.fixture
 def mqtt_patches(mqtt_bus: MqttMessageBus):
-    """Patch async_subscribe and async_publish at the HA MQTT component boundary.
+    """
+    Patch async_subscribe and async_publish at the HA MQTT component boundary.
 
     Also patches mqtt_config_entry_enabled to return True so the provider
     does not bail out during setup.
@@ -155,7 +158,8 @@ def mqtt_patches(mqtt_bus: MqttMessageBus):
 
 @pytest.fixture
 async def mqtt_lock_entity(hass: HomeAssistant) -> er.RegistryEntry:
-    """Create an MQTT config entry, Z2M device, and lock entity.
+    """
+    Create an MQTT config entry, Z2M device, and lock entity.
 
     Sets the MQTT config entry to LOADED state so the provider's
     async_is_integration_connected check passes.
@@ -193,7 +197,8 @@ async def lcm_config_entry(
     mqtt_lock_entity: er.RegistryEntry,
     mqtt_patches,
 ) -> MockConfigEntry:
-    """Set up a full LCM config entry managing the Z2M lock.
+    """
+    Set up a full LCM config entry managing the Z2M lock.
 
     This goes through the real async_setup_entry path: LCM discovers the
     lock entity is from the mqtt platform, instantiates Zigbee2MQTTLock,

--- a/tests/providers/zigbee2mqtt/test_e2e.py
+++ b/tests/providers/zigbee2mqtt/test_e2e.py
@@ -184,7 +184,8 @@ class TestGetUsercodes:
         z2m_lock,
         mqtt_bus: MqttMessageBus,
     ) -> None:
-        """async_get_usercodes publishes GET requests for all managed slots.
+        """
+        async_get_usercodes publishes GET requests for all managed slots.
 
         The auto-responder in the fixture responds with empty slots,
         so the result should contain EMPTY for each slot.

--- a/tests/providers/zwave_js/conftest.py
+++ b/tests/providers/zwave_js/conftest.py
@@ -33,7 +33,7 @@ FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
 def load_json_fixture(filename: str) -> dict[str, Any]:
     """Load a fixture JSON file."""
-    with open(FIXTURES_DIR / filename, encoding="utf-8") as f:
+    with (FIXTURES_DIR / filename).open(encoding="utf-8") as f:
         return json.load(f)
 
 
@@ -252,7 +252,8 @@ async def lcm_config_entry(
     zwave_integration: MockConfigEntry,
     lock_entity: er.RegistryEntry,
 ) -> MockConfigEntry:
-    """Set up a full LCM config entry managing the Z-Wave JS lock.
+    """
+    Set up a full LCM config entry managing the Z-Wave JS lock.
 
     This goes through the real async_setup_entry path: LCM discovers the
     lock entity is from the zwave_js platform and instantiates ZWaveJSLock.

--- a/tests/providers/zwave_js/test_e2e.py
+++ b/tests/providers/zwave_js/test_e2e.py
@@ -123,7 +123,8 @@ class TestGetUsercodes:
         hass: HomeAssistant,
         e2e_zwave_lock: ZWaveJSLock,
     ) -> None:
-        """Get usercodes returns the fixture's cached codes.
+        """
+        Get usercodes returns the fixture's cached codes.
 
         The node fixture has slot 1="9999" (in_use), slot 2="1234" (in_use),
         and slot 3=empty (not in_use).
@@ -144,7 +145,8 @@ class TestEvents:
         e2e_zwave_lock: ZWaveJSLock,
         lock_schlage_be469: Node,
     ) -> None:
-        """Fire a Z-Wave notification event and verify LCM processes it.
+        """
+        Fire a Z-Wave notification event and verify LCM processes it.
 
         A keypad lock notification (type 6, event 5) should be handled by the
         provider's event listener. We verify the listener is active by checking

--- a/tests/providers/zwave_js/test_events.py
+++ b/tests/providers/zwave_js/test_events.py
@@ -88,7 +88,8 @@ def _make_duplicate_code_event(node_id: int, user_id: int | None = None) -> Zwav
 
 @pytest.fixture(autouse=True)
 def mock_get_usercode_from_node():
-    """Mock get_usercode_from_node for all tests.
+    """
+    Mock get_usercode_from_node for all tests.
 
     V1 set/clear calls get_usercode_from_node to poll the slot from the device.
     In tests, the node doesn't have a real Z-Wave JS server connection, so we
@@ -123,7 +124,8 @@ async def zwave_js_lock_fixture(
 
 @pytest.fixture
 def mock_zwave_usercodes(zwave_client: MagicMock):
-    """Mock Z-Wave JS usercode functions with mutable state.
+    """
+    Mock Z-Wave JS usercode functions with mutable state.
 
     Both ``get_usercodes`` and ``get_usercode`` read from a shared mutable
     ``codes`` dict.  The client's ``async_send_command`` is wrapped so that
@@ -1158,7 +1160,8 @@ async def test_internal_set_usercode_raises_duplicate_for_rejected_slot(
     lock_schlage_be469: Node,
     mock_zwave_usercodes: tuple[MagicMock, MagicMock, dict[int, dict]],
 ) -> None:
-    """Test async_internal_set_usercode raises DuplicateCodeError for rejected slots.
+    """
+    Test async_internal_set_usercode raises DuplicateCodeError for rejected slots.
 
     When a slot is in _rejected_code_slots (marked by event 15), the next call to
     async_internal_set_usercode should raise DuplicateCodeError without calling the

--- a/tests/providers/zwave_js/test_provider.py
+++ b/tests/providers/zwave_js/test_provider.py
@@ -37,14 +37,13 @@ async def zwave_js_lock_fixture(
     dev_reg = dr.async_get(hass)
     ent_reg = er.async_get(hass)
 
-    lock = ZWaveJSLock(
+    return ZWaveJSLock(
         hass=hass,
         dev_reg=dev_reg,
         ent_reg=ent_reg,
         lock_config_entry=zwave_integration,
         lock=lock_entity,
     )
-    return lock
 
 
 @pytest.fixture(autouse=True)
@@ -275,7 +274,8 @@ async def test_set_usercode_proceeds_on_cache_failure(
     zwave_js_lock: ZWaveJSLock,
     zwave_integration: MockConfigEntry,
 ) -> None:
-    """Test that set_usercode proceeds when the cache lookup raises.
+    """
+    Test that set_usercode proceeds when the cache lookup raises.
 
     A stale or missing cache entry must not block the set operation —
     the bare-except in the cache short-circuit guards against this.
@@ -318,7 +318,8 @@ async def test_clear_usercode_proceeds_on_cache_failure(
     zwave_js_lock: ZWaveJSLock,
     zwave_integration: MockConfigEntry,
 ) -> None:
-    """Test that clear_usercode proceeds when the cache lookup raises.
+    """
+    Test that clear_usercode proceeds when the cache lookup raises.
 
     Mirrors test_set_usercode_proceeds_on_cache_failure for the clear path.
     """
@@ -512,7 +513,8 @@ async def test_v1_set_usercode_poll_failure_raises_lock_disconnected(
     zwave_integration: MockConfigEntry,
     mock_get_usercode_from_node,
 ) -> None:
-    """Test that a V1 set poll failure raises LockDisconnected.
+    """
+    Test that a V1 set poll failure raises LockDisconnected.
 
     When get_usercode_from_node raises after a V1 set operation, the error
     should be wrapped as LockDisconnected so it routes into the retry path
@@ -542,7 +544,8 @@ async def test_v1_clear_usercode_poll_failure_raises_lock_disconnected(
     zwave_integration: MockConfigEntry,
     mock_get_usercode_from_node,
 ) -> None:
-    """Test that a V1 clear poll failure raises LockDisconnected.
+    """
+    Test that a V1 clear poll failure raises LockDisconnected.
 
     When get_usercode_from_node raises after a V1 clear operation, the error
     should be wrapped as LockDisconnected so it routes into the retry path
@@ -572,7 +575,8 @@ async def test_v1_set_usercode_poll_non_zwave_error_propagates(
     zwave_integration: MockConfigEntry,
     mock_get_usercode_from_node,
 ) -> None:
-    """Non-Z-Wave errors from V1 post-set poll propagate uncaught.
+    """
+    Non-Z-Wave errors from V1 post-set poll propagate uncaught.
 
     Only FailedZWaveCommand is wrapped as LockDisconnected. Other
     exceptions (programming errors) should propagate so the sync

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -1009,7 +1009,8 @@ async def test_sync_tracker_does_not_fire_breaker_with_expired_window(
     mock_lock_config_entry,
     lock_code_manager_config_entry,
 ):
-    """Test that stale sync attempts outside the window do not trigger the circuit breaker.
+    """
+    Test that stale sync attempts outside the window do not trigger the circuit breaker.
 
     When the attempt window expires, _record_sync_attempt resets the counter,
     preventing stale counts from triggering the breaker on a new sync cycle.
@@ -1534,7 +1535,8 @@ async def test_push_update_during_sync_operation_does_not_corrupt_state(
     mock_lock_config_entry,
     lock_code_manager_config_entry,
 ):
-    """A coordinator push_update during _perform_sync does not corrupt the state machine.
+    """
+    A coordinator push_update during _perform_sync does not corrupt the state machine.
 
     Scenario: sync manager is SYNCING (awaiting set_usercode). While waiting,
     the coordinator gets a push_update with different data. The _request_sync_check
@@ -1608,7 +1610,8 @@ async def test_sync_manager_stop_during_active_sync_does_not_raise(
     hass: HomeAssistant,
     mock_lock_config_entry,
 ):
-    """Stopping the sync manager while a sync tick is in progress does not raise.
+    """
+    Stopping the sync manager while a sync tick is in progress does not raise.
 
     Scenario: sync manager is SYNCING. Config entry unloads, calling async_stop()
     which sets _started = False. The tick should gracefully finish or bail out.
@@ -1676,7 +1679,8 @@ async def test_pin_change_during_sync_uses_snapshot(
     mock_lock_config_entry,
     lock_code_manager_config_entry,
 ):
-    """Sync uses the PIN snapshot captured at tick start, not live state.
+    """
+    Sync uses the PIN snapshot captured at tick start, not live state.
 
     The sync manager's _async_tick_impl captures slot_state (including PIN)
     synchronously before any awaits. The PIN passed to _perform_sync is the
@@ -1762,7 +1766,8 @@ async def test_coordinator_refresh_failure_after_sync_retries_on_next_tick(
     mock_lock_config_entry,
     lock_code_manager_config_entry,
 ):
-    """If coordinator refresh fails after a successful sync, retry on next tick.
+    """
+    If coordinator refresh fails after a successful sync, retry on next tick.
 
     This exercises the try/except around coordinator.async_refresh() in
     _async_tick_impl. The sync succeeded but we cannot verify it.
@@ -1821,7 +1826,8 @@ async def test_multiple_slots_sync_sequentially_not_concurrently(
     hass: HomeAssistant,
     mock_lock_config_entry,
 ):
-    """Each slot's sync operation runs sequentially via the lock's asyncio lock.
+    """
+    Each slot's sync operation runs sequentially via the lock's asyncio lock.
 
     Two slots out of sync should not cause concurrent set_usercode calls
     on the same lock -- the _aio_lock serializes them.
@@ -1916,7 +1922,8 @@ async def test_slot_disabled_during_sync_resolves_correctly(
     mock_lock_config_entry,
     lock_code_manager_config_entry,
 ):
-    """Disabling a slot while sync is pending causes a clear instead of a set.
+    """
+    Disabling a slot while sync is pending causes a clear instead of a set.
 
     Scenario: slot is OUT_OF_SYNC, user disables the slot via the enabled switch.
     Next tick should see active_state=OFF and clear the code instead of setting it.
@@ -1978,7 +1985,8 @@ async def test_rapid_coordinator_updates_coalesce(
     mock_lock_config_entry,
     lock_code_manager_config_entry,
 ):
-    """Multiple rapid push_updates do not cause problems.
+    """
+    Multiple rapid push_updates do not cause problems.
 
     _request_sync_check should be idempotent -- calling it many times while
     in OUT_OF_SYNC should not cause issues, and the sync manager should use

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -240,12 +240,9 @@ async def test_config_flow_reauth(
         hass, context={"lock_entity_id": LOCK_1_ENTITY_ID}
     )
     await hass.async_block_till_done()
-    flows = [
-        flow
-        for flow in lock_code_manager_config_entry.async_get_active_flows(
-            hass, {SOURCE_REAUTH}
-        )
-    ]
+    flows = list(
+        lock_code_manager_config_entry.async_get_active_flows(hass, {SOURCE_REAUTH})
+    )
     assert len(flows) == 1
     [result] = flows
 
@@ -593,7 +590,8 @@ async def test_async_get_all_codes_exception(hass: HomeAssistant):
 async def test_async_get_all_codes_provider_failure_logs_warning(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ):
-    """Provider raising LockCodeManagerProviderError logs WARNING (not DEBUG).
+    """
+    Provider raising LockCodeManagerProviderError logs WARNING (not DEBUG).
 
     Distinguishes a real failure (LockDisconnected, a provider error) from
     the expected setup-time skip cases (missing entity / unsupported
@@ -640,7 +638,8 @@ async def test_async_get_all_codes_provider_failure_logs_warning(
 async def test_async_get_all_codes_bare_base_error_logs_warning(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ):
-    """Defensive: a provider raising the bare base LockCodeManagerError still warns.
+    """
+    Defensive: a provider raising the bare base LockCodeManagerError still warns.
 
     All in-tree providers raise LockCodeManagerProviderError, but a third-party
     or not-yet-migrated provider could raise the bare base. We catch and warn
@@ -687,7 +686,8 @@ async def test_async_get_all_codes_bare_base_error_logs_warning(
 
 
 async def test_async_get_all_codes_returns_all_codes(hass: HomeAssistant):
-    """Test _async_get_all_codes returns every slot the lock reports.
+    """
+    Test _async_get_all_codes returns every slot the lock reports.
 
     Filtering empty slots is the caller's responsibility, so this function
     must not drop them.
@@ -865,7 +865,8 @@ async def _start_options_flow(
     locks: list[str] | None = None,
     slots: dict[int, dict] | None = None,
 ) -> tuple[str, MockConfigEntry]:
-    """Create an options flow and return (flow_id, entry).
+    """
+    Create an options flow and return (flow_id, entry).
 
     Mirrors the existing config-flow test helpers: keeps the entry creation
     and options-flow init in one place so the individual tests stay focused

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -783,7 +783,8 @@ async def test_lock_offline_issue_persists_across_shutdown(
     poll_lock: MockLCMLock,
     hass: HomeAssistant,
 ) -> None:
-    """Test that lock_offline repair issue persists across coordinator shutdown.
+    """
+    Test that lock_offline repair issue persists across coordinator shutdown.
 
     The issue is persistent and only cleaned up on entry unload or recovery.
     """

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -85,7 +85,8 @@ def test_diff_no_changes() -> None:
 
 
 def test_diff_str_keys_match_int_keys() -> None:
-    """Stored data has str slot keys; voluptuous output has int.
+    """
+    Stored data has str slot keys; voluptuous output has int.
 
     EntryConfig.from_mapping normalizes keys to int up front, so by the
     time the diff is computed both sides are int-keyed and ``"1"`` /
@@ -121,7 +122,8 @@ def test_diff_slot_dicts_always_int_keyed() -> None:
 
 
 def test_diff_pair_added_for_new_lock_with_existing_slot() -> None:
-    """A new lock with a slot already managed elsewhere is a NEW pair.
+    """
+    A new lock with a slot already managed elsewhere is a NEW pair.
 
     This is the key options-flow case: user has lock.a managing slot 1,
     then adds lock.b — (lock.b, 1) is a brand-new pair to scan, even
@@ -165,7 +167,8 @@ def test_subtraction_operator_is_diff_sugar() -> None:
 
 
 def test_subtraction_with_non_entry_config_raises_type_error() -> None:
-    """``cfg - non_config`` returns NotImplemented -> Python raises TypeError.
+    """
+    ``cfg - non_config`` returns NotImplemented -> Python raises TypeError.
 
     Without the isinstance guard, the operator would succeed and the
     error would surface deep inside EntryConfigDiff.__post_init__ as
@@ -184,7 +187,8 @@ def test_subtraction_with_non_entry_config_raises_type_error() -> None:
 
 
 def test_diff_is_deeply_immutable() -> None:
-    """EntryConfigDiff fields are immutable containers — safe as cached state.
+    """
+    EntryConfigDiff fields are immutable containers — safe as cached state.
 
     The dataclass is frozen (attribute reassignment blocked) AND the
     contained dicts/sets/lists are immutable variants
@@ -228,7 +232,8 @@ def test_diff_is_deeply_immutable() -> None:
 
 
 def test_diff_snapshots_inner_slot_dicts() -> None:
-    """Mutating the source slot config after diff is built doesn't leak in.
+    """
+    Mutating the source slot config after diff is built doesn't leak in.
 
     The defensive ``dict(v)`` copy inside __post_init__ snapshots slot
     configs at construction time — later mutations to the original
@@ -259,7 +264,8 @@ def test_entry_config_empty() -> None:
 
 
 def test_entry_config_from_mapping_normalizes_str_slot_keys_to_int() -> None:
-    """from_mapping normalizes str slot keys (JSON storage) to int.
+    """
+    from_mapping normalizes str slot keys (JSON storage) to int.
 
     The whole point of EntryConfig: every consumer sees int keys
     regardless of how the config was loaded.
@@ -268,11 +274,12 @@ def test_entry_config_from_mapping_normalizes_str_slot_keys_to_int() -> None:
         {CONF_LOCKS: ["lock.a"], CONF_SLOTS: {"1": _slot(), "2": _slot()}}
     )
     assert set(config.slots.keys()) == {1, 2}
-    assert all(isinstance(k, int) for k in config.slots.keys())
+    assert all(isinstance(k, int) for k in config.slots)
 
 
 def test_entry_config_accessors_absorb_str_or_int_slot_num() -> None:
-    """has_slot / slot accept either type and normalize internally.
+    """
+    has_slot / slot accept either type and normalize internally.
 
     Lets callers stop carrying ``int(slot_num)`` casts at every read
     site. The internal storage is still ``int``-keyed; the accessors
@@ -340,7 +347,8 @@ def test_entry_config_is_deeply_immutable() -> None:
 
 
 def test_get_entry_config_uses_runtime_data_when_present() -> None:
-    """get_entry_config returns the cached EntryConfig from runtime_data.
+    """
+    get_entry_config returns the cached EntryConfig from runtime_data.
 
     No fresh construction — same instance is returned, allowing the
     listener's cache to act as a true singleton view of the entry.
@@ -364,7 +372,8 @@ def test_get_entry_config_uses_runtime_data_when_present() -> None:
 
 
 def test_get_entry_config_falls_back_when_no_runtime_data() -> None:
-    """get_entry_config builds fresh from raw data if runtime_data is absent.
+    """
+    get_entry_config builds fresh from raw data if runtime_data is absent.
 
     Covers iteration over hass.config_entries.async_entries(DOMAIN) which
     may yield entries not yet loaded.
@@ -382,7 +391,8 @@ def test_get_entry_config_falls_back_when_no_runtime_data() -> None:
 
 
 def test_get_entry_config_falls_back_when_runtime_data_lacks_config() -> None:
-    """If runtime_data exists but doesn't have a .config attr, fall back.
+    """
+    If runtime_data exists but doesn't have a .config attr, fall back.
 
     Defends against the brief window during async_setup_entry before
     runtime_data.config is initialized.
@@ -475,7 +485,8 @@ def test_with_slot_field_removed_is_noop_when_absent() -> None:
 
 
 def test_to_dict_round_trips_through_from_mapping() -> None:
-    """to_dict → from_mapping reconstructs an equivalent EntryConfig.
+    """
+    to_dict → from_mapping reconstructs an equivalent EntryConfig.
 
     Guards the write path used by entity._update_config_entry and the
     helpers write functions: they build a new EntryConfig, call
@@ -496,7 +507,8 @@ def test_to_dict_round_trips_through_from_mapping() -> None:
 
 
 def test_to_dict_produces_plain_mutable_dicts() -> None:
-    """to_dict output is plain dict (not MappingProxyType).
+    """
+    to_dict output is plain dict (not MappingProxyType).
 
     HA's async_update_entry expects a plain dict it can serialize; the
     read-only wrappers EntryConfig uses internally would break that.

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -83,7 +83,8 @@ async def test_device_diagnostics_lock_device(
     mock_lock_config_entry,
     lock_code_manager_config_entry,
 ) -> None:
-    """Test device diagnostics for a lock device.
+    """
+    Test device diagnostics for a lock device.
 
     The test mock may not create a device_entry for the lock. If that's the
     case, verify the fallback to config entry diagnostics instead.

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -166,7 +166,8 @@ def test_lock_disconnected_inherits_from_provider_error():
 
 
 def test_entity_not_found_is_not_a_provider_error(hass: HomeAssistant):
-    """EntityNotFoundError is LCM-internal, NOT a provider error.
+    """
+    EntityNotFoundError is LCM-internal, NOT a provider error.
 
     This split lets callers catch only real provider failures via
     ``except LockCodeManagerProviderError`` without also swallowing

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -215,12 +215,11 @@ async def test_reauth(hass: HomeAssistant, lock_code_manager_config_entry):
     """Test reauth."""
     assert (
         len(
-            [
-                flow
-                for flow in lock_code_manager_config_entry.async_get_active_flows(
+            list(
+                lock_code_manager_config_entry.async_get_active_flows(
                     hass, {SOURCE_REAUTH}
                 )
-            ]
+            )
         )
         == 1
     )
@@ -1026,7 +1025,8 @@ async def test_two_entries_same_lock_share_suspension_and_recovery(
     mock_lock_config_entry,
     lock_code_manager_config_entry,
 ):
-    """Suspension on one entry's slot affects another entry's out-of-sync slots on the same lock.
+    """
+    Suspension on one entry's slot affects another entry's out-of-sync slots on the same lock.
 
     Lock-level suspension is by design: when one slot's circuit breaker trips,
     ALL sync managers on that lock are blocked from syncing. This prevents a

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -1,6 +1,7 @@
 """Test websockets."""
 
 import asyncio
+import contextlib
 from datetime import datetime
 import logging
 from unittest.mock import AsyncMock, patch
@@ -1038,10 +1039,8 @@ async def test_pin_set_via_service_reflects_in_subscribe_code_slot(
                 if result["pin"] == "9999":
                     return
 
-    try:
+    with contextlib.suppress(TimeoutError):
         await asyncio.wait_for(_wait_for_pin(), timeout=3.0)
-    except TimeoutError:
-        pass
 
     assert result["pin"] == "9999"
 
@@ -1052,7 +1051,8 @@ async def test_pin_clear_via_service_reflects_in_subscribe_code_slot(
     lock_code_manager_config_entry,
     hass_ws_client: WebSocketGenerator,
 ) -> None:
-    """Test that clearing a PIN via service call is reflected in the subscription.
+    """
+    Test that clearing a PIN via service call is reflected in the subscription.
 
     The integration rejects clearing a PIN on an enabled slot, so we must
     disable the slot first before clearing.
@@ -1107,10 +1107,8 @@ async def test_pin_clear_via_service_reflects_in_subscribe_code_slot(
                 if result["pin"] is None:
                     return
 
-    try:
+    with contextlib.suppress(TimeoutError):
         await asyncio.wait_for(_wait_for_cleared_pin(), timeout=3.0)
-    except TimeoutError:
-        pass
 
     assert result["pin"] is None
 
@@ -1254,7 +1252,8 @@ async def test_set_slot_condition_reflects_in_subscribe_code_slot(
     lock_code_manager_config_entry,
     hass_ws_client: WebSocketGenerator,
 ) -> None:
-    """Test that updating a slot condition is visible in a new subscription.
+    """
+    Test that updating a slot condition is visible in a new subscription.
 
     The subscribe_code_slot handler resolves tracked entities at subscription
     time, so a condition added after subscribing requires a new subscription
@@ -2427,7 +2426,8 @@ async def test_subscribe_lock_codes_entity_tracking_refreshes_on_update(
     lock_code_manager_config_entry,
     hass_ws_client: WebSocketGenerator,
 ) -> None:
-    """Test that subscribe_lock_codes re-subscribes when tracked entity set changes.
+    """
+    Test that subscribe_lock_codes re-subscribes when tracked entity set changes.
 
     Verifies the _refresh_lock_state_tracking path where new entities appear
     after the subscription was established (for example, during initial config
@@ -2491,7 +2491,8 @@ async def test_subscribe_lock_codes_tracking_refresh_noop_when_unchanged(
     lock_code_manager_config_entry,
     hass_ws_client: WebSocketGenerator,
 ) -> None:
-    """Test that _refresh_lock_state_tracking is a no-op when entity set is unchanged.
+    """
+    Test that _refresh_lock_state_tracking is a no-op when entity set is unchanged.
 
     When the tracked entity set has not changed between updates, the refresh
     should return early without re-subscribing. This verifies the early-return
@@ -2539,7 +2540,8 @@ async def test_subscribe_code_slot_entity_tracking_refreshes_on_update(
     lock_code_manager_config_entry,
     hass_ws_client: WebSocketGenerator,
 ) -> None:
-    """Test that subscribe_code_slot re-subscribes when tracked entity set changes.
+    """
+    Test that subscribe_code_slot re-subscribes when tracked entity set changes.
 
     Verifies the _refresh_state_tracking path in subscribe_code_slot where
     new entities appear after the subscription was established.
@@ -2610,7 +2612,8 @@ async def test_subscribe_code_slot_calendar_condition_state_change(
     lock_code_manager_config_entry,
     hass_ws_client: WebSocketGenerator,
 ) -> None:
-    """Test that calendar condition entity state changes trigger async calendar fetch.
+    """
+    Test that calendar condition entity state changes trigger async calendar fetch.
 
     When a calendar entity that is the condition entity for a slot changes state,
     the _on_state_change handler should call _async_send_update_with_calendar
@@ -2677,7 +2680,8 @@ async def test_subscribe_code_slot_condition_entity_tracked_after_addition(
     lock_code_manager_config_entry,
     hass_ws_client: WebSocketGenerator,
 ) -> None:
-    """Test that a newly added condition entity gets tracked after refresh.
+    """
+    Test that a newly added condition entity gets tracked after refresh.
 
     Subscribe to slot 1 (no condition), then simulate adding a condition
     entity via _resolve_entity_ids returning it on subsequent calls.
@@ -2739,7 +2743,8 @@ async def test_subscribe_lock_codes_unsub_all_with_empty_state_ref(
     lock_code_manager_config_entry,
     hass_ws_client: WebSocketGenerator,
 ) -> None:
-    """Test that _unsub_all handles empty unsub_state_ref gracefully.
+    """
+    Test that _unsub_all handles empty unsub_state_ref gracefully.
 
     When no entities were tracked (empty unsub_state_ref), unsubscribing
     should not raise an error. This exercises the `if unsub_state_ref:` guard.
@@ -2779,7 +2784,8 @@ async def test_subscribe_code_slot_unsub_all_with_empty_state_ref(
     lock_code_manager_config_entry,
     hass_ws_client: WebSocketGenerator,
 ) -> None:
-    """Test that _unsub_all in subscribe_code_slot handles empty unsub_state_ref.
+    """
+    Test that _unsub_all in subscribe_code_slot handles empty unsub_state_ref.
 
     When no entities were tracked (empty unsub_state_ref), unsubscribing
     should not raise an error. This exercises the `if unsub_state_ref:` guard.


### PR DESCRIPTION
## Proposed change

Expands `[tool.ruff.lint]` `select` to include the rule families `B`, `C4`, `SIM`, `RET`, `PTH`, `RUF`, and removes `D213` from `ignore` so the multi-line docstring style is enforced consistently:

```python
"""
Summary on the line below the opening quotes.

Body paragraph(s) below a blank line.
"""
```

This PR includes the auto-fixes those new rules surface across the existing codebase. The bulk are mechanical:

- D213 reformatting (single-line summary → multi-line shape)
- C4 list-comprehension simplifications
- SIM101/103/115/118 obvious tightenings
- Removing now-redundant `# noqa: BLE001` markers

Test files get a per-file ignore list (`B`, `RUF`, `D`, `PLR`, `SIM117`, `SIM102`, `SIM105`) since those patterns are common in pytest scaffolding and don't improve clarity to flatten.

A separate PR (#1104) fixes a Python 2 syntax error in `websocket.py` that this PR intentionally does not touch — the two changes are orthogonal and the syntax fix should land first to avoid a trivial conflict on that line.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #1104 (must merge first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)