### PR TITLE
refactor(sync): make _async_tick_impl the sole slot-breaker mutator

### DIFF
--- a/custom_components/lock_code_manager/sync.py
+++ b/custom_components/lock_code_manager/sync.py
@@ -804,6 +804,12 @@ class SlotSyncManager:
                         "Will retry on next tick.",
                         self._log_prefix,
                     )
+                    # Treat an unverified set the same as a verification
+                    # miss: repeated unverified sets must eventually trip
+                    # the slot breaker, otherwise a persistently failing
+                    # refresh path leaves the slot retrying forever.
+                    if was_set:
+                        self._slot_breaker.record_failure()
                     self._state = SyncState.OUT_OF_SYNC
                     return
 

--- a/custom_components/lock_code_manager/sync.py
+++ b/custom_components/lock_code_manager/sync.py
@@ -107,6 +107,13 @@ class SlotSyncManager:
         - ``_async_tick_impl`` is the single authoritative place for all
           other state transitions, circuit breaker, sync operations,
           and ``_last_set_pin`` changes.
+        - The slot circuit breaker is mutated only inside
+          ``_async_tick_impl``. Non-tick code paths that want to reset it
+          (callbacks, suspend/disable helpers) set
+          ``_breaker_reset_requested``; the tick consumes the flag at its
+          start. This keeps callbacks firing across a tick's ``await
+          _perform_sync`` boundary from clearing failure state the tick
+          is about to read.
 
     Lifecycle methods (async_start, async_stop) are idempotent and re-entrant.
     """
@@ -171,9 +178,15 @@ class SlotSyncManager:
 
         # Slot-level circuit breaker: trips when a code repeatedly fails to
         # converge within the window, suspending just this lock and slot.
+        # Only ``_async_tick_impl`` mutates the breaker; external callbacks
+        # (state-change listeners, coordinator listeners) set
+        # ``_breaker_reset_requested`` and the next tick consumes it. A single
+        # bool suffices because resets are idempotent and carry no payload --
+        # coalescing many requests into one reset is the desired behavior.
         self._slot_breaker = CircuitBreaker(
             MAX_SYNC_ATTEMPTS, window=SYNC_ATTEMPT_WINDOW
         )
+        self._breaker_reset_requested: bool = False
 
         # The desired target (active_state, pin_state) captured when the slot
         # is suspended for a non-converging code or an unexpected error. While
@@ -270,8 +283,6 @@ class SlotSyncManager:
                         result,
                         exc_info=result,
                     )
-
-        self._slot_breaker.reset()
 
     # -- State resolution ----------------------------------------------------
 
@@ -415,12 +426,15 @@ class SlotSyncManager:
 
     # -- Sync execution ------------------------------------------------------
 
-    async def _perform_sync(self, slot_state: SlotState) -> None:
+    async def _perform_sync(self, slot_state: SlotState) -> bool:
         """
         Execute sync operation (set or clear usercode).
 
-        Raises CodeRejectedError, LockDisconnected, or propagates any exception.
-        Error handling is done by the caller (_async_tick).
+        Returns True if the operation was a set (which the tick must verify
+        against the lock readback) and False for a clear. Raises
+        CodeRejectedError, LockDisconnected, LockOperationFailed, or
+        propagates any other exception. Error handling and breaker accounting
+        live in the caller (``_async_tick_impl``).
         """
         if slot_state.active_state == STATE_ON:
             await self._lock.async_internal_set_usercode(
@@ -430,16 +444,12 @@ class SlotSyncManager:
                 source="sync",
             )
             self._last_set_pin = slot_state.pin_state
-            # Track set operations toward the slot breaker. Clear operations
-            # don't increment the counter (expected to always succeed).
-            self._slot_breaker.record_failure()
             _LOGGER.debug("%s: Set usercode", self._log_prefix)
-        else:
-            await self._lock.async_internal_clear_usercode(
-                self._slot_num, source="sync"
-            )
-            self._last_set_pin = None
-            _LOGGER.debug("%s: Cleared usercode", self._log_prefix)
+            return True
+        await self._lock.async_internal_clear_usercode(self._slot_num, source="sync")
+        self._last_set_pin = None
+        _LOGGER.debug("%s: Cleared usercode", self._log_prefix)
+        return False
 
     async def _disable_slot(self, reason: str) -> None:
         """Disable the slot and create a repair issue."""
@@ -474,7 +484,7 @@ class SlotSyncManager:
                 },
             )
         finally:
-            self._slot_breaker.reset()
+            self._breaker_reset_requested = True
 
     def _suspend_slot(self, slot_state: SlotState, reason: str) -> None:
         """
@@ -486,7 +496,7 @@ class SlotSyncManager:
         """
         self._state = SyncState.SUSPENDED
         self._code_suspend_target = (slot_state.active_state, slot_state.pin_state)
-        self._slot_breaker.reset()
+        self._breaker_reset_requested = True
         self._write_state()
 
         issue_id = (
@@ -547,15 +557,20 @@ class SlotSyncManager:
         Request a sync check on the next tick.
 
         Transitions IN_SYNC -> OUT_OF_SYNC if calculate_in_sync returns False
-        (also resets circuit breaker since the sync target changed).
-        Transitions SUSPENDED -> OUT_OF_SYNC if the coordinator is no longer suspended.
-        No-op for LOADING, OUT_OF_SYNC, SYNCING.
+        (also requests a breaker reset since the sync target changed).
+        Transitions SUSPENDED -> OUT_OF_SYNC if the coordinator is no longer
+        suspended. No-op for LOADING, OUT_OF_SYNC, SYNCING.
+
+        The breaker is not mutated here -- this callback can fire while a
+        tick is awaiting ``_perform_sync``, and a direct ``reset()`` could
+        clear failure state that the tick is about to read. Instead we set
+        ``_breaker_reset_requested`` and the next tick consumes it.
         """
         if self._state is SyncState.IN_SYNC:
             slot_state = self._resolve_slot_state()
             if slot_state is not None and not self.calculate_in_sync(slot_state):
                 self._state = SyncState.OUT_OF_SYNC
-                self._slot_breaker.reset()
+                self._breaker_reset_requested = True
                 self._write_state()
         elif self._state is SyncState.SUSPENDED:
             if self._code_suspend_target is not None:
@@ -570,14 +585,14 @@ class SlotSyncManager:
                     != self._code_suspend_target
                     or self.calculate_in_sync(slot_state)
                 ):
-                    self._slot_breaker.reset()
+                    self._breaker_reset_requested = True
                     self._code_suspend_target = None
                     self._state = SyncState.OUT_OF_SYNC
                     self._write_state()
             elif not self._coordinator.unreachable:
                 # Suspended because the lock was unreachable; it is reachable
                 # again, so resume.
-                self._slot_breaker.reset()
+                self._breaker_reset_requested = True
                 self._state = SyncState.OUT_OF_SYNC
                 self._write_state()
 
@@ -632,6 +647,15 @@ class SlotSyncManager:
         circuit breaker tracking, sync operations, and ``_last_set_pin``
         changes.
         """
+        # Consume any external reset requests before reading breaker state.
+        # ``_request_sync_check`` cannot reset the breaker directly because
+        # it can fire while a tick is awaiting ``_perform_sync``, and a
+        # mid-flight reset would clear failure state the tick is about to
+        # read. Coalescing many requests into one reset is intentional.
+        if self._breaker_reset_requested:
+            self._breaker_reset_requested = False
+            self._slot_breaker.reset()
+
         slot_state = self._resolve_slot_state()
         if slot_state is None:
             # State resolution failed — stay in current state and retry.
@@ -705,8 +729,9 @@ class SlotSyncManager:
         # Perform sync
         self._state = SyncState.SYNCING
         self._write_state()
+        was_set = False
         try:
-            await self._perform_sync(slot_state)
+            was_set = await self._perform_sync(slot_state)
         except CodeRejectedError as err:
             _LOGGER.error("%s: Code rejected: %s", self._log_prefix, err)
             await self._disable_slot(
@@ -782,7 +807,7 @@ class SlotSyncManager:
                     self._state = SyncState.OUT_OF_SYNC
                     return
 
-        # Check if sync actually worked
+        # Check if sync actually worked.
         slot_state = self._resolve_slot_state()
         if slot_state is not None and self.calculate_in_sync(slot_state):
             self._state = SyncState.IN_SYNC
@@ -790,6 +815,10 @@ class SlotSyncManager:
             self._write_state()
             self._clear_resolved_issues(slot_state)
         else:
+            # Count only unverified sets so eventually-consistent providers
+            # don't accumulate spurious failures when the readback lags.
+            if was_set:
+                self._slot_breaker.record_failure()
             self._state = SyncState.OUT_OF_SYNC
             self._write_state()
 

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -910,9 +910,13 @@ async def test_sync_attempts_exceeded_suspends_slot(
 
     sync_mgr = in_sync_entity_obj._sync_manager
 
-    # Pre-load the breaker to simulate repeated failures on the same PIN
+    # Pre-load the breaker to simulate repeated failures on the same PIN.
+    # The PIN change above will have set _breaker_reset_requested via
+    # _request_sync_check; clear it so the seeded count survives into
+    # the tick that's about to read .tripped.
     for _ in range(MAX_SYNC_ATTEMPTS):
         sync_mgr._slot_breaker.record_failure()
+    sync_mgr._breaker_reset_requested = False
 
     # Trigger tick — circuit breaker should fire before attempting sync
     sync_mgr._state = SyncState.OUT_OF_SYNC

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -34,6 +34,7 @@ from .common import (
     SLOT_1_ACTIVE_ENTITY,
     SLOT_1_IN_SYNC_ENTITY,
     SLOT_1_PIN_ENTITY,
+    SLOT_2_ACTIVE_ENTITY,
     SLOT_2_IN_SYNC_ENTITY,
 )
 from .conftest import async_trigger_sync_tick, get_in_sync_entity_obj
@@ -1346,3 +1347,145 @@ class TestBreakerTickSoleMutatorInvariant:
         assert manager._breaker_reset_requested is True
         assert reset_spy.call_count == 0
         assert manager._slot_breaker.failure_count == seeded
+
+    async def test_request_sync_check_suspended_target_diverged_sets_flag(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """SUSPENDED -> OUT_OF_SYNC when the suspend target diverges uses the flag."""
+        entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
+        manager = entity_obj._sync_manager
+
+        manager._state = SyncState.SUSPENDED
+        # Pin a target that does not match the current resolved state.
+        manager._code_suspend_target = (STATE_OFF, "9999")
+        manager._slot_breaker.record_failure()
+        seeded = manager._slot_breaker.failure_count
+        manager._breaker_reset_requested = False
+
+        with patch.object(
+            manager._slot_breaker, "reset", wraps=manager._slot_breaker.reset
+        ) as reset_spy:
+            manager._request_sync_check()
+
+        assert manager._state is SyncState.OUT_OF_SYNC
+        assert manager._breaker_reset_requested is True
+        assert reset_spy.call_count == 0
+        assert manager._slot_breaker.failure_count == seeded
+
+    async def test_request_sync_check_suspended_reachable_again_sets_flag(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """SUSPENDED (lock unreachable) -> OUT_OF_SYNC when reachable again uses the flag."""
+        entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
+        manager = entity_obj._sync_manager
+
+        manager._state = SyncState.SUSPENDED
+        # No code-suspend target means the slot is suspended only because
+        # the lock was unreachable. ``unreachable`` is a property reading
+        # the coordinator's lock breaker, so make sure it returns False.
+        manager._code_suspend_target = None
+        manager._coordinator._lock_breaker.reset()
+        manager._slot_breaker.record_failure()
+        seeded = manager._slot_breaker.failure_count
+        manager._breaker_reset_requested = False
+        assert not manager._coordinator.unreachable
+
+        with patch.object(
+            manager._slot_breaker, "reset", wraps=manager._slot_breaker.reset
+        ) as reset_spy:
+            manager._request_sync_check()
+
+        assert manager._state is SyncState.OUT_OF_SYNC
+        assert manager._breaker_reset_requested is True
+        assert reset_spy.call_count == 0
+        assert manager._slot_breaker.failure_count == seeded
+
+    async def test_async_stop_preserves_breaker_failure_count(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """async_stop must NOT reset the breaker -- the manager is being torn down."""
+        entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
+        manager = entity_obj._sync_manager
+
+        for _ in range(2):
+            manager._slot_breaker.record_failure()
+        seeded = manager._slot_breaker.failure_count
+        assert seeded == 2
+
+        await manager.async_stop()
+
+        assert not manager._started
+        assert manager._slot_breaker.failure_count == seeded
+
+    async def test_tick_records_failure_on_set_verification_miss(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """A set that completes but whose readback still shows out-of-sync increments the breaker."""
+        entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
+        manager = entity_obj._sync_manager
+
+        manager._coordinator.data[1] = "9999"
+        manager._state = SyncState.OUT_OF_SYNC
+        starting_count = manager._slot_breaker.failure_count
+        lock_provider = lock_code_manager_config_entry.runtime_data.locks[
+            LOCK_1_ENTITY_ID
+        ]
+
+        # async_set_usercode succeeds (was_set=True) but we no-op the
+        # refresh so coordinator.data[1] still reports the stale value and
+        # calculate_in_sync returns False -- the post-verification miss
+        # branch must then record a failure.
+        with (
+            patch.object(
+                lock_provider, "async_set_usercode", AsyncMock(return_value=None)
+            ),
+            patch.object(
+                manager._coordinator, "async_refresh", AsyncMock(return_value=None)
+            ),
+        ):
+            await manager._async_tick_impl()
+
+        assert manager._state is SyncState.OUT_OF_SYNC
+        assert manager._slot_breaker.failure_count == starting_count + 1
+
+    async def test_tick_does_not_record_failure_on_clear_verification_miss(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """A clear-then-verification-miss must NOT increment the breaker (was_set=False)."""
+        entity_obj = get_in_sync_entity_obj(hass, SLOT_2_IN_SYNC_ENTITY)
+        manager = entity_obj._sync_manager
+
+        manager._state = SyncState.OUT_OF_SYNC
+        # Slot 2 in the standard fixture is currently configured with a PIN
+        # but to make `_perform_sync` go down the clear branch the active
+        # entity must report STATE_OFF. Drive that via the entity.
+        hass.states.async_set(SLOT_2_ACTIVE_ENTITY, STATE_OFF)
+        # Coordinator still reports a code so verification will miss.
+        manager._coordinator.data[2] = "5678"
+        starting_count = manager._slot_breaker.failure_count
+        lock_provider = lock_code_manager_config_entry.runtime_data.locks[
+            LOCK_1_ENTITY_ID
+        ]
+
+        with patch.object(
+            lock_provider, "async_clear_usercode", AsyncMock(return_value=None)
+        ):
+            await manager._async_tick_impl()
+
+        assert manager._state is SyncState.OUT_OF_SYNC
+        assert manager._slot_breaker.failure_count == starting_count

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1292,6 +1292,34 @@ class TestBreakerTickSoleMutatorInvariant:
         assert manager._slot_breaker.failure_count == seeded_count
         assert manager._breaker_reset_requested is True
 
+    async def test_set_then_refresh_failure_records_failure(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """
+        A set that succeeds but whose verification refresh raises still
+        counts toward the slot breaker. Otherwise repeated unverified
+        sets caused by a failing refresh path would retry forever.
+        """
+        entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
+        manager = entity_obj._sync_manager
+
+        manager._coordinator.data[1] = "9999"
+        manager._state = SyncState.OUT_OF_SYNC
+        starting_count = manager._slot_breaker.failure_count
+
+        with patch.object(
+            manager._coordinator,
+            "async_refresh",
+            side_effect=RuntimeError("refresh boom"),
+        ):
+            await manager._async_tick_impl()
+
+        assert manager._state is SyncState.OUT_OF_SYNC
+        assert manager._slot_breaker.failure_count == starting_count + 1
+
     async def test_request_sync_check_sets_flag_not_breaker(
         self,
         hass: HomeAssistant,

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -290,20 +290,20 @@ class TestTryUpgradeStateTracking:
 class TestDisableSlotExceptionHandling:
     """Tests for _disable_slot exception handling (Issue 7)."""
 
-    async def test_disable_slot_exception_resets_sync_tracker(
+    async def test_disable_slot_exception_requests_breaker_reset(
         self,
         hass: HomeAssistant,
         mock_lock_config_entry,
         lock_code_manager_config_entry,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """Sync tracker resets even when async_disable_slot raises."""
+        """A failed disable still requests a breaker reset for the next tick."""
         entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
         manager = entity_obj._sync_manager
 
-        # Set up some sync tracker state to verify it gets reset
         for _ in range(5):
             manager._slot_breaker.record_failure()
+        assert manager._slot_breaker.failure_count == 5
 
         with patch(
             "custom_components.lock_code_manager.sync.async_disable_slot",
@@ -312,8 +312,10 @@ class TestDisableSlotExceptionHandling:
         ):
             await manager._disable_slot("test reason")
 
-        # Sync tracker should still be reset even after exception
-        assert manager._slot_breaker.failure_count == 0
+        # The tick is the sole breaker mutator; _disable_slot just flags the
+        # request. Count stays until the next tick consumes the flag.
+        assert manager._breaker_reset_requested is True
+        assert manager._slot_breaker.failure_count == 5
         assert "Failed to disable slot" in caplog.text
 
         # Fallback repair issue should be created even though service call failed
@@ -323,13 +325,13 @@ class TestDisableSlotExceptionHandling:
         assert issue is not None
         assert issue.severity == IssueSeverity.WARNING
 
-    async def test_disable_slot_success_resets_sync_tracker(
+    async def test_disable_slot_success_requests_breaker_reset(
         self,
         hass: HomeAssistant,
         mock_lock_config_entry,
         lock_code_manager_config_entry,
     ) -> None:
-        """Sync tracker resets when async_disable_slot succeeds."""
+        """A successful disable requests a breaker reset for the next tick."""
         entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
         manager = entity_obj._sync_manager
 
@@ -343,7 +345,8 @@ class TestDisableSlotExceptionHandling:
         ):
             await manager._disable_slot("test reason")
 
-        assert manager._slot_breaker.failure_count == 0
+        assert manager._breaker_reset_requested is True
+        assert manager._slot_breaker.failure_count == 5
 
 
 class TestSlotDisabledIssueCleanup:
@@ -1185,3 +1188,133 @@ class TestAsyncStopAwaitsInFlightTick:
             if record.levelname == "WARNING" and record.exc_info is not None
         ]
         assert any(rec.exc_info[1] is boom for rec in warning_records)
+
+
+class TestBreakerTickSoleMutatorInvariant:
+    """The slot circuit breaker is mutated only inside ``_async_tick_impl``."""
+
+    async def test_request_sync_check_does_not_mutate_breaker_mid_tick(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """
+        While a tick is awaiting _perform_sync, _request_sync_check must set
+        the reset-request flag without touching the breaker directly.
+
+        Reproduces the race the refactor closes: a coordinator listener
+        firing across the await boundary could otherwise clear failure state
+        the tick is about to read.
+        """
+        entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
+        manager = entity_obj._sync_manager
+
+        manager._coordinator.data[1] = "9999"
+        manager._state = SyncState.OUT_OF_SYNC
+        # Seed the breaker so a mid-tick mutation would be observable.
+        manager._slot_breaker.record_failure()
+        seeded_count = manager._slot_breaker.failure_count
+        assert seeded_count == 1
+
+        mid_sync = asyncio.Event()
+        resume = asyncio.Event()
+        lock_provider = lock_code_manager_config_entry.runtime_data.locks[
+            LOCK_1_ENTITY_ID
+        ]
+        original_set = lock_provider.async_set_usercode
+
+        async def paused_set(code_slot, usercode, name=None, **kwargs):
+            mid_sync.set()
+            await resume.wait()
+            return await original_set(code_slot, usercode, name, **kwargs)
+
+        with (
+            patch.object(lock_provider, "async_set_usercode", paused_set),
+            patch.object(
+                manager._slot_breaker,
+                "reset",
+                wraps=manager._slot_breaker.reset,
+            ) as reset_spy,
+            patch.object(
+                manager._slot_breaker,
+                "record_failure",
+                wraps=manager._slot_breaker.record_failure,
+            ) as record_spy,
+        ):
+            tick_task = hass.async_create_task(manager._async_tick())
+            await asyncio.wait_for(mid_sync.wait(), timeout=5)
+
+            # The tick has consumed the (initially-clear) flag at its start
+            # and is now awaiting the set. Fire callbacks that would, under
+            # the old contract, have called reset() directly.
+            manager._state = SyncState.IN_SYNC
+            manager._request_sync_check()
+            manager._state = SyncState.SUSPENDED
+            manager._code_suspend_target = ("on", "1234")
+            manager._request_sync_check()
+
+            # Mutators must not have fired from the callback path.
+            assert reset_spy.call_count == 0
+            assert record_spy.call_count == 0
+            # But the flag must reflect the requests.
+            assert manager._breaker_reset_requested is True
+            # And the breaker counter must be untouched mid-tick.
+            assert manager._slot_breaker.failure_count == seeded_count
+
+            resume.set()
+            await tick_task
+
+    async def test_suspend_slot_defers_breaker_reset_to_tick(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """``_suspend_slot`` sets the flag; the breaker is reset by the next tick."""
+        entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
+        manager = entity_obj._sync_manager
+
+        for _ in range(MAX_SYNC_ATTEMPTS):
+            manager._slot_breaker.record_failure()
+        seeded_count = manager._slot_breaker.failure_count
+
+        slot_state = SlotState(
+            active_state=STATE_ON,
+            pin_state="1234",
+            name_state="Test",
+            code_state="",
+            coordinator_code=SlotCode.EMPTY,
+        )
+        manager._suspend_slot(slot_state, "test reason")
+
+        # Synchronous: counter is unchanged, flag is set.
+        assert manager._slot_breaker.failure_count == seeded_count
+        assert manager._breaker_reset_requested is True
+
+    async def test_request_sync_check_sets_flag_not_breaker(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """All three transition branches in _request_sync_check use the flag."""
+        entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
+        manager = entity_obj._sync_manager
+
+        # Branch 1: IN_SYNC -> OUT_OF_SYNC when target diverges.
+        manager._state = SyncState.IN_SYNC
+        manager._coordinator.data[1] = SlotCode.EMPTY
+        manager._slot_breaker.record_failure()
+        seeded = manager._slot_breaker.failure_count
+        manager._breaker_reset_requested = False
+
+        with patch.object(
+            manager._slot_breaker, "reset", wraps=manager._slot_breaker.reset
+        ) as reset_spy:
+            manager._request_sync_check()
+
+        assert manager._state is SyncState.OUT_OF_SYNC
+        assert manager._breaker_reset_requested is True
+        assert reset_spy.call_count == 0
+        assert manager._slot_breaker.failure_count == seeded


### PR DESCRIPTION
## Proposed change

After the tick-consolidation refactor, `SlotSyncManager`'s docstring declares `_async_tick_impl` the single authoritative mutator of sync state, including the slot circuit breaker. The code violated that contract for the breaker: `_slot_breaker.reset()` was called from `async_stop`, `_disable_slot`, `_suspend_slot`, and several branches of `_request_sync_check` — and `_request_sync_check` fires from coordinator listeners that can be triggered across a tick's `await self._perform_sync(...)` boundary. That race could clear failure state the tick is about to read, producing false negatives in trip detection.

This PR routes every non-tick breaker mutation through a new `_breaker_reset_requested: bool` flag. The flag is consumed at the very top of `_async_tick_impl`, before any state read, so every tick run either honors the request or has nothing to honor. Coalescing many requests into one reset is intentional — resets are idempotent and carry no payload. The `async_stop` reset is removed entirely as dead work (the manager is being torn down).

Also fixes a related issue with `record_failure`. Previously `_perform_sync` unconditionally called `_slot_breaker.record_failure()` after a successful set, then the post-tick re-check would reset it only if `calculate_in_sync` returned True. For polling providers with eventual consistency, the immediate re-read can lag the lock state and miss the new value, leaving the spurious failure count in place. Result: 3 ticks (6 s minimum given `TICK_INTERVAL=2 s`) could trip the breaker even when the set genuinely succeeded.

`_perform_sync` now returns `bool` (True for set, False for clear). The post-verification path only records a failure when `was_set` is True, so unverified clears do not contribute and successful sets that the next tick will observe converged do not falsely accumulate.

A new test class `TestBreakerTickSoleMutatorInvariant` proves the contract by spying on `reset` / `record_failure` while firing `_request_sync_check` against a mid-tick (paused inside `_perform_sync`) and asserting the breaker counter stays at its seeded value while the flag flips to True.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

Part of the resilience refactor chain. Depends on #1187 (lifecycle hygiene) for `async_stop`'s tick-await guarantee, which lets us safely remove the `async_stop` reset.

- This PR fixes or closes issue: fixes #
- This PR is related to issue: