### PR TITLE
Trim Dependabot homeassistant group to HA + pytest-homeassistant-custom-component

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -26,9 +26,7 @@ updates:
       homeassistant:
         patterns:
           - "homeassistant"
-          - "pytest"
           - "pytest-homeassistant-custom-component"
-          - "zwave-js-server-python"
   - package-ecosystem: npm
     directory: "/" # Location of package manifests
     schedule:

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -26,10 +26,8 @@ updates:
       homeassistant:
         patterns:
           - "homeassistant"
-          - "matter-python-client"
           - "pytest"
           - "pytest-homeassistant-custom-component"
-          - "zeroconf"
           - "zwave-js-server-python"
   - package-ecosystem: npm
     directory: "/" # Location of package manifests


### PR DESCRIPTION
## Proposed change

Trims the `homeassistant` Dependabot group in `.github/dependabot.yaml` so it only contains the two packages whose versions are tightly coupled and must move in lockstep:

- `homeassistant`
- `pytest-homeassistant-custom-component`

The following packages are removed from the group and will be tracked as individual Dependabot PRs:

- `matter-python-client` — transitively pinned by HA, was producing conflicting pins.
- `zeroconf` — transitively pinned by HA; conflicting pins broke PR #1146.
- `pytest` — independent release cadence.
- `zwave-js-server-python` — independent release cadence.

### Concrete motivation

PR #1146 grouped `homeassistant>=2026.5.3` with `zeroconf==0.149.13`, but `homeassistant==2026.5.3` requires `zeroconf==0.148.0`. The resulting `requirements_dev.txt` was unresolvable and pytest failed on Python 3.14. Grouping packages that HA itself pins is the root cause of that class of failure.

### Follow-up

PR #1146 will need to be closed (or Dependabot will regenerate the group without the offending packages on its next run).

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue: #1146