### PR TITLE
Skip notifier triggers on restart/reload via condition + tests

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,14 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    },
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "1.7.1",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6",
+      "integrity": "sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6"
+    }
+  }
+}

--- a/blueprints/automation/lock_code_manager/slot_usage_notifier.yaml
+++ b/blueprints/automation/lock_code_manager/slot_usage_notifier.yaml
@@ -85,6 +85,9 @@ max: 10
 triggers:
   - trigger: state
     entity_id: !input event_entity
+    not_from:
+      - unknown
+      - unavailable
     not_to:
       - unknown
       - unavailable

--- a/blueprints/automation/lock_code_manager/slot_usage_notifier.yaml
+++ b/blueprints/automation/lock_code_manager/slot_usage_notifier.yaml
@@ -85,9 +85,6 @@ max: 10
 triggers:
   - trigger: state
     entity_id: !input event_entity
-    not_from:
-      - unknown
-      - unavailable
     not_to:
       - unknown
       - unavailable
@@ -95,22 +92,45 @@ triggers:
 variables:
   event_entity_id: !input event_entity
   locks: !input locks
+  # Variables are computed before conditions run, so guard every
+  # `trigger.to_state` access against the entity-removal case
+  # (`to_state is None`) — otherwise the variable rendering errors
+  # out before the conditions below can block the action.
   lock_entity_id: >-
     {{ state_attr(trigger.entity_id, 'event_type') }}
   slot_name: >-
-    {{ trigger.to_state.attributes.code_slot_name
-       | default('Unknown slot') }}
+    {{ trigger.to_state.attributes.code_slot_name | default('Unknown slot')
+       if trigger.to_state is not none else 'Unknown slot' }}
   slot_num: >-
-    {{ trigger.to_state.attributes.code_slot
-       | default('?') }}
+    {{ trigger.to_state.attributes.code_slot | default('?')
+       if trigger.to_state is not none else '?' }}
   lock_name: >-
-    {{ state_attr(lock_entity_id, 'friendly_name')
-       | default('Unknown lock') }}
+    {{ state_attr(lock_entity_id, 'friendly_name') | default('Unknown lock')
+       if lock_entity_id is not none else 'Unknown lock' }}
   timestamp: >-
-    {{ trigger.to_state.last_updated | as_local
-       | as_timestamp | timestamp_custom('%Y-%m-%d %H:%M:%S') }}
+    {{ (trigger.to_state.last_updated | as_local
+        | as_timestamp | timestamp_custom('%Y-%m-%d %H:%M:%S'))
+       if trigger.to_state is not none else '' }}
 
 conditions:
+  # Block transitions that aren't real PIN uses:
+  #   - `from_state is None`     -> entity first-appearance after a
+  #                                 config-entry reload or restart
+  #                                 (Python None != the string
+  #                                 'unknown', so `not_from` can't see
+  #                                 this).
+  #   - `to_state is None`       -> entity removal (LCM unload); the
+  #                                 action's variables read
+  #                                 `trigger.to_state.attributes` and
+  #                                 would crash without this guard.
+  #   - `from_state.state ==
+  #      'unavailable'`           -> underlying lock dropped offline
+  #                                 and recovered.
+  - condition: template
+    value_template: >-
+      {{ trigger.from_state is not none
+         and trigger.to_state is not none
+         and trigger.from_state.state != 'unavailable' }}
   - condition: template
     value_template: >-
       {{ locks | count == 0 or lock_entity_id in locks }}

--- a/tests/test_blueprint_behavior.py
+++ b/tests/test_blueprint_behavior.py
@@ -12,17 +12,24 @@ import contextlib
 import pathlib
 from unittest.mock import patch
 
-from pytest_homeassistant_custom_component.common import async_mock_service
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+    async_mock_service,
+    mock_restore_cache_with_extra_data,
+)
 
 from homeassistant.components import automation
 from homeassistant.components.blueprint import models
-from homeassistant.core import Event, HomeAssistant, ServiceCall, callback
+from homeassistant.const import ATTR_FRIENDLY_NAME
+from homeassistant.core import Event, HomeAssistant, ServiceCall, State, callback
 from homeassistant.setup import async_setup_component
 from homeassistant.util import yaml as yaml_util
 
+from custom_components.lock_code_manager.const import DOMAIN
 from custom_components.lock_code_manager.providers import BaseLock
 
 from .common import (
+    BASE_CONFIG,
     LOCK_1_ENTITY_ID,
     LOCK_2_ENTITY_ID,
     SLOT_1_ENABLED_ENTITY,
@@ -207,6 +214,330 @@ async def test_notifier_lock_filter_blocks_non_match(
     await hass.async_block_till_done()
 
     assert captured == []
+
+
+async def test_notifier_fires_on_first_pin_use(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+) -> None:
+    """The very first PIN use on a fresh slot fires the notifier.
+
+    Case: `'unknown' -> <timestamp>`. A freshly-registered LCM event
+    entity sits at `unknown` until its first event. The condition
+    only blocks `from_state is None` and
+    `from_state.state == 'unavailable'`, so this transition is
+    allowed.
+    """
+    captured = async_mock_service(hass, "test", "captured")
+
+    assert hass.states.get(SLOT_1_EVENT_ENTITY).state == "unknown"
+
+    await _setup_blueprint_automation(
+        hass,
+        NOTIFIER_PATH,
+        {
+            "event_entity": [SLOT_1_EVENT_ENTITY],
+            "notify_actions": [{"service": "test.captured"}],
+        },
+    )
+
+    _fire_pin_used(lock_code_manager_config_entry, LOCK_1_ENTITY_ID, 1)
+    await hass.async_block_till_done()
+
+    assert len(captured) == 1
+
+
+async def test_notifier_fires_on_subsequent_pin_use(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+) -> None:
+    """Subsequent PIN uses fire the notifier.
+
+    Case: `<old_timestamp> -> <new_timestamp>`. The second fire
+    transitions between two valid timestamps; the condition passes
+    on both legs.
+    """
+    captured = async_mock_service(hass, "test", "captured")
+
+    await _setup_blueprint_automation(
+        hass,
+        NOTIFIER_PATH,
+        {
+            "event_entity": [SLOT_1_EVENT_ENTITY],
+            "notify_actions": [{"service": "test.captured"}],
+        },
+    )
+
+    _fire_pin_used(lock_code_manager_config_entry, LOCK_1_ENTITY_ID, 1)
+    await hass.async_block_till_done()
+    assert len(captured) == 1
+    first_state = hass.states.get(SLOT_1_EVENT_ENTITY).state
+
+    _fire_pin_used(lock_code_manager_config_entry, LOCK_1_ENTITY_ID, 1)
+    await hass.async_block_till_done()
+    assert len(captured) == 2
+    # Sanity check: the second fire genuinely came from a timestamp
+    # state, not from `unknown` (i.e. case 8, not a repeat of case 4).
+    assert first_state != "unknown"
+
+
+async def test_notifier_skips_unavailable_to_timestamp(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+) -> None:
+    """Recovery from `unavailable` does not fire the notifier.
+
+    When LCM or its underlying lock integration reloads while HA is
+    running, the event entity can briefly drop to `unavailable` before
+    its supporting lock comes back online. Without the condition that
+    rejects `from_state.state == 'unavailable'`, the transition back
+    to a real timestamp would spuriously fire the trigger.
+    """
+    captured = async_mock_service(hass, "test", "captured")
+
+    # Force the entity into `unavailable` so the next state write
+    # produces an `unavailable -> timestamp` transition.
+    hass.states.async_set(SLOT_1_EVENT_ENTITY, "unavailable")
+    await hass.async_block_till_done()
+    assert hass.states.get(SLOT_1_EVENT_ENTITY).state == "unavailable"
+
+    await _setup_blueprint_automation(
+        hass,
+        NOTIFIER_PATH,
+        {
+            "event_entity": [SLOT_1_EVENT_ENTITY],
+            "notify_actions": [{"service": "test.captured"}],
+        },
+    )
+
+    _fire_pin_used(lock_code_manager_config_entry, LOCK_1_ENTITY_ID, 1)
+    await hass.async_block_till_done()
+
+    assert captured == []
+    assert hass.states.get(SLOT_1_EVENT_ENTITY).state != "unavailable"
+
+
+async def test_notifier_skips_entity_appearance_with_restored_state(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """Entity appearing with a restored value does not fire the notifier.
+
+    This is the LCM-reload / fast-restart scenario: HA's recorder
+    restores the slot's last-fired timestamp before LCM finishes
+    setting up, and the automation listener happens to be registered
+    before the entity reappears. The resulting `state_changed` event
+    has `old_state = None` (Python None, not the string 'unknown') —
+    which `not_from: [unknown, unavailable]` could never block, and
+    which the from_state condition explicitly catches.
+
+    We construct the scenario by priming the restore cache before LCM,
+    then registering the automation before LCM's config entry is set
+    up so the listener is in place when the entity appears.
+    """
+    captured = async_mock_service(hass, "test", "captured")
+
+    restored_ts = "2026-01-01T12:00:00.000+00:00"
+    mock_restore_cache_with_extra_data(
+        hass,
+        [
+            (
+                State(
+                    SLOT_1_EVENT_ENTITY,
+                    restored_ts,
+                    {
+                        "event_type": LOCK_1_ENTITY_ID,
+                        "code_slot": 1,
+                        "code_slot_name": "test1",
+                        ATTR_FRIENDLY_NAME: "Code slot 1",
+                    },
+                ),
+                {
+                    "last_event_type": LOCK_1_ENTITY_ID,
+                    "last_event_attributes": {
+                        "code_slot": 1,
+                        "code_slot_name": "test1",
+                    },
+                },
+            )
+        ],
+    )
+
+    await _setup_blueprint_automation(
+        hass,
+        NOTIFIER_PATH,
+        {
+            "event_entity": [SLOT_1_EVENT_ENTITY],
+            "notify_actions": [{"service": "test.captured"}],
+        },
+    )
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data=BASE_CONFIG, unique_id="Mock Title"
+    )
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(SLOT_1_EVENT_ENTITY).state == restored_ts
+    assert captured == []
+
+
+async def test_notifier_skips_fresh_entity_appearance(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """Entity appearing fresh (no restored data) does not fire the notifier.
+
+    Case: `None -> 'unknown'`. The state-trigger's `not_to: unknown`
+    short-circuits before the condition even runs, but verifying this
+    transition is silent is important — if a future refactor drops
+    `not_to`, the `from_state is None` condition would still need to
+    catch it (which it does).
+    """
+    captured = async_mock_service(hass, "test", "captured")
+
+    # Register the automation BEFORE LCM so the listener is active
+    # when the entity first appears. The `event_entity` selector
+    # accepts an entity_id even if the entity doesn't exist yet —
+    # blueprint setup wires up a state-change listener regardless.
+    await _setup_blueprint_automation(
+        hass,
+        NOTIFIER_PATH,
+        {
+            "event_entity": [SLOT_1_EVENT_ENTITY],
+            "notify_actions": [{"service": "test.captured"}],
+        },
+    )
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data=BASE_CONFIG, unique_id="Mock Title"
+    )
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(SLOT_1_EVENT_ENTITY).state == "unknown"
+    assert captured == []
+
+
+async def test_notifier_skips_transition_to_unavailable(
+    hass: HomeAssistant,
+    caplog,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+) -> None:
+    """Going offline does not fire the notifier.
+
+    Case: `<timestamp> -> 'unavailable'`. Blocked at the trigger
+    level by `not_to: unavailable`. Without that filter the trigger
+    would fire and the action's variable rendering would crash on
+    the now-empty attributes — `captured == []` alone would still
+    hold (silent failure), so we also assert no rendering errors
+    were logged.
+    """
+    captured = async_mock_service(hass, "test", "captured")
+
+    await _setup_blueprint_automation(
+        hass,
+        NOTIFIER_PATH,
+        {
+            "event_entity": [SLOT_1_EVENT_ENTITY],
+            "notify_actions": [{"service": "test.captured"}],
+        },
+    )
+
+    _fire_pin_used(lock_code_manager_config_entry, LOCK_1_ENTITY_ID, 1)
+    await hass.async_block_till_done()
+    assert len(captured) == 1
+    captured.clear()
+    caplog.clear()
+
+    # Force the entity to `unavailable`, simulating the lock going
+    # offline after a real PIN use.
+    hass.states.async_set(SLOT_1_EVENT_ENTITY, "unavailable")
+    await hass.async_block_till_done()
+
+    assert captured == []
+    assert "Error rendering variables" not in caplog.text
+
+
+async def test_notifier_skips_transition_to_unknown(
+    hass: HomeAssistant,
+    caplog,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+) -> None:
+    """Losing state does not fire the notifier.
+
+    Case: `<timestamp> -> 'unknown'`. Symmetric to the unavailable
+    case — blocked at the trigger level by `not_to: unknown`.
+    """
+    captured = async_mock_service(hass, "test", "captured")
+
+    await _setup_blueprint_automation(
+        hass,
+        NOTIFIER_PATH,
+        {
+            "event_entity": [SLOT_1_EVENT_ENTITY],
+            "notify_actions": [{"service": "test.captured"}],
+        },
+    )
+
+    _fire_pin_used(lock_code_manager_config_entry, LOCK_1_ENTITY_ID, 1)
+    await hass.async_block_till_done()
+    assert len(captured) == 1
+    captured.clear()
+    caplog.clear()
+
+    hass.states.async_set(SLOT_1_EVENT_ENTITY, "unknown")
+    await hass.async_block_till_done()
+
+    assert captured == []
+    assert "Error rendering variables" not in caplog.text
+
+
+async def test_notifier_skips_entity_removal(
+    hass: HomeAssistant,
+    caplog,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+) -> None:
+    """Entity removal does not fire the notifier (and does not crash).
+
+    Case: `<timestamp> -> None`. The `not_to` filter does NOT block
+    this (Python None is not the string 'unknown' or 'unavailable'),
+    so the `trigger.to_state is not none` condition is what catches
+    it. Without that guard the trigger would fire and the action
+    would crash trying to read `trigger.to_state.attributes` — the
+    service still wouldn't be called (so `captured == []` alone
+    can't detect a regression), but the log would carry a template
+    error. We assert both: no service call AND no template error.
+    """
+    captured = async_mock_service(hass, "test", "captured")
+
+    await _setup_blueprint_automation(
+        hass,
+        NOTIFIER_PATH,
+        {
+            "event_entity": [SLOT_1_EVENT_ENTITY],
+            "notify_actions": [{"service": "test.captured"}],
+        },
+    )
+
+    _fire_pin_used(lock_code_manager_config_entry, LOCK_1_ENTITY_ID, 1)
+    await hass.async_block_till_done()
+    assert len(captured) == 1
+    captured.clear()
+    caplog.clear()
+
+    hass.states.async_remove(SLOT_1_EVENT_ENTITY)
+    await hass.async_block_till_done()
+
+    assert captured == []
+    assert hass.states.get(SLOT_1_EVENT_ENTITY) is None
+    assert "Error rendering variables" not in caplog.text
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Proposed change

The initial `not_from: [unknown, unavailable]` filter on the Slot Usage Notifier trigger is incomplete — it only catches transitions where the prior state is the *string* `'unknown'` or `'unavailable'`. It does NOT catch the case where `trigger.from_state` is Python `None`, which is exactly what happens when the event entity first appears in the state machine after an LCM config-entry reload (or any restart where the automation listener registers before the entity). It also has the side effect of blocking the first-ever PIN use on a fresh slot.

Replace it with a template condition that explicitly checks `from_state is not none`, `to_state is not none`, and `from_state.state != 'unavailable'`. This:

- Catches the restart/reload case that `not_from` misses (the original bug).
- Allows first-ever PIN fires through (removes the side effect).
- Guards against entity-removal crashes when LCM unloads.

Also make the variables defensive against `to_state is None`. Variables in HA are computed before conditions run, so the condition alone can't prevent template rendering errors on unload — without the defensive variables, users see template errors in their logs every time LCM reloads.

### Test coverage

Added behavioral tests covering every meaningful state transition the trigger can see:

| Transition | Should fire? | Blocked by | Test |
|---|---|---|---|
| `None → 'unknown'` (fresh appearance) | No | `not_to` + condition | `test_notifier_skips_fresh_entity_appearance` |
| `None → <ts>` (restored on reload) | No | condition | `test_notifier_skips_entity_appearance_with_restored_state` |
| `'unknown' → <ts>` (first PIN) | **Yes** | (passes) | `test_notifier_fires_on_first_pin_use` |
| `'unavailable' → <ts>` (recovery) | No | condition | `test_notifier_skips_unavailable_to_timestamp` |
| `<ts> → <ts>` (subsequent PIN) | **Yes** | (passes) | `test_notifier_fires_on_subsequent_pin_use` |
| `<ts> → 'unknown'` | No | `not_to: unknown` | `test_notifier_skips_transition_to_unknown` |
| `<ts> → 'unavailable'` | No | `not_to: unavailable` | `test_notifier_skips_transition_to_unavailable` |
| `<ts> → None` (entity removal) | No | condition + safe vars | `test_notifier_skips_entity_removal` |

TDD-verified: each new "skip" test fails when its corresponding mechanism (condition or `not_to`) is removed.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: