### PR TITLE
docs: clarify scheduler-component limitation is condition-entity-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,12 @@ for details.
 
 ## Condition Entity Integrations Not Supported
 
-Some condition entity integrations are not compatible. See the
+Some integrations create entities whose states don't map to LCM condition entity
+semantics ("access allowed" / "access denied"). The integration may still be usable
+with LCM by driving slot Enabled switches from its own automation logic instead of
+attaching its entities as condition entities. See the
 [wiki](https://github.com/raman325/lock_code_manager/wiki/Unsupported-Condition-Entity-Integrations)
-for details.
+for details and the scheduler-component workaround.
 
 ## Installation
 


### PR DESCRIPTION
## Proposed change

The README's "Condition Entity Integrations Not Supported" section currently implies scheduler-component (and similar integrations) are fully incompatible with Lock Code Manager. In practice the limitation is narrower: scheduler-component's entities can't be used as LCM **condition entities** (their `on`/`triggered`/`off`/`unknown` states track the timer's runtime, not whether an access window is currently open), but the integration itself can still drive slot Enabled switches directly from its own schedule actions — bypassing LCM's condition entity system entirely.

This PR updates the README blurb to:
- explicitly scope the limitation to condition-entity semantics
- signal that the underlying integration may still be usable via slot Enabled toggling
- point readers at the wiki where the full scheduler-component workaround is now documented

The companion wiki update lives in [`Unsupported-Condition-Entity-Integrations.md`](https://github.com/raman325/lock_code_manager/wiki/Unsupported-Condition-Entity-Integrations) and was pushed alongside this PR.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: n/a
- This PR is related to issue: n/a

Docs-only change. No code or behavior impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)