### PR TITLE
Auto-label PRs touching blueprints and route to Housekeeping

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -34,6 +34,10 @@ github-config:
   - changed-files:
       - any-glob-to-any-file: '.github/**/*'
 
+blueprints:
+  - changed-files:
+      - any-glob-to-any-file: 'blueprints/**/*'
+
 dependencies:
   - changed-files:
       - any-glob-to-any-file:

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -50,6 +50,7 @@ categories:
     collapse-after: 1
     labels:
       - "github-config"
+      - "blueprints"
     exclude-labels:
       - "python"
       - "javascript"


### PR DESCRIPTION
## Proposed change

Add a `blueprints` file-based label that auto-applies to any PR touching `blueprints/**/*`, and include that label in the release-drafter Housekeeping section.

- `.github/labeler.yml` — new `blueprints` glob pattern
- `.github/release-drafter.yml` — adds `blueprints` to the existing Housekeeping category (which already excludes \`python\` and \`javascript\`)

The exclude-labels behavior means pure blueprint PRs land in Housekeeping, while blueprint PRs that also touch tests or integration code still match higher-priority categories like Bug Fixes or Enhancements first.

The label has already been created in the repo and retroactively applied to all 12 merged PRs that previously touched blueprints (#902, #1008, #1023, #1024, #1144, #1152, #1153, #1154, #1159, #1160, #1162, #1165) so release-drafter has a consistent history.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: