### PR TITLE
Allow Slot Usage Notifier to monitor multiple event entities

### DIFF
--- a/blueprints/automation/lock_code_manager/slot_usage_notifier.yaml
+++ b/blueprints/automation/lock_code_manager/slot_usage_notifier.yaml
@@ -50,7 +50,7 @@ blueprint:
       description: >
         One or more Lock Code Manager event entities that fire when a
         PIN is used. These are named like "Code slot X PIN used". The
-        automation runs whenever any of the selected entities fires.
+        automation runs whenever any of the selected entities fire.
       selector:
         entity:
           domain: event

--- a/blueprints/automation/lock_code_manager/slot_usage_notifier.yaml
+++ b/blueprints/automation/lock_code_manager/slot_usage_notifier.yaml
@@ -38,7 +38,7 @@ blueprint:
 
     1. Import this blueprint and create an automation from it.
 
-    2. Select the code slot event entity to monitor.
+    2. Select one or more code slot event entities to monitor.
 
     3. Configure the actions to run when the PIN is used.
   domain: automation
@@ -46,14 +46,16 @@ blueprint:
   source_url: https://github.com/raman325/lock_code_manager/blob/main/blueprints/automation/lock_code_manager/slot_usage_notifier.yaml
   input:
     event_entity:
-      name: Code slot event entity
+      name: Code slot event entities
       description: >
-        The Lock Code Manager event entity that fires when a PIN
-        is used. These are named like "Code slot X PIN used".
+        One or more Lock Code Manager event entities that fire when a
+        PIN is used. These are named like "Code slot X PIN used". The
+        automation runs whenever any of the selected entities fires.
       selector:
         entity:
           domain: event
           integration: lock_code_manager
+          multiple: true
     locks:
       name: Locks (optional)
       description: >


### PR DESCRIPTION
## Proposed change

Adds `multiple: true` to the `event_entity` selector on the Slot Usage Notifier blueprint, so users can configure the same automation to react to PIN-used events from one or more LCM event entities (e.g. several code slots, or the same slot across multiple locks).

The state trigger already accepts a list of entity IDs as `entity_id`, and the template variables (`lock_entity_id`, `slot_name`, `slot_num`, `lock_name`, `timestamp`) all key off the specific firing entity via `trigger.entity_id` / `trigger.to_state`, so they work unchanged for either a single or multi-entity configuration.

Also updates the input name and setup instructions to reflect that one or more entities can be selected.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue: