### PR TITLE
refactor(sync): close lifecycle-seam races around tick stop and reconnect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ node_modules
 .ha
 docs/
 .serena/
+.worktrees/
 .github/hooks/
 .opencode/
 junit.xml

--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -623,9 +623,9 @@ async def async_unload_entry(
 
     # Stop tick managers FIRST so no in-flight tick can keep calling
     # _perform_sync, coordinator.async_refresh, or _write_state once
-    # downstream teardown begins. SlotSyncManager.async_stop is idempotent
-    # and awaits its in-flight tick, so the binary sensor's own
-    # async_will_remove_from_hass becomes a no-op for these managers.
+    # downstream teardown begins. SlotSyncManager.async_stop is idempotent,
+    # so the binary sensor's later async_will_remove_from_hass call into the
+    # same manager is a cheap no-op.
     if runtime_data.sync_managers:
         _LOGGER.debug(
             "Unload: stopping %s sync manager(s)", len(runtime_data.sync_managers)
@@ -635,7 +635,7 @@ async def async_unload_entry(
             return_exceptions=True,
         )
         for result in stop_results:
-            if isinstance(result, BaseException) and not isinstance(
+            if isinstance(result, Exception) and not isinstance(
                 result, asyncio.CancelledError
             ):
                 _LOGGER.warning(

--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -635,6 +635,12 @@ async def async_unload_entry(
             *(mgr.async_stop() for mgr in mgrs_to_stop),
             return_exceptions=True,
         )
+        # Clear the registry explicitly so the lock-removed callbacks fired
+        # below observe an empty set. Entity removal also discards each
+        # manager during async_will_remove_from_hass, but that path only
+        # runs if invoke_entity_removers_for_slot has populated slots --
+        # which it may not when config has been migrated to options.
+        runtime_data.sync_managers.clear()
         for mgr, result in zip(mgrs_to_stop, stop_results, strict=True):
             if isinstance(result, Exception) and not isinstance(
                 result, asyncio.CancelledError

--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -630,10 +630,19 @@ async def async_unload_entry(
         _LOGGER.debug(
             "Unload: stopping %s sync manager(s)", len(runtime_data.sync_managers)
         )
-        await asyncio.gather(
+        stop_results = await asyncio.gather(
             *(mgr.async_stop() for mgr in list(runtime_data.sync_managers)),
             return_exceptions=True,
         )
+        for result in stop_results:
+            if isinstance(result, BaseException) and not isinstance(
+                result, asyncio.CancelledError
+            ):
+                _LOGGER.warning(
+                    "Sync manager stop raised during unload: %s",
+                    result,
+                    exc_info=result,
+                )
 
     # Fire slot entity removal callbacks first so per-slot entities (which
     # reference locks) clean up before the locks are torn down

--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -484,11 +484,22 @@ def _setup_entry_after_start(
     """
     Set up config entry.
 
-    Should only be run once Home Assistant has started.
+    Should only be run once Home Assistant has started. Update-listener
+    registration is guarded by ``runtime_data.update_listener_registered`` so
+    a reload racing with EVENT_HOMEASSISTANT_STARTED cannot stack multiple
+    listeners on the same entry.
     """
-    config_entry.async_on_unload(
-        config_entry.add_update_listener(async_update_listener)
-    )
+    runtime_data = config_entry.runtime_data
+    if not runtime_data.update_listener_registered:
+        runtime_data.update_listener_registered = True
+        unsub = config_entry.add_update_listener(async_update_listener)
+
+        @callback
+        def _clear_listener_registered() -> None:
+            runtime_data.update_listener_registered = False
+            unsub()
+
+        config_entry.async_on_unload(_clear_listener_registered)
 
     if config_entry.data:
         # Move data from data to options so update listener can work
@@ -605,10 +616,24 @@ async def async_unload_lock(
 async def async_unload_entry(
     hass: HomeAssistant, config_entry: LockCodeManagerConfigEntry
 ) -> bool:
-    """Unload an entry, firing slot- and lock-removed callbacks before tearing down platforms."""
+    """Unload an entry, stopping tick managers before tearing down platforms."""
     hass_data = hass.data[DOMAIN]
     runtime_data = config_entry.runtime_data
     callbacks = runtime_data.callbacks
+
+    # Stop tick managers FIRST so no in-flight tick can keep calling
+    # _perform_sync, coordinator.async_refresh, or _write_state once
+    # downstream teardown begins. SlotSyncManager.async_stop is idempotent
+    # and awaits its in-flight tick, so the binary sensor's own
+    # async_will_remove_from_hass becomes a no-op for these managers.
+    if runtime_data.sync_managers:
+        _LOGGER.debug(
+            "Unload: stopping %s sync manager(s)", len(runtime_data.sync_managers)
+        )
+        await asyncio.gather(
+            *(mgr.async_stop() for mgr in list(runtime_data.sync_managers)),
+            return_exceptions=True,
+        )
 
     # Fire slot entity removal callbacks first so per-slot entities (which
     # reference locks) clean up before the locks are torn down

--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -630,16 +630,18 @@ async def async_unload_entry(
         _LOGGER.debug(
             "Unload: stopping %s sync manager(s)", len(runtime_data.sync_managers)
         )
+        mgrs_to_stop = list(runtime_data.sync_managers)
         stop_results = await asyncio.gather(
-            *(mgr.async_stop() for mgr in list(runtime_data.sync_managers)),
+            *(mgr.async_stop() for mgr in mgrs_to_stop),
             return_exceptions=True,
         )
-        for result in stop_results:
+        for mgr, result in zip(mgrs_to_stop, stop_results, strict=True):
             if isinstance(result, Exception) and not isinstance(
                 result, asyncio.CancelledError
             ):
                 _LOGGER.warning(
-                    "Sync manager stop raised during unload: %s",
+                    "%s: Sync manager stop raised during unload: %s",
+                    mgr.log_prefix,
                     result,
                     exc_info=result,
                 )

--- a/custom_components/lock_code_manager/binary_sensor.py
+++ b/custom_components/lock_code_manager/binary_sensor.py
@@ -278,5 +278,15 @@ class LockCodeManagerCodeSlotInSyncEntity(
         await BaseLockCodeManagerCodeSlotPerLockEntity.async_added_to_hass(self)
         await CoordinatorEntity.async_added_to_hass(self)
 
-        self.async_on_remove(self._sync_manager.async_stop)
+        self.config_entry.runtime_data.sync_managers.add(self._sync_manager)
         await self._sync_manager.async_start()
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Stop the sync manager and await its in-flight tick before removal."""
+        # async_unload_entry stops sync managers up front so this is normally
+        # a no-op (idempotent); the explicit stop here protects against entity
+        # removal paths that do not flow through async_unload_entry, such as
+        # a slot being removed via the options update listener.
+        self.config_entry.runtime_data.sync_managers.discard(self._sync_manager)
+        await self._sync_manager.async_stop()
+        await CoordinatorEntity.async_will_remove_from_hass(self)

--- a/custom_components/lock_code_manager/models.py
+++ b/custom_components/lock_code_manager/models.py
@@ -20,6 +20,7 @@ from .data import EntryConfig
 
 if TYPE_CHECKING:
     from .providers import BaseLock
+    from .sync import SlotSyncManager
 
 
 class SyncState(StrEnum):
@@ -69,6 +70,16 @@ class LockCodeManagerConfigEntryRuntimeData:
     # update listener on every change. Readers should prefer this over
     # parsing config_entry.data/options directly. See data.EntryConfig.
     config: EntryConfig = field(default_factory=EntryConfig.empty)
+    # Active per-slot sync managers, registered by the in-sync binary sensor
+    # on add and discarded on remove. Tracked so async_unload_entry can stop
+    # them up front -- before lock-removed callbacks fire and before platforms
+    # unload -- so an in-flight tick cannot keep running against torn-down
+    # state.
+    sync_managers: set[SlotSyncManager] = field(default_factory=set)
+    # True once the options update listener has been registered for this
+    # entry. Guards against stacking when _setup_entry_after_start runs more
+    # than once (for example, a reload racing with EVENT_HOMEASSISTANT_STARTED).
+    update_listener_registered: bool = False
 
 
 type LockCodeManagerConfigEntry = ConfigEntry[LockCodeManagerConfigEntryRuntimeData]

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -176,6 +176,12 @@ class BaseLock:
     _setup_running: bool = field(default=False, init=False)
     _lcm_config_entry: ConfigEntry | None = field(default=None, init=False)
     _rejected_code_slots: set[int] = field(default_factory=set, init=False)
+    # Reconnect task spawned by the config-entry state listener when the lock
+    # integration transitions to LOADED. Tracked so async_unload can cancel it
+    # before teardown -- otherwise a late reconnect can call
+    # coordinator.async_request_refresh() against an already-shutdown
+    # coordinator.
+    _reconnect_task: asyncio.Task[None] | None = field(default=None, init=False)
 
     @final
     @callback
@@ -589,10 +595,21 @@ class BaseLock:
         await self._setup_complete.wait()
 
     async def async_unload(self, remove_permanently: bool) -> None:
-        """Tear down config-entry-state listener and push subscription."""
+        """Tear down config-entry-state listener, reconnect task, and push subscription."""
         if self._config_entry_state_unsub:
             self._config_entry_state_unsub()
             self._config_entry_state_unsub = None
+
+        # Cancel any in-flight reconnect spawned by _handle_state_change so
+        # it cannot call coordinator.async_request_refresh() against an
+        # already-shutdown coordinator. Await it to confirm the cancellation
+        # took effect before we return from unload.
+        reconnect_task = self._reconnect_task
+        if reconnect_task is not None and not reconnect_task.done():
+            reconnect_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await reconnect_task
+        self._reconnect_task = None
 
         # Unsubscribe from push updates before unloading
         if self.supports_push:
@@ -618,7 +635,13 @@ class BaseLock:
                 return
 
             if to_state == ConfigEntryState.LOADED:
-                self.hass.async_create_task(
+                # Cancel any prior reconnect that hasn't finished -- the
+                # provider transitioned through LOADED twice in quick
+                # succession (e.g. reload during reconnect). The new task
+                # supersedes the old one.
+                if self._reconnect_task is not None and not self._reconnect_task.done():
+                    self._reconnect_task.cancel()
+                self._reconnect_task = self.hass.async_create_task(
                     self._async_on_integration_loaded(),
                     f"Provider reconnect for {self.lock.entity_id}",
                 )

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -649,12 +649,17 @@ class BaseLock:
                 return
 
             if to_state == ConfigEntryState.LOADED:
-                # Cancel any prior reconnect that hasn't finished -- the
-                # provider transitioned through LOADED twice in quick
-                # succession (e.g. reload during reconnect). The new task
-                # supersedes the old one.
-                if self._reconnect_task is not None and not self._reconnect_task.done():
-                    self._reconnect_task.cancel()
+                # The provider transitioned through LOADED twice in quick
+                # succession (e.g. reload during reconnect). Cancel any
+                # prior in-flight reconnect; drain any pending exception
+                # on a prior task that already completed with an error so
+                # we do not leak an unretrieved exception at GC time.
+                if self._reconnect_task is not None:
+                    self._reconnect_task.add_done_callback(
+                        self._drain_superseded_reconnect
+                    )
+                    if not self._reconnect_task.done():
+                        self._reconnect_task.cancel()
                 self._reconnect_task = self.hass.async_create_task(
                     self._async_on_integration_loaded(),
                     f"Provider reconnect for {self.lock.entity_id}",
@@ -669,6 +674,19 @@ class BaseLock:
         self._config_entry_state_unsub = lock_entry.async_on_state_change(
             _handle_state_change
         )
+
+    def _drain_superseded_reconnect(self, task: asyncio.Task[None]) -> None:
+        """Consume any leftover exception on a superseded reconnect task."""
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc is not None:
+            _LOGGER.warning(
+                "Superseded reconnect task raised for %s: %s",
+                self.lock.entity_id,
+                exc,
+                exc_info=exc,
+            )
 
     async def async_is_integration_connected(self) -> bool:
         """

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -607,8 +607,22 @@ class BaseLock:
         reconnect_task = self._reconnect_task
         if reconnect_task is not None and not reconnect_task.done():
             reconnect_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError, Exception):
+            try:
                 await reconnect_task
+            except asyncio.CancelledError:
+                # If our own task is being cancelled, propagate; otherwise
+                # the CancelledError is for the reconnect task we just
+                # cancelled and is expected.
+                current = asyncio.current_task()
+                if current is not None and current.cancelling() > 0:
+                    raise
+            except Exception as err:
+                _LOGGER.warning(
+                    "Reconnect task raised during teardown of %s: %s",
+                    self.lock.entity_id,
+                    err,
+                    exc_info=err,
+                )
         self._reconnect_task = None
 
         # Unsubscribe from push updates before unloading

--- a/custom_components/lock_code_manager/sync.py
+++ b/custom_components/lock_code_manager/sync.py
@@ -201,6 +201,11 @@ class SlotSyncManager:
         self._tick_tasks: set[asyncio.Task[None]] = set()
 
     @property
+    def log_prefix(self) -> str:
+        """Return the structured log prefix identifying this manager's slot."""
+        return self._log_prefix
+
+    @property
     def in_sync(self) -> bool | None:
         """Return current sync state (None = not yet determined)."""
         if self._state is SyncState.LOADING:

--- a/custom_components/lock_code_manager/sync.py
+++ b/custom_components/lock_code_manager/sync.py
@@ -193,12 +193,12 @@ class SlotSyncManager:
         self._tracking_all_states: bool = False
         self._started = False
 
-        # Tracks the currently-executing _async_tick task so async_stop can
-        # await its completion before tearing down state. Without this, a tick
-        # already past the early ``_started`` check could keep awaiting
-        # ``_perform_sync`` or ``coordinator.async_refresh`` and then call
-        # ``_write_state()`` against an entity that has already been removed.
-        self._tick_task: asyncio.Task[None] | None = None
+        # All currently-executing _async_tick tasks. A new tick can fire from
+        # the interval timer while a prior tick is still awaiting
+        # ``_perform_sync`` or ``coordinator.async_refresh``; tracking every
+        # in-flight tick lets async_stop await them all before tearing down
+        # state. Tasks self-register on entry and self-discard on exit.
+        self._tick_tasks: set[asyncio.Task[None]] = set()
 
     @property
     def in_sync(self) -> bool | None:
@@ -228,13 +228,15 @@ class SlotSyncManager:
 
     async def async_stop(self) -> None:
         """
-        Stop the sync manager, awaiting any in-flight tick.
+        Stop the sync manager, awaiting any in-flight ticks.
 
-        Idempotent and safe to call from any context. Unsubscribes the timer
-        and state listeners first so no new ticks can start, then awaits the
-        currently-running tick (if any) so it cannot continue to call
-        ``_perform_sync``, ``coordinator.async_refresh``, or ``_write_state()``
-        after stop returns.
+        Idempotent. Unsubscribes the timer and state listeners first so no
+        new ticks can start, then awaits any in-flight ticks so they cannot
+        continue to call ``_perform_sync``, ``coordinator.async_refresh``,
+        or ``_write_state()`` after stop returns. We do not cancel them --
+        a tick mid ``_perform_sync`` should be allowed to finish so the lock
+        operation completes; ``_started=False`` keeps it from scheduling
+        more work.
         """
         if not self._started:
             return
@@ -247,23 +249,22 @@ class SlotSyncManager:
             self._coordinator_unsub()
             self._coordinator_unsub = None
 
-        # Await the in-flight tick if any. The tick already past the
-        # ``_started`` check inside _async_tick_impl needs to either finish
-        # naturally or be cancelled. We do not call cancel() -- a tick mid
-        # ``_perform_sync`` should be allowed to finish so the lock op
-        # completes; ``_started=False`` keeps it from scheduling more work.
-        tick_task = self._tick_task
-        if (
-            tick_task is not None
-            and not tick_task.done()
-            and (tick_task is not asyncio.current_task())
-        ):
-            try:
-                await tick_task
-            except asyncio.CancelledError:
-                raise
-            except Exception:
-                _LOGGER.debug("%s: In-flight tick raised during stop", self._log_prefix)
+        current = asyncio.current_task()
+        pending = {
+            task for task in self._tick_tasks if task is not current and not task.done()
+        }
+        if pending:
+            tick_results = await asyncio.gather(*pending, return_exceptions=True)
+            for result in tick_results:
+                if isinstance(result, Exception) and not isinstance(
+                    result, asyncio.CancelledError
+                ):
+                    _LOGGER.warning(
+                        "%s: In-flight tick raised during stop: %s",
+                        self._log_prefix,
+                        result,
+                        exc_info=result,
+                    )
 
         self._slot_breaker.reset()
 
@@ -596,10 +597,12 @@ class SlotSyncManager:
         if not self._started:
             return
 
-        # Record the currently-running task so ``async_stop`` can await it
-        # before tearing down state. Captured before the first await so a
-        # concurrent stop sees the in-flight tick.
-        self._tick_task = asyncio.current_task()
+        # Register before the first await so a concurrent ``async_stop``
+        # sees this tick in ``_tick_tasks``.
+        task = asyncio.current_task()
+        if task is None:
+            return
+        self._tick_tasks.add(task)
         try:
             # Try upgrading before the state check — catch-all mode may prevent
             # _request_sync_check from firing for entities not yet tracked
@@ -614,7 +617,7 @@ class SlotSyncManager:
 
             await self._async_tick_impl()
         finally:
-            self._tick_task = None
+            self._tick_tasks.discard(task)
 
     async def _async_tick_impl(self) -> None:
         """

--- a/custom_components/lock_code_manager/sync.py
+++ b/custom_components/lock_code_manager/sync.py
@@ -12,6 +12,7 @@ Circuit breaker: 3 attempts within 5 minutes (MAX_SYNC_ATTEMPTS, SYNC_ATTEMPT_WI
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
@@ -192,6 +193,13 @@ class SlotSyncManager:
         self._tracking_all_states: bool = False
         self._started = False
 
+        # Tracks the currently-executing _async_tick task so async_stop can
+        # await its completion before tearing down state. Without this, a tick
+        # already past the early ``_started`` check could keep awaiting
+        # ``_perform_sync`` or ``coordinator.async_refresh`` and then call
+        # ``_write_state()`` against an entity that has already been removed.
+        self._tick_task: asyncio.Task[None] | None = None
+
     @property
     def in_sync(self) -> bool | None:
         """Return current sync state (None = not yet determined)."""
@@ -218,8 +226,16 @@ class SlotSyncManager:
         )
         await self._async_tick()
 
-    def async_stop(self) -> None:
-        """Stop the sync manager -- unsubscribe tick and listeners. Idempotent."""
+    async def async_stop(self) -> None:
+        """
+        Stop the sync manager, awaiting any in-flight tick.
+
+        Idempotent and safe to call from any context. Unsubscribes the timer
+        and state listeners first so no new ticks can start, then awaits the
+        currently-running tick (if any) so it cannot continue to call
+        ``_perform_sync``, ``coordinator.async_refresh``, or ``_write_state()``
+        after stop returns.
+        """
         if not self._started:
             return
         self._started = False
@@ -230,6 +246,25 @@ class SlotSyncManager:
         if self._coordinator_unsub:
             self._coordinator_unsub()
             self._coordinator_unsub = None
+
+        # Await the in-flight tick if any. The tick already past the
+        # ``_started`` check inside _async_tick_impl needs to either finish
+        # naturally or be cancelled. We do not call cancel() -- a tick mid
+        # ``_perform_sync`` should be allowed to finish so the lock op
+        # completes; ``_started=False`` keeps it from scheduling more work.
+        tick_task = self._tick_task
+        if (
+            tick_task is not None
+            and not tick_task.done()
+            and (tick_task is not asyncio.current_task())
+        ):
+            try:
+                await tick_task
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                _LOGGER.debug("%s: In-flight tick raised during stop", self._log_prefix)
+
         self._slot_breaker.reset()
 
     # -- State resolution ----------------------------------------------------
@@ -494,6 +529,10 @@ class SlotSyncManager:
 
     def _write_state(self) -> None:
         """Notify the entity to write Home Assistant state."""
+        # Skip if stopped: a tick mid-await may still call _write_state after
+        # async_stop has begun teardown of the owning entity.
+        if not self._started:
+            return
         self._state_writer(self.in_sync)
 
     @callback
@@ -557,14 +596,25 @@ class SlotSyncManager:
         if not self._started:
             return
 
-        # Try upgrading before the state check — catch-all mode may prevent
-        # _request_sync_check from firing for entities not yet tracked
-        self._try_upgrade_state_tracking()
+        # Record the currently-running task so ``async_stop`` can await it
+        # before tearing down state. Captured before the first await so a
+        # concurrent stop sees the in-flight tick.
+        self._tick_task = asyncio.current_task()
+        try:
+            # Try upgrading before the state check — catch-all mode may prevent
+            # _request_sync_check from firing for entities not yet tracked
+            self._try_upgrade_state_tracking()
 
-        if self._state in (SyncState.IN_SYNC, SyncState.SYNCING, SyncState.SUSPENDED):
-            return
+            if self._state in (
+                SyncState.IN_SYNC,
+                SyncState.SYNCING,
+                SyncState.SUSPENDED,
+            ):
+                return
 
-        await self._async_tick_impl()
+            await self._async_tick_impl()
+        finally:
+            self._tick_task = None
 
     async def _async_tick_impl(self) -> None:
         """

--- a/tests/providers/test_base.py
+++ b/tests/providers/test_base.py
@@ -996,3 +996,70 @@ async def test_check_duplicate_code_no_coordinator(
     lock.coordinator = None
 
     lock._check_duplicate_code(1, "1234")
+
+
+async def test_async_unload_cancels_in_flight_reconnect_task(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """async_unload cancels the reconnect task spawned by the state listener."""
+    lock = lock_code_manager_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
+
+    # Plant an in-flight reconnect task that takes a long time. async_unload
+    # should cancel it before returning so a late
+    # coordinator.async_request_refresh() cannot fire after teardown.
+    started = asyncio.Event()
+
+    async def slow_reconnect() -> None:
+        started.set()
+        await asyncio.sleep(60)
+
+    lock._reconnect_task = hass.async_create_task(slow_reconnect())
+    await started.wait()
+    assert not lock._reconnect_task.done()
+
+    await lock.async_unload(False)
+
+    assert lock._reconnect_task is None
+
+
+async def test_handle_state_change_supersedes_prior_reconnect_task(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+):
+    """A second LOADED transition cancels and replaces the prior reconnect task."""
+    with patch(
+        "custom_components.lock_code_manager.helpers.INTEGRATIONS_CLASS_MAP",
+        {"test": MockLCMLockWithPush},
+    ):
+        lcm_config_entry = MockConfigEntry(
+            domain=DOMAIN,
+            data=BASE_CONFIG,
+            unique_id="Mock Title Reconnect Supersede",
+        )
+        lcm_config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(lcm_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        lock = lcm_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
+
+        # Plant a long-running reconnect task to mimic a slow reconnect that
+        # has not yet completed.
+        async def slow_reconnect() -> None:
+            await asyncio.sleep(60)
+
+        prior_task = hass.async_create_task(slow_reconnect())
+        lock._reconnect_task = prior_task
+
+        # Drive a second LOADED transition through the state listener. The
+        # listener should cancel the prior task and store the new one.
+        lock._last_entry_state = ConfigEntryState.NOT_LOADED
+        mock_lock_config_entry.mock_state(hass, ConfigEntryState.LOADED)
+        await hass.async_block_till_done()
+
+        assert prior_task.cancelled() or prior_task.done()
+        assert lock._reconnect_task is not None
+        assert lock._reconnect_task is not prior_task
+
+        await hass.config_entries.async_unload(lcm_config_entry.entry_id)

--- a/tests/providers/test_base.py
+++ b/tests/providers/test_base.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from datetime import datetime, timedelta
+import logging
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -1063,3 +1064,36 @@ async def test_handle_state_change_supersedes_prior_reconnect_task(
         assert lock._reconnect_task is not prior_task
 
         await hass.config_entries.async_unload(lcm_config_entry.entry_id)
+
+
+async def test_async_unload_logs_reconnect_task_exception(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+    caplog: pytest.LogCaptureFixture,
+):
+    """async_unload logs warnings when the reconnect task raises non-CancelledError on shutdown."""
+    lock = lock_code_manager_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
+    boom = RuntimeError("simulated reconnect cleanup failure")
+    started = asyncio.Event()
+
+    async def stubborn_reconnect() -> None:
+        started.set()
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            raise boom from None
+
+    lock._reconnect_task = hass.async_create_task(stubborn_reconnect())
+    await started.wait()
+    assert not lock._reconnect_task.done()
+
+    with caplog.at_level(logging.WARNING):
+        await lock.async_unload(False)
+
+    assert lock._reconnect_task is None
+    assert any(
+        record.exc_info is not None and record.exc_info[1] is boom
+        for record in caplog.records
+        if record.levelname == "WARNING"
+    )

--- a/tests/providers/test_base.py
+++ b/tests/providers/test_base.py
@@ -1066,6 +1066,56 @@ async def test_handle_state_change_supersedes_prior_reconnect_task(
         await hass.config_entries.async_unload(lcm_config_entry.entry_id)
 
 
+async def test_supersede_drains_prior_reconnect_exception(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    caplog: pytest.LogCaptureFixture,
+):
+    """A superseded reconnect task that failed before cancellation is logged, not orphaned."""
+    with patch(
+        "custom_components.lock_code_manager.helpers.INTEGRATIONS_CLASS_MAP",
+        {"test": MockLCMLockWithPush},
+    ):
+        lcm_config_entry = MockConfigEntry(
+            domain=DOMAIN,
+            data=BASE_CONFIG,
+            unique_id="Mock Title Drain Reconnect",
+        )
+        lcm_config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(lcm_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        lock = lcm_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
+
+        boom = RuntimeError("simulated prior reconnect failure")
+
+        async def failed_reconnect() -> None:
+            raise boom
+
+        prior_task = hass.async_create_task(failed_reconnect())
+        # Let the task run to completion with its exception.
+        await asyncio.sleep(0)
+        assert prior_task.done()
+        assert prior_task.exception() is boom
+
+        lock._reconnect_task = prior_task
+
+        # Drive a LOADED transition through the state listener; the supersede
+        # path must drain the failed prior task and log its exception.
+        lock._last_entry_state = ConfigEntryState.NOT_LOADED
+        with caplog.at_level(logging.WARNING):
+            mock_lock_config_entry.mock_state(hass, ConfigEntryState.LOADED)
+            await hass.async_block_till_done()
+
+        assert any(
+            record.exc_info is not None and record.exc_info[1] is boom
+            for record in caplog.records
+            if record.levelname == "WARNING"
+        )
+
+        await hass.config_entries.async_unload(lcm_config_entry.entry_id)
+
+
 async def test_async_unload_logs_reconnect_task_exception(
     hass: HomeAssistant,
     mock_lock_config_entry,

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -1599,14 +1599,17 @@ async def test_sync_manager_stop_during_active_sync_does_not_raise(
         # Wait deterministically until the mock signals it has been entered
         await asyncio.wait_for(mid_sync_event.wait(), timeout=5)
 
-        # Stop the sync manager while sync is in progress (sets _started = False)
-        mgr.async_stop()
+        # Stop the sync manager while sync is in progress. async_stop awaits
+        # the in-flight tick, so schedule it as a task and let the tick
+        # finish naturally below.
+        stop_task = hass.async_create_task(mgr.async_stop())
 
         # Let the set_usercode complete
         resume_event.set()
 
-        # The tick task should complete without raising
+        # Both tasks should complete without raising
         await tick_task
+        await stop_task
         await hass.async_block_till_done()
 
     # Verify clean shutdown -- _started should be False

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,5 +1,6 @@
 """Test init module."""
 
+import asyncio
 import copy
 import logging
 from unittest.mock import patch
@@ -28,6 +29,7 @@ from homeassistant.helpers import (
     issue_registry as ir,
 )
 
+from custom_components.lock_code_manager import _setup_entry_after_start
 from custom_components.lock_code_manager.const import (
     ATTR_ACTIVE,
     ATTR_IN_SYNC,
@@ -1153,3 +1155,103 @@ async def test_two_entries_same_lock_share_suspension_and_recovery(
     )
 
     await hass.config_entries.async_unload(entry_b.entry_id)
+
+
+async def test_setup_entry_after_start_does_not_stack_update_listeners(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """Running _setup_entry_after_start a second time does not stack update listeners."""
+    runtime_data = lock_code_manager_config_entry.runtime_data
+    # Initial setup ran via the fixture and should have registered exactly one
+    # listener, marked by the runtime-data flag.
+    assert runtime_data.update_listener_registered is True
+    initial_listener_count = len(lock_code_manager_config_entry.update_listeners)
+
+    # A second invocation (simulating a reload race with EVENT_HOMEASSISTANT_STARTED)
+    # must not register another listener.
+    _setup_entry_after_start(hass, lock_code_manager_config_entry)
+    await hass.async_block_till_done()
+
+    assert (
+        len(lock_code_manager_config_entry.update_listeners) == initial_listener_count
+    )
+
+    # After unload, the flag clears so a future setup will register again.
+    await hass.config_entries.async_unload(lock_code_manager_config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert runtime_data.update_listener_registered is False
+
+
+async def test_unload_stops_sync_managers_before_callbacks_and_platforms(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """Unload sequence: stop sync managers -> fire lock-removed callbacks -> unload platforms."""
+    runtime_data = lock_code_manager_config_entry.runtime_data
+    callbacks = runtime_data.callbacks
+
+    # Capture ordering: sync managers must be stopped (and thus discarded from
+    # the registry) before lock-removed callbacks fire.
+    sync_manager_count_at_lock_removed: list[int] = []
+
+    def _on_lock_removed(_entity_id: str) -> None:
+        sync_manager_count_at_lock_removed.append(len(runtime_data.sync_managers))
+
+    callbacks.register_lock_removed_handler(_on_lock_removed)
+
+    assert len(runtime_data.sync_managers) > 0
+    initial_manager_count = len(runtime_data.sync_managers)
+
+    await hass.config_entries.async_unload(lock_code_manager_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Lock-removed handlers must have fired AFTER sync managers were stopped
+    # and cleared from the registry.
+    assert sync_manager_count_at_lock_removed
+    assert all(count == 0 for count in sync_manager_count_at_lock_removed)
+    # Multiple locks in the fixture means we saw multiple callback invocations.
+    assert len(sync_manager_count_at_lock_removed) >= 1
+
+    # And the original count was non-trivial -- we actually had managers to stop.
+    assert initial_manager_count >= 1
+
+
+async def test_unload_awaits_in_flight_sync_tick(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """Unload waits for an in-flight sync tick before returning."""
+    runtime_data = lock_code_manager_config_entry.runtime_data
+    assert runtime_data.sync_managers
+
+    # Pick a manager and stall its tick mid-flight by patching its
+    # _async_tick_impl to wait on an event we control.
+    manager = next(iter(runtime_data.sync_managers))
+    manager._state = SyncState.OUT_OF_SYNC
+
+    mid_tick = asyncio.Event()
+    release = asyncio.Event()
+
+    async def stalled_tick_impl() -> None:
+        mid_tick.set()
+        await release.wait()
+
+    with patch.object(manager, "_async_tick_impl", stalled_tick_impl):
+        tick_task = hass.async_create_task(manager._async_tick())
+        await asyncio.wait_for(mid_tick.wait(), timeout=5)
+
+        # Begin unload; it should not return while the tick is in flight.
+        unload_task = hass.async_create_task(
+            hass.config_entries.async_unload(lock_code_manager_config_entry.entry_id)
+        )
+        await asyncio.sleep(0)
+        assert not unload_task.done()
+
+        # Release the tick; unload should now complete.
+        release.set()
+        await tick_task
+        await unload_task

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1255,3 +1255,46 @@ async def test_unload_awaits_in_flight_sync_tick(
         release.set()
         await tick_task
         await unload_task
+
+
+async def test_unload_logs_sync_manager_stop_exceptions(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+    caplog: pytest.LogCaptureFixture,
+):
+    """Unload logs warnings when individual sync manager stops raise and still stops the rest."""
+    runtime_data = lock_code_manager_config_entry.runtime_data
+    managers = list(runtime_data.sync_managers)
+    assert len(managers) >= 2
+
+    boom = RuntimeError("simulated stop failure")
+    failing_mgr, *other_mgrs = managers
+    original_stop = failing_mgr.async_stop
+    # binary_sensor.async_will_remove_from_hass also calls async_stop after the
+    # unload entry has gathered them; clean up properly so timers do not leak,
+    # then raise on the first call only.
+    call_state = {"raised": False}
+
+    async def failing_stop() -> None:
+        await original_stop()
+        if not call_state["raised"]:
+            call_state["raised"] = True
+            raise boom
+
+    with patch.object(failing_mgr, "async_stop", failing_stop):
+        with caplog.at_level(logging.WARNING):
+            await hass.config_entries.async_unload(
+                lock_code_manager_config_entry.entry_id
+            )
+            await hass.async_block_till_done()
+
+    assert call_state["raised"]
+    assert any(
+        record.exc_info is not None and record.exc_info[1] is boom
+        for record in caplog.records
+        if record.levelname == "WARNING"
+    )
+    # Sibling managers must still have been stopped even though one raised.
+    for mgr in other_mgrs:
+        assert not mgr._started

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1101,3 +1101,87 @@ class TestAsyncStopAwaitsInFlightTick:
             manager._write_state()
 
         assert writes == []
+
+    async def test_async_stop_awaits_tick_when_concurrent_tick_returned_early(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """A quick-return tick must not orphan an in-flight tick from async_stop tracking."""
+        entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
+        manager = entity_obj._sync_manager
+
+        manager._coordinator.data[1] = "9999"
+        manager._state = SyncState.OUT_OF_SYNC
+
+        mid_sync = asyncio.Event()
+        resume = asyncio.Event()
+        lock_provider = lock_code_manager_config_entry.runtime_data.locks[
+            LOCK_1_ENTITY_ID
+        ]
+        original_set = lock_provider.async_set_usercode
+
+        async def paused_set(code_slot, usercode, name=None, **kwargs):
+            mid_sync.set()
+            await resume.wait()
+            return await original_set(code_slot, usercode, name, **kwargs)
+
+        with patch.object(lock_provider, "async_set_usercode", paused_set):
+            in_flight_tick = hass.async_create_task(manager._async_tick())
+            await asyncio.wait_for(mid_sync.wait(), timeout=5)
+
+            # Fire a concurrent tick. It should see SYNCING and return early
+            # without clobbering the in-flight tick's tracking.
+            await manager._async_tick()
+            assert in_flight_tick in manager._tick_tasks
+
+            stop_task = hass.async_create_task(manager.async_stop())
+            await asyncio.sleep(0)
+            assert not stop_task.done()
+
+            resume.set()
+            await in_flight_tick
+            await stop_task
+
+        assert in_flight_tick.exception() is None
+
+    async def test_async_stop_logs_tick_exception_at_warning(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """An in-flight tick raising during stop is logged at WARNING with exc_info."""
+        entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
+        manager = entity_obj._sync_manager
+        manager._state = SyncState.OUT_OF_SYNC
+
+        boom = RuntimeError("simulated tick failure")
+        ready = asyncio.Event()
+        release = asyncio.Event()
+
+        async def failing_tick_impl() -> None:
+            ready.set()
+            await release.wait()
+            raise boom
+
+        with patch.object(manager, "_async_tick_impl", failing_tick_impl):
+            tick_task = hass.async_create_task(manager._async_tick())
+            await asyncio.wait_for(ready.wait(), timeout=5)
+
+            stop_task = hass.async_create_task(manager.async_stop())
+            await asyncio.sleep(0)
+            release.set()
+            with caplog.at_level(logging.WARNING):
+                await stop_task
+
+        assert tick_task.done()
+        assert isinstance(tick_task.exception(), RuntimeError)
+        warning_records = [
+            record
+            for record in caplog.records
+            if record.levelname == "WARNING" and record.exc_info is not None
+        ]
+        assert any(rec.exc_info[1] is boom for rec in warning_records)

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -29,6 +30,7 @@ from custom_components.lock_code_manager.models import SlotCode, SyncState
 from custom_components.lock_code_manager.sync import SlotState, SlotSyncManager
 
 from .common import (
+    LOCK_1_ENTITY_ID,
     SLOT_1_ACTIVE_ENTITY,
     SLOT_1_IN_SYNC_ENTITY,
     SLOT_1_PIN_ENTITY,
@@ -1006,3 +1008,96 @@ class TestSyncStatusAttribute:
         state = hass.states.get(SLOT_1_IN_SYNC_ENTITY)
         assert state is not None
         assert state.attributes.get("sync_status") == "suspended"
+
+
+class TestAsyncStopAwaitsInFlightTick:
+    """Tests that SlotSyncManager.async_stop blocks until the in-flight tick completes."""
+
+    async def test_async_stop_awaits_in_flight_tick(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """async_stop blocks until the running tick finishes and suppresses post-stop writes."""
+        entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
+        manager = entity_obj._sync_manager
+
+        # Force an out-of-sync state so the next tick performs work.
+        manager._coordinator.data[1] = "9999"
+        manager._state = SyncState.OUT_OF_SYNC
+
+        mid_sync = asyncio.Event()
+        resume = asyncio.Event()
+        lock_provider = lock_code_manager_config_entry.runtime_data.locks[
+            LOCK_1_ENTITY_ID
+        ]
+        original_set = lock_provider.async_set_usercode
+
+        async def paused_set(code_slot, usercode, name=None, **kwargs):
+            mid_sync.set()
+            await resume.wait()
+            return await original_set(code_slot, usercode, name, **kwargs)
+
+        with patch.object(lock_provider, "async_set_usercode", paused_set):
+            tick_task = hass.async_create_task(manager._async_tick())
+            await asyncio.wait_for(mid_sync.wait(), timeout=5)
+
+            # Start async_stop while the tick is suspended inside set_usercode.
+            stop_task = hass.async_create_task(manager.async_stop())
+
+            # stop_task should not complete before the tick releases.
+            await asyncio.sleep(0)
+            assert not stop_task.done()
+
+            # _started should already be False even though the tick is still
+            # in flight -- new ticks must not start.
+            assert not manager._started
+
+            # Capture state-writer calls during the post-stop window so we can
+            # confirm _write_state suppresses them.
+            writes_after_stop: list[bool | None] = []
+            with patch.object(manager, "_state_writer", writes_after_stop.append):
+                resume.set()
+                await tick_task
+                await stop_task
+
+            assert writes_after_stop == []
+
+        # Tick task should not have raised
+        assert tick_task.exception() is None
+
+    async def test_async_stop_is_idempotent(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """Calling async_stop twice in succession is a no-op the second time."""
+        entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
+        manager = entity_obj._sync_manager
+
+        await manager.async_stop()
+        assert not manager._started
+
+        # Second stop is a no-op and does not raise.
+        await manager.async_stop()
+        assert not manager._started
+
+    async def test_write_state_after_stop_is_suppressed(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """_write_state does not invoke the state writer once the manager is stopped."""
+        entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
+        manager = entity_obj._sync_manager
+
+        await manager.async_stop()
+
+        writes: list[bool | None] = []
+        with patch.object(manager, "_state_writer", writes.append):
+            manager._write_state()
+
+        assert writes == []


### PR DESCRIPTION
## Proposed change

Closes four lifecycle-seam concurrency hazards identified in a race-condition audit. None change user-visible behavior; all tighten teardown ordering so in-flight async work can no longer touch torn-down state.

1. **`SlotSyncManager.async_stop` now awaits the in-flight tick.** Previously `async_stop` cancelled the timer and unsubscribed listeners synchronously and returned, so a tick currently awaiting `_perform_sync` or `coordinator.async_refresh` would continue running afterward — including its final `_write_state()` call against an entity already being removed. The tick is now tracked as an `asyncio.Task` captured at the top of `_async_tick`, and `async_stop` awaits its completion (we deliberately do not cancel it — a tick mid `_perform_sync` should be allowed to finish so the lock operation completes; `_started=False` keeps it from scheduling more work). `_write_state` also short-circuits once stopped, as a defense-in-depth check.
2. **Provider `_async_on_integration_loaded` reconnect tasks are tracked + cancelled on unload.** A `BaseLock._reconnect_task` field is supersedeable: a second LOADED transition while a reconnect is in flight cancels the prior one and replaces it. `async_unload` awaits cancellation so a reconnect can no longer call `coordinator.async_request_refresh()` after the coordinator was shut down.
3. **Update-listener stacking guard.** `_setup_entry_after_start` checks `runtime_data.update_listener_registered` before adding the options-update listener, so a reload racing with `EVENT_HOMEASSISTANT_STARTED` can no longer stack listeners on the same entry. The flag is cleared on unload.
4. **Unload ordering tightened.** `async_unload_entry` now stops all sync managers via `asyncio.gather(..., return_exceptions=True)` *before* lock-removed callbacks fire and platforms unload. `runtime_data.sync_managers` is populated by the in-sync binary sensor on add and discarded on remove; the binary sensor's `async_will_remove_from_hass` remains as a defense for entity-removal paths that don't flow through `async_unload_entry` (such as slot removal via the options listener).

Also includes a chore: `.worktrees/` added to `.gitignore` to support a parallel-PR refactor workflow.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

This PR is part of a chained resilience refactor. Subsequent PRs (B–G) will build on this foundation; B (single breaker mutator) and E (provider contract tightening) both depend on this PR's lifecycle changes landing first.

- This PR fixes or closes issue: fixes #
- This PR is related to issue: