### PR TITLE
make text/switch/active sensor read-only views

### DIFF
--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -911,9 +911,9 @@ async def async_update_listener(
             )
         )
         for slot_num in slots_to_remove:
-            coordinator = runtime_data.slot_coordinators.pop(slot_num, None)
-            if coordinator is not None:
-                coordinator.async_stop()
+            if slot_num in runtime_data.slot_coordinators:
+                runtime_data.slot_coordinators[slot_num].async_stop()
+                del runtime_data.slot_coordinators[slot_num]
 
     # Remove old lock entities
     if locks_to_remove:

--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -696,10 +696,14 @@ async def async_unload_entry(
         )
 
     # Stop per-slot coordinators after entity removal so the entities'
-    # async_will_remove_from_hass can still call into them (the writers
-    # are unregistered there). async_stop is idempotent.
-    for coordinator in runtime_data.slot_coordinators.values():
-        coordinator.async_stop()
+    # async_will_remove_from_hass can still call into them. One raising
+    # stop must not block the rest -- the registry is cleared whether
+    # individual stops succeed or fail.
+    for coordinator in list(runtime_data.slot_coordinators.values()):
+        try:
+            coordinator.async_stop()
+        except Exception:
+            _LOGGER.exception("Unload: slot coordinator stop raised")
     runtime_data.slot_coordinators.clear()
 
     # Fire lock-removed callbacks so per-lock entities are notified
@@ -911,9 +915,18 @@ async def async_update_listener(
             )
         )
         for slot_num in slots_to_remove:
-            if slot_num in runtime_data.slot_coordinators:
-                runtime_data.slot_coordinators[slot_num].async_stop()
-                del runtime_data.slot_coordinators[slot_num]
+            coordinator = runtime_data.slot_coordinators.pop(slot_num, None)
+            if coordinator is None:
+                continue
+            try:
+                coordinator.async_stop()
+            except Exception:
+                _LOGGER.exception(
+                    "%s (%s): slot %s coordinator stop raised",
+                    entry_id,
+                    entry_title,
+                    slot_num,
+                )
 
     # Remove old lock entities
     if locks_to_remove:

--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -95,6 +95,7 @@ from .pin_generator import (
     generate_pin,
 )
 from .providers import BaseLock
+from .slot_manager import SlotEntityCoordinator
 from .websocket import async_setup as async_websocket_setup
 
 _LOGGER = logging.getLogger(__name__)
@@ -679,16 +680,27 @@ async def async_unload_entry(
                 )
 
     # Fire slot entity removal callbacks first so per-slot entities (which
-    # reference locks) clean up before the locks are torn down
-    curr_slots = config_entry.data.get(CONF_SLOTS, {})
+    # reference locks) clean up before the locks are torn down. Read
+    # current slots from the cached EntryConfig view because
+    # ``_setup_entry_after_start`` migrates the entry's data to options
+    # at first setup, so ``config_entry.data`` is empty for any
+    # normally-loaded entry.
+    curr_slots = list(get_entry_config(config_entry).slots)
     if curr_slots:
-        _LOGGER.debug("Unload: removing slots %s", list(curr_slots))
+        _LOGGER.debug("Unload: removing slots %s", curr_slots)
         await asyncio.gather(
             *(
-                callbacks.invoke_entity_removers_for_slot(int(slot_num))
+                callbacks.invoke_entity_removers_for_slot(slot_num)
                 for slot_num in curr_slots
             )
         )
+
+    # Stop per-slot coordinators after entity removal so the entities'
+    # async_will_remove_from_hass can still call into them (the writers
+    # are unregistered there). async_stop is idempotent.
+    for coordinator in runtime_data.slot_coordinators.values():
+        coordinator.async_stop()
+    runtime_data.slot_coordinators.clear()
 
     # Fire lock-removed callbacks so per-lock entities are notified
     lock_ids = list(runtime_data.locks)
@@ -829,6 +841,14 @@ async def async_update_listener(
     runtime_data = config_entry.runtime_data
     runtime_data.config = EntryConfig.from_entry(config_entry)
 
+    # Notify per-slot coordinators so derived "active" state and condition-
+    # entity subscriptions stay in sync with the refreshed config view.
+    # Runs on both the entity-driven path (early return below) and the
+    # options-flow path so a calendar/condition swap is picked up the
+    # same way.
+    for coordinator in runtime_data.slot_coordinators.values():
+        coordinator.notify_config_changed()
+
     # No need to do entity creation/removal work if there are no options
     # because that only happens at the end of this function (data + empty
     # options = the post-listener state we just wrote ourselves).
@@ -890,6 +910,10 @@ async def async_update_listener(
                 for slot_num in slots_to_remove
             )
         )
+        for slot_num in slots_to_remove:
+            coordinator = runtime_data.slot_coordinators.pop(slot_num, None)
+            if coordinator is not None:
+                coordinator.async_stop()
 
     # Remove old lock entities
     if locks_to_remove:
@@ -925,6 +949,11 @@ async def async_update_listener(
             entry_title,
             slot_num,
         )
+        # Create the per-slot coordinator first so entities can look it
+        # up in their constructor / async_added_to_hass.
+        coordinator = SlotEntityCoordinator(hass, config_entry, slot_num)
+        runtime_data.slot_coordinators[slot_num] = coordinator
+        coordinator.async_start()
         callbacks.invoke_standard_adders(slot_num, ent_reg)
 
         for lock_entity_id, lock in runtime_data.locks.items():

--- a/custom_components/lock_code_manager/binary_sensor.py
+++ b/custom_components/lock_code_manager/binary_sensor.py
@@ -3,37 +3,17 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from datetime import datetime
 import logging
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
-from homeassistant.const import (
-    CONF_ENTITY_ID,
-    CONF_NAME,
-    CONF_PIN,
-    STATE_OFF,
-    STATE_ON,
-    EntityCategory,
-)
-from homeassistant.core import (
-    Event,
-    EventStateChangedData,
-    HomeAssistant,
-    callback,
-)
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import (
-    ATTR_ACTIVE,
-    ATTR_IN_SYNC,
-    ATTR_SYNC_STATUS,
-    EVENT_PIN_USED,
-)
+from .const import ATTR_ACTIVE, ATTR_IN_SYNC, ATTR_SYNC_STATUS
 from .coordinator import LockUsercodeUpdateCoordinator
-from .data import get_entry_config
 from .entity import BaseLockCodeManagerCodeSlotPerLockEntity, BaseLockCodeManagerEntity
 from .models import LockCodeManagerConfigEntry
 from .providers import BaseLock
@@ -90,129 +70,54 @@ async def async_setup_entry(
 
 
 class LockCodeManagerActiveEntity(BaseLockCodeManagerEntity, BinarySensorEntity):
-    """Active binary sensor entity for lock code manager."""
+    """
+    Active binary sensor entity for lock code manager.
+
+    Read-only view over ``SlotEntityCoordinator``. The coordinator owns
+    the condition-entity subscription and the active-state computation;
+    this entity only renders the current value.
+    """
 
     _attr_entity_category = EntityCategory.DIAGNOSTIC
-    _condition_entity_unsub: Callable[[], None] | None = None
-    _subscribed_condition_entity_id: str | None = None
-
-    @property
-    def _condition_entity_id(self) -> str | None:
-        """Return condition entity ID for this slot."""
-        return (
-            get_entry_config(self.config_entry).slot(self.slot_num).get(CONF_ENTITY_ID)
-        )
+    _coordinator_view_unsub: Callable[[], None] | None = None
 
     @callback
-    def _cleanup_condition_subscription(self) -> None:
-        """Clean up condition entity subscription if one exists."""
-        if self._condition_entity_unsub:
-            self._condition_entity_unsub()
-            self._condition_entity_unsub = None
-
-    @callback
-    def _update_state(self, _: datetime | None = None) -> None:
-        """Update binary sensor state by getting dependent states."""
-        _LOGGER.debug(
-            "%s (%s): Updating %s",
-            self.config_entry.entry_id,
-            self.config_entry.title,
-            self.entity_id,
-        )
-
-        states: dict[str, bool | None] = {}
-        for key, state in (
-            get_entry_config(self.config_entry).slot(self.slot_num).items()
-        ):
-            if key in (EVENT_PIN_USED, CONF_NAME, CONF_PIN, ATTR_IN_SYNC):
-                continue
-
-            # Handle condition entity - ON means access granted
-            if key == CONF_ENTITY_ID and (hass_state := self.hass.states.get(state)):
-                states[key] = (
-                    hass_state.state == STATE_ON
-                    if hass_state.state in (STATE_ON, STATE_OFF)
-                    else None
-                )
-                continue
-
-            states[key] = state
-
-        # For the binary sensor to be on, all states must be 'on'.
-        inactive_because_of = [key for key, state in states.items() if not state]
-        self._attr_is_on = bool(not inactive_because_of)
+    def _apply_coordinator_state(
+        self, is_on: bool | None, inactive_because_of: list[str]
+    ) -> None:
+        """Apply coordinator-derived active state and write Home Assistant state."""
+        self._attr_is_on = bool(is_on)
         if inactive_because_of:
-            self._attr_extra_state_attributes["inactive_because_of"] = (
+            self._attr_extra_state_attributes["inactive_because_of"] = list(
                 inactive_because_of
             )
         else:
             self._attr_extra_state_attributes.pop("inactive_because_of", None)
-        self.async_write_ha_state()
-
-    async def _config_entry_update_listener(
-        self, hass: HomeAssistant, config_entry: LockCodeManagerConfigEntry
-    ) -> None:
-        """Update listener."""
-        if config_entry.options:
-            return
-        # Re-subscribe if condition entity changed
-        self._update_condition_entity_subscription()
-        self._update_state()
-
-    @callback
-    def _handle_condition_entity_state_change(
-        self, event: Event[EventStateChangedData]
-    ) -> None:
-        """Handle condition entity state change."""
-        self._update_state()
-
-    @callback
-    def _update_condition_entity_subscription(self) -> None:
-        """Update subscription for condition entity if it changed."""
-        current_entity_id = self._condition_entity_id
-        old_entity_id = self._subscribed_condition_entity_id
-
-        # No change needed if entity ID hasn't changed
-        if current_entity_id == old_entity_id:
-            return
-
-        # Unsubscribe from old entity if we had one
-        self._cleanup_condition_subscription()
-
-        # Subscribe to new entity if we have one
-        if current_entity_id:
-            self._condition_entity_unsub = async_track_state_change_event(
-                self.hass,
-                [current_entity_id],
-                self._handle_condition_entity_state_change,
-            )
-
-        self._subscribed_condition_entity_id = current_entity_id
-        _LOGGER.debug(
-            "%s (%s): Updated condition entity subscription for %s: %s -> %s",
-            self.config_entry.entry_id,
-            self.config_entry.title,
-            self.entity_id,
-            old_entity_id,
-            current_entity_id,
-        )
+        if self.hass is not None and self.entity_id:
+            self.async_write_ha_state()
 
     async def async_added_to_hass(self) -> None:
         """Handle entity added to hass."""
         await BinarySensorEntity.async_added_to_hass(self)
         await BaseLockCodeManagerEntity.async_added_to_hass(self)
 
-        # Register cleanup for condition entity subscription (called on entity removal)
-        self.async_on_remove(self._cleanup_condition_subscription)
-
-        # Track state changes for configured condition entity
-        self._update_condition_entity_subscription()
-
-        self.async_on_remove(
-            self.config_entry.add_update_listener(self._config_entry_update_listener)
+        coordinator = self.config_entry.runtime_data.slot_coordinators.get(
+            self.slot_num
         )
+        if coordinator is None:
+            _LOGGER.warning(
+                "%s (%s): No slot coordinator for slot %s when registering "
+                "active binary sensor",
+                self.config_entry.entry_id,
+                self.config_entry.title,
+                self.slot_num,
+            )
+            return
 
-        self._update_state()
+        self._coordinator_view_unsub = coordinator.register_active_view(
+            self._apply_coordinator_state
+        )
+        self.async_on_remove(self._coordinator_view_unsub)
 
 
 class LockCodeManagerCodeSlotInSyncEntity(
@@ -223,6 +128,7 @@ class LockCodeManagerCodeSlotInSyncEntity(
     """PIN synced binary sensor entity for lock code manager."""
 
     _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _slot_coordinator_unsub: Callable[[], None] | None = None
 
     def __init__(
         self,
@@ -279,6 +185,13 @@ class LockCodeManagerCodeSlotInSyncEntity(
         await CoordinatorEntity.async_added_to_hass(self)
 
         self.config_entry.runtime_data.sync_managers.add(self._sync_manager)
+        slot_coordinator = self.config_entry.runtime_data.slot_coordinators.get(
+            self.slot_num
+        )
+        if slot_coordinator is not None:
+            self._slot_coordinator_unsub = slot_coordinator.register_sync_manager(
+                self._sync_manager
+            )
         await self._sync_manager.async_start()
 
     async def async_will_remove_from_hass(self) -> None:
@@ -288,5 +201,9 @@ class LockCodeManagerCodeSlotInSyncEntity(
         # removal paths that do not flow through async_unload_entry, such as
         # a slot being removed via the options update listener.
         self.config_entry.runtime_data.sync_managers.discard(self._sync_manager)
+        unsub = getattr(self, "_slot_coordinator_unsub", None)
+        if unsub is not None:
+            unsub()
+            self._slot_coordinator_unsub = None
         await self._sync_manager.async_stop()
         await CoordinatorEntity.async_will_remove_from_hass(self)

--- a/custom_components/lock_code_manager/binary_sensor.py
+++ b/custom_components/lock_code_manager/binary_sensor.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
 import logging
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
@@ -79,7 +78,6 @@ class LockCodeManagerActiveEntity(BaseLockCodeManagerEntity, BinarySensorEntity)
     """
 
     _attr_entity_category = EntityCategory.DIAGNOSTIC
-    _coordinator_view_unsub: Callable[[], None] | None = None
 
     @callback
     def _apply_coordinator_state(
@@ -101,23 +99,12 @@ class LockCodeManagerActiveEntity(BaseLockCodeManagerEntity, BinarySensorEntity)
         await BinarySensorEntity.async_added_to_hass(self)
         await BaseLockCodeManagerEntity.async_added_to_hass(self)
 
-        coordinator = self.config_entry.runtime_data.slot_coordinators.get(
-            self.slot_num
+    def _register_slot_coordinator_subscription(self) -> None:
+        """Subscribe to the derived active-state view rather than the generic state poke."""
+        assert self._slot_coordinator is not None
+        self.async_on_remove(
+            self._slot_coordinator.register_active_view(self._apply_coordinator_state)
         )
-        if coordinator is None:
-            _LOGGER.warning(
-                "%s (%s): No slot coordinator for slot %s when registering "
-                "active binary sensor",
-                self.config_entry.entry_id,
-                self.config_entry.title,
-                self.slot_num,
-            )
-            return
-
-        self._coordinator_view_unsub = coordinator.register_active_view(
-            self._apply_coordinator_state
-        )
-        self.async_on_remove(self._coordinator_view_unsub)
 
 
 class LockCodeManagerCodeSlotInSyncEntity(
@@ -128,7 +115,6 @@ class LockCodeManagerCodeSlotInSyncEntity(
     """PIN synced binary sensor entity for lock code manager."""
 
     _attr_entity_category = EntityCategory.DIAGNOSTIC
-    _slot_coordinator_unsub: Callable[[], None] | None = None
 
     def __init__(
         self,
@@ -185,14 +171,14 @@ class LockCodeManagerCodeSlotInSyncEntity(
         await CoordinatorEntity.async_added_to_hass(self)
 
         self.config_entry.runtime_data.sync_managers.add(self._sync_manager)
-        slot_coordinator = self.config_entry.runtime_data.slot_coordinators.get(
-            self.slot_num
-        )
-        if slot_coordinator is not None:
-            self._slot_coordinator_unsub = slot_coordinator.register_sync_manager(
-                self._sync_manager
-            )
         await self._sync_manager.async_start()
+
+    def _register_slot_coordinator_subscription(self) -> None:
+        """Register the per-lock sync manager with the per-slot coordinator."""
+        assert self._slot_coordinator is not None
+        self.async_on_remove(
+            self._slot_coordinator.register_sync_manager(self._sync_manager)
+        )
 
     async def async_will_remove_from_hass(self) -> None:
         """Stop the sync manager and await its in-flight tick before removal."""
@@ -201,9 +187,5 @@ class LockCodeManagerCodeSlotInSyncEntity(
         # removal paths that do not flow through async_unload_entry, such as
         # a slot being removed via the options update listener.
         self.config_entry.runtime_data.sync_managers.discard(self._sync_manager)
-        unsub = getattr(self, "_slot_coordinator_unsub", None)
-        if unsub is not None:
-            unsub()
-            self._slot_coordinator_unsub = None
         await self._sync_manager.async_stop()
         await CoordinatorEntity.async_will_remove_from_hass(self)

--- a/custom_components/lock_code_manager/binary_sensor.py
+++ b/custom_components/lock_code_manager/binary_sensor.py
@@ -101,6 +101,7 @@ class LockCodeManagerActiveEntity(BaseLockCodeManagerEntity, BinarySensorEntity)
 
     def _register_slot_coordinator_subscription(self) -> None:
         """Subscribe to the derived active-state view rather than the generic state poke."""
+        # Type narrowing; the base only calls this hook when set.
         assert self._slot_coordinator is not None
         self.async_on_remove(
             self._slot_coordinator.register_active_view(self._apply_coordinator_state)
@@ -175,6 +176,7 @@ class LockCodeManagerCodeSlotInSyncEntity(
 
     def _register_slot_coordinator_subscription(self) -> None:
         """Register the per-lock sync manager with the per-slot coordinator."""
+        # Type narrowing; the base only calls this hook when set.
         assert self._slot_coordinator is not None
         self.async_on_remove(
             self._slot_coordinator.register_sync_manager(self._sync_manager)

--- a/custom_components/lock_code_manager/entity.py
+++ b/custom_components/lock_code_manager/entity.py
@@ -88,25 +88,6 @@ class BaseLockCodeManagerEntity(Entity):
             )
         return self._uid_cache[key]
 
-    @callback
-    @final
-    def _update_config_entry(self, value: Any) -> None:
-        """Update config entry data."""
-        _LOGGER.debug(
-            "%s (%s): Updating %s to %s",
-            self.config_entry.entry_id,
-            self.config_entry.title,
-            self.key,
-            value,
-        )
-        new_config = get_entry_config(self.config_entry).with_slot_field_set(
-            self.slot_num, self.key, value
-        )
-        self.hass.config_entries.async_update_entry(
-            self.config_entry, data=new_config.to_dict()
-        )
-        self.async_write_ha_state()
-
     async def _internal_async_remove(self) -> None:
         """
         Handle entity removal.

--- a/custom_components/lock_code_manager/entity.py
+++ b/custom_components/lock_code_manager/entity.py
@@ -27,6 +27,7 @@ from .const import (
 from .data import build_slot_unique_id, get_entry_config
 from .models import LockCodeManagerConfigEntry
 from .providers import BaseLock
+from .slot_manager import SlotEntityCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -72,6 +73,12 @@ class BaseLockCodeManagerEntity(Entity):
         self._attr_extra_state_attributes: dict[str, int | list[str]] = {
             ATTR_CODE_SLOT: int(slot_num)
         }
+
+        # Resolved in ``async_added_to_hass``; the coordinator instance is
+        # stable across the entity's lifetime because slot removal tears
+        # down the entity, and re-adding the slot creates a new entity
+        # bound to the new coordinator. See ``SlotEntityCoordinator``.
+        self._slot_coordinator: SlotEntityCoordinator | None = None
 
     @final
     @property
@@ -216,6 +223,20 @@ class BaseLockCodeManagerEntity(Entity):
         """Handle entity added to hass."""
         await Entity.async_added_to_hass(self)
 
+        self._slot_coordinator = self.config_entry.runtime_data.slot_coordinators.get(
+            self.slot_num
+        )
+        if self._slot_coordinator is not None:
+            self._register_slot_coordinator_subscription()
+        else:
+            _LOGGER.warning(
+                "%s (%s): No slot coordinator for slot %s when adding entity %s",
+                self.config_entry.entry_id,
+                self.config_entry.title,
+                self.slot_num,
+                self.key,
+            )
+
         self._register_callbacks()
         self.async_on_remove(
             async_track_state_change_filtered(
@@ -231,6 +252,20 @@ class BaseLockCodeManagerEntity(Entity):
             self.config_entry.entry_id,
             self.config_entry.title,
             self.entity_id,
+        )
+
+    def _register_slot_coordinator_subscription(self) -> None:
+        """
+        Subscribe to coordinator-driven state changes.
+
+        Default behavior: write Home Assistant state whenever the
+        coordinator pokes its state subscribers (e.g. a sibling entity's
+        config write). Subclasses that need a different subscription
+        shape (active view, sync manager) override.
+        """
+        assert self._slot_coordinator is not None
+        self.async_on_remove(
+            self._slot_coordinator.register_state_subscriber(self.async_write_ha_state)
         )
 
 

--- a/custom_components/lock_code_manager/entity.py
+++ b/custom_components/lock_code_manager/entity.py
@@ -15,6 +15,7 @@ from homeassistant.core import (
     State,
     callback,
 )
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity import DeviceInfo, Entity, EntityCategory
 from homeassistant.helpers.event import TrackStates, async_track_state_change_filtered
@@ -254,15 +255,30 @@ class BaseLockCodeManagerEntity(Entity):
             self.entity_id,
         )
 
+    def _require_slot_coordinator(self) -> SlotEntityCoordinator:
+        """
+        Return the cached slot coordinator, raising ``HomeAssistantError`` if absent.
+
+        Used by intent handlers (text ``async_set_value``, switch
+        ``async_turn_on``/``async_turn_off``) so a missing coordinator
+        surfaces as a failed service call rather than a silent no-op.
+        """
+        if self._slot_coordinator is None:
+            raise HomeAssistantError(f"No slot coordinator for slot {self.slot_num}")
+        return self._slot_coordinator
+
     def _register_slot_coordinator_subscription(self) -> None:
         """
-        Subscribe to coordinator-driven state changes.
+        Register the entity's subscription with the slot coordinator.
 
-        Default behavior: write Home Assistant state whenever the
-        coordinator pokes its state subscribers (e.g. a sibling entity's
-        config write). Subclasses that need a different subscription
-        shape (active view, sync manager) override.
+        Default: write Home Assistant state after the coordinator writes
+        slot config fields (the shape text and switch want). Subclasses
+        that need a different subscription shape (active view, sync
+        manager) override. The base only calls this hook when
+        ``_slot_coordinator`` is not None; subclasses can rely on that
+        precondition.
         """
+        # Type narrowing for mypy; guaranteed non-None by the caller.
         assert self._slot_coordinator is not None
         self.async_on_remove(
             self._slot_coordinator.register_state_subscriber(self.async_write_ha_state)

--- a/custom_components/lock_code_manager/models.py
+++ b/custom_components/lock_code_manager/models.py
@@ -20,6 +20,7 @@ from .data import EntryConfig
 
 if TYPE_CHECKING:
     from .providers import BaseLock
+    from .slot_manager import SlotEntityCoordinator
     from .sync import SlotSyncManager
 
 
@@ -76,6 +77,12 @@ class LockCodeManagerConfigEntryRuntimeData:
     # unload -- so an in-flight tick cannot keep running against torn-down
     # state.
     sync_managers: set[SlotSyncManager] = field(default_factory=set)
+    # Per-slot entity coordinators. Created when a slot is added and torn
+    # down when it is removed. Owns the derived "active" state and the
+    # intent-dispatch surface used by text/switch/active entities so they
+    # do not have to mutate the config entry or call sibling-entity
+    # services directly.
+    slot_coordinators: dict[int, SlotEntityCoordinator] = field(default_factory=dict)
     # True once the options update listener has been registered for this
     # entry. Guards against stacking when _setup_entry_after_start runs more
     # than once (for example, a reload racing with EVENT_HOMEASSISTANT_STARTED).

--- a/custom_components/lock_code_manager/slot_manager.py
+++ b/custom_components/lock_code_manager/slot_manager.py
@@ -1,0 +1,402 @@
+"""
+Per-slot entity coordinator.
+
+A SlotEntityCoordinator instance owns the per-slot state surface that
+text, switch, and active-binary-sensor entities used to compute on their
+own. Entities become read-only views over the coordinator: they register
+write callbacks for state changes and dispatch user intent (set a PIN,
+toggle enabled) through the coordinator. The coordinator updates the
+canonical config entry, manages slot-level repair issues, and asks the
+per-lock SlotSyncManagers to re-evaluate on the next tick.
+
+There is one SlotEntityCoordinator per (config_entry, slot_num); the per-
+lock SlotSyncManager remains one per (config_entry, slot_num, lock).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+import logging
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.const import (
+    CONF_ENABLED,
+    CONF_ENTITY_ID,
+    CONF_NAME,
+    CONF_PIN,
+    STATE_OFF,
+    STATE_ON,
+)
+from homeassistant.core import (
+    Event,
+    EventStateChangedData,
+    HomeAssistant,
+    callback,
+)
+from homeassistant.helpers.event import async_track_state_change_event
+from homeassistant.helpers.issue_registry import (
+    IssueSeverity,
+    async_create_issue,
+    async_delete_issue,
+)
+
+from .const import ATTR_IN_SYNC, DOMAIN, EVENT_PIN_USED
+from .data import get_entry_config
+
+if TYPE_CHECKING:
+    from .models import LockCodeManagerConfigEntry
+    from .sync import SlotSyncManager
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+ActiveViewWriter = Callable[[bool | None, list[str]], None]
+
+
+class SlotEntityCoordinator:
+    """
+    Coordinate per-slot entity state for one (config entry, slot) pair.
+
+    Computes the "active" derived state from the slot config plus the
+    optional condition entity, fans out updates to the active binary
+    sensor, owns slot-level repair issues (``pin_required``), and provides
+    a single intent-dispatch surface so text and switch entities do not
+    have to mutate the config entry or call sibling-entity services
+    directly.
+
+    The coordinator does not own the per-lock SlotSyncManager state
+    machine; it just keeps a reference to the managers for this slot so
+    it can request a sync check after a user-visible state change.
+    """
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        config_entry: LockCodeManagerConfigEntry,
+        slot_num: int,
+    ) -> None:
+        """Initialize the coordinator."""
+        self._hass = hass
+        self._config_entry = config_entry
+        self._slot_num = int(slot_num)
+        self._log_prefix = (
+            f"{config_entry.entry_id} ({config_entry.title}): slot {slot_num}"
+        )
+
+        self._active_view_writers: set[ActiveViewWriter] = set()
+        self._state_subscribers: set[Callable[[], None]] = set()
+        self._sync_managers: set[SlotSyncManager] = set()
+
+        # Condition-entity subscription state
+        self._condition_unsub: Callable[[], None] | None = None
+        self._subscribed_condition_entity_id: str | None = None
+
+        self._started = False
+
+        # Cached derived state, refreshed by _recompute_active(). Initial
+        # values are "unknown" so an entity created before the first
+        # recompute can show STATE_UNKNOWN rather than a stale guess.
+        self._is_active: bool | None = None
+        self._inactive_because_of: list[str] = []
+
+    # -- Lifecycle -----------------------------------------------------------
+
+    @callback
+    def async_start(self) -> None:
+        """Start the coordinator -- subscribe to the condition entity."""
+        if self._started:
+            return
+        self._started = True
+        self._update_condition_subscription()
+        self._recompute_active()
+
+    @callback
+    def async_stop(self) -> None:
+        """Stop the coordinator -- unsubscribe and clear writers."""
+        if not self._started:
+            return
+        self._started = False
+        if self._condition_unsub:
+            self._condition_unsub()
+            self._condition_unsub = None
+        self._subscribed_condition_entity_id = None
+        self._active_view_writers.clear()
+        self._sync_managers.clear()
+
+    # -- Read-only views (consumed by entities) ------------------------------
+
+    @property
+    def slot_num(self) -> int:
+        """Return the slot number."""
+        return self._slot_num
+
+    @property
+    def is_active(self) -> bool | None:
+        """Return the derived active state (None before first compute)."""
+        return self._is_active
+
+    @property
+    def inactive_because_of(self) -> list[str]:
+        """Return the list of keys keeping this slot inactive."""
+        return list(self._inactive_because_of)
+
+    @property
+    def is_enabled(self) -> bool:
+        """Return the slot's enabled flag from the cached config view."""
+        return bool(self._slot_config().get(CONF_ENABLED))
+
+    @property
+    def pin_value(self) -> str | None:
+        """Return the configured PIN, or None if not set."""
+        return self._slot_config().get(CONF_PIN) or None
+
+    @property
+    def condition_entity_id(self) -> str | None:
+        """Return the configured condition entity ID for this slot."""
+        return self._slot_config().get(CONF_ENTITY_ID)
+
+    # -- Registration (entities, sync managers) ------------------------------
+
+    @callback
+    def register_active_view(self, writer: ActiveViewWriter) -> Callable[[], None]:
+        """
+        Register a writer the coordinator calls to update an active-view entity.
+
+        Returns an unsubscribe function. The writer is called immediately
+        with the current derived state so the entity can render before
+        any subsequent state change.
+        """
+        self._active_view_writers.add(writer)
+        writer(self._is_active, list(self._inactive_because_of))
+        return lambda: self._active_view_writers.discard(writer)
+
+    @callback
+    def register_sync_manager(self, manager: SlotSyncManager) -> Callable[[], None]:
+        """Register a per-lock sync manager so the coordinator can poke it on changes."""
+        self._sync_managers.add(manager)
+        return lambda: self._sync_managers.discard(manager)
+
+    @callback
+    def register_state_subscriber(
+        self, callback_fn: Callable[[], None]
+    ) -> Callable[[], None]:
+        """
+        Register a callback fired after the coordinator writes config fields.
+
+        Used by text and switch entities so a coordinator-driven write of
+        a sibling field (for example, auto-disable on PIN clear) causes
+        the sibling entity to push its new state to Home Assistant.
+        """
+        self._state_subscribers.add(callback_fn)
+        return lambda: self._state_subscribers.discard(callback_fn)
+
+    # -- Intent dispatch -----------------------------------------------------
+
+    async def async_request_name_update(self, value: str) -> None:
+        """Apply a slot name write requested by the text entity."""
+        self._write_config(CONF_NAME, value)
+
+    async def async_request_pin_update(self, value: str) -> None:
+        """
+        Apply a PIN write requested by the text entity.
+
+        Normalizing whitespace and the empty-PIN side effect (disabling
+        the slot on an active slot whose PIN was cleared) live here so
+        entities do not have to coordinate sibling state themselves.
+        """
+        if not value.strip():
+            value = ""
+
+        updates: dict[str, Any] = {CONF_PIN: value}
+        if not value and self.is_enabled:
+            _LOGGER.debug(
+                "%s: PIN cleared on enabled slot, auto-disabling",
+                self._log_prefix,
+            )
+            updates[CONF_ENABLED] = False
+
+        self._write_config_fields(updates)
+
+    async def async_request_active_toggle(self, enabled: bool) -> None:
+        """
+        Apply an enabled/disabled toggle requested by the switch entity.
+
+        Returns silently for the disable path. The enable path validates
+        that a PIN exists and creates or clears the ``pin_required``
+        repair issue. Raising is left to the caller -- this method
+        returns a bool so the switch can translate failure into a
+        HomeAssistantError.
+        """
+        if not enabled:
+            self._write_config(CONF_ENABLED, False)
+            return
+
+        if not self.pin_value:
+            self._raise_pin_required_issue()
+            raise PinRequiredError(
+                f"Set a PIN code for slot {self._slot_num} before enabling it"
+            )
+
+        self._write_config(CONF_ENABLED, True)
+        async_delete_issue(
+            self._hass,
+            DOMAIN,
+            f"pin_required_{self._config_entry.entry_id}_{self._slot_num}",
+        )
+
+    # -- Config change hook (called by async_update_listener) ----------------
+
+    @callback
+    def notify_config_changed(self) -> None:
+        """
+        React to a config entry change.
+
+        Called by ``async_update_listener`` after it refreshes
+        ``runtime_data.config``. Updates the condition-entity subscription
+        if the condition entity moved, recomputes derived state, and
+        fans the new state out to writers and sync managers.
+        """
+        if not self._started:
+            return
+        self._update_condition_subscription()
+        self._recompute_active()
+        self._notify_state_subscribers()
+
+    # -- Internal helpers ----------------------------------------------------
+
+    def _slot_config(self) -> dict[str, Any]:
+        """Return the current slot config dict for this slot number."""
+        return dict(get_entry_config(self._config_entry).slot(self._slot_num))
+
+    @callback
+    def _write_config(self, key: str, value: Any) -> None:
+        """Write one slot field to the config entry."""
+        self._write_config_fields({key: value})
+
+    @callback
+    def _write_config_fields(self, fields: dict[str, Any]) -> None:
+        """
+        Write one or more slot fields to the config entry in a single update.
+
+        Coalescing avoids the trap where the update listener has not yet
+        refreshed ``runtime_data.config`` between two consecutive writes,
+        leading the second write to drop the first.
+        """
+        config = get_entry_config(self._config_entry)
+        for key, value in fields.items():
+            config = config.with_slot_field_set(self._slot_num, key, value)
+        self._hass.config_entries.async_update_entry(
+            self._config_entry, data=config.to_dict()
+        )
+        # The async_update_listener call refreshes runtime_data.config
+        # and then re-invokes notify_config_changed on us, but it bails
+        # out of the entity-creation pass because options is empty.
+        # We still update active state synchronously here so the entity's
+        # callback sees the change immediately without waiting for the
+        # listener's task to run.
+        self._recompute_active()
+        self._notify_state_subscribers()
+        self._poke_sync_managers()
+
+    @callback
+    def _notify_state_subscribers(self) -> None:
+        """Notify entity-side write-back subscribers that config changed."""
+        for subscriber in list(self._state_subscribers):
+            try:
+                subscriber()
+            except Exception:
+                _LOGGER.exception("%s: State subscriber raised", self._log_prefix)
+
+    @callback
+    def _poke_sync_managers(self) -> None:
+        """Ask each per-lock sync manager to re-evaluate against fresh state."""
+        for manager in self._sync_managers:
+            manager.request_sync_check()
+
+    @callback
+    def _update_condition_subscription(self) -> None:
+        """(Re-)subscribe to the condition entity if it changed."""
+        current = self.condition_entity_id
+        if current == self._subscribed_condition_entity_id:
+            return
+
+        if self._condition_unsub:
+            self._condition_unsub()
+            self._condition_unsub = None
+        if current:
+            self._condition_unsub = async_track_state_change_event(
+                self._hass,
+                [current],
+                self._handle_condition_state_change,
+            )
+        self._subscribed_condition_entity_id = current
+
+    @callback
+    def _handle_condition_state_change(
+        self, _event: Event[EventStateChangedData]
+    ) -> None:
+        """Recompute active state when the condition entity changes."""
+        self._recompute_active()
+
+    @callback
+    def _recompute_active(self) -> None:
+        """
+        Compute the slot's active state from config + condition entity.
+
+        Mirrors the legacy LockCodeManagerActiveEntity._update_state
+        logic: every relevant slot config key must be truthy. The
+        condition entity (CONF_ENTITY_ID) is truthy when its state is
+        ``on``; ``off`` is False and any other state (unknown,
+        unavailable, missing) is None and treated as inactive.
+        """
+        slot_config = self._slot_config()
+        states: dict[str, bool | None] = {}
+        for key, value in slot_config.items():
+            if key in (EVENT_PIN_USED, CONF_NAME, CONF_PIN, ATTR_IN_SYNC):
+                continue
+            if key == CONF_ENTITY_ID:
+                hass_state = self._hass.states.get(value)
+                if hass_state is None:
+                    states[key] = None
+                elif hass_state.state == STATE_ON:
+                    states[key] = True
+                elif hass_state.state == STATE_OFF:
+                    states[key] = False
+                else:
+                    states[key] = None
+                continue
+            states[key] = bool(value)
+
+        inactive_because_of = [k for k, v in states.items() if not v]
+        new_active = not inactive_because_of
+        if (
+            new_active == self._is_active
+            and inactive_because_of == self._inactive_because_of
+        ):
+            return
+        self._is_active = new_active
+        self._inactive_because_of = inactive_because_of
+        for writer in list(self._active_view_writers):
+            writer(self._is_active, list(self._inactive_because_of))
+
+    @callback
+    def _raise_pin_required_issue(self) -> None:
+        """Create the ``pin_required`` repair issue for this slot."""
+        async_create_issue(
+            self._hass,
+            DOMAIN,
+            f"pin_required_{self._config_entry.entry_id}_{self._slot_num}",
+            is_fixable=True,
+            is_persistent=True,
+            severity=IssueSeverity.WARNING,
+            translation_key="pin_required",
+            translation_placeholders={
+                "slot_num": str(self._slot_num),
+                "config_entry_title": self._config_entry.title,
+            },
+        )
+
+
+class PinRequiredError(Exception):
+    """Raised when a slot cannot be enabled because no PIN is configured."""

--- a/custom_components/lock_code_manager/slot_manager.py
+++ b/custom_components/lock_code_manager/slot_manager.py
@@ -41,7 +41,7 @@ from homeassistant.helpers.issue_registry import (
 )
 
 from .const import ATTR_IN_SYNC, DOMAIN, EVENT_PIN_USED
-from .data import get_entry_config
+from .data import EntryConfig, get_entry_config
 
 if TYPE_CHECKING:
     from .models import LockCodeManagerConfigEntry
@@ -165,10 +165,19 @@ class SlotEntityCoordinator:
 
         Returns an unsubscribe function. The writer is called immediately
         with the current derived state so the entity can render before
-        any subsequent state change.
+        any subsequent state change. If that immediate call raises, the
+        writer is not retained -- otherwise a half-added entity would
+        keep receiving fan-outs without ever being attached.
         """
+        try:
+            writer(self._is_active, list(self._inactive_because_of))
+        except Exception:
+            _LOGGER.exception(
+                "%s: Active-view writer raised on registration; discarding",
+                self._log_prefix,
+            )
+            raise
         self._active_view_writers.add(writer)
-        writer(self._is_active, list(self._inactive_because_of))
         return lambda: self._active_view_writers.discard(writer)
 
     @callback
@@ -222,28 +231,34 @@ class SlotEntityCoordinator:
         """
         Apply an enabled/disabled toggle requested by the switch entity.
 
-        Returns silently for the disable path. The enable path validates
-        that a PIN exists and creates or clears the ``pin_required``
-        repair issue. Raising is left to the caller -- this method
-        returns a bool so the switch can translate failure into a
-        HomeAssistantError.
+        Disable is unconditional. Enable validates that a PIN exists and
+        raises ``PinRequiredError`` if absent (the switch translates
+        that into ``HomeAssistantError``). On a successful enable the
+        ``pin_required`` repair issue is cleared; failures inside the
+        issue registry are logged and do not unwind the write.
         """
         if not enabled:
             self._write_config(CONF_ENABLED, False)
             return
 
         if not self.pin_value:
-            self._raise_pin_required_issue()
+            self._safely_raise_pin_required_issue()
             raise PinRequiredError(
                 f"Set a PIN code for slot {self._slot_num} before enabling it"
             )
 
         self._write_config(CONF_ENABLED, True)
-        async_delete_issue(
-            self._hass,
-            DOMAIN,
-            f"pin_required_{self._config_entry.entry_id}_{self._slot_num}",
-        )
+        try:
+            async_delete_issue(
+                self._hass,
+                DOMAIN,
+                f"pin_required_{self._config_entry.entry_id}_{self._slot_num}",
+            )
+        except Exception:
+            _LOGGER.exception(
+                "%s: Failed to delete pin_required repair issue after enable",
+                self._log_prefix,
+            )
 
     # -- Config change hook (called by async_update_listener) ----------------
 
@@ -282,6 +297,13 @@ class SlotEntityCoordinator:
         Coalescing avoids the trap where the update listener has not yet
         refreshed ``runtime_data.config`` between two consecutive writes,
         leading the second write to drop the first.
+
+        ``async_update_entry`` schedules the update listener as a task,
+        so ``runtime_data.config`` is still stale at the synchronous
+        notify below. Refresh it eagerly here so ``_recompute_active``,
+        ``_notify_state_subscribers``, and ``_poke_sync_managers``
+        observe the new values. The listener will refresh again when it
+        runs -- writing the same value twice is harmless.
         """
         config = get_entry_config(self._config_entry)
         for key, value in fields.items():
@@ -289,12 +311,9 @@ class SlotEntityCoordinator:
         self._hass.config_entries.async_update_entry(
             self._config_entry, data=config.to_dict()
         )
-        # The async_update_listener call refreshes runtime_data.config
-        # and then re-invokes notify_config_changed on us, but it bails
-        # out of the entity-creation pass because options is empty.
-        # We still update active state synchronously here so the entity's
-        # callback sees the change immediately without waiting for the
-        # listener's task to run.
+        self._config_entry.runtime_data.config = EntryConfig.from_entry(
+            self._config_entry
+        )
         self._recompute_active()
         self._notify_state_subscribers()
         self._poke_sync_managers()
@@ -311,8 +330,14 @@ class SlotEntityCoordinator:
     @callback
     def _poke_sync_managers(self) -> None:
         """Ask each per-lock sync manager to re-evaluate against fresh state."""
-        for manager in self._sync_managers:
-            manager.request_sync_check()
+        for manager in list(self._sync_managers):
+            try:
+                manager.request_sync_check()
+            except Exception:
+                _LOGGER.exception(
+                    "%s: Sync manager raised on request_sync_check",
+                    self._log_prefix,
+                )
 
     @callback
     def _update_condition_subscription(self) -> None:
@@ -337,6 +362,8 @@ class SlotEntityCoordinator:
         self, _event: Event[EventStateChangedData]
     ) -> None:
         """Recompute active state when the condition entity changes."""
+        if not self._started:
+            return
         self._recompute_active()
 
     @callback
@@ -344,11 +371,10 @@ class SlotEntityCoordinator:
         """
         Compute the slot's active state from config + condition entity.
 
-        Mirrors the legacy LockCodeManagerActiveEntity._update_state
-        logic: every relevant slot config key must be truthy. The
-        condition entity (CONF_ENTITY_ID) is truthy when its state is
-        ``on``; ``off`` is False and any other state (unknown,
-        unavailable, missing) is None and treated as inactive.
+        Every relevant slot config key must be truthy. The condition
+        entity (``CONF_ENTITY_ID``) is truthy when its state is ``on``;
+        ``off`` is False and any other state (unknown, unavailable,
+        missing) is None and treated as inactive.
         """
         slot_config = self._slot_config()
         states: dict[str, bool | None] = {}
@@ -381,21 +407,27 @@ class SlotEntityCoordinator:
             writer(self._is_active, list(self._inactive_because_of))
 
     @callback
-    def _raise_pin_required_issue(self) -> None:
-        """Create the ``pin_required`` repair issue for this slot."""
-        async_create_issue(
-            self._hass,
-            DOMAIN,
-            f"pin_required_{self._config_entry.entry_id}_{self._slot_num}",
-            is_fixable=True,
-            is_persistent=True,
-            severity=IssueSeverity.WARNING,
-            translation_key="pin_required",
-            translation_placeholders={
-                "slot_num": str(self._slot_num),
-                "config_entry_title": self._config_entry.title,
-            },
-        )
+    def _safely_raise_pin_required_issue(self) -> None:
+        """Create the ``pin_required`` repair issue, logging registry failures."""
+        try:
+            async_create_issue(
+                self._hass,
+                DOMAIN,
+                f"pin_required_{self._config_entry.entry_id}_{self._slot_num}",
+                is_fixable=True,
+                is_persistent=True,
+                severity=IssueSeverity.WARNING,
+                translation_key="pin_required",
+                translation_placeholders={
+                    "slot_num": str(self._slot_num),
+                    "config_entry_title": self._config_entry.title,
+                },
+            )
+        except Exception:
+            _LOGGER.exception(
+                "%s: Failed to create pin_required repair issue",
+                self._log_prefix,
+            )
 
 
 class PinRequiredError(Exception):

--- a/custom_components/lock_code_manager/slot_manager.py
+++ b/custom_components/lock_code_manager/slot_manager.py
@@ -204,7 +204,7 @@ class SlotEntityCoordinator:
 
     async def async_request_name_update(self, value: str) -> None:
         """Apply a slot name write requested by the text entity."""
-        self._write_config(CONF_NAME, value)
+        self._write_config_fields({CONF_NAME: value})
 
     async def async_request_pin_update(self, value: str) -> None:
         """
@@ -238,7 +238,7 @@ class SlotEntityCoordinator:
         issue registry are logged and do not unwind the write.
         """
         if not enabled:
-            self._write_config(CONF_ENABLED, False)
+            self._write_config_fields({CONF_ENABLED: False})
             return
 
         if not self.pin_value:
@@ -247,7 +247,7 @@ class SlotEntityCoordinator:
                 f"Set a PIN code for slot {self._slot_num} before enabling it"
             )
 
-        self._write_config(CONF_ENABLED, True)
+        self._write_config_fields({CONF_ENABLED: True})
         try:
             async_delete_issue(
                 self._hass,
@@ -283,11 +283,6 @@ class SlotEntityCoordinator:
     def _slot_config(self) -> dict[str, Any]:
         """Return the current slot config dict for this slot number."""
         return dict(get_entry_config(self._config_entry).slot(self._slot_num))
-
-    @callback
-    def _write_config(self, key: str, value: Any) -> None:
-        """Write one slot field to the config entry."""
-        self._write_config_fields({key: value})
 
     @callback
     def _write_config_fields(self, fields: dict[str, Any]) -> None:

--- a/custom_components/lock_code_manager/switch.py
+++ b/custom_components/lock_code_manager/switch.py
@@ -13,7 +13,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .entity import BaseLockCodeManagerEntity
 from .models import LockCodeManagerConfigEntry
-from .slot_manager import PinRequiredError, SlotEntityCoordinator
+from .slot_manager import PinRequiredError
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -53,7 +53,7 @@ class LockCodeManagerSwitch(BaseLockCodeManagerEntity, SwitchEntity):
 
     async def async_turn_on(self, **kwargs) -> None:
         """Turn on switch."""
-        coordinator = self._require_coordinator()
+        coordinator = self._require_slot_coordinator()
         try:
             await coordinator.async_request_active_toggle(True)
         except PinRequiredError as err:
@@ -62,12 +62,6 @@ class LockCodeManagerSwitch(BaseLockCodeManagerEntity, SwitchEntity):
 
     async def async_turn_off(self, **kwargs) -> None:
         """Turn off switch."""
-        coordinator = self._require_coordinator()
+        coordinator = self._require_slot_coordinator()
         await coordinator.async_request_active_toggle(False)
         self.async_write_ha_state()
-
-    def _require_coordinator(self) -> SlotEntityCoordinator:
-        """Return the slot coordinator, raising if it has not been created."""
-        if self._slot_coordinator is None:
-            raise HomeAssistantError(f"No slot coordinator for slot {self.slot_num}")
-        return self._slot_coordinator

--- a/custom_components/lock_code_manager/switch.py
+++ b/custom_components/lock_code_manager/switch.py
@@ -13,7 +13,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .entity import BaseLockCodeManagerEntity
 from .models import LockCodeManagerConfigEntry
-from .slot_manager import PinRequiredError
+from .slot_manager import PinRequiredError, SlotEntityCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -66,24 +66,8 @@ class LockCodeManagerSwitch(BaseLockCodeManagerEntity, SwitchEntity):
         await coordinator.async_request_active_toggle(False)
         self.async_write_ha_state()
 
-    def _require_coordinator(self):
+    def _require_coordinator(self) -> SlotEntityCoordinator:
         """Return the slot coordinator, raising if it has not been created."""
-        coordinator = self.config_entry.runtime_data.slot_coordinators.get(
-            self.slot_num
-        )
-        if coordinator is None:
+        if self._slot_coordinator is None:
             raise HomeAssistantError(f"No slot coordinator for slot {self.slot_num}")
-        return coordinator
-
-    async def async_added_to_hass(self) -> None:
-        """Handle entity added to hass."""
-        await BaseLockCodeManagerEntity.async_added_to_hass(self)
-        await SwitchEntity.async_added_to_hass(self)
-
-        coordinator = self.config_entry.runtime_data.slot_coordinators.get(
-            self.slot_num
-        )
-        if coordinator is not None:
-            self.async_on_remove(
-                coordinator.register_state_subscriber(self.async_write_ha_state)
-            )
+        return self._slot_coordinator

--- a/custom_components/lock_code_manager/switch.py
+++ b/custom_components/lock_code_manager/switch.py
@@ -5,20 +5,15 @@ from __future__ import annotations
 import logging
 
 from homeassistant.components.switch import SwitchEntity
-from homeassistant.const import CONF_ENABLED, CONF_PIN, STATE_UNKNOWN, Platform
+from homeassistant.const import CONF_ENABLED
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.issue_registry import (
-    IssueSeverity,
-    async_create_issue,
-    async_delete_issue,
-)
 
-from .const import DOMAIN
 from .entity import BaseLockCodeManagerEntity
 from .models import LockCodeManagerConfigEntry
+from .slot_manager import PinRequiredError
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -51,8 +46,6 @@ async def async_setup_entry(
 class LockCodeManagerSwitch(BaseLockCodeManagerEntity, SwitchEntity):
     """Switch entity for lock code manager."""
 
-    _pin_entity_id: str = ""
-
     @property
     def is_on(self) -> bool:
         """Return native value."""
@@ -60,43 +53,37 @@ class LockCodeManagerSwitch(BaseLockCodeManagerEntity, SwitchEntity):
 
     async def async_turn_on(self, **kwargs) -> None:
         """Turn on switch."""
-        if not self._pin_entity_id:
-            self._pin_entity_id = self.ent_reg.async_get_entity_id(
-                Platform.TEXT, DOMAIN, self._get_uid(CONF_PIN)
-            )
-        if (
-            self._pin_entity_id
-            and (state := self.hass.states.get(self._pin_entity_id))
-            and state.state in (None, "", STATE_UNKNOWN)
-        ):
-            async_create_issue(
-                self.hass,
-                DOMAIN,
-                f"pin_required_{self.config_entry.entry_id}_{self.slot_num}",
-                is_fixable=True,
-                is_persistent=True,
-                severity=IssueSeverity.WARNING,
-                translation_key="pin_required",
-                translation_placeholders={
-                    "slot_num": str(self.slot_num),
-                    "config_entry_title": self.config_entry.title,
-                },
-            )
-            raise HomeAssistantError(
-                f"Set a PIN code for slot {self.slot_num} before enabling it"
-            )
-        self._update_config_entry(True)
-        async_delete_issue(
-            self.hass,
-            DOMAIN,
-            f"pin_required_{self.config_entry.entry_id}_{self.slot_num}",
-        )
+        coordinator = self._require_coordinator()
+        try:
+            await coordinator.async_request_active_toggle(True)
+        except PinRequiredError as err:
+            raise HomeAssistantError(str(err)) from err
+        self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs) -> None:
         """Turn off switch."""
-        self._update_config_entry(False)
+        coordinator = self._require_coordinator()
+        await coordinator.async_request_active_toggle(False)
+        self.async_write_ha_state()
+
+    def _require_coordinator(self):
+        """Return the slot coordinator, raising if it has not been created."""
+        coordinator = self.config_entry.runtime_data.slot_coordinators.get(
+            self.slot_num
+        )
+        if coordinator is None:
+            raise HomeAssistantError(f"No slot coordinator for slot {self.slot_num}")
+        return coordinator
 
     async def async_added_to_hass(self) -> None:
         """Handle entity added to hass."""
         await BaseLockCodeManagerEntity.async_added_to_hass(self)
         await SwitchEntity.async_added_to_hass(self)
+
+        coordinator = self.config_entry.runtime_data.slot_coordinators.get(
+            self.slot_num
+        )
+        if coordinator is not None:
+            self.async_on_remove(
+                coordinator.register_state_subscriber(self.async_write_ha_state)
+            )

--- a/custom_components/lock_code_manager/sync.py
+++ b/custom_components/lock_code_manager/sync.py
@@ -552,6 +552,17 @@ class SlotSyncManager:
         self._state_writer(self.in_sync)
 
     @callback
+    def request_sync_check(self) -> None:
+        """
+        Public entry point for external callers (slot coordinator) to nudge sync.
+
+        Routes through the same internal handler that coordinator and
+        entity-state listeners use so the state-transition rules stay in
+        one place.
+        """
+        self._request_sync_check()
+
+    @callback
     def _request_sync_check(self, *_args: Any) -> None:
         """
         Request a sync check on the next tick.

--- a/custom_components/lock_code_manager/sync.py
+++ b/custom_components/lock_code_manager/sync.py
@@ -554,11 +554,12 @@ class SlotSyncManager:
     @callback
     def request_sync_check(self) -> None:
         """
-        Public entry point for external callers (slot coordinator) to nudge sync.
+        Public no-arg wrapper over ``_request_sync_check``.
 
-        Routes through the same internal handler that coordinator and
-        entity-state listeners use so the state-transition rules stay in
-        one place.
+        ``_request_sync_check`` accepts ``*_args`` so it can serve as a
+        coordinator/state-change listener; callers that want to nudge sync
+        directly should not have to pretend to be a listener. Routing
+        through it keeps the state-transition rules in one place.
         """
         self._request_sync_check()
 

--- a/custom_components/lock_code_manager/text.py
+++ b/custom_components/lock_code_manager/text.py
@@ -71,20 +71,11 @@ class LockCodeManagerText(BaseLockCodeManagerEntity, TextEntity):
 
     async def async_set_value(self, value: str) -> None:
         """Set value of text."""
-        if self._slot_coordinator is None:
-            _LOGGER.warning(
-                "%s (%s): No slot coordinator for slot %s; cannot apply %s update",
-                self.config_entry.entry_id,
-                self.config_entry.title,
-                self.slot_num,
-                self.key,
-            )
-            return
-
+        coordinator = self._require_slot_coordinator()
         if self.key == CONF_PIN:
-            await self._slot_coordinator.async_request_pin_update(value)
+            await coordinator.async_request_pin_update(value)
         else:
-            await self._slot_coordinator.async_request_name_update(value)
+            await coordinator.async_request_name_update(value)
         self.async_write_ha_state()
 
     async def async_added_to_hass(self) -> None:

--- a/custom_components/lock_code_manager/text.py
+++ b/custom_components/lock_code_manager/text.py
@@ -5,15 +5,13 @@ from __future__ import annotations
 import logging
 
 from homeassistant.components.text import TextEntity, TextMode
-from homeassistant.const import CONF_ENABLED, CONF_NAME, CONF_PIN, STATE_ON, Platform
+from homeassistant.const import CONF_NAME, CONF_PIN
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
 from .entity import BaseLockCodeManagerEntity
 from .models import LockCodeManagerConfigEntry
-from .util import async_disable_slot
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -50,7 +48,6 @@ class LockCodeManagerText(BaseLockCodeManagerEntity, TextEntity):
 
     _attr_native_min = 0
     _attr_native_max = 9999
-    _enabled_entity_id: str = ""
 
     def __init__(
         self,
@@ -74,49 +71,34 @@ class LockCodeManagerText(BaseLockCodeManagerEntity, TextEntity):
 
     async def async_set_value(self, value: str) -> None:
         """Set value of text."""
-        # Normalize whitespace-only PINs to empty string
-        if self.key == CONF_PIN and not value.strip():
-            value = ""
-
-        if not self._enabled_entity_id:
-            self._enabled_entity_id = (
-                self.ent_reg.async_get_entity_id(
-                    Platform.SWITCH, DOMAIN, self._get_uid(CONF_ENABLED)
-                )
-                or ""
+        coordinator = self.config_entry.runtime_data.slot_coordinators.get(
+            self.slot_num
+        )
+        if coordinator is None:
+            _LOGGER.warning(
+                "%s (%s): No slot coordinator for slot %s; cannot apply %s update",
+                self.config_entry.entry_id,
+                self.config_entry.title,
+                self.slot_num,
+                self.key,
             )
-        # When clearing a PIN on an enabled slot, auto-disable the slot first so the
-        # sync logic will clear the code on the lock, then proceed to clear the PIN value.
-        if self.key == CONF_PIN and not value:
-            if (
-                self._enabled_entity_id
-                and (state := self.hass.states.get(self._enabled_entity_id))
-                and state.state == STATE_ON
-            ):
-                _LOGGER.debug(
-                    "%s (%s): Clearing PIN on enabled slot %s, auto-disabling slot",
-                    self.config_entry.entry_id,
-                    self.config_entry.title,
-                    self.slot_num,
-                )
-                await async_disable_slot(
-                    self.hass,
-                    self.ent_reg,
-                    self.config_entry.entry_id,
-                    self.slot_num,
-                )
-            elif not self._enabled_entity_id:
-                _LOGGER.warning(
-                    "%s (%s): Clearing PIN on slot %s but cannot resolve enabled "
-                    "switch entity to auto-disable; slot may not be fully set up",
-                    self.config_entry.entry_id,
-                    self.config_entry.title,
-                    self.slot_num,
-                )
+            return
 
-        self._update_config_entry(value)
+        if self.key == CONF_PIN:
+            await coordinator.async_request_pin_update(value)
+        else:
+            await coordinator.async_request_name_update(value)
+        self.async_write_ha_state()
 
     async def async_added_to_hass(self) -> None:
         """Handle entity added to hass."""
         await BaseLockCodeManagerEntity.async_added_to_hass(self)
         await TextEntity.async_added_to_hass(self)
+
+        coordinator = self.config_entry.runtime_data.slot_coordinators.get(
+            self.slot_num
+        )
+        if coordinator is not None:
+            self.async_on_remove(
+                coordinator.register_state_subscriber(self.async_write_ha_state)
+            )

--- a/custom_components/lock_code_manager/text.py
+++ b/custom_components/lock_code_manager/text.py
@@ -71,10 +71,7 @@ class LockCodeManagerText(BaseLockCodeManagerEntity, TextEntity):
 
     async def async_set_value(self, value: str) -> None:
         """Set value of text."""
-        coordinator = self.config_entry.runtime_data.slot_coordinators.get(
-            self.slot_num
-        )
-        if coordinator is None:
+        if self._slot_coordinator is None:
             _LOGGER.warning(
                 "%s (%s): No slot coordinator for slot %s; cannot apply %s update",
                 self.config_entry.entry_id,
@@ -85,20 +82,12 @@ class LockCodeManagerText(BaseLockCodeManagerEntity, TextEntity):
             return
 
         if self.key == CONF_PIN:
-            await coordinator.async_request_pin_update(value)
+            await self._slot_coordinator.async_request_pin_update(value)
         else:
-            await coordinator.async_request_name_update(value)
+            await self._slot_coordinator.async_request_name_update(value)
         self.async_write_ha_state()
 
     async def async_added_to_hass(self) -> None:
         """Handle entity added to hass."""
         await BaseLockCodeManagerEntity.async_added_to_hass(self)
         await TextEntity.async_added_to_hass(self)
-
-        coordinator = self.config_entry.runtime_data.slot_coordinators.get(
-            self.slot_num
-        )
-        if coordinator is not None:
-            self.async_on_remove(
-                coordinator.register_state_subscriber(self.async_write_ha_state)
-            )

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -483,10 +483,10 @@ def test_to_dict_round_trips_through_from_mapping() -> None:
     """
     to_dict → from_mapping reconstructs an equivalent EntryConfig.
 
-    Guards the write path used by entity._update_config_entry and the
-    helpers write functions: they build a new EntryConfig, call
-    to_dict(), hand it to async_update_entry, and expect the eventual
-    listener re-read to produce the same logical config.
+    Guards the write path used by SlotEntityCoordinator and the helpers
+    write functions: they build a new EntryConfig, call to_dict(), hand
+    it to async_update_entry, and expect the eventual listener re-read
+    to produce the same logical config.
     """
     original = EntryConfig.from_mapping(
         {

--- a/tests/test_slot_manager.py
+++ b/tests/test_slot_manager.py
@@ -1,0 +1,298 @@
+"""Tests for the per-slot entity coordinator."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from homeassistant.components.switch import (
+    DOMAIN as SWITCH_DOMAIN,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+)
+from homeassistant.components.text import (
+    ATTR_VALUE,
+    DOMAIN as TEXT_DOMAIN,
+    SERVICE_SET_VALUE,
+)
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    CONF_ENABLED,
+    CONF_ENTITY_ID,
+    CONF_NAME,
+    CONF_PIN,
+    STATE_OFF,
+    STATE_ON,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.issue_registry import async_get as async_get_issue_registry
+
+from custom_components.lock_code_manager.const import (
+    CONF_LOCKS,
+    CONF_SLOTS,
+    DOMAIN,
+)
+from custom_components.lock_code_manager.data import get_entry_config
+from custom_components.lock_code_manager.slot_manager import (
+    PinRequiredError,
+    SlotEntityCoordinator,
+)
+
+from .common import (
+    LOCK_1_ENTITY_ID,
+    SLOT_1_ACTIVE_ENTITY,
+    SLOT_1_ENABLED_ENTITY,
+    SLOT_1_PIN_ENTITY,
+    SLOT_2_ACTIVE_ENTITY,
+    SLOT_2_ENABLED_ENTITY,
+    SLOT_2_PIN_ENTITY,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def test_coordinator_registered_for_each_slot(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """One coordinator per configured slot is registered on runtime data."""
+    coordinators = lock_code_manager_config_entry.runtime_data.slot_coordinators
+    assert set(coordinators) == {1, 2}
+    for slot_num, coordinator in coordinators.items():
+        assert isinstance(coordinator, SlotEntityCoordinator)
+        assert coordinator.slot_num == slot_num
+
+
+async def test_coordinator_drives_active_view(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """The active binary sensor renders the coordinator's derived state."""
+    state = hass.states.get(SLOT_1_ACTIVE_ENTITY)
+    assert state is not None
+    assert state.state == STATE_ON
+    # Slot 2 has a calendar condition; the calendar starts OFF, so slot 2 is inactive
+    state = hass.states.get(SLOT_2_ACTIVE_ENTITY)
+    assert state is not None
+    assert state.state == STATE_OFF
+
+
+async def test_request_pin_update_auto_disables_on_empty(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """Clearing the PIN on an enabled slot disables the slot in one write."""
+    runtime_data = lock_code_manager_config_entry.runtime_data
+    coordinator = runtime_data.slot_coordinators[1]
+    assert coordinator.is_enabled is True
+    assert coordinator.pin_value == "1234"
+
+    await coordinator.async_request_pin_update("")
+    await hass.async_block_till_done()
+
+    config = get_entry_config(lock_code_manager_config_entry).slot(1)
+    assert config.get(CONF_PIN) == ""
+    assert config.get(CONF_ENABLED) is False
+    assert coordinator.is_enabled is False
+
+    state = hass.states.get(SLOT_1_PIN_ENTITY)
+    assert state is not None
+    assert state.state == ""
+    state = hass.states.get(SLOT_1_ENABLED_ENTITY)
+    assert state is not None
+    assert state.state == STATE_OFF
+
+
+async def test_request_pin_update_normalizes_whitespace(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """A whitespace-only PIN normalizes to empty and auto-disables the slot."""
+    coordinator = lock_code_manager_config_entry.runtime_data.slot_coordinators[1]
+    await coordinator.async_request_pin_update("   ")
+    await hass.async_block_till_done()
+
+    config = get_entry_config(lock_code_manager_config_entry).slot(1)
+    assert config.get(CONF_PIN) == ""
+    assert config.get(CONF_ENABLED) is False
+
+
+async def test_request_active_toggle_blocks_when_no_pin(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """Toggling active=True without a PIN raises and writes a repair issue."""
+    coordinator = lock_code_manager_config_entry.runtime_data.slot_coordinators[1]
+    # Clear PIN first (auto-disables the slot)
+    await coordinator.async_request_pin_update("")
+    await hass.async_block_till_done()
+    assert coordinator.is_enabled is False
+    assert coordinator.pin_value is None
+
+    with pytest.raises(PinRequiredError):
+        await coordinator.async_request_active_toggle(True)
+
+    issue_registry = async_get_issue_registry(hass)
+    issue = issue_registry.async_get_issue(
+        DOMAIN, f"pin_required_{lock_code_manager_config_entry.entry_id}_1"
+    )
+    assert issue is not None
+    assert coordinator.is_enabled is False
+
+
+async def test_request_active_toggle_clears_pin_required_issue(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """Successful enable removes the pin_required repair issue."""
+    coordinator = lock_code_manager_config_entry.runtime_data.slot_coordinators[1]
+    await coordinator.async_request_pin_update("")
+    await hass.async_block_till_done()
+    with pytest.raises(PinRequiredError):
+        await coordinator.async_request_active_toggle(True)
+    issue_registry = async_get_issue_registry(hass)
+    assert (
+        issue_registry.async_get_issue(
+            DOMAIN, f"pin_required_{lock_code_manager_config_entry.entry_id}_1"
+        )
+        is not None
+    )
+
+    # Re-add a PIN and successfully enable; the repair issue must be cleared
+    await coordinator.async_request_pin_update("4242")
+    await hass.async_block_till_done()
+    await coordinator.async_request_active_toggle(True)
+    await hass.async_block_till_done()
+
+    assert coordinator.is_enabled is True
+    assert (
+        issue_registry.async_get_issue(
+            DOMAIN, f"pin_required_{lock_code_manager_config_entry.entry_id}_1"
+        )
+        is None
+    )
+
+
+async def test_switch_turn_on_raises_homeassistanterror_for_pin_required(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """The switch entity translates PinRequiredError into HomeAssistantError."""
+    # Disable slot 2 so we can test the enable path; clear its PIN to trigger
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_OFF,
+        target={ATTR_ENTITY_ID: SLOT_2_ENABLED_ENTITY},
+        blocking=True,
+    )
+    await hass.services.async_call(
+        TEXT_DOMAIN,
+        SERVICE_SET_VALUE,
+        service_data={ATTR_VALUE: ""},
+        target={ATTR_ENTITY_ID: SLOT_2_PIN_ENTITY},
+        blocking=True,
+    )
+
+    with pytest.raises(HomeAssistantError, match="Set a PIN code"):
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_ON,
+            target={ATTR_ENTITY_ID: SLOT_2_ENABLED_ENTITY},
+            blocking=True,
+        )
+
+
+async def test_condition_entity_subscription_owned_by_coordinator(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+):
+    """The coordinator owns the condition-entity subscription, not the entity."""
+    hass.states.async_set("input_boolean.gate", STATE_ON)
+    await hass.async_block_till_done()
+
+    config = {
+        CONF_LOCKS: [LOCK_1_ENTITY_ID],
+        CONF_SLOTS: {
+            1: {
+                CONF_NAME: "alice",
+                CONF_PIN: "1234",
+                CONF_ENABLED: True,
+                CONF_ENTITY_ID: "input_boolean.gate",
+            },
+        },
+    }
+    entry = MockConfigEntry(domain=DOMAIN, data=config, unique_id="Test Cond")
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    coordinator = entry.runtime_data.slot_coordinators[1]
+    assert coordinator.condition_entity_id == "input_boolean.gate"
+    assert coordinator.is_active is True
+
+    hass.states.async_set("input_boolean.gate", STATE_OFF)
+    await hass.async_block_till_done()
+    assert coordinator.is_active is False
+
+    await hass.config_entries.async_unload(entry.entry_id)
+
+
+async def test_coordinator_removed_on_slot_removal(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """Removing a slot via options tears down its coordinator."""
+    runtime_data = lock_code_manager_config_entry.runtime_data
+    assert 2 in runtime_data.slot_coordinators
+
+    new_options = {
+        CONF_LOCKS: list(runtime_data.locks.keys()),
+        CONF_SLOTS: {
+            1: {CONF_NAME: "test1", CONF_PIN: "1234", CONF_ENABLED: True},
+        },
+    }
+    hass.config_entries.async_update_entry(
+        lock_code_manager_config_entry, options=new_options
+    )
+    await hass.async_block_till_done()
+
+    assert 2 not in runtime_data.slot_coordinators
+    assert 1 in runtime_data.slot_coordinators
+
+
+async def test_unload_reads_slots_via_entry_config_view(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """async_unload_entry routes slot enumeration through EntryConfig.
+
+    Reading via ``get_entry_config`` rather than ``config_entry.data``
+    keeps the unload slot loop functional regardless of which side of
+    the data/options migration last wrote the entry — covers the case
+    where an update listener has just migrated data to options but the
+    write-back has not run yet.
+    """
+    runtime_data = lock_code_manager_config_entry.runtime_data
+    removed_slots: list[int] = []
+    original_invoke = runtime_data.callbacks.invoke_entity_removers_for_slot
+
+    async def record_invoke(slot_num: int) -> None:
+        removed_slots.append(slot_num)
+        await original_invoke(slot_num)
+
+    runtime_data.callbacks.invoke_entity_removers_for_slot = record_invoke  # type: ignore[method-assign]
+    await hass.config_entries.async_unload(lock_code_manager_config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert set(removed_slots) == {1, 2}

--- a/tests/test_slot_manager.py
+++ b/tests/test_slot_manager.py
@@ -32,6 +32,9 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.issue_registry import async_get as async_get_issue_registry
 
+from custom_components.lock_code_manager.binary_sensor import (
+    LockCodeManagerActiveEntity,
+)
 from custom_components.lock_code_manager.const import (
     CONF_LOCKS,
     CONF_SLOTS,
@@ -387,3 +390,113 @@ async def test_condition_entity_swap_resubscribes(
     assert coordinator.is_active is True
 
     await hass.config_entries.async_unload(entry.entry_id)
+
+
+async def test_slot_remove_then_readd_creates_fresh_coordinator(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """Re-adding a removed slot creates a NEW coordinator with fresh state.
+
+    A regression that retained a stale coordinator across remove + re-add
+    would let prior state (condition subscription, registered writers,
+    repair-issue history) leak into the new slot lifecycle.
+    """
+    runtime_data = lock_code_manager_config_entry.runtime_data
+    original_slot_2_coordinator = runtime_data.slot_coordinators[2]
+
+    # Remove slot 2.
+    options_without_2 = {
+        CONF_LOCKS: list(runtime_data.locks.keys()),
+        CONF_SLOTS: {
+            1: {CONF_NAME: "test1", CONF_PIN: "1234", CONF_ENABLED: True},
+        },
+    }
+    hass.config_entries.async_update_entry(
+        lock_code_manager_config_entry, options=options_without_2
+    )
+    await hass.async_block_till_done()
+    assert 2 not in runtime_data.slot_coordinators
+
+    # Re-add slot 2 with different config.
+    options_with_2 = {
+        CONF_LOCKS: list(runtime_data.locks.keys()),
+        CONF_SLOTS: {
+            1: {CONF_NAME: "test1", CONF_PIN: "1234", CONF_ENABLED: True},
+            2: {CONF_NAME: "fresh2", CONF_PIN: "9999", CONF_ENABLED: False},
+        },
+    }
+    hass.config_entries.async_update_entry(
+        lock_code_manager_config_entry, options=options_with_2
+    )
+    await hass.async_block_till_done()
+
+    assert 2 in runtime_data.slot_coordinators
+    new_slot_2_coordinator = runtime_data.slot_coordinators[2]
+    assert new_slot_2_coordinator is not original_slot_2_coordinator
+    assert new_slot_2_coordinator.pin_value == "9999"
+    assert new_slot_2_coordinator.is_enabled is False
+    # The discarded coordinator must have been stopped.
+    assert original_slot_2_coordinator._started is False
+
+
+async def test_request_sync_check_public_wrapper_delegates(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """The public ``request_sync_check`` forwards to the private handler.
+
+    The wrapper exists so callers that aren't listener-shaped don't have
+    to pretend to be one (``_request_sync_check`` accepts ``*_args`` to
+    serve as a state-change listener). A regression that bypasses the
+    private handler would lose the centralized state-transition rules.
+    """
+    runtime_data = lock_code_manager_config_entry.runtime_data
+    assert runtime_data.sync_managers
+    manager = next(iter(runtime_data.sync_managers))
+
+    with patch.object(manager, "_request_sync_check") as private:
+        manager.request_sync_check()
+
+    private.assert_called_once_with()
+
+
+async def test_active_binary_sensor_does_not_self_track_state(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """``LockCodeManagerActiveEntity`` must not subscribe to state changes itself.
+
+    All condition-entity tracking lives on ``SlotEntityCoordinator``;
+    a regression that re-added ``async_track_state_change_event`` inside
+    the entity would risk double subscriptions and re-introduce the
+    cross-entity-state-coupling D removed.
+    """
+    # The entity's only subscription handle should be the coordinator
+    # view unsub. The pre-D version tracked the condition entity and a
+    # config-entry update listener via additional unsub attributes.
+    assert not any(
+        attr.startswith("_condition_") or attr.startswith("_config_entry_")
+        for attr in vars(LockCodeManagerActiveEntity)
+        if attr.endswith("_unsub")
+    )
+    instance_attrs = set()
+    for entity in hass.states.async_all("binary_sensor"):
+        if not entity.entity_id.endswith("_active"):
+            continue
+        runtime_data = lock_code_manager_config_entry.runtime_data
+        for slot_coord in runtime_data.slot_coordinators.values():
+            for writer in slot_coord._active_view_writers:
+                # The writer is the entity's bound method; reach its instance.
+                if hasattr(writer, "__self__"):
+                    instance_attrs.update(vars(writer.__self__).keys())
+
+    # Same assertion at instance level: no condition / config-entry unsubs.
+    assert not any(
+        attr.startswith("_condition_") or attr.startswith("_config_entry_")
+        for attr in instance_attrs
+        if attr.endswith("_unsub")
+    )

--- a/tests/test_slot_manager.py
+++ b/tests/test_slot_manager.py
@@ -28,7 +28,7 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.issue_registry import async_get as async_get_issue_registry
 
@@ -466,40 +466,76 @@ async def test_request_sync_check_public_wrapper_delegates(
 async def test_active_binary_sensor_does_not_self_track_state(
     hass: HomeAssistant,
     mock_lock_config_entry,
-    lock_code_manager_config_entry,
 ):
-    """``LockCodeManagerActiveEntity`` must not subscribe to state changes itself.
+    """``LockCodeManagerActiveEntity`` must not subscribe to the condition entity itself.
 
-    All condition-entity tracking lives on ``SlotEntityCoordinator``;
-    a regression that re-added ``async_track_state_change_event`` inside
-    the entity would risk double subscriptions and re-introduce the
-    cross-entity-state-coupling D removed.
+    The slot coordinator owns the condition-entity subscription. A
+    regression that re-added ``async_track_state_change_event`` inside
+    the entity (under any attribute name) would produce a SECOND
+    subscription for the same condition entity, observable as two
+    listeners on that state-changed event.
     """
-    # The entity's only subscription handle should be the coordinator
-    # view unsub. The pre-D version tracked the condition entity and a
-    # config-entry update listener via additional unsub attributes.
-    assert not any(
-        attr.startswith("_condition_") or attr.startswith("_config_entry_")
-        for attr in vars(LockCodeManagerActiveEntity)
-        if attr.endswith("_unsub")
-    )
-    instance_attrs = set()
-    for entity in hass.states.async_all("binary_sensor"):
-        if not entity.entity_id.endswith("_active"):
-            continue
-        runtime_data = lock_code_manager_config_entry.runtime_data
-        for slot_coord in runtime_data.slot_coordinators.values():
-            for writer in slot_coord._active_view_writers:
-                # The writer is the entity's bound method; reach its instance.
-                if hasattr(writer, "__self__"):
-                    instance_attrs.update(vars(writer.__self__).keys())
+    condition_entity = "input_boolean.gate_a"
+    hass.states.async_set(condition_entity, STATE_ON)
+    await hass.async_block_till_done()
 
-    # Same assertion at instance level: no condition / config-entry unsubs.
-    assert not any(
-        attr.startswith("_condition_") or attr.startswith("_config_entry_")
-        for attr in instance_attrs
-        if attr.endswith("_unsub")
+    config = {
+        CONF_LOCKS: [LOCK_1_ENTITY_ID],
+        CONF_SLOTS: {
+            1: {
+                CONF_NAME: "alice",
+                CONF_PIN: "1234",
+                CONF_ENABLED: True,
+                CONF_ENTITY_ID: condition_entity,
+            },
+        },
+    }
+    entry = MockConfigEntry(
+        domain=DOMAIN, data=config, unique_id="Test Active No Track"
     )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    coordinator = entry.runtime_data.slot_coordinators[1]
+    assert len(coordinator._active_view_writers) == 1
+
+    active_entity = next(
+        writer.__self__
+        for writer in coordinator._active_view_writers
+        if hasattr(writer, "__self__")
+        and isinstance(writer.__self__, LockCodeManagerActiveEntity)
+    )
+
+    # No attribute on the active entity should hold a tracker we added
+    # ourselves (HA internals like ``_unsub_device_updates`` are allowed).
+    forbidden_prefixes = ("_condition_", "_config_entry_", "_track_", "_state_change_")
+    leaked = [
+        attr
+        for attr in vars(active_entity)
+        if attr.startswith(forbidden_prefixes) and attr.endswith("_unsub")
+    ]
+    assert leaked == [], (
+        f"Active entity holds entity-side tracker unsubs: {leaked} -- the "
+        "coordinator should own all condition-state subscriptions."
+    )
+
+    # And the coordinator's condition subscription is the SOLE wiring: a
+    # state change on the condition entity flips the active state once,
+    # not twice (no double-fire indicating duplicate listeners).
+    flips: list[bool | None] = []
+
+    @callback
+    def record_writer(is_on: bool | None, _inactive: list[str]) -> None:
+        flips.append(is_on)
+
+    coordinator.register_active_view(record_writer)
+    flips.clear()
+    hass.states.async_set(condition_entity, STATE_OFF)
+    await hass.async_block_till_done()
+    assert flips == [False], f"expected single flip, saw {flips}"
+
+    await hass.config_entries.async_unload(entry.entry_id)
 
 
 async def test_write_config_fields_refreshes_runtime_config_before_notify(
@@ -529,11 +565,13 @@ async def test_write_config_fields_refreshes_runtime_config_before_notify(
     finally:
         unsub()
 
-    # The subscriber fires twice: once synchronously after the eager refresh
-    # inside _write_config_fields, and once when the listener task re-runs
-    # notify_config_changed. Both reads must observe the post-write value;
-    # without the eager refresh the first would be the stale pre-write PIN.
-    assert captured_pin
+    # The subscriber fires twice (synchronous notify after the eager
+    # refresh, plus the listener-task notify). Both must observe the
+    # post-write value; the FIRST one is the load-bearing assertion --
+    # without the eager refresh, that synchronous fire would observe
+    # the stale "1234" because the listener task has not yet run.
+    assert captured_pin, "subscriber must fire at least once"
+    assert captured_pin[0] == "5555"
     assert all(pin == "5555" for pin in captured_pin)
 
 
@@ -710,6 +748,141 @@ async def test_poke_sync_managers_isolates_individual_failures(
         coordinator._sync_managers.discard(healthy)  # type: ignore[arg-type]
 
     assert healthy_called["value"] is True
+    assert any(
+        record.exc_info is not None and record.exc_info[1] is boom
+        for record in caplog.records
+        if record.levelname == "ERROR"
+    )
+
+
+async def test_base_entity_caches_slot_coordinator_on_add(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """``async_added_to_hass`` populates ``_slot_coordinator`` from runtime_data.
+
+    Pins the hoist contract: a regression that broke the resolution
+    would leave entities silently coordinator-less even though one
+    exists in the registry.
+    """
+    runtime_data = lock_code_manager_config_entry.runtime_data
+    for slot_num, coordinator in runtime_data.slot_coordinators.items():
+        all_entities = [
+            writer.__self__
+            for writer in coordinator._active_view_writers
+            if hasattr(writer, "__self__")
+        ]
+        all_entities.extend(
+            sub.__self__
+            for sub in coordinator._state_subscribers
+            if hasattr(sub, "__self__")
+        )
+        assert all_entities, (
+            f"Slot {slot_num} coordinator has no registered entity writers"
+        )
+        for entity in all_entities:
+            cached = getattr(entity, "_slot_coordinator", "<missing>")
+            assert cached is coordinator, (
+                f"Entity {type(entity).__name__} for slot {slot_num} cached "
+                f"coordinator {cached!r}, expected {coordinator!r}"
+            )
+
+
+async def test_hook_dispatch_routes_each_entity_kind_to_the_right_collection(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """text/switch -> _state_subscribers; active -> _active_view_writers.
+
+    Pins the polymorphic ``_register_slot_coordinator_subscription`` hook
+    for the slot-scoped entities. A regression that broke either
+    subclass's override would route the entity into the wrong
+    collection. (In-sync per-lock entities go through a separate
+    lock-slot adder path that fires before the slot coordinator exists
+    on initial setup -- a pre-existing D-design limitation; their
+    ``register_sync_manager`` registration is exercised only via the
+    options-flow ``_async_setup_new_locks`` path, covered by the slot
+    add/remove lifecycle tests.)
+    """
+    runtime_data = lock_code_manager_config_entry.runtime_data
+    coordinator = runtime_data.slot_coordinators[1]
+
+    state_subscriber_owners = {
+        type(sub.__self__).__name__
+        for sub in coordinator._state_subscribers
+        if hasattr(sub, "__self__")
+    }
+    active_view_owners = {
+        type(w.__self__).__name__
+        for w in coordinator._active_view_writers
+        if hasattr(w, "__self__")
+    }
+
+    assert "LockCodeManagerText" in state_subscriber_owners
+    assert "LockCodeManagerSwitch" in state_subscriber_owners
+    assert active_view_owners == {"LockCodeManagerActiveEntity"}
+
+
+async def test_text_set_value_raises_when_slot_coordinator_missing(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """text ``async_set_value`` surfaces a HomeAssistantError, not a silent no-op.
+
+    Pins the asymmetry fix where text used to log a WARNING and return
+    while switch raised; both should raise so the user sees the failed
+    service call.
+    """
+    runtime_data = lock_code_manager_config_entry.runtime_data
+    coordinator = runtime_data.slot_coordinators[1]
+    text_entity = next(
+        sub.__self__
+        for sub in coordinator._state_subscribers
+        if hasattr(sub, "__self__")
+        and type(sub.__self__).__name__ == "LockCodeManagerText"
+    )
+
+    text_entity._slot_coordinator = None
+    with pytest.raises(
+        HomeAssistantError, match=f"No slot coordinator for slot {text_entity.slot_num}"
+    ):
+        await text_entity.async_set_value("9999")
+
+
+async def test_unload_clears_registry_when_coordinator_stop_raises_before_cleanup(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+    caplog: pytest.LogCaptureFixture,
+):
+    """A coordinator whose ``async_stop`` raises BEFORE cleanup is still cleared.
+
+    Complements ``test_unload_continues_when_slot_coordinator_stop_raises``
+    which covers the call-original-then-raise pattern. This variant covers
+    the raise-before-cleanup mode -- proving the registry is cleared
+    regardless of how stop fails.
+    """
+    runtime_data = lock_code_manager_config_entry.runtime_data
+    failing = next(iter(runtime_data.slot_coordinators.values()))
+    boom = RuntimeError("simulated coordinator stop failure (before cleanup)")
+
+    def failing_stop() -> None:
+        # Do NOT call the real stop -- raise immediately so internal
+        # state is left intact, simulating a stop that fails at its
+        # very first statement.
+        raise boom
+
+    with patch.object(failing, "async_stop", failing_stop):
+        with caplog.at_level(logging.ERROR):
+            await hass.config_entries.async_unload(
+                lock_code_manager_config_entry.entry_id
+            )
+            await hass.async_block_till_done()
+
+    assert runtime_data.slot_coordinators == {}
     assert any(
         record.exc_info is not None and record.exc_info[1] is boom
         for record in caplog.records

--- a/tests/test_slot_manager.py
+++ b/tests/test_slot_manager.py
@@ -500,3 +500,218 @@ async def test_active_binary_sensor_does_not_self_track_state(
         for attr in instance_attrs
         if attr.endswith("_unsub")
     )
+
+
+async def test_write_config_fields_refreshes_runtime_config_before_notify(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """A synchronous notify after async_update_entry sees the fresh config.
+
+    ``async_update_entry`` schedules the listener as a task, so
+    ``runtime_data.config`` is still stale at the synchronous
+    ``_notify_state_subscribers`` call inside ``_write_config_fields``.
+    Subscribers must observe the post-write value, not the pre-write one.
+    """
+    runtime_data = lock_code_manager_config_entry.runtime_data
+    coordinator = runtime_data.slot_coordinators[1]
+
+    captured_pin: list[str | None] = []
+
+    def capture_subscriber() -> None:
+        captured_pin.append(coordinator.pin_value)
+
+    unsub = coordinator.register_state_subscriber(capture_subscriber)
+    try:
+        await coordinator.async_request_pin_update("5555")
+        await hass.async_block_till_done()
+    finally:
+        unsub()
+
+    # The subscriber fires twice: once synchronously after the eager refresh
+    # inside _write_config_fields, and once when the listener task re-runs
+    # notify_config_changed. Both reads must observe the post-write value;
+    # without the eager refresh the first would be the stale pre-write PIN.
+    assert captured_pin
+    assert all(pin == "5555" for pin in captured_pin)
+
+
+async def test_unload_continues_when_slot_coordinator_stop_raises(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+    caplog: pytest.LogCaptureFixture,
+):
+    """``async_unload_entry`` clears every slot coordinator even when one stop raises."""
+    runtime_data = lock_code_manager_config_entry.runtime_data
+    coordinators = list(runtime_data.slot_coordinators.values())
+    assert len(coordinators) >= 2
+
+    failing = coordinators[0]
+    boom = RuntimeError("simulated coordinator stop failure")
+    original_stop = failing.async_stop
+    raised = {"value": False}
+
+    def failing_stop() -> None:
+        original_stop()
+        if not raised["value"]:
+            raised["value"] = True
+            raise boom
+
+    with patch.object(failing, "async_stop", failing_stop):
+        with caplog.at_level(logging.WARNING):
+            await hass.config_entries.async_unload(
+                lock_code_manager_config_entry.entry_id
+            )
+            await hass.async_block_till_done()
+
+    assert raised["value"]
+    assert runtime_data.slot_coordinators == {}
+    assert any(
+        record.exc_info is not None and record.exc_info[1] is boom
+        for record in caplog.records
+        if record.levelname == "ERROR"
+    )
+
+
+async def test_register_active_view_initial_writer_failure_propagates_and_discards(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """A raising writer at registration is dropped and the exception propagates.
+
+    Otherwise the platform layer would see a half-added entity that the
+    coordinator kept fanning out to.
+    """
+    runtime_data = lock_code_manager_config_entry.runtime_data
+    coordinator = runtime_data.slot_coordinators[1]
+    boom = RuntimeError("simulated writer failure")
+    initial_count = len(coordinator._active_view_writers)
+
+    def failing_writer(_is_on: bool | None, _inactive: list[str]) -> None:
+        raise boom
+
+    with pytest.raises(RuntimeError, match="simulated writer failure"):
+        coordinator.register_active_view(failing_writer)
+
+    assert failing_writer not in coordinator._active_view_writers
+    assert len(coordinator._active_view_writers) == initial_count
+
+
+async def test_active_toggle_enable_survives_repair_issue_delete_failure(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+    caplog: pytest.LogCaptureFixture,
+):
+    """A failure deleting the pin_required repair issue does not unwind the enable."""
+    runtime_data = lock_code_manager_config_entry.runtime_data
+    coordinator = runtime_data.slot_coordinators[1]
+    # Disable so the toggle has work to do.
+    await coordinator.async_request_active_toggle(False)
+    await hass.async_block_till_done()
+    assert coordinator.is_enabled is False
+
+    boom = RuntimeError("issue registry boom")
+    with patch(
+        "custom_components.lock_code_manager.slot_manager.async_delete_issue",
+        side_effect=boom,
+    ):
+        with caplog.at_level(logging.ERROR):
+            await coordinator.async_request_active_toggle(True)
+            await hass.async_block_till_done()
+
+    # Write succeeded; the swallowed delete failure was logged.
+    assert coordinator.is_enabled is True
+    assert any(
+        record.exc_info is not None and record.exc_info[1] is boom
+        for record in caplog.records
+        if record.levelname == "ERROR"
+    )
+
+
+async def test_handle_condition_state_change_after_stop_is_noop(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+):
+    """A queued condition-entity callback firing after async_stop must not recompute."""
+    hass.states.async_set("input_boolean.gate_a", STATE_ON)
+    await hass.async_block_till_done()
+    config = {
+        CONF_LOCKS: [LOCK_1_ENTITY_ID],
+        CONF_SLOTS: {
+            1: {
+                CONF_NAME: "alice",
+                CONF_PIN: "1234",
+                CONF_ENABLED: True,
+                CONF_ENTITY_ID: "input_boolean.gate_a",
+            },
+        },
+    }
+    entry = MockConfigEntry(domain=DOMAIN, data=config, unique_id="Test Stopped Cb")
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    coordinator = entry.runtime_data.slot_coordinators[1]
+    assert coordinator.is_active is True
+
+    coordinator.async_stop()
+    assert coordinator._started is False
+
+    # Simulate a late-firing condition-entity callback. The guard must
+    # short-circuit before _recompute_active runs (and would touch
+    # _active_view_writers etc.).
+    with patch.object(coordinator, "_recompute_active") as recompute:
+        coordinator._handle_condition_state_change(None)  # type: ignore[arg-type]
+
+    recompute.assert_not_called()
+
+    await hass.config_entries.async_unload(entry.entry_id)
+
+
+async def test_poke_sync_managers_isolates_individual_failures(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+    caplog: pytest.LogCaptureFixture,
+):
+    """One raising sync manager does not abort the poke of the others."""
+    runtime_data = lock_code_manager_config_entry.runtime_data
+    coordinator = runtime_data.slot_coordinators[1]
+
+    # Inject two stand-in managers so the poke loop has predictable
+    # targets regardless of how many real sync managers ended up wired
+    # to this slot via the fixture entity registrations.
+    boom = RuntimeError("simulated sync manager poke failure")
+    healthy_called = {"value": False}
+
+    class _StandIn:
+        def __init__(self, raise_on_call: bool) -> None:
+            self._raise = raise_on_call
+
+        def request_sync_check(self) -> None:
+            if self._raise:
+                raise boom
+            healthy_called["value"] = True
+
+    failing = _StandIn(raise_on_call=True)
+    healthy = _StandIn(raise_on_call=False)
+    coordinator._sync_managers.add(failing)  # type: ignore[arg-type]
+    coordinator._sync_managers.add(healthy)  # type: ignore[arg-type]
+
+    try:
+        with caplog.at_level(logging.ERROR):
+            coordinator._poke_sync_managers()
+    finally:
+        coordinator._sync_managers.discard(failing)  # type: ignore[arg-type]
+        coordinator._sync_managers.discard(healthy)  # type: ignore[arg-type]
+
+    assert healthy_called["value"] is True
+    assert any(
+        record.exc_info is not None and record.exc_info[1] is boom
+        for record in caplog.records
+        if record.levelname == "ERROR"
+    )

--- a/tests/test_slot_manager.py
+++ b/tests/test_slot_manager.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import logging
+from typing import Any
+from unittest.mock import patch
 
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -296,3 +298,92 @@ async def test_unload_reads_slots_via_entry_config_view(
     await hass.config_entries.async_unload(lock_code_manager_config_entry.entry_id)
     await hass.async_block_till_done()
     assert set(removed_slots) == {1, 2}
+
+
+async def test_request_pin_update_auto_disables_in_single_write(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """Empty-PIN auto-disable coalesces PIN and ENABLED into one async_update_entry call.
+
+    Two consecutive writes would let the second read a stale
+    ``runtime_data.config`` and silently drop the first; one write keys
+    both fields off the same snapshot.
+    """
+    coordinator = lock_code_manager_config_entry.runtime_data.slot_coordinators[1]
+
+    captured: list[dict[str, Any]] = []
+    original = hass.config_entries.async_update_entry
+
+    def capture(entry, **kwargs):
+        if entry is lock_code_manager_config_entry and "data" in kwargs:
+            captured.append(kwargs["data"])
+        return original(entry, **kwargs)
+
+    with patch.object(hass.config_entries, "async_update_entry", side_effect=capture):
+        await coordinator.async_request_pin_update("")
+        await hass.async_block_till_done()
+
+    assert len(captured) == 1
+    slot_1 = captured[0][CONF_SLOTS][1]
+    assert slot_1[CONF_PIN] == ""
+    assert slot_1[CONF_ENABLED] is False
+
+
+async def test_condition_entity_swap_resubscribes(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+):
+    """Changing CONF_ENTITY_ID via options unsubscribes from the old condition entity."""
+    hass.states.async_set("input_boolean.gate_a", STATE_ON)
+    hass.states.async_set("input_boolean.gate_b", STATE_OFF)
+    await hass.async_block_till_done()
+
+    config = {
+        CONF_LOCKS: [LOCK_1_ENTITY_ID],
+        CONF_SLOTS: {
+            1: {
+                CONF_NAME: "alice",
+                CONF_PIN: "1234",
+                CONF_ENABLED: True,
+                CONF_ENTITY_ID: "input_boolean.gate_a",
+            },
+        },
+    }
+    entry = MockConfigEntry(domain=DOMAIN, data=config, unique_id="Test Swap")
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    coordinator = entry.runtime_data.slot_coordinators[1]
+    assert coordinator.is_active is True
+
+    new_options = {
+        CONF_LOCKS: [LOCK_1_ENTITY_ID],
+        CONF_SLOTS: {
+            1: {
+                CONF_NAME: "alice",
+                CONF_PIN: "1234",
+                CONF_ENABLED: True,
+                CONF_ENTITY_ID: "input_boolean.gate_b",
+            },
+        },
+    }
+    hass.config_entries.async_update_entry(entry, options=new_options)
+    await hass.async_block_till_done()
+
+    # gate_b is OFF, so the slot is now inactive.
+    assert coordinator.is_active is False
+
+    # Toggling the OLD condition entity must NOT affect the slot anymore.
+    hass.states.async_set("input_boolean.gate_a", STATE_OFF)
+    await hass.async_block_till_done()
+    assert coordinator.is_active is False
+
+    # Toggling the NEW condition entity to ON makes the slot active again.
+    hass.states.async_set("input_boolean.gate_b", STATE_ON)
+    await hass.async_block_till_done()
+    assert coordinator.is_active is True
+
+    await hass.config_entries.async_unload(entry.entry_id)


### PR DESCRIPTION
## Proposed change

Multi-part PR that finalizes the entity → tick refactor (audit items #9, #11, #12, #13, #14) plus a hoist that emerged across three rounds of review.

### 1. Introduce `SlotEntityCoordinator`

New per-`(config_entry, slot)` coordinator in `slot_manager.py` that owns:
- The derived "active" state (computed from `enabled` + condition entity) and the `inactive_because_of` attribute.
- The condition-entity subscription itself.
- Slot-level repair-issue lifecycle (`pin_required` create/delete).
- Three intent dispatchers that entities call: `async_request_name_update`, `async_request_pin_update`, `async_request_active_toggle`. These coalesce the config write (`_write_config_fields` accepts a dict so empty-PIN auto-disable is one combined write rather than two — closing a stale-`runtime_data.config` race) and poke each lock's `SlotSyncManager.request_sync_check()` so the next tick reconciles.

Entities collapse to thin views:
- `LockCodeManagerActiveEntity` (binary sensor) goes from ~150 to ~25 lines; the config-entry update listener and condition-entity subscription move to the coordinator.
- `text.py` `async_set_value` calls `coordinator.async_request_pin_update / name_update`. No more `_enabled_entity_id`, registry-string sibling lookup, or direct `async_disable_slot` import.
- `switch.py` `async_turn_on/off` call `coordinator.async_request_active_toggle`. No more `_pin_entity_id`, sibling registry lookups, or inline repair-issue management.

The per-lock `SlotSyncManager` is unchanged in role; it now exposes `request_sync_check()` as a public verb so the slot coordinator can nudge sync without reaching into `_request_sync_check`.

### 2. Hoist slot-coordinator caching to `BaseLockCodeManagerEntity`

Every entity platform was re-resolving `runtime_data.slot_coordinators.get(self.slot_num)` on every method call with duplicated null checks. Hoisted to the base:

- `_slot_coordinator: SlotEntityCoordinator | None` attribute initialized in `__init__`, resolved once in the base's `async_added_to_hass`. Lifecycle is safe because slot removal tears down the entity, and re-adding the slot creates a new entity bound to the new coordinator — the cached reference never goes stale.
- `_register_slot_coordinator_subscription` hook on the base with a state-subscriber default (the shape text and switch want). `LockCodeManagerActiveEntity` overrides to register the active view; `LockCodeManagerCodeSlotInSyncEntity` overrides to register the per-lock sync manager.
- `_require_slot_coordinator` helper on the base for intent paths. text and switch both call it so a missing coordinator surfaces as `HomeAssistantError` rather than the prior asymmetric behavior (text silently logged WARNING and returned; switch raised).
- Missing-coordinator at add time logs ERROR with a comment explaining the internal-inconsistency intent.

### 3. `curr_slots` fix (deferred from #1187 review)

`async_unload_entry`'s `curr_slots = config_entry.data.get(CONF_SLOTS, {})` returned `{}` for any normally-loaded entry because `_setup_entry_after_start` migrates `data → options` at first setup. Replaced with `list(get_entry_config(config_entry).slots)` so the entity-removers actually fire on unload. Slot coordinators are stopped after the entity removers (so `async_will_remove_from_hass` can still unregister cleanly) and cleared from `runtime_data`. The stop loop tolerates per-coordinator failures (logged at ERROR; registry cleared regardless).

### 4. Coordinator-error isolation and defensive fixes (round 1 review)

- Eager `runtime_data.config = EntryConfig.from_entry(...)` refresh after `async_update_entry` so the synchronous notify observes the post-write value, not the stale pre-write one (`async_update_entry` schedules the listener as a task, so the listener's refresh hasn't run yet).
- `register_active_view` immediate writer call now wraps the initial fire in try/except, logs and discards the writer if it raises, then re-raises so the platform rejects the half-added entity cleanly.
- `async_request_active_toggle` repair-issue create and delete each wrapped in try/except so a registry failure doesn't unwind the config write or mask the actual outcome.
- `_handle_condition_state_change` guards on `_started` so late-firing callbacks against a torn-down coordinator no-op.
- `_poke_sync_managers` per-manager try/except so one raising manager doesn't abort the loop.
- Unload paths use `pop` / `list(...)` and per-coordinator try/except so a raising stop is logged and the registry is cleared either way.

### 5. Test coverage

`tests/test_slot_manager.py` grew from 10 tests in the original PR to 28 across three review rounds:
- Lifecycle: slot add/remove/re-add produces a fresh coordinator instance with fresh fields, condition-entity swap re-subscribes.
- Hoist contract: `_slot_coordinator` is populated on add; text/switch land in `_state_subscribers`; active sensor lands in `_active_view_writers`; text raises `HomeAssistantError` when coordinator missing.
- Defensive fixes each pinned by a regression test (writer raise on registration, repair-issue delete failure, condition-state guard, sync-manager isolation, unload-with-stop-raises in two variants, eager-refresh observable to subscribers).
- Behavioral check that the active binary sensor doesn't re-introduce entity-side condition tracking (a condition-entity state flip produces exactly one active-view fire).

### Out-of-scope findings worth flagging

- `slot_disabled` and `slot_suspended` repair issues still live in `SlotSyncManager._disable_slot / _suspend_slot` because they're per-lock-slot events emitted from the tick. Moving them under the slot coordinator would invert the layering. Flag for PR F if the data-model rewrite revisits issue ownership.
- **In-sync per-lock entities are added via a separate adder path (`__init__.py:829`) that fires BEFORE the slot coordinator exists on initial setup.** Their `register_sync_manager` registration with the slot coordinator is unreachable on initial setup; it only happens for slots added via the options-flow `_async_setup_new_locks` path. This means `SlotEntityCoordinator._poke_sync_managers` is effectively a no-op for entries set up via initial entry setup. Worth fixing in G or as a follow-up.
- Pre-existing mypy errors in `__init__.py` (StaticPathConfig, async_start_reauth, ResourceYAMLCollection) and `websocket.py` are untouched.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

Part of the resilience refactor chain. Depends on #1187 (lifecycle hygiene), #1188 (lock ownership), #1189 (single breaker mutator). Interacts cleanly with #1190 (no provider overlap). #1192 (data-model rewrite) is stacked on top of this branch and will auto-retarget to main when this lands. G (god-module cleanup) remains.

- This PR fixes or closes issue: fixes #
- This PR is related to issue: