### PR TITLE
refactor(providers): tighten contract — classification, sequence lock, idempotency, unsub registry

### DIFF
--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -164,6 +164,16 @@ class BaseLock:
     device_entry: dr.DeviceEntry | None = field(default=None, init=False)
     coordinator: LockUsercodeUpdateCoordinator | None = field(default=None, init=False)
     _aio_lock: asyncio.Lock = field(default_factory=asyncio.Lock, init=False)
+    # Sequence lock for read-modify-write operations that need atomicity
+    # across multiple service calls. Outer lock so each leaf call can
+    # still acquire _aio_lock for rate limiting without deadlocking.
+    _sequence_lock: asyncio.Lock = field(default_factory=asyncio.Lock, init=False)
+    # Registry of push-subscription unsub callables. Providers append to
+    # this list via _register_push_unsub() so the base helper can release
+    # everything on teardown without each provider tracking its own field.
+    _push_unsubs: list[Callable[[], None]] = field(
+        default_factory=list, init=False, repr=False
+    )
     _last_operation_time: float = field(default=0.0, init=False)
     _min_operation_delay: float = field(default=MIN_OPERATION_DELAY, init=False)
     _last_connection_up: bool | None = field(default=None, init=False)
@@ -238,6 +248,45 @@ class BaseLock:
             result = await func(*args, **kwargs)
             self._last_operation_time = time.monotonic()
             return result
+
+    @final
+    def _serialize_sequence(self) -> contextlib.AbstractAsyncContextManager[None]:
+        """
+        Return an async context manager that serializes a multi-step operation.
+
+        Use around read-modify-write sequences (e.g. get-codes/delete/add)
+        so concurrent callers see each sequence as atomic. Uses a separate
+        lock from ``_aio_lock`` so leaf calls inside the sequence can still
+        go through ``_execute_rate_limited`` without deadlocking.
+        """
+        return self._sequence_lock
+
+    @final
+    @callback
+    def _register_push_unsub(self, unsub: Callable[[], None]) -> None:
+        """
+        Register a push-subscription unsub for base teardown management.
+
+        Providers append integration-specific unsub callables (cluster
+        listeners, event subscriptions, MQTT unsubscribes, bus listeners)
+        here so ``_clear_push_unsubs`` can release them in one place.
+        """
+        self._push_unsubs.append(unsub)
+
+    @final
+    @callback
+    def _clear_push_unsubs(self) -> None:
+        """Release every registered push-subscription unsub, logging individual failures."""
+        for unsub in self._push_unsubs:
+            try:
+                unsub()
+            except Exception as err:
+                LOGGER.warning(
+                    "Lock %s: push unsubscribe raised, continuing teardown: %s",
+                    self.lock.entity_id,
+                    err,
+                )
+        self._push_unsubs.clear()
 
     @final
     @callback

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -267,9 +267,12 @@ class BaseLock:
         """
         Register a push-subscription unsub for base teardown management.
 
-        Providers append integration-specific unsub callables (cluster
-        listeners, event subscriptions, MQTT unsubscribes, bus listeners)
-        here so ``_clear_push_unsubs`` can release them in one place.
+        Scope is explicitly the push-subscription lifecycle: cluster
+        listeners, event subscriptions, and MQTT unsubscribes wired from
+        ``subscribe_push_updates`` / ``setup_push_subscription``.
+        Listeners with a different lifecycle (Home Assistant event-bus
+        listeners tied to setup/unload, like Z-Wave JS's) do NOT belong
+        here -- they must be tracked separately.
         """
         self._push_unsubs.append(unsub)
 
@@ -277,7 +280,11 @@ class BaseLock:
     @callback
     def _clear_push_unsubs(self) -> None:
         """Release every registered push-subscription unsub, logging individual failures."""
-        for unsub in self._push_unsubs:
+        # Snapshot first: an unsub that re-registers (or otherwise mutates
+        # the registry) would otherwise break iteration.
+        unsubs = list(self._push_unsubs)
+        self._push_unsubs.clear()
+        for unsub in unsubs:
             try:
                 unsub()
             except Exception as err:
@@ -286,7 +293,6 @@ class BaseLock:
                     self.lock.entity_id,
                     err,
                 )
-        self._push_unsubs.clear()
 
     @final
     @callback

--- a/custom_components/lock_code_manager/providers/akuvox.py
+++ b/custom_components/lock_code_manager/providers/akuvox.py
@@ -14,7 +14,7 @@ services (``list_users``, ``add_user``, ``modify_user``, ``delete_user``).
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import timedelta
 from typing import Any, Literal
 
@@ -66,6 +66,12 @@ class AkuvoxLock(BaseLock):
     PINs are readable from the device, so occupied slots report the actual
     PIN value. Cleared slots report SlotCode.EMPTY.
     """
+
+    # Tracks whether the initial auto-tag pass already ran for this
+    # provider instance. Skips re-tagging on reconnects so a drifted
+    # device list does not produce double-tag / rename storms. Reset
+    # naturally when the provider instance is recreated on full reload.
+    _tagged_once: bool = field(default=False, init=False)
 
     @property
     def domain(self) -> str:
@@ -160,13 +166,30 @@ class AkuvoxLock(BaseLock):
         )
 
     async def async_setup(self, config_entry: ConfigEntry) -> None:
-        """Set up lock by tagging any pre-existing unmanaged users."""
+        """
+        Set up lock by tagging any pre-existing unmanaged users.
+
+        Idempotent: the tag pass runs only once per provider instance to
+        prevent double-tag / rename storms on reconnect (the device list
+        may have drifted since the previous load).
+        """
         await super().async_setup(config_entry)
+        if self._tagged_once:
+            return
         await self._async_tag_unmanaged_users()
+        self._tagged_once = True
 
     async def async_hard_refresh_codes(self) -> dict[int, str | SlotCode]:
-        """Re-tag unmanaged users, then return all codes."""
-        await self._async_tag_unmanaged_users()
+        """
+        Re-tag unmanaged users, then return all codes.
+
+        Hard refresh is an explicit drift-detection request, so the
+        setup-time idempotency gate does not apply.
+        """
+        managed_slots = self.managed_slots
+        if managed_slots:
+            async with self._serialize_sequence():
+                await self._async_run_tag_pass(managed_slots)
         return await self.async_get_usercodes()
 
     async def _async_tag_unmanaged_users(self) -> None:
@@ -175,12 +198,20 @@ class AkuvoxLock(BaseLock):
 
         Untagged local users that have a PIN are assigned to the next
         available managed slot and their names are updated on the device
-        to include the ``[LCM:<slot>]`` tag via ``modify_user``.
+        to include the ``[LCM:<slot>]`` tag via ``modify_user``. The
+        list/modify sequence runs under the sequence lock so concurrent
+        set/clear/hard-refresh callers do not interleave their own
+        multi-step writes.
         """
         managed_slots = self.managed_slots
         if not managed_slots:
             return
 
+        async with self._serialize_sequence():
+            await self._async_run_tag_pass(managed_slots)
+
+    async def _async_run_tag_pass(self, managed_slots: set[int]) -> None:
+        """Body of the tag pass; caller holds the sequence lock."""
         users = await self._async_list_users()
 
         assigned_slots: set[int] = set()
@@ -287,31 +318,35 @@ class AkuvoxLock(BaseLock):
         a new user is created via ``add_user``.
 
         Returns True unconditionally because the Akuvox API does not
-        indicate whether the value actually changed.
+        indicate whether the value actually changed. The list/modify
+        (or list/add) sequence runs under the sequence lock so concurrent
+        callers cannot interleave their own multi-step writes against the
+        same slot.
         """
-        users = await self._async_list_users()
+        async with self._serialize_sequence():
+            users = await self._async_list_users()
 
-        existing_device_id: str | None = None
-        existing_friendly_name: str | None = None
-        for user in users:
-            if not _is_local_user(user):
-                continue
-            user_name = user.get("name", "")
-            parsed_slot, friendly = _parse_tag(user_name)
-            if parsed_slot == code_slot:
-                existing_device_id = str(user.get("id", ""))
-                existing_friendly_name = friendly
-                break
+            existing_device_id: str | None = None
+            existing_friendly_name: str | None = None
+            for user in users:
+                if not _is_local_user(user):
+                    continue
+                user_name = user.get("name", "")
+                parsed_slot, friendly = _parse_tag(user_name)
+                if parsed_slot == code_slot:
+                    existing_device_id = str(user.get("id", ""))
+                    existing_friendly_name = friendly
+                    break
 
-        effective_name = name or existing_friendly_name
-        tagged_name = _make_tagged_name(code_slot, effective_name)
+            effective_name = name or existing_friendly_name
+            tagged_name = _make_tagged_name(code_slot, effective_name)
 
-        if existing_device_id:
-            await self._async_modify_user(
-                existing_device_id, name=tagged_name, pin=usercode
-            )
-        else:
-            await self._async_add_user(tagged_name, usercode)
+            if existing_device_id:
+                await self._async_modify_user(
+                    existing_device_id, name=tagged_name, pin=usercode
+                )
+            else:
+                await self._async_add_user(tagged_name, usercode)
 
         LOGGER.debug(
             "Lock %s: set usercode on slot %s",
@@ -324,22 +359,25 @@ class AkuvoxLock(BaseLock):
         """
         Clear user code from a virtual slot by deleting the user.
 
-        Returns True if a user was deleted, False if the slot was already empty.
+        Returns True if a user was deleted, False if the slot was already
+        empty. The list/delete sequence runs under the sequence lock for
+        the same reason ``async_set_usercode`` does.
         """
-        users = await self._async_list_users()
-        target_device_id: str | None = None
-        for user in users:
-            if not _is_local_user(user):
-                continue
-            parsed_slot, _ = _parse_tag(user.get("name", ""))
-            if parsed_slot == code_slot:
-                target_device_id = str(user.get("id", ""))
-                break
+        async with self._serialize_sequence():
+            users = await self._async_list_users()
+            target_device_id: str | None = None
+            for user in users:
+                if not _is_local_user(user):
+                    continue
+                parsed_slot, _ = _parse_tag(user.get("name", ""))
+                if parsed_slot == code_slot:
+                    target_device_id = str(user.get("id", ""))
+                    break
 
-        if not target_device_id:
-            return False
+            if not target_device_id:
+                return False
 
-        await self._async_delete_user(target_device_id)
+            await self._async_delete_user(target_device_id)
         LOGGER.debug(
             "Lock %s: cleared usercode from slot %s",
             self.lock.entity_id,

--- a/custom_components/lock_code_manager/providers/akuvox.py
+++ b/custom_components/lock_code_manager/providers/akuvox.py
@@ -241,7 +241,7 @@ class AkuvoxLock(BaseLock):
                 untagged.append((device_id, pin, name))
 
         available = sorted(managed_slots - assigned_slots)
-        saw_disconnect = False
+        first_disconnect: LockDisconnected | None = None
         for device_id, _pin, original_name in untagged:
             if not available:
                 LOGGER.debug(
@@ -264,8 +264,8 @@ class AkuvoxLock(BaseLock):
                     slot_num,
                     err,
                 )
-                if isinstance(err, LockDisconnected):
-                    saw_disconnect = True
+                if first_disconnect is None and isinstance(err, LockDisconnected):
+                    first_disconnect = err
                 continue
 
             available.pop(0)
@@ -278,11 +278,11 @@ class AkuvoxLock(BaseLock):
                 tagged_name,
             )
 
-        if saw_disconnect:
+        if first_disconnect is not None:
             raise LockDisconnected(
-                f"Lock {self.lock.entity_id}: disconnect during initial tag pass; "
-                "reconnect will retry"
-            )
+                f"Lock {self.lock.entity_id}: disconnect during tag pass; "
+                "will be retried on reconnect"
+            ) from first_disconnect
 
     async def async_get_usercodes(self) -> dict[int, str | SlotCode]:
         """

--- a/custom_components/lock_code_manager/providers/akuvox.py
+++ b/custom_components/lock_code_manager/providers/akuvox.py
@@ -211,7 +211,16 @@ class AkuvoxLock(BaseLock):
             await self._async_run_tag_pass(managed_slots)
 
     async def _async_run_tag_pass(self, managed_slots: set[int]) -> None:
-        """Body of the tag pass; caller holds the sequence lock."""
+        """
+        Body of the tag pass; caller holds the sequence lock.
+
+        Per-user ``LockDisconnected`` is logged and the loop continues so
+        any remaining users still get a chance to tag, but the disconnect
+        is re-raised at the end. ``async_setup`` then leaves
+        ``_tagged_once`` False so the reconnect path retries once the lock
+        is reachable. ``LockOperationFailed`` is a per-user condition and
+        does not gate idempotency.
+        """
         users = await self._async_list_users()
 
         assigned_slots: set[int] = set()
@@ -232,6 +241,7 @@ class AkuvoxLock(BaseLock):
                 untagged.append((device_id, pin, name))
 
         available = sorted(managed_slots - assigned_slots)
+        saw_disconnect = False
         for device_id, _pin, original_name in untagged:
             if not available:
                 LOGGER.debug(
@@ -246,13 +256,16 @@ class AkuvoxLock(BaseLock):
             tagged_name = _make_tagged_name(slot_num, original_name)
             try:
                 await self._async_modify_user(device_id, name=tagged_name)
-            except LockDisconnected, LockOperationFailed:
+            except (LockDisconnected, LockOperationFailed) as err:
                 LOGGER.error(
-                    "Lock %s: failed to tag user '%s' for slot %d",
+                    "Lock %s: failed to tag user '%s' for slot %d: %s",
                     self.lock.entity_id,
                     original_name,
                     slot_num,
+                    err,
                 )
+                if isinstance(err, LockDisconnected):
+                    saw_disconnect = True
                 continue
 
             available.pop(0)
@@ -263,6 +276,12 @@ class AkuvoxLock(BaseLock):
                 device_id,
                 slot_num,
                 tagged_name,
+            )
+
+        if saw_disconnect:
+            raise LockDisconnected(
+                f"Lock {self.lock.entity_id}: disconnect during initial tag pass; "
+                "reconnect will retry"
             )
 
     async def async_get_usercodes(self) -> dict[int, str | SlotCode]:

--- a/custom_components/lock_code_manager/providers/matter.py
+++ b/custom_components/lock_code_manager/providers/matter.py
@@ -9,8 +9,7 @@ code slot tracking (LockOperation) and occupancy updates (LockUserChange).
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import timedelta
 from typing import Any, Literal
 
@@ -63,10 +62,6 @@ _DATA_OP_MODIFY = 2
 @dataclass(repr=False, eq=False)
 class MatterLock(BaseLock):
     """Class to represent a Matter lock."""
-
-    _event_unsub: Callable[[], None] | None = field(
-        default=None, init=False, repr=False
-    )
 
     @property
     def domain(self) -> str:
@@ -198,7 +193,7 @@ class MatterLock(BaseLock):
         Called by BaseLock.subscribe_push_updates(). On failure, the
         reconnect handlers will retry when the integration reloads.
         """
-        if self._event_unsub is not None:
+        if self._push_unsubs:
             return
 
         client = self._get_matter_client()
@@ -209,10 +204,12 @@ class MatterLock(BaseLock):
                 f"Matter client or node ID unavailable for {self.lock.entity_id}"
             )
 
-        self._event_unsub = client.subscribe_events(
-            callback=self._on_node_event,
-            event_filter=EventType.NODE_EVENT,
-            node_filter=node_id,
+        self._register_push_unsub(
+            client.subscribe_events(
+                callback=self._on_node_event,
+                event_filter=EventType.NODE_EVENT,
+                node_filter=node_id,
+            )
         )
         LOGGER.debug(
             "Lock %s: subscribed to Matter events (node %s)",
@@ -223,9 +220,7 @@ class MatterLock(BaseLock):
     @callback
     def teardown_push_subscription(self) -> None:
         """Unsubscribe from Matter DoorLock cluster events."""
-        if self._event_unsub:
-            self._event_unsub()
-            self._event_unsub = None
+        self._clear_push_unsubs()
 
     @callback
     def _on_node_event(self, _event: Any, node_event: Any) -> None:

--- a/custom_components/lock_code_manager/providers/schlage.py
+++ b/custom_components/lock_code_manager/providers/schlage.py
@@ -164,7 +164,16 @@ class SchlageLock(BaseLock):
             await self._async_run_tag_pass(managed_slots)
 
     async def _async_run_tag_pass(self, managed_slots: set[int]) -> None:
-        """Body of the tag pass; caller holds the sequence lock."""
+        """
+        Body of the tag pass; caller holds the sequence lock.
+
+        Per-code ``LockDisconnected`` is logged and the loop continues so
+        any remaining codes still get a chance to tag, but the disconnect
+        is re-raised at the end. ``async_setup`` then leaves
+        ``_tagged_once`` False so the reconnect path retries once the lock
+        is reachable. ``LockOperationFailed`` is a per-code condition and
+        does not gate idempotency.
+        """
         codes = await self._async_get_codes()
 
         assigned_slots: set[int] = set()
@@ -182,6 +191,7 @@ class SchlageLock(BaseLock):
 
         sorted_managed = sorted(managed_slots)
         next_slot_idx = 0
+        saw_disconnect = False
         for _code_id, original_name, pin in untagged:
             if not original_name or not original_name.strip():
                 LOGGER.debug(
@@ -227,6 +237,8 @@ class SchlageLock(BaseLock):
                     prospective_slot,
                     err,
                 )
+                if isinstance(err, LockDisconnected):
+                    saw_disconnect = True
                 continue
 
             try:
@@ -240,6 +252,8 @@ class SchlageLock(BaseLock):
                     prospective_slot,
                     err,
                 )
+                if isinstance(err, LockDisconnected):
+                    saw_disconnect = True
                 try:
                     await self._async_delete_code(tagged_name)
                 except (LockDisconnected, LockOperationFailed) as rollback_err:
@@ -259,6 +273,12 @@ class SchlageLock(BaseLock):
                 original_name,
                 prospective_slot,
                 tagged_name,
+            )
+
+        if saw_disconnect:
+            raise LockDisconnected(
+                f"Lock {self.lock.entity_id}: disconnect during initial tag pass; "
+                "reconnect will retry"
             )
 
     async def async_get_usercodes(self) -> dict[int, str | SlotCode]:

--- a/custom_components/lock_code_manager/providers/schlage.py
+++ b/custom_components/lock_code_manager/providers/schlage.py
@@ -19,7 +19,7 @@ SlotCode.UNREADABLE_CODE and cleared slots report SlotCode.EMPTY.
 from __future__ import annotations
 
 import contextlib
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import timedelta
 from typing import Literal
 
@@ -51,6 +51,12 @@ class SchlageLock(BaseLock):
     coordinator sees SlotCode.UNREADABLE_CODE for occupied slots and SlotCode.EMPTY
     for cleared slots.
     """
+
+    # Tracks whether the initial auto-tag pass already ran for this
+    # provider instance. Skips re-tagging on reconnects so a drifted
+    # device list does not produce double-tag / rename storms. Reset
+    # naturally when the provider instance is recreated on full reload.
+    _tagged_once: bool = field(default=False, init=False)
 
     @property
     def domain(self) -> str:
@@ -128,21 +134,37 @@ class SchlageLock(BaseLock):
         return True
 
     async def async_setup(self, config_entry: ConfigEntry) -> None:
-        """Set up lock by performing initial auto-tagging of unmanaged codes."""
+        """
+        Set up lock by performing initial auto-tagging of unmanaged codes.
+
+        Idempotent: the tag pass runs only once per provider instance to
+        prevent double-tag / rename storms on reconnect (the device list
+        may have drifted since the previous load).
+        """
         await super().async_setup(config_entry)
+        if self._tagged_once:
+            return
         await self._async_tag_unmanaged_codes()
+        self._tagged_once = True
 
     async def _async_tag_unmanaged_codes(self) -> None:
         """
         Tag unmanaged codes on the lock with Lock Code Manager slot numbers.
 
         Discovers untagged codes and assigns them to the next available managed
-        slot by renaming (add tagged, delete original).
+        slot by renaming (add tagged, delete original). Runs under the
+        sequence lock so concurrent set/clear/hard-refresh callers do not
+        interleave with the multi-step rename.
         """
         managed_slots = self.managed_slots
         if not managed_slots:
             return
 
+        async with self._serialize_sequence():
+            await self._async_run_tag_pass(managed_slots)
+
+    async def _async_run_tag_pass(self, managed_slots: set[int]) -> None:
+        """Body of the tag pass; caller holds the sequence lock."""
         codes = await self._async_get_codes()
 
         assigned_slots: set[int] = set()
@@ -307,51 +329,55 @@ class SchlageLock(BaseLock):
 
         If a code already exists for the given slot it is replaced.
         Returns True unconditionally because Schlage PINs are write-only
-        and we cannot determine whether the value actually changed.
+        and we cannot determine whether the value actually changed. The
+        get/delete/add sequence runs under the sequence lock so concurrent
+        sync ticks cannot interleave their own multi-step writes against
+        the same slot.
         """
-        codes = await self._async_get_codes()
+        async with self._serialize_sequence():
+            codes = await self._async_get_codes()
 
-        # Look for an existing code on this slot so we can preserve its
-        # friendly name when the caller does not supply one.
-        existing_full_name: str | None = None
-        existing_friendly_name: str | None = None
-        for code_data in codes.values():
-            code_name = code_data.get("name", "")
-            parsed_slot, friendly = _parse_tag(code_name)
-            if parsed_slot == code_slot:
-                existing_full_name = code_name
-                existing_friendly_name = friendly
-                break
+            # Look for an existing code on this slot so we can preserve its
+            # friendly name when the caller does not supply one.
+            existing_full_name: str | None = None
+            existing_friendly_name: str | None = None
+            for code_data in codes.values():
+                code_name = code_data.get("name", "")
+                parsed_slot, friendly = _parse_tag(code_name)
+                if parsed_slot == code_slot:
+                    existing_full_name = code_name
+                    existing_friendly_name = friendly
+                    break
 
-        effective_name = name or existing_friendly_name
-        tagged_name = _make_tagged_name(code_slot, effective_name)
+            effective_name = name or existing_friendly_name
+            tagged_name = _make_tagged_name(code_slot, effective_name)
 
-        # Clear any existing code on this slot before adding. Schlage rejects
-        # add_code with a duplicate name, and eventual consistency in the cloud
-        # API means get_codes may not reflect a recently-added code.
-        names_to_delete = {n for n in (existing_full_name, tagged_name) if n}
-        for code_name in names_to_delete:
-            # code may not exist — that's fine
-            with contextlib.suppress(LockDisconnected, LockOperationFailed):
-                await self._async_delete_code(code_name)
+            # Clear any existing code on this slot before adding. Schlage rejects
+            # add_code with a duplicate name, and eventual consistency in the cloud
+            # API means get_codes may not reflect a recently-added code.
+            names_to_delete = {n for n in (existing_full_name, tagged_name) if n}
+            for code_name in names_to_delete:
+                # code may not exist — that's fine
+                with contextlib.suppress(LockDisconnected, LockOperationFailed):
+                    await self._async_delete_code(code_name)
 
-        try:
-            await self._async_add_code(tagged_name, usercode)
-        except (LockDisconnected, LockOperationFailed) as err:
-            # Schlage's cloud API has eventual consistency: a delete may not
-            # propagate before the add, causing "already exists".  Since PINs
-            # are write-only we can't verify the value, but the code IS on the
-            # lock — treat it as success so _last_set_pin gets recorded and the
-            # sync manager doesn't loop.
-            if "already exists" not in str(err).lower():
-                raise
+            try:
+                await self._async_add_code(tagged_name, usercode)
+            except (LockDisconnected, LockOperationFailed) as err:
+                # Schlage's cloud API has eventual consistency: a delete may not
+                # propagate before the add, causing "already exists".  Since PINs
+                # are write-only we can't verify the value, but the code IS on the
+                # lock — treat it as success so _last_set_pin gets recorded and the
+                # sync manager doesn't loop.
+                if "already exists" not in str(err).lower():
+                    raise
 
-            LOGGER.debug(
-                "Lock %s: code for slot %s already exists on lock "
-                "(eventual consistency), treating as successful set",
-                self.lock.entity_id,
-                code_slot,
-            )
+                LOGGER.debug(
+                    "Lock %s: code for slot %s already exists on lock "
+                    "(eventual consistency), treating as successful set",
+                    self.lock.entity_id,
+                    code_slot,
+                )
 
         LOGGER.debug(
             "Lock %s: set usercode on slot %s",
@@ -364,25 +390,28 @@ class SchlageLock(BaseLock):
         """
         Clear user code from a virtual slot.
 
-        Returns True if a code was deleted, False if the slot was already empty.
+        Returns True if a code was deleted, False if the slot was already
+        empty. The get/delete sequence runs under the sequence lock for
+        the same reason ``async_set_usercode`` does.
         """
-        codes = await self._async_get_codes()
-        target_name: str | None = None
-        for code_data in codes.values():
-            parsed_slot, _ = _parse_tag(code_data.get("name", ""))
-            if parsed_slot == code_slot:
-                target_name = code_data.get("name", "")
-                break
+        async with self._serialize_sequence():
+            codes = await self._async_get_codes()
+            target_name: str | None = None
+            for code_data in codes.values():
+                parsed_slot, _ = _parse_tag(code_data.get("name", ""))
+                if parsed_slot == code_slot:
+                    target_name = code_data.get("name", "")
+                    break
 
-        if not target_name:
-            LOGGER.debug(
-                "Lock %s: no code found for slot %s, already clear",
-                self.lock.entity_id,
-                code_slot,
-            )
-            return False
+            if not target_name:
+                LOGGER.debug(
+                    "Lock %s: no code found for slot %s, already clear",
+                    self.lock.entity_id,
+                    code_slot,
+                )
+                return False
 
-        await self._async_delete_code(target_name)
+            await self._async_delete_code(target_name)
 
         LOGGER.debug(
             "Lock %s: cleared usercode from slot %s",
@@ -396,7 +425,11 @@ class SchlageLock(BaseLock):
         Perform hard refresh and return all codes.
 
         Schlage has no cache to invalidate; re-tags unmanaged codes and then
-        reads the current state.
+        reads the current state. Hard refresh is an explicit drift-detection
+        request, so the setup-time idempotency gate does not apply here.
         """
-        await self._async_tag_unmanaged_codes()
+        managed_slots = self.managed_slots
+        if managed_slots:
+            async with self._serialize_sequence():
+                await self._async_run_tag_pass(managed_slots)
         return await self.async_get_usercodes()

--- a/custom_components/lock_code_manager/providers/schlage.py
+++ b/custom_components/lock_code_manager/providers/schlage.py
@@ -191,7 +191,7 @@ class SchlageLock(BaseLock):
 
         sorted_managed = sorted(managed_slots)
         next_slot_idx = 0
-        saw_disconnect = False
+        first_disconnect: LockDisconnected | None = None
         for _code_id, original_name, pin in untagged:
             if not original_name or not original_name.strip():
                 LOGGER.debug(
@@ -237,8 +237,8 @@ class SchlageLock(BaseLock):
                     prospective_slot,
                     err,
                 )
-                if isinstance(err, LockDisconnected):
-                    saw_disconnect = True
+                if first_disconnect is None and isinstance(err, LockDisconnected):
+                    first_disconnect = err
                 continue
 
             try:
@@ -252,8 +252,8 @@ class SchlageLock(BaseLock):
                     prospective_slot,
                     err,
                 )
-                if isinstance(err, LockDisconnected):
-                    saw_disconnect = True
+                if first_disconnect is None and isinstance(err, LockDisconnected):
+                    first_disconnect = err
                 try:
                     await self._async_delete_code(tagged_name)
                 except (LockDisconnected, LockOperationFailed) as rollback_err:
@@ -264,6 +264,10 @@ class SchlageLock(BaseLock):
                         tagged_name,
                         rollback_err,
                     )
+                    if first_disconnect is None and isinstance(
+                        rollback_err, LockDisconnected
+                    ):
+                        first_disconnect = rollback_err
                 continue
 
             assigned_slots.add(prospective_slot)
@@ -275,11 +279,11 @@ class SchlageLock(BaseLock):
                 tagged_name,
             )
 
-        if saw_disconnect:
+        if first_disconnect is not None:
             raise LockDisconnected(
-                f"Lock {self.lock.entity_id}: disconnect during initial tag pass; "
-                "reconnect will retry"
-            )
+                f"Lock {self.lock.entity_id}: disconnect during tag pass; "
+                "will be retried on reconnect"
+            ) from first_disconnect
 
     async def async_get_usercodes(self) -> dict[int, str | SlotCode]:
         """

--- a/custom_components/lock_code_manager/providers/zha.py
+++ b/custom_components/lock_code_manager/providers/zha.py
@@ -10,7 +10,6 @@ polling.
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import timedelta
 import logging
@@ -25,7 +24,7 @@ from homeassistant.components.zha.helpers import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import callback
 
-from ..exceptions import CodeRejectedError, LockDisconnected, LockOperationFailed
+from ..exceptions import CodeRejectedError, LockDisconnected
 from ..models import SlotCode
 from ._base import BaseLock
 
@@ -77,7 +76,6 @@ class ZHALock(BaseLock):
 
     _door_lock_cluster: DoorLock | None = field(init=False, default=None)
     _endpoint_id: int | None = field(init=False, default=None)
-    _cluster_listener_unsub: Callable[[], None] | None = field(init=False, default=None)
     _supports_programming_events: bool | None = field(init=False, default=None)
 
     # -- Properties ----------------------------------------------------------
@@ -262,7 +260,17 @@ class ZHALock(BaseLock):
         name: str | None = None,
         source: Literal["sync", "direct"] = "direct",
     ) -> bool:
-        """Set a PIN code on a slot."""
+        """
+        Set a PIN code on a slot.
+
+        Bypasses ``async_call_service`` because ZHA exposes its cluster
+        operations as zigpy method calls rather than Home Assistant
+        services. ``cluster.set_pin_code`` raises zigpy-level errors
+        (``DeliveryError``, ``asyncio.TimeoutError``) on communication
+        failure — these are routed to ``LockDisconnected`` so retries
+        and reconnect handling apply, mirroring the OSError branch of
+        the service-call wrapper.
+        """
         cluster = await self._get_connected_cluster()
         try:
             result = await cluster.set_pin_code(
@@ -271,50 +279,51 @@ class ZHALock(BaseLock):
                 DoorLock.UserType.Unrestricted,
                 str(usercode),
             )
-            _LOGGER.debug(
-                "Lock %s slot %s set_pin_code: %s",
-                self.lock.entity_id,
-                code_slot,
-                result,
-            )
-            if hasattr(result, "status") and result.status != 0:
-                raise CodeRejectedError(
-                    code_slot=code_slot,
-                    lock_entity_id=self.lock.entity_id,
-                    reason=f"set_pin_code rejected: status {result.status}",
-                )
-            if self.coordinator:
-                self.coordinator.push_update({code_slot: usercode})
-            return True
-        except CodeRejectedError, LockDisconnected:
-            raise
         except Exception as err:
-            raise LockOperationFailed(f"Failed to set PIN: {err}") from err
+            raise LockDisconnected(f"Failed to set PIN: {err}") from err
+        _LOGGER.debug(
+            "Lock %s slot %s set_pin_code: %s",
+            self.lock.entity_id,
+            code_slot,
+            result,
+        )
+        if hasattr(result, "status") and result.status != 0:
+            raise CodeRejectedError(
+                code_slot=code_slot,
+                lock_entity_id=self.lock.entity_id,
+                reason=f"set_pin_code rejected: status {result.status}",
+            )
+        if self.coordinator:
+            self.coordinator.push_update({code_slot: usercode})
+        return True
 
     async def async_clear_usercode(self, code_slot: int) -> bool:
-        """Clear a PIN code from a slot."""
+        """
+        Clear a PIN code from a slot.
+
+        See ``async_set_usercode`` for why bare zigpy failures route to
+        ``LockDisconnected`` instead of ``LockOperationFailed``.
+        """
         cluster = await self._get_connected_cluster()
         try:
             result = await cluster.clear_pin_code(code_slot)
-            _LOGGER.debug(
-                "Lock %s slot %s clear_pin_code: %s",
-                self.lock.entity_id,
-                code_slot,
-                result,
-            )
-            if hasattr(result, "status") and result.status != 0:
-                raise CodeRejectedError(
-                    code_slot=code_slot,
-                    lock_entity_id=self.lock.entity_id,
-                    reason=f"clear_pin_code rejected: status {result.status}",
-                )
-            if self.coordinator:
-                self.coordinator.push_update({code_slot: SlotCode.EMPTY})
-            return True
-        except CodeRejectedError, LockDisconnected:
-            raise
         except Exception as err:
-            raise LockOperationFailed(f"Failed to clear PIN: {err}") from err
+            raise LockDisconnected(f"Failed to clear PIN: {err}") from err
+        _LOGGER.debug(
+            "Lock %s slot %s clear_pin_code: %s",
+            self.lock.entity_id,
+            code_slot,
+            result,
+        )
+        if hasattr(result, "status") and result.status != 0:
+            raise CodeRejectedError(
+                code_slot=code_slot,
+                lock_entity_id=self.lock.entity_id,
+                reason=f"clear_pin_code rejected: status {result.status}",
+            )
+        if self.coordinator:
+            self.coordinator.push_update({code_slot: SlotCode.EMPTY})
+        return True
 
     async def async_hard_refresh_codes(self) -> dict[int, str | SlotCode]:
         """Re-read all codes from the lock (no cache to invalidate)."""
@@ -342,7 +351,7 @@ class ZHALock(BaseLock):
     @callback
     def setup_push_subscription(self) -> None:
         """Subscribe to DoorLock cluster events."""
-        if self._cluster_listener_unsub is not None:
+        if self._push_unsubs:
             return
 
         cluster = self._get_door_lock_cluster()
@@ -352,7 +361,7 @@ class ZHALock(BaseLock):
             )
 
         cluster.add_listener(self)
-        self._cluster_listener_unsub = lambda: cluster.remove_listener(self)
+        self._register_push_unsub(lambda: cluster.remove_listener(self))
         _LOGGER.debug(
             "Lock %s: subscribed to DoorLock cluster events",
             self.lock.entity_id,
@@ -361,13 +370,13 @@ class ZHALock(BaseLock):
     @callback
     def teardown_push_subscription(self) -> None:
         """Unsubscribe from DoorLock cluster events."""
-        if self._cluster_listener_unsub is not None:
-            self._cluster_listener_unsub()
-            self._cluster_listener_unsub = None
-            _LOGGER.debug(
-                "Lock %s: unsubscribed from DoorLock cluster events",
-                self.lock.entity_id,
-            )
+        if not self._push_unsubs:
+            return
+        self._clear_push_unsubs()
+        _LOGGER.debug(
+            "Lock %s: unsubscribed from DoorLock cluster events",
+            self.lock.entity_id,
+        )
 
     # -- Cluster listener callbacks ------------------------------------------
 

--- a/custom_components/lock_code_manager/providers/zigbee2mqtt.py
+++ b/custom_components/lock_code_manager/providers/zigbee2mqtt.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import timedelta
 import json
@@ -73,7 +72,6 @@ class Zigbee2MQTTLock(BaseLock):
 
     _base_topic: str = field(init=False, default=DEFAULT_BASE_TOPIC)
     _friendly_name: str | None = field(init=False, default=None)
-    _unsubscribe: Callable[[], None] | None = field(init=False, default=None)
     _pending_codes: dict[int, asyncio.Future[str | None]] = field(
         init=False, default_factory=dict
     )
@@ -300,7 +298,7 @@ class Zigbee2MQTTLock(BaseLock):
 
     async def _async_ensure_device_subscription(self) -> None:
         """Subscribe to the Z2M device topic; idempotent."""
-        if self._unsubscribe is not None:
+        if self._push_unsubs:
             return
 
         if not mqtt_config_entry_enabled(self.hass):
@@ -328,9 +326,7 @@ class Zigbee2MQTTLock(BaseLock):
             self.hass.add_job(self._process_z2m_device_payload, payload)
 
         try:
-            self._unsubscribe = await async_subscribe(
-                self.hass, topic, message_received
-            )
+            unsub = await async_subscribe(self.hass, topic, message_received)
         except HomeAssistantError as err:
             LOGGER.error(
                 "Failed to subscribe to MQTT for %s: %s",
@@ -340,10 +336,8 @@ class Zigbee2MQTTLock(BaseLock):
             raise LockDisconnected(
                 f"Failed to subscribe to MQTT for {self.lock.entity_id}"
             ) from err
-        else:
-            LOGGER.debug(
-                "Subscribed to MQTT topic %s for %s", topic, self.lock.entity_id
-            )
+        self._register_push_unsub(unsub)
+        LOGGER.debug("Subscribed to MQTT topic %s for %s", topic, self.lock.entity_id)
 
     @callback
     def setup_push_subscription(self) -> None:
@@ -352,7 +346,7 @@ class Zigbee2MQTTLock(BaseLock):
 
         Primary subscribe is ``await`` in ``async_setup``.
         """
-        if self._unsubscribe is not None:
+        if self._push_unsubs:
             return
 
         topic = self._get_topic()
@@ -397,9 +391,9 @@ class Zigbee2MQTTLock(BaseLock):
     @callback
     def teardown_push_subscription(self) -> None:
         """Unsubscribe from MQTT updates."""
-        if self._unsubscribe:
-            self._unsubscribe()
-            self._unsubscribe = None
+        had_subscription = bool(self._push_unsubs)
+        self._clear_push_unsubs()
+        if had_subscription:
             LOGGER.debug("Unsubscribed from MQTT for %s", self.lock.entity_id)
 
         # Cancel any pending futures
@@ -517,7 +511,18 @@ class Zigbee2MQTTLock(BaseLock):
 
         try:
             await async_publish(self.hass, set_topic, payload)
-        except (HomeAssistantError, OSError) as err:
+        except OSError as err:
+            # Network-level publish failure (broker unreachable). Route to
+            # disconnect so the reconnect path runs instead of breaking
+            # per-slot.
+            LOGGER.error(
+                "Failed to set PIN for %s slot %s: %s",
+                self.lock.entity_id,
+                code_slot,
+                err,
+            )
+            raise LockDisconnected(f"Failed to set PIN: {err}") from err
+        except HomeAssistantError as err:
             LOGGER.error(
                 "Failed to set PIN for %s slot %s: %s",
                 self.lock.entity_id,
@@ -564,7 +569,16 @@ class Zigbee2MQTTLock(BaseLock):
 
         try:
             await async_publish(self.hass, set_topic, payload)
-        except (HomeAssistantError, OSError) as err:
+        except OSError as err:
+            # See ``async_set_usercode`` for the OSError split rationale.
+            LOGGER.error(
+                "Failed to clear PIN for %s slot %s: %s",
+                self.lock.entity_id,
+                code_slot,
+                err,
+            )
+            raise LockDisconnected(f"Failed to clear PIN: {err}") from err
+        except HomeAssistantError as err:
             LOGGER.error(
                 "Failed to clear PIN for %s slot %s: %s",
                 self.lock.entity_id,

--- a/custom_components/lock_code_manager/providers/zwave_js.py
+++ b/custom_components/lock_code_manager/providers/zwave_js.py
@@ -86,8 +86,10 @@ class ZWaveJSLock(BaseLock):
     """Class to represent ZWave JS lock."""
 
     lock_config_entry: ConfigEntry = field(repr=False)
+    # Home Assistant event-bus listeners (separate lifecycle from push
+    # subscriptions: registered in ``async_setup``, released in
+    # ``async_unload``).
     _listeners: list[Callable[[], None]] = field(init=False, default_factory=list)
-    _value_update_unsub: Callable[[], None] | None = field(init=False, default=None)
     _set_in_progress_code_slot: int | None = field(init=False, default=None)
 
     @property
@@ -231,7 +233,7 @@ class ZWaveJSLock(BaseLock):
     def setup_push_subscription(self) -> None:
         """Subscribe to User Code CC value update events."""
         # Idempotent - skip if already subscribed
-        if self._value_update_unsub is not None:
+        if self._push_unsubs:
             return
 
         ready, reason = self._get_client_state()
@@ -275,16 +277,15 @@ class ZWaveJSLock(BaseLock):
                 self._handle_usercode_value_update(code_slot, args.get("newValue"))
 
         try:
-            self._value_update_unsub = self.node.on("value updated", on_value_updated)
+            unsub = self.node.on("value updated", on_value_updated)
         except ValueError as err:
             raise LockDisconnected(f"node not ready: {err}") from err
+        self._register_push_unsub(unsub)
 
     @callback
     def teardown_push_subscription(self) -> None:
         """Unsubscribe from value update events."""
-        if self._value_update_unsub:
-            self._value_update_unsub()
-            self._value_update_unsub = None
+        self._clear_push_unsubs()
 
     @callback
     def _zwave_js_event_filter(self, event_data: dict[str, Any]) -> bool:

--- a/tests/providers/akuvox/test_provider.py
+++ b/tests/providers/akuvox/test_provider.py
@@ -574,19 +574,12 @@ class TestAutoTagging:
             "_async_modify_user",
             side_effect=LockDisconnected("offline"),
         ):
-            with pytest.raises(LockDisconnected):
+            with pytest.raises(LockDisconnected, match="disconnect during tag pass"):
                 await akuvox_lock.async_setup(lcm_config_entry)
         assert akuvox_lock._tagged_once is False
 
         # Reconnect: now the underlying modify succeeds.
-        with patch.object(
-            akuvox_lock,
-            "_async_modify_user",
-            wraps=akuvox_lock._async_modify_user,
-        ) as second_modify:
-            await akuvox_lock.async_setup(lcm_config_entry)
-
-        assert second_modify.await_count >= 1
+        await akuvox_lock.async_setup(lcm_config_entry)
         assert akuvox_lock._tagged_once is True
 
     async def test_concurrent_set_usercode_serialized_under_sequence_lock(

--- a/tests/providers/akuvox/test_provider.py
+++ b/tests/providers/akuvox/test_provider.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import timedelta
 from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -522,6 +523,60 @@ class TestAutoTagging:
         # No LCM config entry means no managed slots
         await akuvox_lock._async_tag_unmanaged_users()
         # No service calls should have been made (no list_users registered)
+
+    async def test_async_setup_idempotent_skips_repeat_tag_pass(
+        self,
+        hass: HomeAssistant,
+        akuvox_lock: AkuvoxLock,
+        lcm_config_entry: MockConfigEntry,
+    ) -> None:
+        """A second async_setup call must not re-run the tag pass."""
+        register_mock_service(
+            hass,
+            AKUVOX_DOMAIN,
+            "list_users",
+            AsyncMock(return_value={LOCK_ENTITY_ID: {"users": []}}),
+        )
+
+        with patch.object(
+            akuvox_lock,
+            "_async_run_tag_pass",
+            wraps=akuvox_lock._async_run_tag_pass,
+        ) as mock_pass:
+            await akuvox_lock.async_setup(lcm_config_entry)
+            await akuvox_lock.async_setup(lcm_config_entry)
+
+        assert mock_pass.await_count == 1
+        assert akuvox_lock._tagged_once is True
+
+    async def test_concurrent_set_usercode_serialized_under_sequence_lock(
+        self,
+        hass: HomeAssistant,
+        akuvox_lock: AkuvoxLock,
+        lcm_config_entry: MockConfigEntry,
+    ) -> None:
+        """Concurrent set_usercode calls must not interleave their read-modify-write."""
+        in_section = [0]
+        max_overlap = [0]
+
+        async def list_handler(call):
+            in_section[0] += 1
+            max_overlap[0] = max(max_overlap[0], in_section[0])
+            await asyncio.sleep(0)
+            in_section[0] -= 1
+            return {LOCK_ENTITY_ID: {"users": []}}
+
+        register_mock_service(hass, AKUVOX_DOMAIN, "list_users", list_handler)
+        register_mock_service(
+            hass, AKUVOX_DOMAIN, "add_user", AsyncMock(return_value=None)
+        )
+
+        await asyncio.gather(
+            akuvox_lock.async_set_usercode(1, "1111"),
+            akuvox_lock.async_set_usercode(2, "2222"),
+        )
+
+        assert max_overlap[0] == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/providers/akuvox/test_provider.py
+++ b/tests/providers/akuvox/test_provider.py
@@ -15,6 +15,7 @@ from homeassistant.exceptions import HomeAssistantError
 
 from custom_components.lock_code_manager.exceptions import (
     LockCodeManagerError,
+    LockDisconnected,
     LockOperationFailed,
 )
 from custom_components.lock_code_manager.models import SlotCode
@@ -547,6 +548,45 @@ class TestAutoTagging:
             await akuvox_lock.async_setup(lcm_config_entry)
 
         assert mock_pass.await_count == 1
+        assert akuvox_lock._tagged_once is True
+
+    async def test_async_setup_retries_after_disconnect_during_first_pass(
+        self,
+        hass: HomeAssistant,
+        akuvox_lock: AkuvoxLock,
+        lcm_config_entry: MockConfigEntry,
+    ) -> None:
+        """LockDisconnected during the first tag pass must leave _tagged_once False so reconnect retries."""
+        untagged_users = {
+            LOCK_ENTITY_ID: {
+                "users": [make_user("200", "Guest", "9999")],
+            },
+        }
+        register_mock_service(
+            hass,
+            AKUVOX_DOMAIN,
+            "list_users",
+            AsyncMock(return_value=untagged_users),
+        )
+
+        with patch.object(
+            akuvox_lock,
+            "_async_modify_user",
+            side_effect=LockDisconnected("offline"),
+        ):
+            with pytest.raises(LockDisconnected):
+                await akuvox_lock.async_setup(lcm_config_entry)
+        assert akuvox_lock._tagged_once is False
+
+        # Reconnect: now the underlying modify succeeds.
+        with patch.object(
+            akuvox_lock,
+            "_async_modify_user",
+            wraps=akuvox_lock._async_modify_user,
+        ) as second_modify:
+            await akuvox_lock.async_setup(lcm_config_entry)
+
+        assert second_modify.await_count >= 1
         assert akuvox_lock._tagged_once is True
 
     async def test_concurrent_set_usercode_serialized_under_sequence_lock(

--- a/tests/providers/matter/test_provider.py
+++ b/tests/providers/matter/test_provider.py
@@ -1091,10 +1091,10 @@ class TestEventSubscription:
 
     def test_setup_push_idempotent(self, matter_lock_simple: MatterLock) -> None:
         """Test setup_push_subscription is a no-op if already subscribed."""
-        matter_lock_simple._event_unsub = lambda: None  # already subscribed
+        matter_lock_simple._push_unsubs.append(lambda: None)  # already subscribed
         matter_lock_simple.setup_push_subscription()  # should be a no-op
         # If it tried to subscribe again, it would fail (no client)
-        assert matter_lock_simple._event_unsub is not None
+        assert matter_lock_simple._push_unsubs
 
     def test_setup_push_no_client_raises(
         self, hass: HomeAssistant, matter_lock_simple: MatterLock
@@ -1111,16 +1111,16 @@ class TestEventSubscription:
         def _unsub() -> None:
             unsub_called[0] = True
 
-        matter_lock_simple._event_unsub = _unsub
+        matter_lock_simple._push_unsubs.append(_unsub)
         matter_lock_simple.teardown_push_subscription()
         assert unsub_called[0]
-        assert matter_lock_simple._event_unsub is None
+        assert not matter_lock_simple._push_unsubs
 
     def test_teardown_push_no_subscription(
         self, matter_lock_simple: MatterLock
     ) -> None:
         """Test teardown_push_subscription handles no active subscription."""
-        matter_lock_simple._event_unsub = None
+        assert not matter_lock_simple._push_unsubs
         matter_lock_simple.teardown_push_subscription()  # should not crash
 
     # -- Tests using the full Matter integration fixture --
@@ -1143,7 +1143,7 @@ class TestEventSubscription:
     ) -> None:
         """Test setup_push_subscription subscribes with correct node ID."""
         matter_lock.setup_push_subscription()
-        assert matter_lock._event_unsub is not None
+        assert matter_lock._push_unsubs
         # Find LCM's subscription by its callback method name
         lcm_calls = [
             call
@@ -1182,7 +1182,7 @@ class TestEventSubscription:
         with pytest.raises(LockDisconnected):
             matter_lock_simple.setup_push_subscription()
 
-        assert matter_lock_simple._event_unsub is None
+        assert not matter_lock_simple._push_unsubs
         mock_client.subscribe_events.assert_not_called()
 
 

--- a/tests/providers/schlage/test_provider.py
+++ b/tests/providers/schlage/test_provider.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import timedelta
 from unittest.mock import AsyncMock, patch
 
@@ -299,6 +300,78 @@ async def test_tag_unmanaged_codes_no_managed_slots(
     assert add_handler.call_count == 0
 
 
+async def test_async_setup_idempotent_skips_repeat_tag_pass(
+    hass: HomeAssistant,
+    schlage_lock: SchlageLock,
+    simple_lcm_config_entry: MockConfigEntry,
+) -> None:
+    """A second async_setup call must not re-run the tag pass.
+
+    Reconnect can call async_setup again on the same provider instance;
+    re-tagging there would produce double-tag / rename storms against a
+    possibly-drifted device list.
+    """
+    get_response = {
+        LOCK_ENTITY_ID: {
+            "code1": {"name": "Guest", "code": "1234"},
+        },
+    }
+    register_mock_service(
+        hass, SCHLAGE_DOMAIN, "get_codes", AsyncMock(return_value=get_response)
+    )
+    register_mock_service(
+        hass, SCHLAGE_DOMAIN, "add_code", AsyncMock(return_value=None)
+    )
+    register_mock_service(
+        hass, SCHLAGE_DOMAIN, "delete_code", AsyncMock(return_value=None)
+    )
+
+    with patch.object(
+        schlage_lock,
+        "_async_run_tag_pass",
+        wraps=schlage_lock._async_run_tag_pass,
+    ) as mock_pass:
+        await schlage_lock.async_setup(simple_lcm_config_entry)
+        await schlage_lock.async_setup(simple_lcm_config_entry)
+
+    assert mock_pass.await_count == 1
+    assert schlage_lock._tagged_once is True
+
+
+async def test_concurrent_set_usercode_serialized_under_sequence_lock(
+    hass: HomeAssistant,
+    schlage_lock: SchlageLock,
+    simple_lcm_config_entry: MockConfigEntry,
+) -> None:
+    """Concurrent set_usercode calls must not interleave their read-modify-write."""
+    in_section = [0]
+    max_overlap = [0]
+
+    async def get_codes_handler(call):
+        in_section[0] += 1
+        max_overlap[0] = max(max_overlap[0], in_section[0])
+        # Yield so other tasks could observe overlap if sequencing fails
+        await asyncio.sleep(0)
+        in_section[0] -= 1
+        return {LOCK_ENTITY_ID: {}}
+
+    register_mock_service(hass, SCHLAGE_DOMAIN, "get_codes", get_codes_handler)
+    register_mock_service(
+        hass, SCHLAGE_DOMAIN, "add_code", AsyncMock(return_value=None)
+    )
+    register_mock_service(
+        hass, SCHLAGE_DOMAIN, "delete_code", AsyncMock(return_value=None)
+    )
+
+    await asyncio.gather(
+        schlage_lock.async_set_usercode(1, "1111"),
+        schlage_lock.async_set_usercode(2, "2222"),
+        schlage_lock.async_set_usercode(3, "3333"),
+    )
+
+    assert max_overlap[0] == 1
+
+
 # ---------------------------------------------------------------------------
 # set_usercode tests
 # ---------------------------------------------------------------------------
@@ -485,7 +558,7 @@ async def test_hard_refresh_codes(
     handler = AsyncMock(return_value=mock_response)
     register_mock_service(hass, SCHLAGE_DOMAIN, "get_codes", handler)
 
-    with patch.object(schlage_lock, "_async_tag_unmanaged_codes") as mock_tag:
+    with patch.object(schlage_lock, "_async_run_tag_pass") as mock_tag:
         codes = await schlage_lock.async_hard_refresh_codes()
         mock_tag.assert_awaited_once()
 

--- a/tests/providers/schlage/test_provider.py
+++ b/tests/providers/schlage/test_provider.py
@@ -368,21 +368,48 @@ async def test_async_setup_retries_after_disconnect_during_first_pass(
         "_async_add_code",
         side_effect=LockDisconnected("offline"),
     ):
-        with pytest.raises(LockDisconnected):
+        with pytest.raises(LockDisconnected, match="disconnect during tag pass"):
             await schlage_lock.async_setup(simple_lcm_config_entry)
     assert schlage_lock._tagged_once is False
 
     # Reconnect: now the underlying add succeeds. The pass must actually
     # complete and the guard must be set so a further reconnect skips.
+    await schlage_lock.async_setup(simple_lcm_config_entry)
+    assert schlage_lock._tagged_once is True
+
+
+async def test_async_setup_retries_after_disconnect_on_delete_step(
+    hass: HomeAssistant,
+    schlage_lock: SchlageLock,
+    simple_lcm_config_entry: MockConfigEntry,
+) -> None:
+    """LockDisconnected on the delete-original step also re-raises after the loop."""
+    untagged_codes = {
+        LOCK_ENTITY_ID: {
+            "code1": {"name": "Guest", "code": "1234"},
+        },
+    }
+    register_mock_service(
+        hass, SCHLAGE_DOMAIN, "get_codes", AsyncMock(return_value=untagged_codes)
+    )
+    register_mock_service(
+        hass, SCHLAGE_DOMAIN, "add_code", AsyncMock(return_value=None)
+    )
+    register_mock_service(
+        hass, SCHLAGE_DOMAIN, "delete_code", AsyncMock(return_value=None)
+    )
+
+    # Patch only _async_delete_code so the add succeeds and the delete-
+    # original failure path is exercised. The rollback (delete tagged)
+    # would also be called; we stub both via the same patch.
     with patch.object(
         schlage_lock,
-        "_async_add_code",
-        wraps=schlage_lock._async_add_code,
-    ) as second_add:
-        await schlage_lock.async_setup(simple_lcm_config_entry)
-
-    assert second_add.await_count >= 1
-    assert schlage_lock._tagged_once is True
+        "_async_delete_code",
+        side_effect=LockDisconnected("delete offline"),
+    ):
+        with pytest.raises(LockDisconnected, match="disconnect during tag pass"):
+            await schlage_lock.async_setup(simple_lcm_config_entry)
+    assert schlage_lock._tagged_once is False
 
 
 async def test_concurrent_set_usercode_serialized_under_sequence_lock(

--- a/tests/providers/schlage/test_provider.py
+++ b/tests/providers/schlage/test_provider.py
@@ -14,6 +14,7 @@ from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 
 from custom_components.lock_code_manager.exceptions import (
     LockCodeManagerError,
+    LockDisconnected,
     LockOperationFailed,
 )
 from custom_components.lock_code_manager.models import SlotCode
@@ -335,6 +336,52 @@ async def test_async_setup_idempotent_skips_repeat_tag_pass(
         await schlage_lock.async_setup(simple_lcm_config_entry)
 
     assert mock_pass.await_count == 1
+    assert schlage_lock._tagged_once is True
+
+
+async def test_async_setup_retries_after_disconnect_during_first_pass(
+    hass: HomeAssistant,
+    schlage_lock: SchlageLock,
+    simple_lcm_config_entry: MockConfigEntry,
+) -> None:
+    """A LockDisconnected during the first tag pass must leave _tagged_once False so reconnect retries."""
+    untagged_codes = {
+        LOCK_ENTITY_ID: {
+            "code1": {"name": "Guest", "code": "1234"},
+        },
+    }
+    register_mock_service(
+        hass, SCHLAGE_DOMAIN, "get_codes", AsyncMock(return_value=untagged_codes)
+    )
+    register_mock_service(
+        hass, SCHLAGE_DOMAIN, "add_code", AsyncMock(return_value=None)
+    )
+    register_mock_service(
+        hass, SCHLAGE_DOMAIN, "delete_code", AsyncMock(return_value=None)
+    )
+
+    # First pass: _async_add_code is patched to raise LockDisconnected on
+    # every untagged entry. The tag pass must re-raise after logging so
+    # _tagged_once stays False.
+    with patch.object(
+        schlage_lock,
+        "_async_add_code",
+        side_effect=LockDisconnected("offline"),
+    ):
+        with pytest.raises(LockDisconnected):
+            await schlage_lock.async_setup(simple_lcm_config_entry)
+    assert schlage_lock._tagged_once is False
+
+    # Reconnect: now the underlying add succeeds. The pass must actually
+    # complete and the guard must be set so a further reconnect skips.
+    with patch.object(
+        schlage_lock,
+        "_async_add_code",
+        wraps=schlage_lock._async_add_code,
+    ) as second_add:
+        await schlage_lock.async_setup(simple_lcm_config_entry)
+
+    assert second_add.await_count >= 1
     assert schlage_lock._tagged_once is True
 
 

--- a/tests/providers/test_base.py
+++ b/tests/providers/test_base.py
@@ -1147,3 +1147,99 @@ async def test_async_unload_logs_reconnect_task_exception(
         for record in caplog.records
         if record.levelname == "WARNING"
     )
+
+
+# =============================================================================
+# Push unsub registry
+# =============================================================================
+
+
+async def test_clear_push_unsubs_invokes_and_empties_registry(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """_clear_push_unsubs invokes every registered unsub and clears the list."""
+    lock = lock_code_manager_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
+
+    calls: list[str] = []
+    lock._register_push_unsub(lambda: calls.append("a"))
+    lock._register_push_unsub(lambda: calls.append("b"))
+    assert len(lock._push_unsubs) == 2
+
+    lock._clear_push_unsubs()
+
+    assert calls == ["a", "b"]
+    assert lock._push_unsubs == []
+
+
+async def test_clear_push_unsubs_continues_on_individual_failure(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+    caplog: pytest.LogCaptureFixture,
+):
+    """A raising unsub does not prevent later unsubs from running."""
+    lock = lock_code_manager_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
+
+    second_called = [False]
+
+    def boom_unsub() -> None:
+        raise RuntimeError("unsub failed")
+
+    def second_unsub() -> None:
+        second_called[0] = True
+
+    lock._register_push_unsub(boom_unsub)
+    lock._register_push_unsub(second_unsub)
+
+    with caplog.at_level(logging.WARNING):
+        lock._clear_push_unsubs()
+
+    assert second_called[0]
+    assert lock._push_unsubs == []
+
+
+# =============================================================================
+# Sequence lock context manager
+# =============================================================================
+
+
+async def test_serialize_sequence_serializes_concurrent_blocks(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """_serialize_sequence forces concurrent multi-step ops to run one at a time."""
+    lock = lock_code_manager_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
+    in_section = [0]
+    max_overlap = [0]
+    order: list[int] = []
+
+    async def section(tag: int) -> None:
+        async with lock._serialize_sequence():
+            in_section[0] += 1
+            max_overlap[0] = max(max_overlap[0], in_section[0])
+            await asyncio.sleep(0)
+            order.append(tag)
+            in_section[0] -= 1
+
+    await asyncio.gather(section(1), section(2), section(3))
+
+    assert max_overlap[0] == 1
+    assert sorted(order) == [1, 2, 3]
+
+
+async def test_serialize_sequence_allows_rate_limited_inside(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """A rate-limited leaf call inside _serialize_sequence does not deadlock."""
+    lock = lock_code_manager_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
+    lock._min_operation_delay = TEST_OPERATION_DELAY
+
+    async with lock._serialize_sequence():
+        result = await lock.async_internal_set_usercode(5, "5555", "Test 5")
+
+    assert result is None

--- a/tests/providers/test_base.py
+++ b/tests/providers/test_base.py
@@ -1200,6 +1200,32 @@ async def test_clear_push_unsubs_continues_on_individual_failure(
     assert lock._push_unsubs == []
 
 
+async def test_clear_push_unsubs_safe_when_unsub_reregisters(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """An unsub that re-registers must not corrupt iteration or loop forever."""
+    lock = lock_code_manager_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
+
+    calls: list[str] = []
+
+    def reregistering_unsub() -> None:
+        calls.append("first")
+        # Re-register self after the original snapshot was taken; the
+        # re-registration must survive clear() but must not be called
+        # again in this _clear_push_unsubs invocation.
+        lock._register_push_unsub(reregistering_unsub)
+
+    lock._register_push_unsub(reregistering_unsub)
+    lock._register_push_unsub(lambda: calls.append("second"))
+
+    lock._clear_push_unsubs()
+
+    assert calls == ["first", "second"]
+    assert lock._push_unsubs == [reregistering_unsub]
+
+
 # =============================================================================
 # Sequence lock context manager
 # =============================================================================

--- a/tests/providers/zha/test_provider.py
+++ b/tests/providers/zha/test_provider.py
@@ -15,7 +15,6 @@ from homeassistant.core import HomeAssistant
 from custom_components.lock_code_manager.exceptions import (
     CodeRejectedError,
     LockDisconnected,
-    LockOperationFailed,
 )
 from custom_components.lock_code_manager.models import SlotCode
 from custom_components.lock_code_manager.providers.zha import (
@@ -201,19 +200,19 @@ async def test_clear_usercode_failure(
 async def test_subscribe_push_updates(hass: HomeAssistant, zha_lock: ZHALock) -> None:
     """Test subscribing to push updates."""
     zha_lock.setup_push_subscription()
-    assert zha_lock._cluster_listener_unsub is not None
+    assert zha_lock._push_unsubs
 
     zha_lock.teardown_push_subscription()
-    assert zha_lock._cluster_listener_unsub is None
+    assert not zha_lock._push_unsubs
 
 
 async def test_subscribe_is_idempotent(hass: HomeAssistant, zha_lock: ZHALock) -> None:
     """Test that calling subscribe multiple times is safe."""
     zha_lock.setup_push_subscription()
-    first_unsub = zha_lock._cluster_listener_unsub
+    first_unsubs = list(zha_lock._push_unsubs)
 
     zha_lock.setup_push_subscription()
-    assert zha_lock._cluster_listener_unsub is first_unsub
+    assert list(zha_lock._push_unsubs) == first_unsubs
 
     zha_lock.teardown_push_subscription()
 
@@ -489,9 +488,9 @@ async def test_teardown_push_when_not_subscribed(
     hass: HomeAssistant, zha_lock: ZHALock
 ) -> None:
     """Test teardown when not subscribed is a no-op."""
-    assert zha_lock._cluster_listener_unsub is None
+    assert not zha_lock._push_unsubs
     zha_lock.teardown_push_subscription()
-    assert zha_lock._cluster_listener_unsub is None
+    assert not zha_lock._push_unsubs
 
 
 # ---------------------------------------------------------------------------
@@ -542,13 +541,13 @@ async def test_async_setup_is_idempotent(
 
     await zha_lock.async_setup(simple_lcm_config_entry)
     zha_lock.setup_push_subscription()
-    assert zha_lock._cluster_listener_unsub is not None
+    assert zha_lock._push_unsubs
 
     # Simulate ZHA reload — async_setup tears down and re-initializes
     await zha_lock.async_setup(simple_lcm_config_entry)
 
     # Listener torn down by async_setup's teardown call
-    assert zha_lock._cluster_listener_unsub is None
+    assert not zha_lock._push_unsubs
 
 
 async def test_check_programming_support_no_cluster(
@@ -606,12 +605,12 @@ async def test_set_usercode_generic_exception(
     zha_lock: ZHALock,
     simple_lcm_config_entry: MockConfigEntry,
 ) -> None:
-    """Test set_usercode wraps generic exceptions as LockOperationFailed."""
+    """Test set_usercode wraps zigpy comms failures as LockDisconnected."""
     cluster = zha_lock._get_door_lock_cluster()
     assert cluster is not None
     cluster.set_pin_code = AsyncMock(side_effect=RuntimeError("zigpy error"))
 
-    with pytest.raises(LockOperationFailed, match="Failed to set PIN"):
+    with pytest.raises(LockDisconnected, match="Failed to set PIN"):
         await zha_lock.async_set_usercode(1, "1234")
 
 
@@ -620,10 +619,10 @@ async def test_clear_usercode_generic_exception(
     zha_lock: ZHALock,
     simple_lcm_config_entry: MockConfigEntry,
 ) -> None:
-    """Test clear_usercode wraps generic exceptions as LockOperationFailed."""
+    """Test clear_usercode wraps zigpy comms failures as LockDisconnected."""
     cluster = zha_lock._get_door_lock_cluster()
     assert cluster is not None
     cluster.clear_pin_code = AsyncMock(side_effect=RuntimeError("zigpy error"))
 
-    with pytest.raises(LockOperationFailed, match="Failed to clear PIN"):
+    with pytest.raises(LockDisconnected, match="Failed to clear PIN"):
         await zha_lock.async_clear_usercode(1)

--- a/tests/providers/zigbee2mqtt/test_provider.py
+++ b/tests/providers/zigbee2mqtt/test_provider.py
@@ -167,7 +167,7 @@ class TestPushSubscription:
             lock.setup_push_subscription()
             await hass.async_block_till_done()
 
-        assert lock._unsubscribe is None
+        assert not lock._push_unsubs
 
     async def test_teardown_push_unsubscribes_and_cancels_pending(
         self,
@@ -176,14 +176,14 @@ class TestPushSubscription:
         """Teardown calls MQTT unsubscribe and cancels outstanding futures."""
         lock = zigbee2mqtt_lock_with_device
         unsub = MagicMock()
-        lock._unsubscribe = unsub
+        lock._push_unsubs.append(unsub)
         fut = asyncio.get_running_loop().create_future()
         lock._pending_codes[3] = fut
 
         lock.teardown_push_subscription()
 
         unsub.assert_called_once()
-        assert lock._unsubscribe is None
+        assert not lock._push_unsubs
         assert fut.cancelled()
 
 
@@ -576,15 +576,43 @@ class TestAsyncSetClearHardRefresh:
         ):
             assert await lock.async_set_usercode(2, "9999") is True
 
-    async def test_async_set_usercode_publish_failure_raises(
+    async def test_async_set_usercode_publish_oserror_raises_lock_disconnected(
         self,
         hass: HomeAssistant,
         zigbee2mqtt_lock_with_device: Zigbee2MQTTLock,
     ) -> None:
-        """Publish errors surface as LockOperationFailed."""
+        """Set path maps MQTT OSError publish failures to LockDisconnected.
+
+        OSError reflects a broker-reachability problem; routing it to
+        LockDisconnected lets the reconnect/backoff path handle recovery
+        instead of breaking per-slot.
+        """
         lock = zigbee2mqtt_lock_with_device
         hass.states.async_set(lock.lock.entity_id, "locked")
         mock_pub = AsyncMock(side_effect=OSError("broker"))
+
+        with (
+            patch(
+                "custom_components.lock_code_manager.providers.zigbee2mqtt.mqtt_config_entry_enabled",
+                return_value=True,
+            ),
+            patch(
+                "custom_components.lock_code_manager.providers.zigbee2mqtt.async_publish",
+                mock_pub,
+            ),
+            pytest.raises(LockDisconnected, match="Failed to set PIN"),
+        ):
+            await lock.async_set_usercode(1, "1111")
+
+    async def test_async_set_usercode_publish_ha_error_raises_operation_failed(
+        self,
+        hass: HomeAssistant,
+        zigbee2mqtt_lock_with_device: Zigbee2MQTTLock,
+    ) -> None:
+        """HomeAssistantError from publish surfaces as LockOperationFailed."""
+        lock = zigbee2mqtt_lock_with_device
+        hass.states.async_set(lock.lock.entity_id, "locked")
+        mock_pub = AsyncMock(side_effect=HomeAssistantError("payload rejected"))
 
         with (
             patch(
@@ -622,15 +650,38 @@ class TestAsyncSetClearHardRefresh:
         ):
             await lock.async_clear_usercode(4)
 
-    async def test_async_clear_usercode_publish_oserror_raises_operation_failed(
+    async def test_async_clear_usercode_publish_oserror_raises_lock_disconnected(
         self,
         hass: HomeAssistant,
         zigbee2mqtt_lock_with_device: Zigbee2MQTTLock,
     ) -> None:
-        """Clear path maps MQTT publish failures to LockOperationFailed."""
+        """Clear path maps MQTT OSError publish failures to LockDisconnected."""
         lock = zigbee2mqtt_lock_with_device
         hass.states.async_set(lock.lock.entity_id, "locked")
         mock_pub = AsyncMock(side_effect=OSError("broker"))
+
+        with (
+            patch(
+                "custom_components.lock_code_manager.providers.zigbee2mqtt.mqtt_config_entry_enabled",
+                return_value=True,
+            ),
+            patch(
+                "custom_components.lock_code_manager.providers.zigbee2mqtt.async_publish",
+                mock_pub,
+            ),
+            pytest.raises(LockDisconnected, match="Failed to clear PIN"),
+        ):
+            await lock.async_clear_usercode(4)
+
+    async def test_async_clear_usercode_publish_ha_error_raises_operation_failed(
+        self,
+        hass: HomeAssistant,
+        zigbee2mqtt_lock_with_device: Zigbee2MQTTLock,
+    ) -> None:
+        """HomeAssistantError from publish surfaces as LockOperationFailed."""
+        lock = zigbee2mqtt_lock_with_device
+        hass.states.async_set(lock.lock.entity_id, "locked")
+        mock_pub = AsyncMock(side_effect=HomeAssistantError("payload rejected"))
 
         with (
             patch(

--- a/tests/providers/zwave_js/test_e2e.py
+++ b/tests/providers/zwave_js/test_e2e.py
@@ -62,7 +62,7 @@ class TestFullSetupLifecycle:
         e2e_zwave_lock: ZWaveJSLock,
     ) -> None:
         """The provider subscribes to Z-Wave JS value updates during setup."""
-        assert e2e_zwave_lock._value_update_unsub is not None
+        assert e2e_zwave_lock._push_unsubs
 
 
 class TestSetAndClearUsercodes:

--- a/tests/providers/zwave_js/test_events.py
+++ b/tests/providers/zwave_js/test_events.py
@@ -236,10 +236,10 @@ async def test_subscribe_push_updates(
     # Subscribe to push updates (idempotent - may already be subscribed)
     zwave_js_lock.subscribe_push_updates()
 
-    assert zwave_js_lock._value_update_unsub is not None
+    assert zwave_js_lock._push_unsubs
 
     zwave_js_lock.unsubscribe_push_updates()
-    assert zwave_js_lock._value_update_unsub is None
+    assert not zwave_js_lock._push_unsubs
 
     await zwave_js_lock.async_unload(False)
 
@@ -255,10 +255,10 @@ async def test_subscribe_is_idempotent(
     await zwave_js_lock.async_setup_internal(lcm_entry)
 
     zwave_js_lock.subscribe_push_updates()
-    first_unsub = zwave_js_lock._value_update_unsub
+    first_unsubs = list(zwave_js_lock._push_unsubs)
 
     zwave_js_lock.subscribe_push_updates()
-    assert zwave_js_lock._value_update_unsub is first_unsub
+    assert list(zwave_js_lock._push_unsubs) == first_unsubs
 
     zwave_js_lock.unsubscribe_push_updates()
     await zwave_js_lock.async_unload(False)
@@ -275,7 +275,7 @@ async def test_subscribe_push_no_crash_on_client_not_ready(
     await zwave_js_lock.async_setup_internal(lcm_entry)
 
     zwave_js_lock.unsubscribe_push_updates()
-    assert zwave_js_lock._value_update_unsub is None
+    assert not zwave_js_lock._push_unsubs
 
     # Make client appear not ready — should not crash
     with patch.object(
@@ -284,7 +284,7 @@ async def test_subscribe_push_no_crash_on_client_not_ready(
         zwave_js_lock.subscribe_push_updates()
 
     # Should not have subscribed (no crash, no retry timer)
-    assert zwave_js_lock._value_update_unsub is None
+    assert not zwave_js_lock._push_unsubs
 
     await zwave_js_lock.async_unload(False)
 
@@ -301,13 +301,13 @@ async def test_subscribe_push_no_crash_on_node_error(
     await zwave_js_lock.async_setup_internal(lcm_entry)
 
     zwave_js_lock.unsubscribe_push_updates()
-    assert zwave_js_lock._value_update_unsub is None
+    assert not zwave_js_lock._push_unsubs
 
     # Make node.on raise — should not crash
     with patch.object(lock_schlage_be469, "on", side_effect=ValueError("not ready")):
         zwave_js_lock.subscribe_push_updates()
 
-    assert zwave_js_lock._value_update_unsub is None
+    assert not zwave_js_lock._push_unsubs
 
     await zwave_js_lock.async_unload(False)
 

--- a/tests/providers/zwave_js/test_provider.py
+++ b/tests/providers/zwave_js/test_provider.py
@@ -703,10 +703,10 @@ async def test_unload_cleans_up_push_subscription(
     await zwave_js_lock.async_setup_internal(lcm_entry)
 
     zwave_js_lock.subscribe_push_updates()
-    assert zwave_js_lock._value_update_unsub is not None
+    assert zwave_js_lock._push_unsubs
 
     await zwave_js_lock.async_unload(False)
-    assert zwave_js_lock._value_update_unsub is None
+    assert not zwave_js_lock._push_unsubs
 
 
 # Hard refresh tests


### PR DESCRIPTION
## Proposed change

Five related provider-layer cleanups, mostly one per commit. The first four were the original scope; the fifth was surfaced by review.

### 1. Failure classification post-#1184 (`ec0eb15a`)

After #1184 routes service-call failures to `LockOperationFailed` and breaks per-slot on that, the wrong exception classification has user-visible consequences: a transient communication failure misclassified as `LockOperationFailed` now breaks the slot instead of triggering reconnect.

- **ZHA**: `cluster.set_pin_code` / `cluster.clear_pin_code` bare-`Exception` catch now raises `LockDisconnected` instead of `LockOperationFailed`. Generic exceptions from a Zigbee cluster call are overwhelmingly comms/timing issues, not operational rejections. The non-zero-status branch still raises `CodeRejectedError`.
- **Zigbee2MQTT**: split MQTT publish errors — `OSError` → `LockDisconnected` (transient/connectivity), `HomeAssistantError` → `LockOperationFailed` (operational).
- **Matter** is left unchanged for now: Matter helpers raise `HomeAssistantError` for both transient comms failure and operational rejection, with no finer-grained type available. Currently all map to `LockDisconnected`. Flagged as an out-of-scope item for the eventual Matter data-model rewrite.

### 2. Sequence lock for multi-step provider ops (`99d2861b`)

Schlage and Akuvox do read-modify-write sequences (`get-codes → delete → add` for renames; `get → delete → set` for `async_set_usercode`). Only the leaf service calls go through `_execute_rate_limited`, which means concurrent callers can interleave and produce duplicate names / "already exists" loops (already noted as eventual-consistency comments in the code).

New base context manager `_serialize_sequence()` returns a separate `_sequence_lock` distinct from `_aio_lock`. Leaf calls inside a sequence still go through `_execute_rate_limited` against `_aio_lock` without deadlocking. Schlage and Akuvox wrap their multi-step paths.

### 3. Idempotent setup tag pass (`99d2861b`)

Schlage and Akuvox auto-tag unmanaged codes at setup. The base contract says `async_setup` must be idempotent; running the tag pass again on reconnect against a possibly-drifted device list produces double-tag / rename storms.

Adds `_tagged_once: bool` on both providers; the setup tag pass short-circuits if already True. Hard refresh bypasses the gate by calling the inner `_async_run_tag_pass` directly (the deliberate-reset case).

### 4. Push-unsub registry on the base (`aaba229f`, `38286f1f`)

Each provider previously invented its own unsub field — `_event_unsub` (Matter), `_cluster_listener_unsub` (ZHA), `_unsubscribe` (Zigbee2MQTT), `_value_update_unsub` (Z-Wave JS). Lifted to a shared `_push_unsubs: list[Callable[[], None]]` registry on the base with `_register_push_unsub` / `_clear_push_unsubs` helpers. Each unsub is invoked in try/except so one provider's broken teardown does not strand the others.

The `_clear_push_unsubs` follow-up (`b2118f22`) snapshots the registry before invoking so an unsub that re-registers won't corrupt iteration, and tightens the docstring to call out that Home Assistant event-bus listeners (Z-Wave JS's `_listeners`, lifecycle = setup/unload) must NOT be registered here.

Z-Wave JS's separate `_listeners` list (HA event-bus listeners, setup/unload lifecycle) is intentionally kept distinct from push-subscription teardown.

### 5. Tag-pass disconnect propagation so the idempotency guard does its job (`c06797c9`)

Surfaced by review: the original `_async_run_tag_pass` in Schlage/Akuvox caught `(LockDisconnected, LockOperationFailed)` as a single class and logged-and-continued. A hard-disconnect storm during the first setup pass would leave every per-code attempt logged but the function would return normally, `async_setup` would set `_tagged_once = True`, and no reconnect would ever retry the pass — defeating the guard's purpose.

Both providers now distinguish `LockDisconnected` from `LockOperationFailed` in the per-code (per-user) catches: operation failures stay per-code (do not gate idempotency), but a disconnect anywhere in the pass flips a `saw_disconnect` flag that re-raises `LockDisconnected` at the end. The re-raise propagates through `_async_tag_unmanaged_codes` / `_async_tag_unmanaged_users` into `async_setup` so the `_tagged_once = True` assignment is skipped and `_async_on_integration_loaded` retries on reconnect. Also fixes the latent `except LockDisconnected, LockOperationFailed:` style at `akuvox.py:249` (Py3 tuple-expression form — functional but stylistically broken).

## Out-of-scope findings worth flagging

- Matter's coarse `HomeAssistantError` → `LockDisconnected` mapping → PR F.
- `except E1, E2:` Py3 tuple-expression style appears in 4 remaining places (`_base.py:508`, `_util.py:48`, `zwave_js.py:157`, `zha.py:399, 444`) — functional, cosmetic only.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

Part of the resilience refactor chain. Depends on #1187 (lifecycle hygiene).

- This PR fixes or closes issue: fixes #
- This PR is related to issue: