### PR TITLE
Add optional lock filter to Slot Usage Limiter blueprint

### DIFF
--- a/blueprints/automation/lock_code_manager/slot_usage_limiter.yaml
+++ b/blueprints/automation/lock_code_manager/slot_usage_limiter.yaml
@@ -5,7 +5,8 @@ blueprint:
     Decrements an `input_number` helper each time a Lock Code Manager code
     slot PIN is used on the lock. When the counter reaches 0, the Lock Code
     Manager slot is automatically disabled. Optionally resets the counter
-    when the slot is re-enabled in Lock Code Manager.
+    when the slot is re-enabled in Lock Code Manager. Optionally restricts
+    the limit to a specific lock or set of locks.
 
 
     **Special values**
@@ -59,6 +60,18 @@ blueprint:
         entity:
           domain: event
           integration: lock_code_manager
+    locks:
+      name: Locks (optional)
+      description: >
+        Restrict the limit to a specific lock or set of locks. When empty,
+        PIN uses on any lock count toward the limit. When one or more locks
+        are selected, only uses on those locks decrement the counter — uses
+        on other locks are ignored.
+      default: []
+      selector:
+        entity:
+          domain: lock
+          multiple: true
     enabled_switch:
       name: Slot enabled switch
       description: >
@@ -115,6 +128,7 @@ variables:
   initial_uses: !input initial_uses
   uses_counter: !input uses_counter
   notify_target: !input notify_target
+  locks: !input locks
   _config_entry: !input config_entry
   _config_entry_title: >
     {{ config_entry_attr(_config_entry, 'title') }}
@@ -125,6 +139,10 @@ actions:
       - conditions:
           - condition: trigger
             id: pin_used
+          - condition: template
+            value_template: >-
+              {{ locks | count == 0
+                 or trigger.to_state.attributes.event_type in locks }}
         sequence:
           - variables:
               current: >


### PR DESCRIPTION
## Proposed change

Adds the same optional `locks` filter pattern from #1152 to the Slot Usage Limiter blueprint. The input is a multi-select lock entity selector that defaults to an empty list.

- When the list is empty, every PIN use counts toward the limit (existing behavior — fully backwards compatible).
- When one or more locks are selected, only uses on those locks decrement the counter; uses on other locks are ignored.

Implementation notes:
- The filter is added as an additional `condition: template` inside the `pin_used` choose-branch, gated on `trigger.to_state.attributes.event_type` (the firing lock's entity ID, as carried by LCM event entities). Scoping it inside the branch — rather than at the automation's top level — means the `slot_enabled` re-enable reset is unaffected, since "re-enable" isn't a per-lock concept.
- Wording in the input description makes the quota semantic explicit ("uses on other locks are ignored") so users don't misread it as "skip notification only."

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #1152