### PR TITLE
Fix lock_name variable in Slot Usage Notifier blueprint

### DIFF
--- a/blueprints/automation/lock_code_manager/slot_usage_notifier.yaml
+++ b/blueprints/automation/lock_code_manager/slot_usage_notifier.yaml
@@ -83,7 +83,7 @@ variables:
     {{ trigger.to_state.attributes.code_slot
        | default('?') }}
   lock_name: >-
-    {{ state_attr(trigger.to_state.state, 'friendly_name')
+    {{ state_attr(trigger.to_state.attributes.event_type, 'friendly_name')
        | default('Unknown lock') }}
   timestamp: >-
     {{ trigger.to_state.last_updated | as_local


### PR DESCRIPTION
The lock_name variable was reading state_attr(trigger.to_state.state, ...)
     but trigger.to_state.state on an event entity is the firing timestamp,
     not the lock entity ID. This caused lock_name to always return None.
     
     Changed to use trigger.to_state.attributes.event_type, which holds the
     lock entity ID in LCM v1.0+. Also added true as the second arg to
     default() so None values are caught (not just undefined).

