### PR TITLE
Add schema validation test for shipped blueprints

### DIFF
--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -1,0 +1,34 @@
+"""Validate that every shipped blueprint parses against the Home Assistant schema."""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+from homeassistant.components.blueprint import BLUEPRINT_SCHEMA, models
+from homeassistant.util import yaml as yaml_util
+
+BLUEPRINT_ROOT = pathlib.Path(__file__).resolve().parent.parent / "blueprints"
+
+
+def _discover_blueprints() -> list[pytest.ParameterSet]:
+    """Discover every (domain, path) blueprint pair shipped in the repo."""
+    return [
+        pytest.param(
+            path.parent.parent.name, path, id=f"{path.parent.parent.name}/{path.name}"
+        )
+        for path in sorted(BLUEPRINT_ROOT.glob("*/lock_code_manager/*.yaml"))
+    ]
+
+
+@pytest.mark.parametrize(("domain", "blueprint_path"), _discover_blueprints())
+def test_blueprint_schema(domain: str, blueprint_path: pathlib.Path) -> None:
+    """Load each blueprint and assert it conforms to the blueprint schema."""
+    data = yaml_util.load_yaml(blueprint_path)
+    models.Blueprint(
+        data,
+        expected_domain=domain,
+        path=str(blueprint_path),
+        schema=BLUEPRINT_SCHEMA,
+    )


### PR DESCRIPTION
## Proposed change

Adds `tests/test_blueprints.py`, which discovers every YAML file under `blueprints/automation/lock_code_manager/` and `blueprints/template/lock_code_manager/`, loads each one, and asserts it parses against Home Assistant's `BLUEPRINT_SCHEMA`. Each blueprint is a separately-parametrized test case so a failure points directly at the offending file.

This is the same pattern Home Assistant core uses in `tests/components/blueprint/test_default_blueprints.py`. It catches a specific regression class — unknown selector keys, renamed inputs, schema-level typos — at CI time, before users see them.

Runtime: ~0.2s for all 8 blueprints. No `hass` fixture required, so it doesn't add to the integration-test wall time.

Behavioral tests (firing triggers, asserting on side effects) are intentionally out of scope here and will follow in a separate PR.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue: