### PR TITLE
docs: add ZHA to supported integrations table

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Supported lock integrations:
 | Integration | Read PINs | Push Updates | Code Events | Notes |
 | --- | --- | --- | --- | --- |
 | [Z-Wave][wiki-zwave] | Varies | ✅ | ✅ | Some locks mask PINs |
+| [ZHA][wiki-zha] | ✅ | ✅ | ✅ | Drift detection fallback if lock lacks programming events |
 | [Zigbee2MQTT][wiki-zigbee2mqtt] (MQTT)² | Varies | ✅ | ✅ | Same broker as Z2M; PIN support depends on lock |
 | [Matter][wiki-matter] | ❌ | ✅ | ✅ | PINs write-only per spec |
 | [Schlage WiFi][wiki-schlage] | ❌ | ❌ | ❌ | Cloud-based, PINs masked |
@@ -50,6 +51,7 @@ If you rename the device in HA, keep it aligned with the **friendly name** in Zi
 [wiki-virtual]: https://github.com/raman325/lock_code_manager/wiki/Virtual-integration
 [local-akuvox]: https://github.com/pjaudiomv/hass-local-akuvox
 [hass-virtual]: https://github.com/twrecked/hass-virtual
+[wiki-zha]: https://github.com/raman325/lock_code_manager/wiki/ZHA-integration
 [wiki-zwave]: https://github.com/raman325/lock_code_manager/wiki/Z-Wave-integration
 
 Adding support for new lock integrations is straightforward — see the
@@ -73,7 +75,7 @@ for details.
 The best way to install this integration is via HACS.
 
 1. Set up your locks in Home Assistant through a supported integration
-   (Z-Wave, Matter, Schlage, Zigbee2MQTT/MQTT, etc.)
+   (Z-Wave, ZHA, Matter, Schlage, Zigbee2MQTT/MQTT, etc.)
 2. Add this repository as a custom integration repository in HACS
 3. Go to Settings > Devices & Services > Add Integration
 4. Select Lock Code Manager


### PR DESCRIPTION
## Proposed change

Adds ZHA to the README's supported integrations table. The ZHA provider has been in the codebase and the [ZHA wiki page](https://github.com/raman325/lock_code_manager/wiki/ZHA-integration) exists, but the README's support matrix didn't reflect it, so users browsing the repo had no signal that ZHA is supported.

The new row shows full read/push/event support and notes the drift-detection fallback for locks that don't emit programming-event notifications. ZHA is also added to the install-step example list.

ZHA is inserted between Z-Wave and Zigbee2MQTT to group the two Zigbee paths together.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

🤖 Generated with [Claude Code](https://claude.com/claude-code)