### PR TITLE
fix(strings): capitalize Active/Enabled/Name entity translations

### DIFF
--- a/custom_components/lock_code_manager/strings.json
+++ b/custom_components/lock_code_manager/strings.json
@@ -74,7 +74,7 @@
   "entity": {
     "binary_sensor": {
       "active": {
-        "name": "active"
+        "name": "Active"
       },
       "in_sync": {
         "name": "Code slot {slot_num} in sync",
@@ -108,13 +108,12 @@
     },
     "switch": {
       "enabled": {
-        "name": "enabled"
-
+        "name": "Enabled"
       }
     },
     "text": {
       "name": {
-        "name": "name"
+        "name": "Name"
       },
       "pin": {
         "name": "PIN"

--- a/custom_components/lock_code_manager/translations/en.json
+++ b/custom_components/lock_code_manager/translations/en.json
@@ -74,7 +74,7 @@
   "entity": {
     "binary_sensor": {
       "active": {
-        "name": "active"
+        "name": "Active"
       },
       "in_sync": {
         "name": "Code slot {slot_num} in sync",
@@ -108,13 +108,12 @@
     },
     "switch": {
       "enabled": {
-        "name": "enabled"
-
+        "name": "Enabled"
       }
     },
     "text": {
       "name": {
-        "name": "name"
+        "name": "Name"
       },
       "pin": {
         "name": "PIN"


### PR DESCRIPTION
## Proposed change

The translation values for three Lock Code Manager entities were written in lowercase in `strings.json` (and the synced `translations/en.json`):

| Entity | Before | After |
| --- | --- | --- |
| `binary_sensor.active.name` | `active` | `Active` |
| `switch.enabled.name` | `enabled` | `Enabled` |
| `text.name.name` | `name` | `Name` |

Because these entities inherit from `BaseLockCodeManagerEntity` (with `_attr_has_entity_name = True`), HA renders them as `"<device name> <translation>"`. The lowercase translation produced names like `"House Locks Code slot 1 active"` instead of `"...Active"`. The sibling `text.pin` entry already uses the correct casing (`"PIN"`), confirming this was an oversight rather than a deliberate style.

Also drops a stray blank line inside the `switch.enabled` block.

The other entity translations (`in_sync`, `code`, `pin_used` state, `sync_status` states) were audited and follow HA's sentence-case convention correctly — no further changes needed.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

🤖 Generated with [Claude Code](https://claude.com/claude-code)