### PR TITLE
refactor: make runtime_data.locks the sole source of truth for managed locks

### DIFF
--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -19,6 +19,7 @@ from homeassistant.components.lovelace.resources import (
     ResourceStorageCollection,
     ResourceYAMLCollection,
 )
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import (
     ATTR_AREA_ID,
     ATTR_DEVICE_ID,
@@ -63,7 +64,6 @@ from .const import (
     ATTR_USERCODE,
     CONDITION_ENTITY_DOMAINS,
     CONF_CALENDAR,
-    CONF_LOCKS,
     CONF_SLOTS,
     DOMAIN,
     PLATFORM_MAP,
@@ -300,7 +300,7 @@ async def _async_cleanup_strategy_resource(
 
 async def async_setup(hass: HomeAssistant, config: Config) -> bool:
     """Set up integration."""
-    hass.data.setdefault(DOMAIN, {CONF_LOCKS: {}, "resources": False})
+    hass.data.setdefault(DOMAIN, {"resources": False})
     hass.data[DOMAIN]["instance_id"] = await instance_id.async_get(hass)
     # Expose strategy javascript
     await hass.http.async_register_static_paths(
@@ -522,7 +522,7 @@ async def async_setup_entry(
             f"Unable to start because lock {entity_id} can't be found"
         )
 
-    hass.data.setdefault(DOMAIN, {CONF_LOCKS: {}, "resources": False})
+    hass.data.setdefault(DOMAIN, {"resources": False})
     await _async_register_strategy_resource(hass)
 
     config_entry.runtime_data = LockCodeManagerConfigEntryRuntimeData(
@@ -580,6 +580,33 @@ def _lock_managed_by_other_entry(
     )
 
 
+def _find_shared_lock_instance(
+    hass: HomeAssistant,
+    config_entry: LockCodeManagerConfigEntry,
+    lock_entity_id: str,
+) -> BaseLock | None:
+    """
+    Return an existing BaseLock for ``lock_entity_id`` from another loaded entry.
+
+    A single physical lock may be referenced by multiple Lock Code Manager
+    entries. We keep one BaseLock instance and share it: when a new entry
+    references a lock that another loaded entry is already managing,
+    reuse that entry's instance instead of creating a duplicate.
+    """
+    return next(
+        (
+            entry.runtime_data.locks[lock_entity_id]
+            for entry in hass.config_entries.async_entries(
+                DOMAIN, include_disabled=False, include_ignore=False
+            )
+            if entry.entry_id != config_entry.entry_id
+            and entry.state is ConfigEntryState.LOADED
+            and lock_entity_id in entry.runtime_data.locks
+        ),
+        None,
+    )
+
+
 async def async_unload_lock(
     hass: HomeAssistant,
     config_entry: LockCodeManagerConfigEntry,
@@ -587,19 +614,18 @@ async def async_unload_lock(
     remove_permanently: bool = False,
 ):
     """Unload lock."""
-    hass_data = hass.data[DOMAIN]
     runtime_data = config_entry.runtime_data
     lock_entity_ids = (
         [lock_entity_id] if lock_entity_id else list(runtime_data.locks.keys())
     )
     for _lock_entity_id in lock_entity_ids:
+        lock = runtime_data.locks.pop(_lock_entity_id, None)
+        if lock is None:
+            continue
         if not _lock_managed_by_other_entry(hass, config_entry, _lock_entity_id):
-            lock: BaseLock = hass_data[CONF_LOCKS].pop(_lock_entity_id)
             await lock.async_unload(remove_permanently)
             if lock.coordinator is not None:
                 await lock.coordinator.async_shutdown()
-
-        runtime_data.locks.pop(_lock_entity_id, None)
 
 
 async def async_unload_entry(
@@ -657,7 +683,18 @@ async def async_unload_entry(
                     f"slot_suspended_{entry_id}_{lock_entity_id}_{slot_num}",
                 )
 
-    if not hass_data.get(CONF_LOCKS):
+    # Only clean up the strategy resource if no other Lock Code Manager
+    # entries remain loaded. The current entry is still listed (in
+    # UNLOAD_IN_PROGRESS / NOT_LOADED state at this point) so filter it
+    # out before checking.
+    other_loaded_entries = any(
+        entry.entry_id != config_entry.entry_id
+        and entry.state is ConfigEntryState.LOADED
+        for entry in hass.config_entries.async_entries(
+            DOMAIN, include_disabled=False, include_ignore=False
+        )
+    )
+    if not other_loaded_entries:
         await _async_cleanup_strategy_resource(hass, hass_data)
 
     return unload_ok
@@ -674,7 +711,6 @@ async def _async_setup_new_locks(
     """Set up newly added locks and create per-slot entities for them."""
     entry_id = config_entry.entry_id
     entry_title = config_entry.title
-    hass_data = hass.data[DOMAIN]
     runtime_data = config_entry.runtime_data
 
     _LOGGER.debug(
@@ -685,21 +721,18 @@ async def _async_setup_new_locks(
     )
     added_locks: list[BaseLock] = []
     for lock_entity_id in locks_to_add:
-        if lock_entity_id in hass_data[CONF_LOCKS]:
+        existing_lock = _find_shared_lock_instance(hass, config_entry, lock_entity_id)
+        if existing_lock is not None:
             _LOGGER.debug(
                 "%s (%s): Reusing lock instance for lock %s",
                 entry_id,
                 entry_title,
-                hass_data[CONF_LOCKS][lock_entity_id],
+                existing_lock,
             )
-            lock = runtime_data.locks[lock_entity_id] = hass_data[CONF_LOCKS][
-                lock_entity_id
-            ]
+            lock = runtime_data.locks[lock_entity_id] = existing_lock
             await lock.async_wait_for_setup()
         else:
-            lock = hass_data[CONF_LOCKS][lock_entity_id] = runtime_data.locks[
-                lock_entity_id
-            ] = async_create_lock_instance(
+            lock = runtime_data.locks[lock_entity_id] = async_create_lock_instance(
                 hass,
                 dr.async_get(hass),
                 ent_reg,
@@ -823,7 +856,7 @@ async def async_update_listener(
         )
     for lock_entity_id in locks_to_remove:
         callbacks.invoke_lock_removed_handlers(lock_entity_id)
-        lock: BaseLock = hass.data[DOMAIN][CONF_LOCKS][lock_entity_id]
+        lock: BaseLock = runtime_data.locks[lock_entity_id]
         if lock.device_entry:
             dev_reg = dr.async_get(hass)
             dev_reg.async_update_device(

--- a/custom_components/lock_code_manager/diagnostics.py
+++ b/custom_components/lock_code_manager/diagnostics.py
@@ -8,7 +8,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
-from .const import CONF_LOCKS, DOMAIN
+from .const import DOMAIN
 from .data import get_entry_config
 from .models import SlotCode
 from .providers._base import BaseLock
@@ -177,7 +177,10 @@ async def async_get_config_entry_diagnostics(
     ent_reg = er.async_get(hass)
     dev_reg = dr.async_get(hass)
     entry_config = get_entry_config(config_entry)
-    all_locks: dict[str, BaseLock] = hass.data.get(DOMAIN, {}).get(CONF_LOCKS, {})
+    runtime_data = getattr(config_entry, "runtime_data", None)
+    all_locks: dict[str, BaseLock] = (
+        dict(runtime_data.locks) if runtime_data is not None else {}
+    )
 
     return {
         "config_entry": {
@@ -207,7 +210,10 @@ async def async_get_device_diagnostics(
     ent_reg = er.async_get(hass)
     dev_reg = dr.async_get(hass)
     entry_config = get_entry_config(config_entry)
-    all_locks: dict[str, BaseLock] = hass.data.get(DOMAIN, {}).get(CONF_LOCKS, {})
+    runtime_data = getattr(config_entry, "runtime_data", None)
+    all_locks: dict[str, BaseLock] = (
+        dict(runtime_data.locks) if runtime_data is not None else {}
+    )
 
     # Check if this is a slot device: (DOMAIN, entry_id|slot_num)
     for identifier in device.identifiers:

--- a/custom_components/lock_code_manager/helpers.py
+++ b/custom_components/lock_code_manager/helpers.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Iterator, Mapping
 import logging
 from typing import Any
 
@@ -22,7 +22,7 @@ from homeassistant.helpers import (
     entity_registry as er,
 )
 
-from .const import CONF_LOCKS, DOMAIN, EXCLUDED_CONDITION_PLATFORMS
+from .const import DOMAIN, EXCLUDED_CONDITION_PLATFORMS
 from .data import get_entry_config
 from .providers import INTEGRATIONS_CLASS_MAP, BaseLock
 
@@ -53,6 +53,39 @@ def async_create_lock_instance(
     return lock
 
 
+def _iter_loaded_lcm_entries(hass: HomeAssistant) -> Iterator[ConfigEntry]:
+    """
+    Yield loaded Lock Code Manager config entries.
+
+    A lock may be shared by multiple LCM entries (same physical lock
+    managed from multiple Lock Code Manager configurations); callers
+    should treat the iteration as authoritative for "which locks does
+    Lock Code Manager manage right now".
+    """
+    return (
+        entry
+        for entry in hass.config_entries.async_entries(
+            DOMAIN, include_disabled=False, include_ignore=False
+        )
+        if entry.state is ConfigEntryState.LOADED
+    )
+
+
+def get_managed_locks(hass: HomeAssistant) -> dict[str, BaseLock]:
+    """
+    Return the union of locks across all loaded Lock Code Manager entries.
+
+    When two entries share the same physical lock they hold the same
+    ``BaseLock`` instance, so a flat ``entity_id -> BaseLock`` mapping is
+    well-defined.
+    """
+    return {
+        entity_id: lock
+        for entry in _iter_loaded_lcm_entries(hass)
+        for entity_id, lock in entry.runtime_data.locks.items()
+    }
+
+
 def get_locks_from_targets(
     hass: HomeAssistant, target_data: dict[str, Any]
 ) -> set[BaseLock]:
@@ -61,8 +94,9 @@ def get_locks_from_targets(
     area_ids: list[str] = cv.ensure_list(target_data.get(ATTR_AREA_ID, []))
     device_ids: list[str] = cv.ensure_list(target_data.get(ATTR_DEVICE_ID, []))
     entity_ids: list[str] = cv.ensure_list(target_data.get(ATTR_ENTITY_ID, []))
+    managed_locks = get_managed_locks(hass)
+    lcm_lock_entity_ids = managed_locks.keys()
     lock_entity_ids: set[str] = set()
-    lcm_lock_entity_ids: set[str] = set(hass.data[DOMAIN][CONF_LOCKS].keys())
     ent_reg = er.async_get(hass)
     lock_entity_ids.update(
         ent.entity_id
@@ -105,13 +139,20 @@ def get_locks_from_targets(
     return {
         lock
         for ent_id in (lock_entity_ids & lcm_lock_entity_ids)
-        if (lock := hass.data[DOMAIN][CONF_LOCKS].get(ent_id))
+        if (lock := managed_locks.get(ent_id))
     }
 
 
 def get_managed_lock(hass: HomeAssistant, lock_entity_id: str) -> BaseLock:
     """Get a managed lock by entity ID, raising if not found."""
-    lock = hass.data.get(DOMAIN, {}).get(CONF_LOCKS, {}).get(lock_entity_id)
+    lock = next(
+        (
+            entry.runtime_data.locks[lock_entity_id]
+            for entry in _iter_loaded_lcm_entries(hass)
+            if lock_entity_id in entry.runtime_data.locks
+        ),
+        None,
+    )
     if not lock:
         raise ServiceValidationError(
             f"Lock {lock_entity_id} is not managed by Lock Code Manager"

--- a/custom_components/lock_code_manager/websocket.py
+++ b/custom_components/lock_code_manager/websocket.py
@@ -101,6 +101,7 @@ from .helpers import (
     async_clear_usercode,
     async_set_slot_condition,
     async_set_usercode,
+    get_managed_locks,
 )
 from .models import SlotCode
 from .providers import BaseLock
@@ -380,7 +381,7 @@ async def get_config_entry_data(
     config_entry: ConfigEntry,
 ) -> None:
     """Return the config entry fragment, entity registry entries, lock list, and slot calendar mapping."""
-    all_locks = hass.data.get(DOMAIN, {}).get(CONF_LOCKS, {})
+    entry_locks = config_entry.runtime_data.locks
     entry_config = get_entry_config(config_entry)
 
     connection.send_result(
@@ -398,8 +399,7 @@ async def get_config_entry_data(
                     ATTR_ENTITY_ID: lock_id,
                     CONF_NAME: _get_lock_friendly_name(hass, lock),
                 }
-                for lock_id, lock in all_locks.items()
-                if entry_config.has_lock(lock_id)
+                for lock_id, lock in entry_locks.items()
             ],
             CONF_SLOTS: {
                 k: v.get(CONF_ENTITY_ID) for k, v in entry_config.slots.items()
@@ -629,7 +629,7 @@ async def subscribe_lock_codes(
     """
     lock_entity_id = msg[ATTR_LOCK_ENTITY_ID]
     reveal = msg["reveal"]
-    lock = hass.data.get(DOMAIN, {}).get(CONF_LOCKS, {}).get(lock_entity_id)
+    lock = get_managed_locks(hass).get(lock_entity_id)
     if not lock:
         connection.send_error(
             msg["id"],
@@ -927,7 +927,7 @@ def _serialize_slot_card_data(
     condition_entity_id = _get_slot_condition_entity_id(config_entry, slot_num)
 
     # Build per-lock status
-    all_locks = hass.data.get(DOMAIN, {}).get(CONF_LOCKS, {})
+    entry_locks = config_entry.runtime_data.locks
     entry_lock_ids = get_entry_config(config_entry).locks
 
     locks_data: list[dict[str, Any]] = [
@@ -939,7 +939,7 @@ def _serialize_slot_card_data(
             reveal=reveal,
         )
         for lock_entity_id in entry_lock_ids
-        if (lock := all_locks.get(lock_entity_id))
+        if (lock := entry_locks.get(lock_entity_id))
     ]
 
     # Build result
@@ -1117,11 +1117,11 @@ async def subscribe_code_slot(
 
     # Track coordinator updates for all locks
     unsub_coordinators: list[Any] = []
-    all_locks = hass.data.get(DOMAIN, {}).get(CONF_LOCKS, {})
+    entry_locks = config_entry.runtime_data.locks
     entry_lock_ids = get_entry_config(config_entry).locks
 
     for lock_entity_id in entry_lock_ids:
-        lock = all_locks.get(lock_entity_id)
+        lock = entry_locks.get(lock_entity_id)
         if lock and lock.coordinator:
             unsub_coordinators.append(lock.coordinator.async_add_listener(_send_update))
 

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -89,8 +89,7 @@ async def test_device_diagnostics_lock_device(
     The test mock may not create a device_entry for the lock. If that's the
     case, verify the fallback to config entry diagnostics instead.
     """
-    all_locks = hass.data.get(DOMAIN, {}).get("locks", {})
-    lock = all_locks.get(LOCK_1_ENTITY_ID)
+    lock = lock_code_manager_config_entry.runtime_data.locks.get(LOCK_1_ENTITY_ID)
     assert lock is not None
 
     if lock.device_entry:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -65,6 +65,16 @@ _LOGGER = logging.getLogger(__name__)
 LEGACY_NUMBER_OF_USES_KEY = "number_of_uses"
 
 
+def _loaded_lcm_lock_entity_ids(hass: HomeAssistant) -> set[str]:
+    """Return entity IDs of locks held by any loaded Lock Code Manager entry."""
+    return {
+        entity_id
+        for entry in hass.config_entries.async_entries(DOMAIN)
+        if (runtime_data := getattr(entry, "runtime_data", None)) is not None
+        for entity_id in runtime_data.locks
+    }
+
+
 @pytest.mark.parametrize("config", [{}])
 async def test_entry_setup_and_unload(
     hass: HomeAssistant,
@@ -401,7 +411,7 @@ async def test_resource_not_loaded_on_unload(
     await hass.config_entries.async_unload(config_entry.entry_id)
 
     assert not any(item[CONF_URL] == STRATEGY_PATH for item in resources.async_items())
-    assert not hass.data[DOMAIN].get(CONF_LOCKS)
+    assert not _loaded_lcm_lock_entity_ids(hass)
 
 
 @pytest.mark.parametrize("config", [{}])
@@ -444,7 +454,7 @@ async def test_resource_reregistered_after_unload_and_new_entry(
     await hass.config_entries.async_remove(config_entry_2.entry_id)
     await hass.async_block_till_done()
     assert not any(item[CONF_URL] == STRATEGY_PATH for item in resources.async_items())
-    assert not hass.data[DOMAIN].get(CONF_LOCKS)
+    assert not _loaded_lcm_lock_entity_ids(hass)
 
     # Set up a new config entry - resource should be re-registered
     config_entry_3 = MockConfigEntry(

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -17,7 +17,6 @@ from custom_components.lock_code_manager.const import (
     ATTR_LOCK_ENTITY_ID,
     ATTR_SLOT,
     ATTR_USERCODE,
-    CONF_LOCKS,
     DOMAIN,
     SERVICE_CLEAR_SLOT_CONDITION,
     SERVICE_CLEAR_USERCODE,
@@ -36,7 +35,7 @@ async def test_set_usercode_service(
     lock_code_manager_config_entry,
 ) -> None:
     """Test set_usercode service sets a code on the lock."""
-    lock = hass.data[DOMAIN][CONF_LOCKS][LOCK_1_ENTITY_ID]
+    lock = lock_code_manager_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
     lock.async_internal_set_usercode = AsyncMock()
 
     await hass.services.async_call(
@@ -78,7 +77,7 @@ async def test_clear_usercode_service(
     lock_code_manager_config_entry,
 ) -> None:
     """Test clear_usercode service clears a code on the lock."""
-    lock = hass.data[DOMAIN][CONF_LOCKS][LOCK_1_ENTITY_ID]
+    lock = lock_code_manager_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
     lock.async_internal_clear_usercode = AsyncMock()
 
     await hass.services.async_call(


### PR DESCRIPTION
## Proposed change

Removes the duplicate `hass.data[DOMAIN][CONF_LOCKS]` lock registry. Lock instances now live exclusively in `config_entry.runtime_data.locks`, eliminating a split-brain hazard where add/remove could update one store and not the other.

`helpers.get_locks_from_targets` and `helpers.get_managed_lock` (both called from domain-global service handlers that have no natural config entry in scope) now iterate loaded Lock Code Manager entries via a new private `_iter_loaded_lcm_entries` helper. A new `get_managed_locks(hass)` helper returns the merged `entity_id -> BaseLock` mapping across all loaded entries. Call sites that already have a `config_entry` in scope (diagnostics, websocket entry handlers, the lock-removal branch of `async_update_listener`) now read `config_entry.runtime_data.locks` directly — fewer indirections.

The cross-entry shared-`BaseLock` semantics are preserved: when a new entry references a lock that another loaded entry already manages, `_find_shared_lock_instance` reuses that entry's `BaseLock` instead of creating a duplicate. Strategy-resource cleanup in `async_unload_entry` now keys on "no other Lock Code Manager entries remain loaded" instead of "no locks left in the global store" — semantically equivalent and easier to reason about.

`CONF_LOCKS` constant is retained because it's still used by the config flow, `EntryConfig`, and websocket payload keys.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

Part of a chained resilience refactor. PR D (entity → tick) builds on this lock-ownership consolidation.

- This PR fixes or closes issue: fixes #
- This PR is related to issue: