### PR TITLE
Consolidate retry/backoff/suspend into a CircuitBreaker primitive

### DIFF
--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -668,9 +668,12 @@ async def async_unload_entry(
             )
             if not still_managed:
                 async_delete_issue(hass, DOMAIN, f"lock_offline_{lock_entity_id}")
-            async_delete_issue(
-                hass, DOMAIN, f"slot_suspended_{entry_id}_{lock_entity_id}"
-            )
+            for slot_num in config.slots:
+                async_delete_issue(
+                    hass,
+                    DOMAIN,
+                    f"slot_suspended_{entry_id}_{lock_entity_id}_{slot_num}",
+                )
 
     if not hass_data.get(CONF_LOCKS):
         await _async_cleanup_strategy_resource(hass, hass_data)

--- a/custom_components/lock_code_manager/coordinator.py
+++ b/custom_components/lock_code_manager/coordinator.py
@@ -126,6 +126,16 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator[dict[int, str | SlotCo
 
         self.async_set_updated_data(new_data)
 
+    def note_connectivity_failure(self) -> None:
+        """
+        Record a connectivity failure observed outside the poll path.
+
+        Lets the sync layer feed set/clear transport failures into the same
+        lock breaker that polling uses, so "lock is unreachable" converges
+        from both code paths.
+        """
+        self._apply_backoff()
+
     def _apply_backoff(self) -> None:
         """Record a connectivity failure and apply exponential polling backoff."""
         self._lock_breaker.record_failure()

--- a/custom_components/lock_code_manager/coordinator.py
+++ b/custom_components/lock_code_manager/coordinator.py
@@ -31,6 +31,7 @@ from .const import (
 from .data import get_entry_config
 from .exceptions import LockCodeManagerError
 from .models import SlotCode
+from .resilience import CircuitBreaker
 
 if TYPE_CHECKING:
     from .providers import BaseLock
@@ -60,7 +61,11 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator[dict[int, str | SlotCo
         self.data: dict[int, str | SlotCode] = {}
         self._slot_sync_mgrs_suspended: bool = False
         self._config_entry = config_entry
-        self._consecutive_failures: int = 0
+        self._lock_breaker = CircuitBreaker(
+            BACKOFF_FAILURE_THRESHOLD,
+            backoff_initial=timedelta(seconds=BACKOFF_INITIAL_SECONDS),
+            backoff_max=timedelta(seconds=BACKOFF_MAX_SECONDS),
+        )
         self._original_update_interval: timedelta | None = update_interval
 
         # Set up drift detection timer for locks with hard_refresh_interval
@@ -123,34 +128,29 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator[dict[int, str | SlotCo
         self.async_set_updated_data(new_data)
 
     def _apply_backoff(self) -> None:
-        """Increment failure counter and apply exponential backoff if threshold met."""
-        self._consecutive_failures += 1
-        if self._consecutive_failures >= BACKOFF_FAILURE_THRESHOLD:
-            backoff_secs = min(
-                BACKOFF_INITIAL_SECONDS
-                * 2 ** (self._consecutive_failures - BACKOFF_FAILURE_THRESHOLD),
-                BACKOFF_MAX_SECONDS,
-            )
+        """Record a connectivity failure and apply exponential polling backoff."""
+        self._lock_breaker.record_failure()
+        if self._lock_breaker.tripped:
             if self._original_update_interval is not None:
-                new_interval = timedelta(seconds=backoff_secs)
+                new_interval = self._lock_breaker.backoff_delay
                 if new_interval != self.update_interval:  # type: ignore[has-type]
                     self.update_interval = new_interval
                     _LOGGER.warning(
                         "Update failed %d consecutive times for %s, "
                         "backing off polling interval to %ds",
-                        self._consecutive_failures,
+                        self._lock_breaker.failure_count,
                         self._lock.lock.entity_id,
-                        backoff_secs,
+                        new_interval.total_seconds(),
                     )
             else:
                 _LOGGER.warning(
                     "Update failed %d consecutive times for %s, "
                     "suppressing drift checks until recovery",
-                    self._consecutive_failures,
+                    self._lock_breaker.failure_count,
                     self._lock.lock.entity_id,
                 )
 
-        if self._consecutive_failures == POLL_FAILURE_ALERT_THRESHOLD:
+        if self._lock_breaker.failure_count == POLL_FAILURE_ALERT_THRESHOLD:
             async_create_issue(
                 self.hass,
                 DOMAIN,
@@ -169,6 +169,11 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator[dict[int, str | SlotCo
         """Return whether slot sync operations are suspended for this lock."""
         return self._slot_sync_mgrs_suspended
 
+    @property
+    def unreachable(self) -> bool:
+        """Return whether the lock is currently considered unreachable."""
+        return self._lock_breaker.tripped
+
     def suspend_slot_sync_mgrs(self) -> None:
         """
         Suspend slot sync managers for this lock.
@@ -185,15 +190,15 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator[dict[int, str | SlotCo
         self.async_update_listeners()
 
     def _reset_backoff(self) -> None:
-        """Reset failure counter and restore original update interval."""
+        """Reset the lock breaker and restore the original update interval."""
         self._slot_sync_mgrs_suspended = False
-        if self._consecutive_failures > 0:
+        if self._lock_breaker.failure_count > 0:
             _LOGGER.info(
                 "Lock %s recovered after %d consecutive failures",
                 self._lock.lock.entity_id,
-                self._consecutive_failures,
+                self._lock_breaker.failure_count,
             )
-            self._consecutive_failures = 0
+            self._lock_breaker.reset()
             if self._original_update_interval is not None:
                 self.update_interval = self._original_update_interval
         # Unconditionally clear lock_offline issue on any successful poll.
@@ -234,11 +239,11 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator[dict[int, str | SlotCo
         if not self.last_update_success:
             return
 
-        if self._consecutive_failures >= BACKOFF_FAILURE_THRESHOLD:
+        if self._lock_breaker.tripped:
             _LOGGER.debug(
                 "Skipping drift check for %s (in backoff after %d failures)",
                 self._lock.lock.entity_id,
-                self._consecutive_failures,
+                self._lock_breaker.failure_count,
             )
             return
 

--- a/custom_components/lock_code_manager/coordinator.py
+++ b/custom_components/lock_code_manager/coordinator.py
@@ -59,7 +59,6 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator[dict[int, str | SlotCo
             config_entry=config_entry,
         )
         self.data: dict[int, str | SlotCode] = {}
-        self._slot_sync_mgrs_suspended: bool = False
         self._config_entry = config_entry
         self._lock_breaker = CircuitBreaker(
             BACKOFF_FAILURE_THRESHOLD,
@@ -165,33 +164,12 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator[dict[int, str | SlotCo
             )
 
     @property
-    def slot_sync_mgrs_suspended(self) -> bool:
-        """Return whether slot sync operations are suspended for this lock."""
-        return self._slot_sync_mgrs_suspended
-
-    @property
     def unreachable(self) -> bool:
         """Return whether the lock is currently considered unreachable."""
         return self._lock_breaker.tripped
 
-    def suspend_slot_sync_mgrs(self) -> None:
-        """
-        Suspend slot sync managers for this lock.
-
-        Called by any SlotSyncManager that hits a circuit breaker or
-        unexpected error. All sync managers for this lock will see the
-        flag and stop retrying. Cleared automatically on recovery via
-        _reset_backoff (successful poll or push update).
-        """
-        self._slot_sync_mgrs_suspended = True
-        _LOGGER.info("Slot sync suspended for %s", self._lock.lock.entity_id)
-        # Notify listeners so other SlotSyncManagers for this lock
-        # transition to SUSPENDED on their next _request_sync_check.
-        self.async_update_listeners()
-
     def _reset_backoff(self) -> None:
         """Reset the lock breaker and restore the original update interval."""
-        self._slot_sync_mgrs_suspended = False
         if self._lock_breaker.failure_count > 0:
             _LOGGER.info(
                 "Lock %s recovered after %d consecutive failures",
@@ -203,7 +181,7 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator[dict[int, str | SlotCo
                 self.update_interval = self._original_update_interval
         # Unconditionally clear lock_offline issue on any successful poll.
         # Runs outside the if-block so it also clears persisted issues that
-        # survive HA restarts (where _consecutive_failures resets to 0).
+        # survive HA restarts (where the breaker resets to 0).
         async_delete_issue(
             self.hass,
             DOMAIN,

--- a/custom_components/lock_code_manager/coordinator.py
+++ b/custom_components/lock_code_manager/coordinator.py
@@ -132,31 +132,33 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator[dict[int, str | SlotCo
 
         Lets the sync layer feed set/clear transport failures into the same
         lock breaker that polling uses, so "lock is unreachable" converges
-        from both code paths.
+        from both code paths. When this is what trips the breaker, kick a
+        refresh so a provider that does not normally poll (push) starts
+        probing for recovery.
         """
+        was_tripped = self._lock_breaker.tripped
         self._apply_backoff()
+        if self._lock_breaker.tripped and not was_tripped:
+            self.hass.async_create_task(self.async_request_refresh())
 
     def _apply_backoff(self) -> None:
-        """Record a connectivity failure and apply exponential polling backoff."""
+        """Record a connectivity failure and poll on a backoff until recovery."""
         self._lock_breaker.record_failure()
         if self._lock_breaker.tripped:
-            if self._original_update_interval is not None:
-                new_interval = self._lock_breaker.backoff_delay
-                if new_interval != self.update_interval:  # type: ignore[has-type]
-                    self.update_interval = new_interval
-                    _LOGGER.warning(
-                        "Update failed %d consecutive times for %s, "
-                        "backing off polling interval to %ds",
-                        self._lock_breaker.failure_count,
-                        self._lock.lock.entity_id,
-                        new_interval.total_seconds(),
-                    )
-            else:
+            # Poll on the backoff interval until a successful update clears the
+            # breaker. Push providers normally do not poll, but while the lock
+            # is unreachable we poll to probe for recovery -- otherwise a push
+            # provider whose writes fail (with no push arriving) could stay
+            # suspended indefinitely.
+            new_interval = self._lock_breaker.backoff_delay
+            if new_interval != self.update_interval:  # type: ignore[has-type]
+                self.update_interval = new_interval
                 _LOGGER.warning(
                     "Update failed %d consecutive times for %s, "
-                    "suppressing drift checks until recovery",
+                    "polling every %ds until it recovers",
                     self._lock_breaker.failure_count,
                     self._lock.lock.entity_id,
+                    new_interval.total_seconds(),
                 )
 
         if self._lock_breaker.failure_count == POLL_FAILURE_ALERT_THRESHOLD:
@@ -187,8 +189,9 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator[dict[int, str | SlotCo
                 self._lock_breaker.failure_count,
             )
             self._lock_breaker.reset()
-            if self._original_update_interval is not None:
-                self.update_interval = self._original_update_interval
+            # Restore the normal cadence. For push providers this is None,
+            # which stops the recovery probe polling.
+            self.update_interval = self._original_update_interval  # type: ignore[assignment]
         # Unconditionally clear lock_offline issue on any successful poll.
         # Runs outside the if-block so it also clears persisted issues that
         # survive HA restarts (where the breaker resets to 0).

--- a/custom_components/lock_code_manager/diagnostics.py
+++ b/custom_components/lock_code_manager/diagnostics.py
@@ -110,9 +110,7 @@ def _lock_diagnostic(
             "last_update_success": (
                 coordinator.last_update_success if coordinator else None
             ),
-            "slot_sync_mgrs_suspended": (
-                coordinator.slot_sync_mgrs_suspended if coordinator else None
-            ),
+            "lock_unreachable": (coordinator.unreachable if coordinator else None),
             "data": coordinator_data,
         },
     }

--- a/custom_components/lock_code_manager/resilience.py
+++ b/custom_components/lock_code_manager/resilience.py
@@ -20,10 +20,10 @@ class CircuitBreaker:
     for connectivity.
 
     Windowed trip (set ``window``, leave the backoff arguments unset): counts
-    failures within a sliding window. ``tripped`` latches once the threshold is
-    reached and stays latched until ``reset`` is called, so a caller decides
-    when recovery happens. Used at the slot level for a code that never
-    converges.
+    failures within a sliding window. ``tripped`` is True only while the
+    threshold is met within the trailing window; once the window elapses with
+    no new failures it clears on its own (and ``reset`` clears it immediately).
+    Used at the slot level for a code that never converges.
     """
 
     def __init__(

--- a/custom_components/lock_code_manager/resilience.py
+++ b/custom_components/lock_code_manager/resilience.py
@@ -72,8 +72,18 @@ class CircuitBreaker:
 
     @property
     def tripped(self) -> bool:
-        """Return whether the failure threshold has been reached."""
-        return self._failure_count >= self._threshold
+        """
+        Return whether the failure threshold has been reached.
+
+        For a windowed breaker the breaches must fall within the trailing
+        window; once the window elapses with no new failures the stale
+        breaches no longer count as tripped.
+        """
+        if self._failure_count < self._threshold:
+            return False
+        if self._window is not None and self._first_failure is not None:
+            return dt_util.utcnow() - self._first_failure <= self._window
+        return True
 
     @property
     def backoff_delay(self) -> timedelta:

--- a/custom_components/lock_code_manager/resilience.py
+++ b/custom_components/lock_code_manager/resilience.py
@@ -1,0 +1,86 @@
+"""Reusable circuit breaker primitive for resilience tracking."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from homeassistant.util import dt as dt_util
+
+
+class CircuitBreaker:
+    """
+    Track failures and decide when to stop or back off.
+
+    A single primitive covers two policies, chosen by the constructor
+    arguments:
+
+    Consecutive backoff (set ``backoff_initial`` / ``backoff_max``, leave
+    ``window`` unset): counts consecutive failures and escalates
+    ``backoff_delay`` exponentially once ``tripped``. Used at the lock level
+    for connectivity.
+
+    Windowed trip (set ``window``, leave the backoff arguments unset): counts
+    failures within a sliding window. ``tripped`` latches once the threshold is
+    reached and stays latched until ``reset`` is called, so a caller decides
+    when recovery happens. Used at the slot level for a code that never
+    converges.
+    """
+
+    def __init__(
+        self,
+        threshold: int,
+        *,
+        window: timedelta | None = None,
+        backoff_initial: timedelta | None = None,
+        backoff_max: timedelta | None = None,
+    ) -> None:
+        """Initialize the circuit breaker."""
+        self._threshold = threshold
+        self._window = window
+        self._backoff_initial = backoff_initial
+        self._backoff_max = backoff_max
+        self._failure_count = 0
+        self._first_failure: datetime | None = None
+
+    def record_failure(self) -> None:
+        """Record a failure, restarting the count if the window has elapsed."""
+        now = dt_util.utcnow()
+        if (
+            self._window is not None
+            and self._first_failure is not None
+            and now - self._first_failure > self._window
+        ):
+            self._failure_count = 0
+            self._first_failure = None
+        if self._first_failure is None:
+            self._first_failure = now
+        self._failure_count += 1
+
+    def record_success(self) -> None:
+        """Record a success, clearing all failure state."""
+        self.reset()
+
+    def reset(self) -> None:
+        """Clear all failure state."""
+        self._failure_count = 0
+        self._first_failure = None
+
+    @property
+    def failure_count(self) -> int:
+        """Return the current failure count."""
+        return self._failure_count
+
+    @property
+    def tripped(self) -> bool:
+        """Return whether the failure threshold has been reached."""
+        return self._failure_count >= self._threshold
+
+    @property
+    def backoff_delay(self) -> timedelta:
+        """Return the current backoff delay, or zero when not tripped."""
+        if not self.tripped or self._backoff_initial is None:
+            return timedelta(0)
+        delay = self._backoff_initial * 2 ** (self._failure_count - self._threshold)
+        if self._backoff_max is not None and delay > self._backoff_max:
+            return self._backoff_max
+        return delay

--- a/custom_components/lock_code_manager/strings.json
+++ b/custom_components/lock_code_manager/strings.json
@@ -204,7 +204,7 @@
         "step": {
           "init": {
             "title": "Sync suspended for slot {slot_num} on {lock_name}",
-            "description": "Sync has been suspended for slot {slot_num} on lock `{lock_entity_id}`.\n\n**Reason:** {reason}\n\nSyncing for this slot will resume automatically when the lock recovers. Click **Submit** to acknowledge this issue."
+            "description": "Sync has been suspended for slot {slot_num} on lock `{lock_entity_id}`.\n\n**Reason:** {reason}\n\nSyncing for this slot will resume automatically once the lock accepts the code or you change the PIN for this slot. Click **Submit** to acknowledge this issue."
           }
         }
       }

--- a/custom_components/lock_code_manager/strings.json
+++ b/custom_components/lock_code_manager/strings.json
@@ -199,12 +199,12 @@
       }
     },
     "slot_suspended": {
-      "title": "Lock Code Manager: Sync suspended for {lock_name}",
+      "title": "Lock Code Manager: Sync suspended for slot {slot_num} on {lock_name}",
       "fix_flow": {
         "step": {
           "init": {
-            "title": "Sync suspended for {lock_name}",
-            "description": "Sync has been suspended for lock `{lock_entity_id}`.\n\n**Reason:** {reason}\n\nThe lock will resume syncing automatically when it recovers. Click **Submit** to acknowledge this issue."
+            "title": "Sync suspended for slot {slot_num} on {lock_name}",
+            "description": "Sync has been suspended for slot {slot_num} on lock `{lock_entity_id}`.\n\n**Reason:** {reason}\n\nSyncing for this slot will resume automatically when the lock recovers. Click **Submit** to acknowledge this issue."
           }
         }
       }

--- a/custom_components/lock_code_manager/sync.py
+++ b/custom_components/lock_code_manager/sync.py
@@ -627,6 +627,9 @@ class SlotSyncManager:
                 "set" if slot_state.active_state == STATE_ON else "clear",
                 err,
             )
+            # Feed the lock breaker so repeated connectivity failures during
+            # sync converge to "unreachable" alongside poll failures.
+            self._coordinator.note_connectivity_failure()
             self._state = SyncState.OUT_OF_SYNC
             return
         except Exception as err:

--- a/custom_components/lock_code_manager/sync.py
+++ b/custom_components/lock_code_manager/sync.py
@@ -627,8 +627,9 @@ class SlotSyncManager:
                 f"{self._slot_breaker.failure_count} consecutive attempts. "
                 f"The lock may be rejecting the code silently or "
                 f"experiencing communication issues. "
-                f"Sync has been suspended for this slot. It will "
-                f"resume automatically when the lock recovers.",
+                f"Sync has been suspended for this slot. It will resume "
+                f"automatically once the lock accepts the code or you change "
+                f"the PIN for this slot.",
             )
             return
 

--- a/custom_components/lock_code_manager/sync.py
+++ b/custom_components/lock_code_manager/sync.py
@@ -165,6 +165,14 @@ class SlotSyncManager:
             MAX_SYNC_ATTEMPTS, window=SYNC_ATTEMPT_WINDOW
         )
 
+        # The desired target (active_state, pin_state) captured when the slot
+        # is suspended for a non-converging code or an unexpected error. While
+        # set, the slot stays suspended until that target changes (user edits
+        # the PIN or toggles the slot) or it returns to sync -- it does NOT
+        # resume on unrelated coordinator updates. None for a slot that is not
+        # suspended, or that is suspended only because the lock is unreachable.
+        self._code_suspend_target: tuple[str, str] | None = None
+
         # Invalid state tracking (for initial load)
         self._logged_invalid_state: bool = False
 
@@ -415,9 +423,16 @@ class SlotSyncManager:
         finally:
             self._slot_breaker.reset()
 
-    def _suspend_slot(self, reason: str) -> None:
-        """Suspend this lock and slot and create a per-slot repair issue."""
+    def _suspend_slot(self, slot_state: SlotState, reason: str) -> None:
+        """
+        Suspend this lock and slot and create a per-slot repair issue.
+
+        Records the desired target so the slot stays suspended until that
+        target changes or it returns to sync, rather than resuming on
+        unrelated coordinator updates.
+        """
         self._state = SyncState.SUSPENDED
+        self._code_suspend_target = (slot_state.active_state, slot_state.pin_state)
         self._slot_breaker.reset()
         self._write_state()
 
@@ -464,11 +479,25 @@ class SlotSyncManager:
                 self._slot_breaker.reset()
                 self._write_state()
         elif self._state is SyncState.SUSPENDED:
-            if not self._coordinator.unreachable:
-                # Lock is reachable again: reset the slot breaker and retry.
-                # For a code that won't converge this restarts the attempt
-                # window each recovery cycle; for connectivity suspension the
-                # breaker is already clear.
+            if self._code_suspend_target is not None:
+                # Suspended for a non-converging code or an unexpected error.
+                # Only retry once the desired target changes (e.g. the user
+                # edits the PIN or toggles the slot) or the slot returns to
+                # sync on its own -- otherwise stay suspended so we don't
+                # hammer the lock with a code it keeps rejecting.
+                slot_state = self._resolve_slot_state()
+                if slot_state is not None and (
+                    (slot_state.active_state, slot_state.pin_state)
+                    != self._code_suspend_target
+                    or self.calculate_in_sync(slot_state)
+                ):
+                    self._slot_breaker.reset()
+                    self._code_suspend_target = None
+                    self._state = SyncState.OUT_OF_SYNC
+                    self._write_state()
+            elif not self._coordinator.unreachable:
+                # Suspended because the lock was unreachable; it is reachable
+                # again, so resume.
                 self._slot_breaker.reset()
                 self._state = SyncState.OUT_OF_SYNC
                 self._write_state()
@@ -592,6 +621,7 @@ class SlotSyncManager:
                 SYNC_ATTEMPT_WINDOW,
             )
             self._suspend_slot(
+                slot_state,
                 f"Lock **{self._lock.lock.entity_id}**: slot "
                 f"**{self._slot_num}** failed to sync after "
                 f"{self._slot_breaker.failure_count} consecutive attempts. "
@@ -643,6 +673,7 @@ class SlotSyncManager:
                 err,
             )
             self._suspend_slot(
+                slot_state,
                 f"Lock **{self._lock.lock.entity_id}**: slot **{self._slot_num}** "
                 f"encountered an unexpected error during sync. This may indicate a bug "
                 f"in the lock code manager integration. Check logs for details and "

--- a/custom_components/lock_code_manager/sync.py
+++ b/custom_components/lock_code_manager/sync.py
@@ -42,7 +42,6 @@ from homeassistant.helpers.issue_registry import (
     async_create_issue,
     async_delete_issue,
 )
-from homeassistant.util import dt as dt_util
 
 from .const import (
     ATTR_ACTIVE,
@@ -54,6 +53,7 @@ from .const import (
 )
 from .exceptions import CodeRejectedError, LockDisconnected, LockOperationFailed
 from .models import SlotCode, SyncState
+from .resilience import CircuitBreaker
 from .util import async_disable_slot
 
 if TYPE_CHECKING:
@@ -159,9 +159,11 @@ class SlotSyncManager:
         # masked/write-only slot on every restart.
         self._last_set_pin: str | None = None
 
-        # Circuit breaker
-        self._sync_attempt_count: int = 0
-        self._sync_attempt_first: datetime | None = None
+        # Slot-level circuit breaker: trips when a code repeatedly fails to
+        # converge within the window, suspending just this lock and slot.
+        self._slot_breaker = CircuitBreaker(
+            MAX_SYNC_ATTEMPTS, window=SYNC_ATTEMPT_WINDOW
+        )
 
         # Invalid state tracking (for initial load)
         self._logged_invalid_state: bool = False
@@ -211,7 +213,7 @@ class SlotSyncManager:
         if self._coordinator_unsub:
             self._coordinator_unsub()
             self._coordinator_unsub = None
-        self._reset_sync_tracker()
+        self._slot_breaker.reset()
 
     # -- State resolution ----------------------------------------------------
 
@@ -367,9 +369,9 @@ class SlotSyncManager:
                 source="sync",
             )
             self._last_set_pin = slot_state.pin_state
-            # Track set operations toward circuit breaker. Clear operations
+            # Track set operations toward the slot breaker. Clear operations
             # don't increment the counter (expected to always succeed).
-            self._record_sync_attempt()
+            self._slot_breaker.record_failure()
             _LOGGER.debug("%s: Set usercode", self._log_prefix)
         else:
             await self._lock.async_internal_clear_usercode(
@@ -411,17 +413,17 @@ class SlotSyncManager:
                 },
             )
         finally:
-            self._reset_sync_tracker()
+            self._slot_breaker.reset()
 
-    def _suspend_lock(self, reason: str) -> None:
-        """Suspend this lock and create a per-lock repair issue."""
+    def _suspend_slot(self, reason: str) -> None:
+        """Suspend this lock and slot and create a per-slot repair issue."""
         self._state = SyncState.SUSPENDED
-        self._coordinator.suspend_slot_sync_mgrs()
-        self._reset_sync_tracker()
+        self._slot_breaker.reset()
         self._write_state()
 
         issue_id = (
-            f"slot_suspended_{self._config_entry.entry_id}_{self._lock.lock.entity_id}"
+            f"slot_suspended_{self._config_entry.entry_id}_"
+            f"{self._lock.lock.entity_id}_{self._slot_num}"
         )
         async_create_issue(
             self._hass,
@@ -434,44 +436,10 @@ class SlotSyncManager:
             translation_placeholders={
                 "lock_entity_id": self._lock.lock.entity_id,
                 "lock_name": self._lock.display_name or self._lock.lock.entity_id,
+                "slot_num": str(self._slot_num),
                 "reason": reason,
             },
         )
-
-    # -- Attempt tracking + circuit breaker ----------------------------------
-
-    def _reset_sync_tracker(self) -> None:
-        """Reset the sync attempt tracker."""
-        self._sync_attempt_count = 0
-        self._sync_attempt_first = None
-
-    def _record_sync_attempt(self) -> None:
-        """
-        Record a sync attempt toward circuit breaker counter.
-
-        Called for set operations. Successful clear operations and transient
-        LockDisconnected errors are not tracked since they represent
-        transient lock communication issues, not persistent failures.
-        """
-        now = dt_util.utcnow()
-        if (
-            self._sync_attempt_first is not None
-            and now - self._sync_attempt_first > SYNC_ATTEMPT_WINDOW
-        ):
-            self._sync_attempt_count = 0
-            self._sync_attempt_first = None
-
-        if self._sync_attempt_first is None:
-            self._sync_attempt_first = now
-        self._sync_attempt_count += 1
-
-    def _sync_attempts_exceeded(self) -> bool:
-        """Check if sync attempts exceeded the limit within the time window."""
-        if self._sync_attempt_count < MAX_SYNC_ATTEMPTS:
-            return False
-        if self._sync_attempt_first is None:
-            return False
-        return dt_util.utcnow() - self._sync_attempt_first <= SYNC_ATTEMPT_WINDOW
 
     # -- Orchestration -------------------------------------------------------
 
@@ -493,10 +461,15 @@ class SlotSyncManager:
             slot_state = self._resolve_slot_state()
             if slot_state is not None and not self.calculate_in_sync(slot_state):
                 self._state = SyncState.OUT_OF_SYNC
-                self._reset_sync_tracker()
+                self._slot_breaker.reset()
                 self._write_state()
         elif self._state is SyncState.SUSPENDED:
-            if not self._coordinator.slot_sync_mgrs_suspended:
+            if not self._coordinator.unreachable:
+                # Lock is reachable again: reset the slot breaker and retry.
+                # For a code that won't converge this restarts the attempt
+                # window each recovery cycle; for connectivity suspension the
+                # breaker is already clear.
+                self._slot_breaker.reset()
                 self._state = SyncState.OUT_OF_SYNC
                 self._write_state()
 
@@ -570,7 +543,8 @@ class SlotSyncManager:
                 async_delete_issue(
                     self._hass,
                     DOMAIN,
-                    f"slot_suspended_{self._config_entry.entry_id}_{self._lock.lock.entity_id}",
+                    f"slot_suspended_{self._config_entry.entry_id}_"
+                    f"{self._lock.lock.entity_id}_{self._slot_num}",
                 )
             else:
                 self._state = SyncState.OUT_OF_SYNC
@@ -583,8 +557,8 @@ class SlotSyncManager:
             self._write_state()
             return
 
-        # -- OUT_OF_SYNC: check coordinator suspend flag, then attempt sync --
-        if self._coordinator.slot_sync_mgrs_suspended:
+        # -- OUT_OF_SYNC: check lock reachability, then attempt sync --
+        if self._coordinator.unreachable:
             self._state = SyncState.SUSPENDED
             self._write_state()
             return
@@ -592,7 +566,7 @@ class SlotSyncManager:
         if expected_in_sync:
             # Became in sync without us doing anything (external change)
             self._state = SyncState.IN_SYNC
-            self._reset_sync_tracker()
+            self._slot_breaker.reset()
             self._write_state()
             if slot_state.active_state == STATE_ON:
                 async_delete_issue(
@@ -604,25 +578,26 @@ class SlotSyncManager:
             async_delete_issue(
                 self._hass,
                 DOMAIN,
-                f"slot_suspended_{self._config_entry.entry_id}_{self._lock.lock.entity_id}",
+                f"slot_suspended_{self._config_entry.entry_id}_"
+                f"{self._lock.lock.entity_id}_{self._slot_num}",
             )
             return
 
         # Circuit breaker check (set operations only)
-        if slot_state.active_state == STATE_ON and self._sync_attempts_exceeded():
+        if slot_state.active_state == STATE_ON and self._slot_breaker.tripped:
             _LOGGER.error(
-                "%s: Sync attempts exceeded (%s in %s window), suspending lock",
+                "%s: Sync attempts exceeded (%s in %s window), suspending slot",
                 self._log_prefix,
-                self._sync_attempt_count,
+                self._slot_breaker.failure_count,
                 SYNC_ATTEMPT_WINDOW,
             )
-            self._suspend_lock(
+            self._suspend_slot(
                 f"Lock **{self._lock.lock.entity_id}**: slot "
                 f"**{self._slot_num}** failed to sync after "
-                f"{self._sync_attempt_count} consecutive attempts. "
+                f"{self._slot_breaker.failure_count} consecutive attempts. "
                 f"The lock may be rejecting the code silently or "
                 f"experiencing communication issues. "
-                f"Sync has been suspended for this lock. It will "
+                f"Sync has been suspended for this slot. It will "
                 f"resume automatically when the lock recovers.",
             )
             return
@@ -664,7 +639,7 @@ class SlotSyncManager:
                 type(err).__name__,
                 err,
             )
-            self._suspend_lock(
+            self._suspend_slot(
                 f"Lock **{self._lock.lock.entity_id}**: slot **{self._slot_num}** "
                 f"encountered an unexpected error during sync. This may indicate a bug "
                 f"in the lock code manager integration. Check logs for details and "
@@ -692,7 +667,7 @@ class SlotSyncManager:
         slot_state = self._resolve_slot_state()
         if slot_state is not None and self.calculate_in_sync(slot_state):
             self._state = SyncState.IN_SYNC
-            self._reset_sync_tracker()
+            self._slot_breaker.reset()
             self._write_state()
             if slot_state.active_state == STATE_ON:
                 async_delete_issue(
@@ -704,7 +679,8 @@ class SlotSyncManager:
             async_delete_issue(
                 self._hass,
                 DOMAIN,
-                f"slot_suspended_{self._config_entry.entry_id}_{self._lock.lock.entity_id}",
+                f"slot_suspended_{self._config_entry.entry_id}_"
+                f"{self._lock.lock.entity_id}_{self._slot_num}",
             )
         else:
             self._state = SyncState.OUT_OF_SYNC

--- a/custom_components/lock_code_manager/translations/en.json
+++ b/custom_components/lock_code_manager/translations/en.json
@@ -204,7 +204,7 @@
         "step": {
           "init": {
             "title": "Sync suspended for slot {slot_num} on {lock_name}",
-            "description": "Sync has been suspended for slot {slot_num} on lock `{lock_entity_id}`.\n\n**Reason:** {reason}\n\nSyncing for this slot will resume automatically when the lock recovers. Click **Submit** to acknowledge this issue."
+            "description": "Sync has been suspended for slot {slot_num} on lock `{lock_entity_id}`.\n\n**Reason:** {reason}\n\nSyncing for this slot will resume automatically once the lock accepts the code or you change the PIN for this slot. Click **Submit** to acknowledge this issue."
           }
         }
       }

--- a/custom_components/lock_code_manager/translations/en.json
+++ b/custom_components/lock_code_manager/translations/en.json
@@ -199,12 +199,12 @@
       }
     },
     "slot_suspended": {
-      "title": "Lock Code Manager: Sync suspended for {lock_name}",
+      "title": "Lock Code Manager: Sync suspended for slot {slot_num} on {lock_name}",
       "fix_flow": {
         "step": {
           "init": {
-            "title": "Sync suspended for {lock_name}",
-            "description": "Sync has been suspended for lock `{lock_entity_id}`.\n\n**Reason:** {reason}\n\nThe lock will resume syncing automatically when it recovers. Click **Submit** to acknowledge this issue."
+            "title": "Sync suspended for slot {slot_num} on {lock_name}",
+            "description": "Sync has been suspended for slot {slot_num} on lock `{lock_entity_id}`.\n\n**Reason:** {reason}\n\nSyncing for this slot will resume automatically when the lock recovers. Click **Submit** to acknowledge this issue."
           }
         }
       }

--- a/custom_components/lock_code_manager/websocket.py
+++ b/custom_components/lock_code_manager/websocket.py
@@ -510,7 +510,7 @@ def _serialize_lock_coordinator(
         ATTR_LOCK_NAME: _get_lock_friendly_name(hass, lock),
         CONF_SLOTS: slots,
     }
-    if coordinator and coordinator.slot_sync_mgrs_suspended:
+    if coordinator and coordinator.unreachable:
         result[ATTR_SYNC_STATUS] = "suspended"
     return result
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -14,6 +14,6 @@ universal-silabs-flasher>=1.1.0
 usb-devices>=0.4.5
 uv
 zeroconf==0.148.0
-zha>=1.3.1
+zha>=1.3.1,<1.4
 zigpy>=1.4.1
 zwave-js-server-python==0.71.0

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -884,12 +884,12 @@ async def test_sync_disables_slot_on_duplicate_code(
     assert lock_provider.codes.get(1) != "9999"
 
 
-async def test_sync_attempts_exceeded_disables_slot(
+async def test_sync_attempts_exceeded_suspends_slot(
     hass: HomeAssistant,
     mock_lock_config_entry,
     lock_code_manager_config_entry,
 ):
-    """Test that exceeding sync attempts disables slot and notifies."""
+    """Test that exceeding sync attempts suspends the slot."""
     await async_initial_tick(hass, SLOT_1_IN_SYNC_ENTITY)
 
     lock_provider = lock_code_manager_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
@@ -910,19 +910,18 @@ async def test_sync_attempts_exceeded_disables_slot(
 
     sync_mgr = in_sync_entity_obj._sync_manager
 
-    # Pre-load the tracker to simulate repeated failures on the same PIN
-    now = dt_util.utcnow()
-    sync_mgr._sync_attempt_count = MAX_SYNC_ATTEMPTS
-    sync_mgr._sync_attempt_first = now
+    # Pre-load the breaker to simulate repeated failures on the same PIN
+    for _ in range(MAX_SYNC_ATTEMPTS):
+        sync_mgr._slot_breaker.record_failure()
 
     # Trigger tick — circuit breaker should fire before attempting sync
     sync_mgr._state = SyncState.OUT_OF_SYNC
     await sync_mgr._async_tick()
     await hass.async_block_till_done()
 
-    # Lock should be suspended (not slot disabled)
+    # Slot should be suspended; the lock itself is not marked unreachable
     assert sync_mgr._state is SyncState.SUSPENDED
-    assert coordinator.slot_sync_mgrs_suspended is True
+    assert coordinator.unreachable is False
 
     # The "9999" code should never have been sent to the lock — the tracker
     # check fires BEFORE the sync operation
@@ -970,7 +969,7 @@ async def test_sync_tracker_resets_when_back_in_sync(
     # tracker should not be at the circuit breaker threshold
     synced_state = hass.states.get(SLOT_1_IN_SYNC_ENTITY)
     assert synced_state.state == STATE_ON
-    assert not in_sync_entity_obj._sync_manager._sync_attempts_exceeded()
+    assert not in_sync_entity_obj._sync_manager._slot_breaker.tripped
 
 
 async def test_sync_tracker_does_not_fire_breaker_with_expired_window(
@@ -981,7 +980,7 @@ async def test_sync_tracker_does_not_fire_breaker_with_expired_window(
     """
     Test that stale sync attempts outside the window do not trigger the circuit breaker.
 
-    When the attempt window expires, _record_sync_attempt resets the counter,
+    When the attempt window expires, record_failure resets the counter,
     preventing stale counts from triggering the breaker on a new sync cycle.
     """
     await async_initial_tick(hass, SLOT_1_IN_SYNC_ENTITY)
@@ -993,8 +992,8 @@ async def test_sync_tracker_does_not_fire_breaker_with_expired_window(
     assert hass.states.get(SLOT_1_IN_SYNC_ENTITY).state == STATE_ON
 
     # Simulate prior sync attempts from an EXPIRED window
-    sync_mgr._sync_attempt_count = MAX_SYNC_ATTEMPTS - 1
-    sync_mgr._sync_attempt_first = dt_util.utcnow() - SYNC_ATTEMPT_WINDOW * 2
+    sync_mgr._slot_breaker._failure_count = MAX_SYNC_ATTEMPTS - 1
+    sync_mgr._slot_breaker._first_failure = dt_util.utcnow() - SYNC_ATTEMPT_WINDOW * 2
 
     # Change PIN to trigger out-of-sync
     await hass.services.async_call(
@@ -1009,16 +1008,16 @@ async def test_sync_tracker_does_not_fire_breaker_with_expired_window(
     # _request_sync_check transitions IN_SYNC -> OUT_OF_SYNC
     assert sync_mgr._state is SyncState.OUT_OF_SYNC
 
-    # Tick fires — expired window causes _record_sync_attempt to reset
-    # the counter, so the breaker does not fire. Sync succeeds and
-    # resets the tracker.
+    # Tick fires — expired window causes record_failure to reset the
+    # counter, so the breaker does not fire. Sync succeeds and resets the
+    # breaker.
     await sync_mgr._async_tick()
     await hass.async_block_till_done()
 
     # Sync succeeded — lock should be IN_SYNC, not SUSPENDED
     assert sync_mgr._state is SyncState.IN_SYNC
-    # Tracker reset after successful sync
-    assert sync_mgr._sync_attempt_count == 0
+    # Breaker reset after successful sync
+    assert sync_mgr._slot_breaker.failure_count == 0
 
 
 async def test_sync_tracker_expired_window_resets(
@@ -1033,14 +1032,14 @@ async def test_sync_tracker_expired_window_resets(
 
     in_sync_entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
 
-    # Set up tracker with max attempts but with an expired window
-    in_sync_entity_obj._sync_manager._sync_attempt_count = MAX_SYNC_ATTEMPTS
-    in_sync_entity_obj._sync_manager._sync_attempt_first = (
+    # Set up breaker with max attempts but with an expired window
+    in_sync_entity_obj._sync_manager._slot_breaker._failure_count = MAX_SYNC_ATTEMPTS
+    in_sync_entity_obj._sync_manager._slot_breaker._first_failure = (
         dt_util.utcnow() - SYNC_ATTEMPT_WINDOW * 2
     )
 
-    # The _sync_attempts_exceeded check should return False (window expired)
-    assert not in_sync_entity_obj._sync_manager._sync_attempts_exceeded()
+    # tripped should be False since the breaches fall outside the window
+    assert not in_sync_entity_obj._sync_manager._slot_breaker.tripped
 
 
 async def test_clear_operation_does_not_increment_tracker(
@@ -1056,7 +1055,7 @@ async def test_clear_operation_does_not_increment_tracker(
     in_sync_entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
 
     # Verify starting at zero
-    assert in_sync_entity_obj._sync_manager._sync_attempt_count == 0
+    assert in_sync_entity_obj._sync_manager._slot_breaker.failure_count == 0
 
     # Disable slot to trigger a clear sync cycle
     await hass.services.async_call(
@@ -1069,7 +1068,7 @@ async def test_clear_operation_does_not_increment_tracker(
     await _async_force_sync_cycle(hass, coordinator)
 
     # Clear operation should NOT have incremented the tracker
-    assert in_sync_entity_obj._sync_manager._sync_attempt_count == 0
+    assert in_sync_entity_obj._sync_manager._slot_breaker.failure_count == 0
 
 
 async def test_invalid_active_state_during_initial_load(
@@ -1100,12 +1099,12 @@ async def test_invalid_active_state_during_initial_load(
     assert in_sync_entity_obj._sync_manager._state is SyncState.LOADING
 
 
-async def test_unexpected_error_during_sync_suspends_lock(
+async def test_unexpected_error_during_sync_suspends_slot(
     hass: HomeAssistant,
     mock_lock_config_entry,
     lock_code_manager_config_entry,
 ):
-    """Test that unexpected errors during sync operation suspend the lock."""
+    """Test that unexpected errors during sync operation suspend the slot."""
     in_sync_entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
     lock_provider = lock_code_manager_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
     coordinator = lock_provider.coordinator
@@ -1128,9 +1127,9 @@ async def test_unexpected_error_during_sync_suspends_lock(
         await in_sync_entity_obj._sync_manager._async_tick()
         await hass.async_block_till_done()
 
-        # Verify that the lock was suspended
+        # Verify that the slot was suspended without marking the lock unreachable
         assert in_sync_entity_obj._sync_manager._state is SyncState.SUSPENDED
-        assert coordinator.slot_sync_mgrs_suspended is True
+        assert coordinator.unreachable is False
 
 
 async def test_sync_manager_handles_string_slot_num(
@@ -1287,11 +1286,11 @@ async def test_push_update_triggers_sync_state_change_on_binary_sensor(
     await hass.config_entries.async_unload(config_entry.entry_id)
 
 
-async def test_suspension_propagates_to_out_of_sync_managers_on_next_tick(
+async def test_slot_suspension_isolated_from_other_slots(
     hass: HomeAssistant,
     mock_lock_config_entry,
 ):
-    """When one slot suspends the lock, other out-of-sync slots transition to SUSPENDED on next tick."""
+    """A generic error on one slot suspends only that slot, not its siblings or the lock."""
     config = {
         CONF_LOCKS: [LOCK_1_ENTITY_ID],
         CONF_SLOTS: {
@@ -1303,7 +1302,7 @@ async def test_suspension_propagates_to_out_of_sync_managers_on_next_tick(
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         data=config,
-        unique_id="Test Suspension Propagation",
+        unique_id="Test Suspension Isolation",
         title="Test LCM",
     )
     config_entry.add_to_hass(hass)
@@ -1318,51 +1317,25 @@ async def test_suspension_propagates_to_out_of_sync_managers_on_next_tick(
     lock_provider = config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
     coordinator = lock_provider.coordinator
 
-    entity_obj_1 = get_in_sync_entity_obj(hass, in_sync_slot_1)
-    entity_obj_2 = get_in_sync_entity_obj(hass, in_sync_slot_2)
+    mgr_1 = get_in_sync_entity_obj(hass, in_sync_slot_1)._sync_manager
+    mgr_2 = get_in_sync_entity_obj(hass, in_sync_slot_2)._sync_manager
 
-    mgr_1 = entity_obj_1._sync_manager
-    mgr_2 = entity_obj_2._sync_manager
-
-    # Make slot 1 out of sync by changing the lock code externally
-    lock_provider.codes[1] = "9999"
-    await coordinator.async_refresh()
-    await hass.async_block_till_done()
-
-    # Make slot 2's sync fail with an unexpected error
+    # Only slot 2's sync hits an unexpected error; slot 1 is left in sync.
     with patch.object(
-        lock_provider,
-        "async_internal_set_usercode",
-        AsyncMock(side_effect=ValueError("Unexpected hardware error")),
+        mgr_2,
+        "_perform_sync",
+        new_callable=AsyncMock,
+        side_effect=ValueError("Unexpected hardware error"),
     ):
-        # Also make slot 2 out of sync
-        lock_provider.codes[2] = "0000"
-        await coordinator.async_refresh()
+        mgr_2._state = SyncState.OUT_OF_SYNC
+        coordinator.data[2] = "0000"
+        await mgr_2._async_tick()
         await hass.async_block_till_done()
 
-        # Fire tick — slot 2 tries to sync, hits generic exception, suspends lock
-        async_fire_time_changed(hass, dt_util.utcnow() + TICK_INTERVAL * 2)
-        await hass.async_block_till_done()
-
-    # Verify the lock is suspended
-    assert coordinator.slot_sync_mgrs_suspended is True
-
-    # One of the managers should be SUSPENDED (the one that hit the error)
-    # The other should transition to SUSPENDED on the next tick
-    suspended_count = sum(1 for m in (mgr_1, mgr_2) if m._state is SyncState.SUSPENDED)
-    assert suspended_count >= 1, "At least one manager should be SUSPENDED"
-
-    # Fire another tick so the other slot transitions to SUSPENDED too
-    async_fire_time_changed(hass, dt_util.utcnow() + TICK_INTERVAL * 3)
-    await hass.async_block_till_done()
-
-    # Both managers should now be SUSPENDED
-    assert mgr_1._state is SyncState.SUSPENDED, (
-        f"Expected slot 1 SUSPENDED, got {mgr_1._state}"
-    )
-    assert mgr_2._state is SyncState.SUSPENDED, (
-        f"Expected slot 2 SUSPENDED, got {mgr_2._state}"
-    )
+    # Slot 2 is suspended; slot 1 and the lock itself are unaffected.
+    assert mgr_2._state is SyncState.SUSPENDED
+    assert mgr_1._state is not SyncState.SUSPENDED
+    assert coordinator.unreachable is False
 
     await hass.config_entries.async_unload(config_entry.entry_id)
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -588,12 +588,12 @@ async def test_drift_check_runs_below_backoff_threshold(
         mock_hard_refresh.assert_called_once()
 
 
-async def test_backoff_push_provider_does_not_change_interval(
+async def test_backoff_push_provider_polls_to_probe_recovery(
     push_coordinator: LockUsercodeUpdateCoordinator,
     push_lock: MockLCMPushLock,
 ) -> None:
-    """Test that push-based providers do not modify update_interval during backoff."""
-    # Push providers have update_interval=None
+    """A push provider starts polling on a backoff once the breaker trips, then stops on recovery."""
+    # Push providers normally have update_interval=None (no polling)
     assert push_coordinator.update_interval is None
     push_coordinator.last_update_success = True
 
@@ -603,10 +603,45 @@ async def test_backoff_push_provider_does_not_change_interval(
             with pytest.raises(UpdateFailed):
                 await push_coordinator.async_get_usercodes()
 
-    # update_interval should remain None for push providers
-    assert push_coordinator.update_interval is None
-    # But failure counter should still be tracked
+    # While unreachable, the push provider polls on the backoff interval to
+    # probe for recovery.
+    assert push_coordinator.unreachable is True
+    assert (
+        push_coordinator.update_interval == push_coordinator._lock_breaker.backoff_delay
+    )
     assert push_coordinator._lock_breaker.failure_count == BACKOFF_FAILURE_THRESHOLD + 2
+
+    # A successful poll clears the breaker and stops the probe polling.
+    mock_get_ok = AsyncMock(return_value={1: "1234"})
+    with patch.object(push_lock, "async_internal_get_usercodes", mock_get_ok):
+        await push_coordinator.async_get_usercodes()
+
+    assert push_coordinator.unreachable is False
+    assert push_coordinator.update_interval is None
+
+
+async def test_note_connectivity_failure_kicks_probe_for_push(
+    hass: HomeAssistant,
+    push_coordinator: LockUsercodeUpdateCoordinator,
+) -> None:
+    """Set-side failures that trip the breaker start probe polling on a push provider."""
+    assert push_coordinator.update_interval is None
+
+    with patch.object(
+        push_coordinator, "async_request_refresh", new_callable=AsyncMock
+    ) as mock_refresh:
+        for _ in range(BACKOFF_FAILURE_THRESHOLD):
+            push_coordinator.note_connectivity_failure()
+        await hass.async_block_till_done()
+
+    assert push_coordinator.unreachable is True
+    # Probe polling enabled at the backoff cadence.
+    assert (
+        push_coordinator.update_interval == push_coordinator._lock_breaker.backoff_delay
+    )
+    # A refresh was kicked once, on the trip transition, so a push provider
+    # that otherwise never polls begins probing for recovery.
+    mock_refresh.assert_called_once()
 
 
 async def test_backoff_init_stores_original_interval(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -408,7 +408,7 @@ async def test_backoff_failure_counter_increments(
         for i in range(1, 4):
             with pytest.raises(UpdateFailed):
                 await poll_coordinator.async_get_usercodes()
-            assert poll_coordinator._consecutive_failures == i
+            assert poll_coordinator._lock_breaker.failure_count == i
 
 
 async def test_backoff_first_failure_returns_empty_dict(
@@ -424,7 +424,7 @@ async def test_backoff_first_failure_returns_empty_dict(
         result = await poll_coordinator.async_get_usercodes()
 
     assert result == {}
-    assert poll_coordinator._consecutive_failures == 1
+    assert poll_coordinator._lock_breaker.failure_count == 1
 
 
 async def test_backoff_subsequent_failure_raises_update_failed(
@@ -439,7 +439,7 @@ async def test_backoff_subsequent_failure_raises_update_failed(
         with pytest.raises(UpdateFailed):
             await poll_coordinator.async_get_usercodes()
 
-    assert poll_coordinator._consecutive_failures == 1
+    assert poll_coordinator._lock_breaker.failure_count == 1
 
 
 async def test_backoff_activates_after_threshold(
@@ -463,7 +463,7 @@ async def test_backoff_activates_after_threshold(
         with pytest.raises(UpdateFailed):
             await poll_coordinator.async_get_usercodes()
 
-        assert poll_coordinator._consecutive_failures == BACKOFF_FAILURE_THRESHOLD
+        assert poll_coordinator._lock_breaker.failure_count == BACKOFF_FAILURE_THRESHOLD
         expected_backoff = timedelta(
             seconds=BACKOFF_INITIAL_SECONDS * 2**0  # 2^(3-3) = 1
         )
@@ -521,7 +521,7 @@ async def test_backoff_resets_on_success(
             with pytest.raises(UpdateFailed):
                 await poll_coordinator.async_get_usercodes()
 
-    assert poll_coordinator._consecutive_failures == BACKOFF_FAILURE_THRESHOLD + 1
+    assert poll_coordinator._lock_breaker.failure_count == BACKOFF_FAILURE_THRESHOLD + 1
     assert poll_coordinator.update_interval != original_interval
 
     # Now succeed
@@ -530,7 +530,7 @@ async def test_backoff_resets_on_success(
         result = await poll_coordinator.async_get_usercodes()
 
     assert result == {1: "1234"}
-    assert poll_coordinator._consecutive_failures == 0
+    assert poll_coordinator._lock_breaker.failure_count == 0
     assert poll_coordinator.update_interval == original_interval
 
 
@@ -546,7 +546,7 @@ async def test_backoff_no_reset_when_no_prior_failures(
         result = await poll_coordinator.async_get_usercodes()
 
     assert result == {1: "1234"}
-    assert poll_coordinator._consecutive_failures == 0
+    assert poll_coordinator._lock_breaker.failure_count == 0
     assert poll_coordinator.update_interval == original_interval
 
 
@@ -556,7 +556,8 @@ async def test_drift_check_skipped_during_backoff(
 ) -> None:
     """Test that drift check is skipped when in backoff."""
     push_coordinator.last_update_success = True
-    push_coordinator._consecutive_failures = BACKOFF_FAILURE_THRESHOLD
+    for _ in range(BACKOFF_FAILURE_THRESHOLD):
+        push_coordinator._lock_breaker.record_failure()
 
     mock_hard_refresh = AsyncMock()
     with patch.object(
@@ -574,7 +575,8 @@ async def test_drift_check_runs_below_backoff_threshold(
 ) -> None:
     """Test that drift check runs when failures are below threshold."""
     push_coordinator.last_update_success = True
-    push_coordinator._consecutive_failures = BACKOFF_FAILURE_THRESHOLD - 1
+    for _ in range(BACKOFF_FAILURE_THRESHOLD - 1):
+        push_coordinator._lock_breaker.record_failure()
 
     mock_hard_refresh = AsyncMock(return_value={1: "1234"})
     with patch.object(
@@ -604,7 +606,7 @@ async def test_backoff_push_provider_does_not_change_interval(
     # update_interval should remain None for push providers
     assert push_coordinator.update_interval is None
     # But failure counter should still be tracked
-    assert push_coordinator._consecutive_failures == BACKOFF_FAILURE_THRESHOLD + 2
+    assert push_coordinator._lock_breaker.failure_count == BACKOFF_FAILURE_THRESHOLD + 2
 
 
 async def test_backoff_init_stores_original_interval(
@@ -615,7 +617,7 @@ async def test_backoff_init_stores_original_interval(
     assert (
         poll_coordinator._original_update_interval == poll_lock.usercode_scan_interval
     )
-    assert poll_coordinator._consecutive_failures == 0
+    assert poll_coordinator._lock_breaker.failure_count == 0
 
 
 async def test_backoff_init_push_stores_none_interval(
@@ -623,7 +625,7 @@ async def test_backoff_init_push_stores_none_interval(
 ) -> None:
     """Test that __init__ stores None for push-based providers."""
     assert push_coordinator._original_update_interval is None
-    assert push_coordinator._consecutive_failures == 0
+    assert push_coordinator._lock_breaker.failure_count == 0
 
 
 async def test_push_update_resets_backoff(
@@ -640,13 +642,13 @@ async def test_push_update_resets_backoff(
             with pytest.raises(UpdateFailed):
                 await push_coordinator.async_get_usercodes()
 
-    assert push_coordinator._consecutive_failures == BACKOFF_FAILURE_THRESHOLD + 2
+    assert push_coordinator._lock_breaker.failure_count == BACKOFF_FAILURE_THRESHOLD + 2
 
     # Push update with new data should reset backoff
     push_coordinator.data = {1: "old"}
     push_coordinator.push_update({1: "1234"})
 
-    assert push_coordinator._consecutive_failures == 0
+    assert push_coordinator._lock_breaker.failure_count == 0
 
 
 async def test_push_update_no_reset_when_data_unchanged(
@@ -663,13 +665,13 @@ async def test_push_update_no_reset_when_data_unchanged(
             with pytest.raises(UpdateFailed):
                 await push_coordinator.async_get_usercodes()
 
-    assert push_coordinator._consecutive_failures == BACKOFF_FAILURE_THRESHOLD + 1
+    assert push_coordinator._lock_breaker.failure_count == BACKOFF_FAILURE_THRESHOLD + 1
 
     # Push update with same data should NOT reset backoff
     push_coordinator.data = {1: "1234"}
     push_coordinator.push_update({1: "1234"})
 
-    assert push_coordinator._consecutive_failures == BACKOFF_FAILURE_THRESHOLD + 1
+    assert push_coordinator._lock_breaker.failure_count == BACKOFF_FAILURE_THRESHOLD + 1
 
 
 async def test_poll_failure_alert_created_after_threshold(
@@ -803,3 +805,43 @@ async def test_lock_offline_issue_persists_across_shutdown(
     # Shutdown should NOT delete the issue — it persists across restarts
     await poll_coordinator.async_shutdown()
     assert issue_registry.async_get_issue(DOMAIN, issue_id) is not None
+
+
+async def test_unreachable_reflects_backoff_trip(
+    poll_coordinator: LockUsercodeUpdateCoordinator,
+    poll_lock: MockLCMLock,
+) -> None:
+    """unreachable is False until the lock breaker trips, then True."""
+    poll_coordinator.last_update_success = True
+    assert poll_coordinator.unreachable is False
+
+    mock_get = AsyncMock(side_effect=LockDisconnected("Lock offline"))
+    with patch.object(poll_lock, "async_internal_get_usercodes", mock_get):
+        for _ in range(BACKOFF_FAILURE_THRESHOLD):
+            with pytest.raises(UpdateFailed):
+                await poll_coordinator.async_get_usercodes()
+
+    assert poll_coordinator.unreachable is True
+
+
+async def test_unreachable_clears_on_recovery(
+    poll_coordinator: LockUsercodeUpdateCoordinator,
+    poll_lock: MockLCMLock,
+) -> None:
+    """A successful poll resets the breaker and clears unreachable."""
+    poll_coordinator.last_update_success = True
+    mock_get = AsyncMock(side_effect=LockDisconnected("Lock offline"))
+    with patch.object(poll_lock, "async_internal_get_usercodes", mock_get):
+        for _ in range(BACKOFF_FAILURE_THRESHOLD):
+            with pytest.raises(UpdateFailed):
+                await poll_coordinator.async_get_usercodes()
+    assert poll_coordinator.unreachable is True
+
+    mock_get_ok = AsyncMock(return_value={1: "1234"})
+    with patch.object(poll_lock, "async_internal_get_usercodes", mock_get_ok):
+        await poll_coordinator.async_get_usercodes()
+
+    assert poll_coordinator.unreachable is False
+    assert (
+        poll_coordinator.update_interval == poll_coordinator._original_update_interval
+    )

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -744,42 +744,6 @@ async def test_poll_failure_alert_dismissed_on_recovery(
     assert issue_registry.async_get_issue(DOMAIN, issue_id) is None
 
 
-async def test_coordinator_suspended_flag_defaults_false(
-    hass: HomeAssistant, poll_lock, lcm_config_entry
-) -> None:
-    """Coordinator starts with suspended=False."""
-    coordinator = LockUsercodeUpdateCoordinator(hass, poll_lock, lcm_config_entry)
-    assert coordinator.slot_sync_mgrs_suspended is False
-
-
-async def test_coordinator_suspended_cleared_on_successful_poll(
-    hass: HomeAssistant, poll_lock, poll_coordinator
-) -> None:
-    """Successful poll clears suspended flag."""
-    poll_coordinator.suspend_slot_sync_mgrs()
-    await poll_coordinator.async_refresh()
-    assert poll_coordinator.slot_sync_mgrs_suspended is False
-
-
-async def test_coordinator_suspended_cleared_on_push_update(
-    hass: HomeAssistant, push_lock, push_coordinator
-) -> None:
-    """Push update clears suspended flag."""
-    push_coordinator.suspend_slot_sync_mgrs()
-    push_coordinator.push_update({1: "1234"})
-    assert push_coordinator.slot_sync_mgrs_suspended is False
-
-
-async def test_coordinator_suspended_not_cleared_on_failed_poll(
-    hass: HomeAssistant, poll_lock, poll_coordinator
-) -> None:
-    """Failed poll does not clear suspended flag."""
-    poll_coordinator.suspend_slot_sync_mgrs()
-    poll_lock.set_connected(False)
-    await poll_coordinator.async_refresh()
-    assert poll_coordinator.slot_sync_mgrs_suspended is True
-
-
 async def test_lock_offline_issue_persists_across_shutdown(
     poll_coordinator: LockUsercodeUpdateCoordinator,
     poll_lock: MockLCMLock,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -31,6 +31,7 @@ from homeassistant.helpers import (
 from custom_components.lock_code_manager.const import (
     ATTR_ACTIVE,
     ATTR_IN_SYNC,
+    BACKOFF_FAILURE_THRESHOLD,
     CONF_CALENDAR,
     CONF_LOCKS,
     CONF_SLOTS,
@@ -1062,12 +1063,13 @@ async def test_two_entries_same_lock_share_suspension_and_recovery(
     lock_code_manager_config_entry,
 ):
     """
-    Suspension on one entry's slot affects another entry's out-of-sync slots on the same lock.
+    An unreachable lock blocks another entry's out-of-sync slots on the same lock.
 
-    Lock-level suspension is by design: when one slot's circuit breaker trips,
-    ALL sync managers on that lock are blocked from syncing. This prevents a
-    misbehaving lock from being hammered by multiple entries. When the coordinator
-    recovers, all entries' sync managers resume.
+    Lock-level suspension is by design: when the lock becomes unreachable
+    (its circuit breaker trips), ALL sync managers on that lock are blocked
+    from syncing. This prevents a misbehaving lock from being hammered by
+    multiple entries. When the coordinator recovers, all entries' sync
+    managers resume.
     """
     entry_a = lock_code_manager_config_entry
 
@@ -1106,7 +1108,9 @@ async def test_two_entries_same_lock_share_suspension_and_recovery(
     assert entry_b_entity_obj._sync_manager._state == SyncState.IN_SYNC
 
     # Suspend the coordinator (simulating circuit breaker trip from entry A)
-    lock_a.coordinator.suspend_slot_sync_mgrs()
+    for _ in range(BACKOFF_FAILURE_THRESHOLD):
+        lock_a.coordinator._lock_breaker.record_failure()
+    lock_a.coordinator.async_update_listeners()
     await hass.async_block_till_done()
 
     # An IN_SYNC slot stays IN_SYNC during suspension (nothing to do), which
@@ -1118,18 +1122,19 @@ async def test_two_entries_same_lock_share_suspension_and_recovery(
     lock_a.coordinator.push_update({3: "different"})
     await hass.async_block_till_done()
 
-    # The push_update call above clears the suspension flag (successful
-    # push proves lock is reachable). Re-suspend to test blocking, then
-    # let _request_sync_check detect the mismatch naturally.
-    lock_a.coordinator.suspend_slot_sync_mgrs()
+    # The push_update call above resets the lock breaker (successful push
+    # proves the lock is reachable). Re-trip it to test blocking, then let
+    # _request_sync_check detect the mismatch naturally.
+    for _ in range(BACKOFF_FAILURE_THRESHOLD):
+        lock_a.coordinator._lock_breaker.record_failure()
+    lock_a.coordinator.async_update_listeners()
     await hass.async_block_till_done()
 
     # The coordinator listener fires _request_sync_check. Since the code
     # changed ("different" != "0123"), the slot should be OUT_OF_SYNC.
-    # But wait — suspend_slot_sync_mgrs calls async_update_listeners,
-    # which fires _request_sync_check on all managers. For an IN_SYNC
-    # manager with a mismatch, it transitions to OUT_OF_SYNC. Then on
-    # the next tick, the suspension check blocks it into SUSPENDED.
+    # async_update_listeners fires _request_sync_check on all managers. For
+    # an IN_SYNC manager with a mismatch, it transitions to OUT_OF_SYNC.
+    # Then on the next tick, the unreachable check blocks it into SUSPENDED.
     await async_trigger_sync_tick(hass, entry_b_in_sync_entity, set_dirty=False)
     await hass.async_block_till_done()
     assert entry_b_entity_obj._sync_manager._state == SyncState.SUSPENDED, (
@@ -1141,7 +1146,7 @@ async def test_two_entries_same_lock_share_suspension_and_recovery(
     await hass.async_block_till_done()
 
     # After recovery, entry B's sync manager should resume from SUSPENDED
-    # via _request_sync_check detecting the cleared suspension flag
+    # via _request_sync_check detecting the lock is reachable again
     assert entry_b_entity_obj._sync_manager._state == SyncState.OUT_OF_SYNC, (
         f"Entry B's sync manager should have resumed to OUT_OF_SYNC, "
         f"but state is {entry_b_entity_obj._sync_manager._state}"

--- a/tests/test_resilience.py
+++ b/tests/test_resilience.py
@@ -97,14 +97,19 @@ class TestWindowedTripPolicy:
         breaker.record_failure()
         assert breaker.tripped
 
-    def test_tripped_latches_until_reset(self, freezer) -> None:
+    def test_tripped_clears_when_window_elapses(self, freezer) -> None:
         breaker = self._breaker()
         for _ in range(3):
             breaker.record_failure()
         assert breaker.tripped
-        # Even after the window elapses, tripped stays True until reset()
-        # (reads do not re-evaluate the window -- only record_failure does).
-        freezer.tick(timedelta(minutes=10))
+        # Once the window passes with no new failures, the stale breaches no
+        # longer count as tripped.
+        freezer.tick(timedelta(minutes=5, seconds=1))
+        assert not breaker.tripped
+        # reset() also clears the tripped state immediately.
+        breaker.record_failure()
+        breaker.record_failure()
+        breaker.record_failure()
         assert breaker.tripped
         breaker.reset()
         assert not breaker.tripped

--- a/tests/test_resilience.py
+++ b/tests/test_resilience.py
@@ -1,0 +1,110 @@
+"""Tests for the CircuitBreaker resilience primitive."""
+
+from datetime import timedelta
+
+from custom_components.lock_code_manager.resilience import CircuitBreaker
+
+
+class TestConsecutiveBackoffPolicy:
+    """Lock-level config: threshold + exponential backoff, no window."""
+
+    def _breaker(self) -> CircuitBreaker:
+        return CircuitBreaker(
+            3,
+            backoff_initial=timedelta(seconds=60),
+            backoff_max=timedelta(seconds=1800),
+        )
+
+    def test_not_tripped_below_threshold(self) -> None:
+        breaker = self._breaker()
+        for _ in range(2):
+            breaker.record_failure()
+        assert breaker.failure_count == 2
+        assert not breaker.tripped
+        assert breaker.backoff_delay == timedelta(0)
+
+    def test_tripped_at_threshold_uses_initial_delay(self) -> None:
+        breaker = self._breaker()
+        for _ in range(3):
+            breaker.record_failure()
+        assert breaker.tripped
+        # 60 * 2 ** (3 - 3) == 60
+        assert breaker.backoff_delay == timedelta(seconds=60)
+
+    def test_backoff_escalates_exponentially(self) -> None:
+        breaker = self._breaker()
+        for _ in range(6):  # threshold + 3
+            breaker.record_failure()
+        # 60 * 2 ** (6 - 3) == 480
+        assert breaker.backoff_delay == timedelta(seconds=480)
+
+    def test_backoff_caps_at_max(self) -> None:
+        breaker = self._breaker()
+        for _ in range(30):
+            breaker.record_failure()
+        assert breaker.backoff_delay == timedelta(seconds=1800)
+
+    def test_reset_clears_state(self) -> None:
+        breaker = self._breaker()
+        for _ in range(5):
+            breaker.record_failure()
+        breaker.reset()
+        assert breaker.failure_count == 0
+        assert not breaker.tripped
+        assert breaker.backoff_delay == timedelta(0)
+
+    def test_record_success_is_reset(self) -> None:
+        breaker = self._breaker()
+        breaker.record_failure()
+        breaker.record_success()
+        assert breaker.failure_count == 0
+
+
+class TestWindowedTripPolicy:
+    """Slot-level config: threshold within a sliding window, no backoff."""
+
+    def _breaker(self) -> CircuitBreaker:
+        return CircuitBreaker(3, window=timedelta(minutes=5))
+
+    def test_trips_at_threshold_within_window(self) -> None:
+        breaker = self._breaker()
+        for _ in range(3):
+            breaker.record_failure()
+        assert breaker.tripped
+
+    def test_backoff_delay_unused_is_zero(self) -> None:
+        breaker = self._breaker()
+        for _ in range(3):
+            breaker.record_failure()
+        assert breaker.backoff_delay == timedelta(0)
+
+    def test_window_expiry_resets_count(self, freezer) -> None:
+        breaker = self._breaker()
+        breaker.record_failure()
+        breaker.record_failure()
+        freezer.tick(timedelta(minutes=5, seconds=1))
+        # First failure is now outside the window: count restarts at 1.
+        breaker.record_failure()
+        assert breaker.failure_count == 1
+        assert not breaker.tripped
+
+    def test_failures_within_window_accumulate(self, freezer) -> None:
+        breaker = self._breaker()
+        breaker.record_failure()
+        freezer.tick(timedelta(minutes=1))
+        breaker.record_failure()
+        freezer.tick(timedelta(minutes=1))
+        breaker.record_failure()
+        assert breaker.tripped
+
+    def test_tripped_latches_until_reset(self, freezer) -> None:
+        breaker = self._breaker()
+        for _ in range(3):
+            breaker.record_failure()
+        assert breaker.tripped
+        # Even after the window elapses, tripped stays True until reset()
+        # (reads do not re-evaluate the window -- only record_failure does).
+        freezer.tick(timedelta(minutes=10))
+        assert breaker.tripped
+        breaker.reset()
+        assert not breaker.tripped

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -882,6 +882,41 @@ class TestSyncStateMachine:
         await manager._async_tick()
         assert manager._state is SyncState.SUSPENDED
 
+    async def test_code_suspension_latches_until_target_changes(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """A code-suspended slot stays suspended until its desired target changes."""
+        manager = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)._sync_manager
+
+        # Trip the slot breaker so the tick suspends for a non-converging code.
+        manager._state = SyncState.OUT_OF_SYNC
+        manager._coordinator.data[1] = SlotCode.EMPTY
+        for _ in range(MAX_SYNC_ATTEMPTS):
+            manager._slot_breaker.record_failure()
+        await manager._async_tick()
+        await hass.async_block_till_done()
+
+        assert manager._state is SyncState.SUSPENDED
+        assert manager._code_suspend_target is not None
+        # The lock is reachable, so this is NOT a connectivity suspension.
+        assert manager._coordinator.unreachable is False
+
+        # A sync check with the same desired target must not resume the slot —
+        # this is the key fix: it no longer hot-loops on a reachable lock.
+        manager._request_sync_check()
+        assert manager._state is SyncState.SUSPENDED
+
+        # Simulate the desired target changing (e.g. the user edits the PIN):
+        # the recorded target now differs from the resolved state, so the slot
+        # resumes.
+        manager._code_suspend_target = (STATE_ON, "0000")
+        manager._request_sync_check()
+        assert manager._state is SyncState.OUT_OF_SYNC
+        assert manager._code_suspend_target is None
+
 
 class TestSyncStatusAttribute:
     """Tests for sync_status extra state attribute."""

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -14,9 +14,12 @@ from homeassistant.helpers.issue_registry import (
     async_create_issue,
     async_get as async_get_issue_registry,
 )
-from homeassistant.util import dt as dt_util
 
-from custom_components.lock_code_manager.const import DOMAIN, MAX_SYNC_ATTEMPTS
+from custom_components.lock_code_manager.const import (
+    BACKOFF_FAILURE_THRESHOLD,
+    DOMAIN,
+    MAX_SYNC_ATTEMPTS,
+)
 from custom_components.lock_code_manager.exceptions import (
     CodeRejectedError,
     LockDisconnected,
@@ -25,7 +28,12 @@ from custom_components.lock_code_manager.exceptions import (
 from custom_components.lock_code_manager.models import SlotCode, SyncState
 from custom_components.lock_code_manager.sync import SlotState, SlotSyncManager
 
-from .common import SLOT_1_ACTIVE_ENTITY, SLOT_1_IN_SYNC_ENTITY, SLOT_1_PIN_ENTITY
+from .common import (
+    SLOT_1_ACTIVE_ENTITY,
+    SLOT_1_IN_SYNC_ENTITY,
+    SLOT_1_PIN_ENTITY,
+    SLOT_2_IN_SYNC_ENTITY,
+)
 from .conftest import async_trigger_sync_tick, get_in_sync_entity_obj
 
 
@@ -292,8 +300,8 @@ class TestDisableSlotExceptionHandling:
         manager = entity_obj._sync_manager
 
         # Set up some sync tracker state to verify it gets reset
-        manager._sync_attempt_count = 5
-        manager._sync_attempt_first = MagicMock()
+        for _ in range(5):
+            manager._slot_breaker.record_failure()
 
         with patch(
             "custom_components.lock_code_manager.sync.async_disable_slot",
@@ -303,8 +311,7 @@ class TestDisableSlotExceptionHandling:
             await manager._disable_slot("test reason")
 
         # Sync tracker should still be reset even after exception
-        assert manager._sync_attempt_count == 0
-        assert manager._sync_attempt_first is None
+        assert manager._slot_breaker.failure_count == 0
         assert "Failed to disable slot" in caplog.text
 
         # Fallback repair issue should be created even though service call failed
@@ -324,8 +331,8 @@ class TestDisableSlotExceptionHandling:
         entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
         manager = entity_obj._sync_manager
 
-        manager._sync_attempt_count = 5
-        manager._sync_attempt_first = MagicMock()
+        for _ in range(5):
+            manager._slot_breaker.record_failure()
 
         with patch(
             "custom_components.lock_code_manager.sync.async_disable_slot",
@@ -334,8 +341,7 @@ class TestDisableSlotExceptionHandling:
         ):
             await manager._disable_slot("test reason")
 
-        assert manager._sync_attempt_count == 0
-        assert manager._sync_attempt_first is None
+        assert manager._slot_breaker.failure_count == 0
 
 
 class TestSlotDisabledIssueCleanup:
@@ -602,7 +608,7 @@ class TestSyncStateMachine:
             await hass.async_block_till_done()
 
         assert manager._state is SyncState.SUSPENDED
-        assert manager._coordinator.slot_sync_mgrs_suspended is True
+        assert manager._coordinator.unreachable is False
 
     async def test_syncing_to_suspended_on_circuit_breaker(
         self,
@@ -616,14 +622,14 @@ class TestSyncStateMachine:
 
         manager._state = SyncState.OUT_OF_SYNC
         manager._coordinator.data[1] = SlotCode.EMPTY
-        manager._sync_attempt_count = MAX_SYNC_ATTEMPTS
-        manager._sync_attempt_first = dt_util.utcnow()
+        for _ in range(MAX_SYNC_ATTEMPTS):
+            manager._slot_breaker.record_failure()
 
         await manager._async_tick()
         await hass.async_block_till_done()
 
         assert manager._state is SyncState.SUSPENDED
-        assert manager._coordinator.slot_sync_mgrs_suspended is True
+        assert manager._coordinator.unreachable is False
 
     async def test_suspended_skips_tick(
         self,
@@ -647,30 +653,34 @@ class TestSyncStateMachine:
         mock_lock_config_entry,
         lock_code_manager_config_entry,
     ) -> None:
-        """SUSPENDED transitions to OUT_OF_SYNC when coordinator clears suspended flag."""
+        """SUSPENDED transitions to OUT_OF_SYNC when the lock becomes reachable."""
         entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
         manager = entity_obj._sync_manager
 
+        # Lock unreachable suspends the slot.
+        for _ in range(BACKOFF_FAILURE_THRESHOLD):
+            manager._coordinator._lock_breaker.record_failure()
         manager._state = SyncState.SUSPENDED
-        manager._coordinator.suspend_slot_sync_mgrs()
 
-        manager._coordinator._slot_sync_mgrs_suspended = False
+        # Lock recovers: breaker resets, so the next sync check resumes.
+        manager._coordinator._lock_breaker.reset()
         manager._request_sync_check()
 
         assert manager._state is SyncState.OUT_OF_SYNC
 
-    async def test_suspended_stays_suspended_when_coordinator_still_suspended(
+    async def test_suspended_stays_suspended_when_lock_still_unreachable(
         self,
         hass: HomeAssistant,
         mock_lock_config_entry,
         lock_code_manager_config_entry,
     ) -> None:
-        """SUSPENDED stays SUSPENDED when coordinator flag is still set."""
+        """SUSPENDED stays SUSPENDED while the lock is still unreachable."""
         entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
         manager = entity_obj._sync_manager
 
+        for _ in range(BACKOFF_FAILURE_THRESHOLD):
+            manager._coordinator._lock_breaker.record_failure()
         manager._state = SyncState.SUSPENDED
-        manager._coordinator.suspend_slot_sync_mgrs()
 
         manager._request_sync_check()
         assert manager._state is SyncState.SUSPENDED
@@ -705,7 +715,7 @@ class TestSyncStateMachine:
             await hass.async_block_till_done()
 
         mock_disable.assert_called_once()
-        assert manager._coordinator.slot_sync_mgrs_suspended is False
+        assert manager._coordinator.unreachable is False
 
     async def test_suspend_creates_repair_issue(
         self,
@@ -713,7 +723,7 @@ class TestSyncStateMachine:
         mock_lock_config_entry,
         lock_code_manager_config_entry,
     ) -> None:
-        """Suspension creates a per-lock slot_suspended repair issue."""
+        """Suspension creates a per-slot slot_suspended repair issue."""
         entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
         manager = entity_obj._sync_manager
 
@@ -732,8 +742,9 @@ class TestSyncStateMachine:
         issue_registry = async_get_issue_registry(hass)
         entry_id = lock_code_manager_config_entry.entry_id
         lock_entity_id = manager._lock.lock.entity_id
+        slot_num = manager._slot_num
         issue = issue_registry.async_get_issue(
-            DOMAIN, f"slot_suspended_{entry_id}_{lock_entity_id}"
+            DOMAIN, f"slot_suspended_{entry_id}_{lock_entity_id}_{slot_num}"
         )
         assert issue is not None
         assert issue.severity == IssueSeverity.WARNING
@@ -749,9 +760,10 @@ class TestSyncStateMachine:
         manager = entity_obj._sync_manager
         entry_id = lock_code_manager_config_entry.entry_id
         lock_entity_id = manager._lock.lock.entity_id
+        slot_num = manager._slot_num
 
         # Create a slot_suspended issue
-        issue_id = f"slot_suspended_{entry_id}_{lock_entity_id}"
+        issue_id = f"slot_suspended_{entry_id}_{lock_entity_id}_{slot_num}"
         async_create_issue(
             hass,
             DOMAIN,
@@ -813,6 +825,33 @@ class TestSyncStateMachine:
         # Sync "succeeded" but verify check shows still out of sync
         assert manager._state is SyncState.OUT_OF_SYNC
 
+    async def test_non_converging_code_suspends_only_its_slot(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """A code that won't converge suspends its own slot, not siblings."""
+        failing = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)._sync_manager
+        sibling = get_in_sync_entity_obj(hass, SLOT_2_IN_SYNC_ENTITY)._sync_manager
+        # Both slots are on the same lock and share one coordinator.
+        assert failing._coordinator is sibling._coordinator
+
+        # Trip the failing slot's breaker so the next tick suspends it.
+        failing._state = SyncState.OUT_OF_SYNC
+        failing._coordinator.data[1] = SlotCode.EMPTY
+        for _ in range(MAX_SYNC_ATTEMPTS):
+            failing._slot_breaker.record_failure()
+
+        await failing._async_tick()
+        await hass.async_block_till_done()
+
+        assert failing._state is SyncState.SUSPENDED
+        # The sibling slot on the same lock is unaffected.
+        assert sibling._state is not SyncState.SUSPENDED
+        # A slot-level failure does not mark the whole lock unreachable.
+        assert failing._coordinator.unreachable is False
+
 
 class TestSyncStatusAttribute:
     """Tests for sync_status extra state attribute."""
@@ -858,7 +897,10 @@ class TestSyncStatusAttribute:
         entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
         manager = entity_obj._sync_manager
 
-        manager._coordinator.suspend_slot_sync_mgrs()
+        # Make the lock unreachable so the suspended state is not immediately
+        # cleared by a sync check.
+        for _ in range(BACKOFF_FAILURE_THRESHOLD):
+            manager._coordinator._lock_breaker.record_failure()
         manager._state = SyncState.SUSPENDED
         manager._write_state()
         await hass.async_block_till_done()

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -852,6 +852,36 @@ class TestSyncStateMachine:
         # A slot-level failure does not mark the whole lock unreachable.
         assert failing._coordinator.unreachable is False
 
+    async def test_set_disconnect_failures_trip_lock_breaker(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """Repeated LockDisconnected on set trips the lock breaker and suspends the tick."""
+        manager = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)._sync_manager
+        manager._coordinator.data[1] = SlotCode.EMPTY
+
+        with patch.object(
+            manager,
+            "_perform_sync",
+            new_callable=AsyncMock,
+            side_effect=LockDisconnected("offline"),
+        ):
+            for _ in range(BACKOFF_FAILURE_THRESHOLD):
+                manager._state = SyncState.OUT_OF_SYNC
+                await manager._async_tick()
+                await hass.async_block_till_done()
+
+        # Connectivity failures during set converged to "unreachable".
+        assert manager._coordinator.unreachable is True
+
+        # The next tick observes the unreachable lock and suspends instead of
+        # retrying every tick.
+        manager._state = SyncState.OUT_OF_SYNC
+        await manager._async_tick()
+        assert manager._state is SyncState.SUSPENDED
+
 
 class TestSyncStatusAttribute:
     """Tests for sync_status extra state attribute."""

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -54,6 +54,7 @@ from custom_components.lock_code_manager.const import (
     ATTR_SLOT_NUM,
     ATTR_SYNC_STATUS,
     ATTR_USERCODE,
+    BACKOFF_FAILURE_THRESHOLD,
     CONF_CONDITIONS,
     CONF_CONFIG_ENTRY,
     CONF_ENABLED,
@@ -252,9 +253,11 @@ async def test_subscribe_lock_codes_sync_status(
     assert event["type"] == "event"
     assert ATTR_SYNC_STATUS not in event["event"]
 
-    # Suspend sync managers
+    # Make the lock unreachable (trips the lock breaker) and notify listeners
     lock = lock_code_manager_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
-    lock.coordinator.suspend_slot_sync_mgrs()
+    for _ in range(BACKOFF_FAILURE_THRESHOLD):
+        lock.coordinator._lock_breaker.record_failure()
+    lock.coordinator.async_update_listeners()
     await hass.async_block_till_done()
 
     # Updated event should have sync_status == "suspended"


### PR DESCRIPTION
## Proposed change

Consolidates the integration's scattered resilience logic into a single reusable primitive. Previously, "is this lock failing?" was tracked by three independent pieces of state mutated on three different schedules:

- `_consecutive_failures` (coordinator poll backoff)
- `_sync_attempt_count` / `_sync_attempt_first` (per-slot sync circuit breaker)
- `_slot_sync_mgrs_suspended` (the lock-wide suspend gate)

These are replaced by one `CircuitBreaker` value type (`resilience.py`) instantiated at two scopes:

- **Lock-level** (owned by the coordinator): consecutive-failure exponential backoff that drives the poll interval and exposes `unreachable`, the single gate the sync layer reads.
- **Slot-level** (owned by each `SlotSyncManager`): a sliding-window trip that suspends just that lock+slot when a code repeatedly fails to converge.

The breaker is a pure, `hass`-free class, so the backoff/window logic is now directly unit-testable (`test_resilience.py`) instead of only reachable by driving the event loop.

### Behavior improvements (intentional)

- **Connectivity now pauses the sync tick.** When the lock breaker trips (consecutive connectivity failures), sync managers suspend until a poll/push succeeds, instead of retrying every 2s and failing fast. This closes a gap where poll backoff and sync retries were uncoupled.
- **"Code won't converge" isolates to the slot.** A single non-converging PIN now suspends only that lock+slot (per-slot `slot_suspended` repair issue) instead of freezing every slot on the lock.
- **Set-side connectivity failures feed the lock breaker**, so an unreachable lock is detected from both the poll path and the sync path.

Lock-level (connectivity) suspension remains shared across slots and across config entries that share a lock — that breadth is by design to avoid hammering a misbehaving lock.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- Net diff is roughly +55 source / +180 test lines: the consolidation adds a small, fully unit-tested primitive while removing scattered, hard-to-test state. The win is fewer mutable state variables, one recovery path, and a single source of truth — not raw line count.
- Diagnostics: the coordinator's `slot_sync_mgrs_suspended` field is renamed to `lock_unreachable`.
- Full test suite passes (909 tests); all pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)