### PR TITLE
Use state_attr for lock entity lookup in slot usage blueprints

### DIFF
--- a/blueprints/automation/lock_code_manager/slot_usage_limiter.yaml
+++ b/blueprints/automation/lock_code_manager/slot_usage_limiter.yaml
@@ -142,7 +142,7 @@ actions:
           - condition: template
             value_template: >-
               {{ locks | count == 0
-                 or trigger.to_state.attributes.event_type in locks }}
+                 or state_attr(trigger.entity_id, 'event_type') in locks }}
         sequence:
           - variables:
               current: >

--- a/blueprints/automation/lock_code_manager/slot_usage_notifier.yaml
+++ b/blueprints/automation/lock_code_manager/slot_usage_notifier.yaml
@@ -91,7 +91,7 @@ variables:
   event_entity_id: !input event_entity
   locks: !input locks
   lock_entity_id: >-
-    {{ trigger.to_state.attributes.event_type }}
+    {{ state_attr(trigger.entity_id, 'event_type') }}
   slot_name: >-
     {{ trigger.to_state.attributes.code_slot_name
        | default('Unknown slot') }}


### PR DESCRIPTION
## Proposed change

Follow-up to #1152 and #1153. In both blueprints, the new lock-filter template referenced `trigger.to_state.attributes.event_type`. This switches both to `state_attr(trigger.entity_id, 'event_type')`:

- Removes any dependency on `trigger.to_state` being non-null (it can be `None` in edge cases like the entity being removed mid-trigger).
- Matches the pattern already used in the limiter's notification message (`slot_usage_limiter.yaml` line 187 prior to this change), so the file is internally consistent.

No behavioral change for the normal case — the two expressions resolve to the same value when `trigger.to_state` is present.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue: #1152, #1153