### PR TITLE
Add optional lock filter to Slot Usage Notifier blueprint

### DIFF
--- a/blueprints/automation/lock_code_manager/slot_usage_notifier.yaml
+++ b/blueprints/automation/lock_code_manager/slot_usage_notifier.yaml
@@ -54,6 +54,19 @@ blueprint:
         entity:
           domain: event
           integration: lock_code_manager
+    locks:
+      name: Locks (optional)
+      description: >
+        Restrict the automation to a specific lock or set of locks.
+        When empty, the actions run for any lock the event entity
+        reports. When one or more locks are selected, the actions
+        only run when one of those locks is the lock that used the
+        PIN.
+      default: []
+      selector:
+        entity:
+          domain: lock
+          multiple: true
     notify_actions:
       name: Actions
       description: >
@@ -76,6 +89,9 @@ triggers:
 
 variables:
   event_entity_id: !input event_entity
+  locks: !input locks
+  lock_entity_id: >-
+    {{ trigger.to_state.attributes.event_type }}
   slot_name: >-
     {{ trigger.to_state.attributes.code_slot_name
        | default('Unknown slot') }}
@@ -83,10 +99,15 @@ variables:
     {{ trigger.to_state.attributes.code_slot
        | default('?') }}
   lock_name: >-
-    {{ state_attr(trigger.to_state.attributes.event_type, 'friendly_name')
+    {{ state_attr(lock_entity_id, 'friendly_name')
        | default('Unknown lock') }}
   timestamp: >-
     {{ trigger.to_state.last_updated | as_local
        | as_timestamp | timestamp_custom('%Y-%m-%d %H:%M:%S') }}
+
+conditions:
+  - condition: template
+    value_template: >-
+      {{ locks | count == 0 or lock_entity_id in locks }}
 
 actions: !input notify_actions


### PR DESCRIPTION
## Proposed change

Adds a new optional `locks` input to the Slot Usage Notifier blueprint. The input is a multi-select lock entity selector that defaults to an empty list.

- When the list is empty, the automation runs for any lock that fires the configured event entity (existing behavior — fully backwards compatible).
- When one or more locks are selected, a top-level template condition gates the actions so they only run when the firing lock's entity ID is in the list.

Implementation notes:
- The lock's entity ID comes from `trigger.to_state.attributes.event_type` on the LCM PIN-used event entity. Lifted that into a new `lock_entity_id` variable so the existing `lock_name` template and the new condition share the same source.
- Used a top-level `conditions:` block rather than wrapping `!input notify_actions` in an `if`, so automation traces show the skip explicitly and the user's injected action block stays untouched.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: