### PR TITLE
Derive config_entry and slot_number from PIN used event entity in Slot Usage Limiter

### DIFF
--- a/blueprints/automation/lock_code_manager/slot_usage_limiter.yaml
+++ b/blueprints/automation/lock_code_manager/slot_usage_limiter.yaml
@@ -35,22 +35,6 @@ blueprint:
   # yamllint disable-line rule:line-length
   source_url: https://github.com/raman325/lock_code_manager/blob/main/blueprints/automation/lock_code_manager/slot_usage_limiter.yaml
   input:
-    config_entry:
-      name: Lock Code Manager config entry
-      description: >
-        The Lock Code Manager config entry that manages your lock(s).
-        Used to identify the setup in notifications.
-      selector:
-        config_entry:
-          integration: lock_code_manager
-    slot_number:
-      name: Code slot number
-      description: The Lock Code Manager code slot number.
-      selector:
-        number:
-          min: 1
-          max: 999
-          mode: box
     pin_used_entity:
       name: PIN used event entity
       description: >
@@ -129,10 +113,13 @@ variables:
   uses_counter: !input uses_counter
   notify_target: !input notify_target
   locks: !input locks
-  _config_entry: !input config_entry
+  pin_used_entity_id: !input pin_used_entity
+  _config_entry: >
+    {{ config_entry_id(pin_used_entity_id) }}
   _config_entry_title: >
     {{ config_entry_attr(_config_entry, 'title') }}
-  _slot_number: !input slot_number
+  _slot_number: >
+    {{ state_attr(pin_used_entity_id, 'code_slot') }}
 
 actions:
   - choose:

--- a/blueprints/automation/lock_code_manager/slot_usage_limiter.yaml
+++ b/blueprints/automation/lock_code_manager/slot_usage_limiter.yaml
@@ -114,12 +114,12 @@ variables:
   notify_target: !input notify_target
   locks: !input locks
   pin_used_entity_id: !input pin_used_entity
-  _config_entry: >
+  _config_entry: >-
     {{ config_entry_id(pin_used_entity_id) }}
-  _config_entry_title: >
-    {{ config_entry_attr(_config_entry, 'title') }}
-  _slot_number: >
-    {{ state_attr(pin_used_entity_id, 'code_slot') }}
+  _config_entry_title: >-
+    {{ config_entry_attr(_config_entry, 'title') | default('Lock Code Manager') }}
+  _slot_number: >-
+    {{ state_attr(pin_used_entity_id, 'code_slot') | default('?') }}
 
 actions:
   - choose:


### PR DESCRIPTION
# Breaking change

Existing automations built from the prior version of the **Slot Usage Limiter** blueprint must be re-imported or re-saved after this change. The `config_entry` and `slot_number` input keys are removed; their values are now derived from the `pin_used_entity` input.

## Proposed change

Removes the explicit `config_entry` and `slot_number` inputs from the Slot Usage Limiter blueprint and derives both from the user's `pin_used_entity` selection:

- `_config_entry` ← `config_entry_id(pin_used_entity)` — LCM-created event entities are registered to the LCM config entry by construction, so this returns the correct config entry ID without asking.
- `_slot_number` ← `state_attr(pin_used_entity, 'code_slot')` — LCM stores the slot number as a `code_slot` attribute on the event entity (the same attribute the Slot Usage Notifier already reads).

The form now asks for one PIN-used entity instead of three coupled inputs (config entry + slot number + entity), removing a class of "wrong slot number for the entity you picked" misconfigurations.

### Trade-offs accepted

- **Tighter coupling to LCM's event-entity attribute schema** — if LCM ever renames the `code_slot` attribute, this blueprint breaks at trigger time. The Slot Usage Notifier already has the same coupling, so this is not a new fragility class.
- **Validation moves from setup to runtime** — the explicit `number` selector previously enforced `1 ≤ slot ≤ 999` at setup; an invalid/unloaded entity now surfaces only when the trigger fires.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue: