### PR TITLE
Second-pass complexity trims

### DIFF
--- a/custom_components/lock_code_manager/binary_sensor.py
+++ b/custom_components/lock_code_manager/binary_sensor.py
@@ -38,6 +38,7 @@ from .entity import BaseLockCodeManagerCodeSlotPerLockEntity, BaseLockCodeManage
 from .models import LockCodeManagerConfigEntry
 from .providers import BaseLock
 from .sync import SlotSyncManager
+from .util import get_slot_coordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -66,15 +67,8 @@ async def async_setup_entry(
         lock: BaseLock, slot_num: int, ent_reg: er.EntityRegistry
     ):
         """Add code slot sensor entities for slot."""
-        coordinator = lock.coordinator
+        coordinator = get_slot_coordinator(config_entry, lock, slot_num)
         if coordinator is None:
-            _LOGGER.warning(
-                "%s (%s): Coordinator missing for lock %s when adding slot %s entities",
-                config_entry.entry_id,
-                config_entry.title,
-                lock.lock.entity_id,
-                slot_num,
-            )
             return
         async_add_entities(
             [

--- a/custom_components/lock_code_manager/exceptions.py
+++ b/custom_components/lock_code_manager/exceptions.py
@@ -28,17 +28,6 @@ class LockCodeManagerProviderError(LockCodeManagerError):
     """
 
 
-class EntityNotFoundError(LockCodeManagerError):
-    """Raise when en entity is not found."""
-
-    def __init__(self, lock: BaseLock, slot_num: int, key: str):
-        """Initialize the error."""
-        self.lock = lock
-        self.key = key
-        self.slot_num = slot_num
-        super().__init__(f"Entity not found for lock {lock} slot {slot_num} key {key}")
-
-
 class CodeRejectedError(LockCodeManagerProviderError):
     """Raised when the lock will not accept a PIN on a slot."""
 

--- a/custom_components/lock_code_manager/providers/matter.py
+++ b/custom_components/lock_code_manager/providers/matter.py
@@ -120,12 +120,6 @@ class MatterLock(BaseLock):
             )
             return None
 
-    @property
-    def _matter_node_id(self) -> int | None:
-        """Resolve the Matter node ID."""
-        node = self._get_matter_node()
-        return node.node_id if node else None
-
     def _get_matter_client(self) -> Any | None:
         """Get the MatterClient via the Matter integration helper."""
         try:
@@ -208,7 +202,8 @@ class MatterLock(BaseLock):
             return
 
         client = self._get_matter_client()
-        node_id = self._matter_node_id
+        node = self._get_matter_node()
+        node_id = node.node_id if node else None
         if not client or node_id is None:
             raise LockDisconnected(
                 f"Matter client or node ID unavailable for {self.lock.entity_id}"

--- a/custom_components/lock_code_manager/sensor.py
+++ b/custom_components/lock_code_manager/sensor.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import logging
-
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
@@ -16,8 +14,7 @@ from .coordinator import LockUsercodeUpdateCoordinator
 from .entity import BaseLockCodeManagerCodeSlotPerLockEntity
 from .models import LockCodeManagerConfigEntry, SlotCode
 from .providers import BaseLock
-
-_LOGGER = logging.getLogger(__name__)
+from .util import get_slot_coordinator
 
 
 async def async_setup_entry(
@@ -32,15 +29,8 @@ async def async_setup_entry(
         lock: BaseLock, slot_num: int, ent_reg: er.EntityRegistry
     ) -> None:
         """Add code slot sensor entities for slot."""
-        coordinator = lock.coordinator
+        coordinator = get_slot_coordinator(config_entry, lock, slot_num)
         if coordinator is None:
-            _LOGGER.warning(
-                "%s (%s): Coordinator missing for lock %s when adding slot %s entities",
-                config_entry.entry_id,
-                config_entry.title,
-                lock.lock.entity_id,
-                slot_num,
-            )
             return
         async_add_entities(
             [

--- a/custom_components/lock_code_manager/util.py
+++ b/custom_components/lock_code_manager/util.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from typing import TYPE_CHECKING
 import zlib
 
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN, SERVICE_TURN_OFF
@@ -14,7 +15,35 @@ from homeassistant.helpers.issue_registry import IssueSeverity, async_create_iss
 from .const import DOMAIN
 from .data import build_slot_unique_id
 
+if TYPE_CHECKING:
+    from .coordinator import LockUsercodeUpdateCoordinator
+    from .models import LockCodeManagerConfigEntry
+    from .providers import BaseLock
+
 _LOGGER = logging.getLogger(__name__)
+
+
+def get_slot_coordinator(
+    config_entry: LockCodeManagerConfigEntry,
+    lock: BaseLock,
+    slot_num: int,
+) -> LockUsercodeUpdateCoordinator | None:
+    """
+    Return the lock's coordinator, or None if it is not yet available.
+
+    When the coordinator is missing a warning is logged so the slot
+    entities are simply skipped rather than raising during setup.
+    """
+    coordinator = lock.coordinator
+    if coordinator is None:
+        _LOGGER.warning(
+            "%s (%s): Coordinator missing for lock %s when adding slot %s entities",
+            config_entry.entry_id,
+            config_entry.title,
+            lock.lock.entity_id,
+            slot_num,
+        )
+    return coordinator
 
 
 def mask_pin(

--- a/tests/providers/matter/test_provider.py
+++ b/tests/providers/matter/test_provider.py
@@ -1077,7 +1077,7 @@ class TestLockOperationEvent:
 class TestEventSubscription:
     """Test event subscription setup and teardown."""
 
-    def test_matter_node_id_no_device(self, matter_lock_simple: MatterLock) -> None:
+    def test_get_matter_node_no_device(self, matter_lock_simple: MatterLock) -> None:
         """Test node resolution returns None when no device entry."""
         matter_lock_simple.device_entry = None
         assert matter_lock_simple._get_matter_node() is None
@@ -1125,7 +1125,7 @@ class TestEventSubscription:
 
     # -- Tests using the full Matter integration fixture --
 
-    def test_matter_node_id_resolves(self, matter_lock: MatterLock) -> None:
+    def test_get_matter_node_resolves(self, matter_lock: MatterLock) -> None:
         """Test node resolves from real Matter integration device."""
         node = matter_lock._get_matter_node()
         assert node is not None

--- a/tests/providers/matter/test_provider.py
+++ b/tests/providers/matter/test_provider.py
@@ -1078,9 +1078,9 @@ class TestEventSubscription:
     """Test event subscription setup and teardown."""
 
     def test_matter_node_id_no_device(self, matter_lock_simple: MatterLock) -> None:
-        """Test _matter_node_id returns None when no device entry."""
+        """Test node resolution returns None when no device entry."""
         matter_lock_simple.device_entry = None
-        assert matter_lock_simple._matter_node_id is None
+        assert matter_lock_simple._get_matter_node() is None
 
     def test_get_matter_client_no_data(
         self, hass: HomeAssistant, matter_lock_simple: MatterLock
@@ -1126,8 +1126,10 @@ class TestEventSubscription:
     # -- Tests using the full Matter integration fixture --
 
     def test_matter_node_id_resolves(self, matter_lock: MatterLock) -> None:
-        """Test _matter_node_id resolves from real Matter integration device."""
-        assert matter_lock._matter_node_id == 16  # from mock_door_lock.json
+        """Test node resolves from real Matter integration device."""
+        node = matter_lock._get_matter_node()
+        assert node is not None
+        assert node.node_id == 16  # from mock_door_lock.json
 
     def test_get_matter_client_from_integration(
         self, matter_lock: MatterLock, matter_client: MagicMock

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -13,7 +13,6 @@ from custom_components.lock_code_manager.const import DOMAIN
 from custom_components.lock_code_manager.exceptions import (
     CodeRejectedError,
     DuplicateCodeError,
-    EntityNotFoundError,
     LockCodeManagerError,
     LockCodeManagerProviderError,
     LockDisconnected,
@@ -163,38 +162,6 @@ def test_lock_disconnected_inherits_from_provider_error():
     assert isinstance(err, LockCodeManagerProviderError)
     assert isinstance(err, LockCodeManagerError)
     assert "lock offline" in str(err)
-
-
-def test_entity_not_found_is_not_a_provider_error(hass: HomeAssistant):
-    """
-    EntityNotFoundError is LCM-internal, NOT a provider error.
-
-    This split lets callers catch only real provider failures via
-    ``except LockCodeManagerProviderError`` without also swallowing
-    LCM-internal entity-registry misses.
-    """
-    config_entry = MockConfigEntry(domain=DOMAIN)
-    config_entry.add_to_hass(hass)
-
-    lock = create_minimal_lock(hass, config_entry)
-    err = EntityNotFoundError(lock, 1, "pin")
-    assert isinstance(err, LockCodeManagerError)
-    assert not isinstance(err, LockCodeManagerProviderError)
-
-
-async def test_entity_not_found_error(hass: HomeAssistant):
-    """Test EntityNotFoundError contains lock, slot, and key info."""
-    config_entry = MockConfigEntry(domain=DOMAIN)
-    config_entry.add_to_hass(hass)
-
-    lock = create_minimal_lock(hass, config_entry)
-    err = EntityNotFoundError(lock, 5, "pin")
-
-    assert err.lock is lock
-    assert err.slot_num == 5
-    assert err.key == "pin"
-    assert "slot 5" in str(err)
-    assert "pin" in str(err)
 
 
 # =============================================================================


### PR DESCRIPTION
## Proposed change

A small, safe second complexity-reduction pass (net −34 lines). Three behavior-preserving changes:

- Inline the single-use `_matter_node_id` property in the matter provider.
- Delete the dead `EntityNotFoundError` exception — verified 0 raises / 0 catches in source (only referenced by its own tests) — and its tests.
- Extract the verbatim "coordinator missing" guard duplicated in the binary-sensor and code-sensor platforms into a `get_slot_coordinator` helper.

Deliberately **not** included (the deeper review showed they aren't clean wins): deleting the `async_added_to_hass` overrides (MRO double-invoke risk — most carry load-bearing init ordering), and a shared schlage/akuvox base (the two providers differ by algorithm — clear-before-add+rollback vs modify-in-place — so a template-method base would add more indirection than it removes).

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- Full suite: 907 passing (909 − 2 deleted dead-exception tests). All pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)