### PR TITLE
fix(zha): use unsubscribe_push_updates() instead

### DIFF
--- a/custom_components/lock_code_manager/providers/zha.py
+++ b/custom_components/lock_code_manager/providers/zha.py
@@ -120,7 +120,7 @@ class ZHALock(BaseLock):
         ``hard_refresh_interval`` during init, so detection must complete
         before coordinator creation.
         """
-        self.teardown_push_subscription()
+        self.unsubscribe_push_updates()
         self._door_lock_cluster = None
         self._endpoint_id = None
         await super().async_setup(config_entry)

--- a/tests/providers/test_base.py
+++ b/tests/providers/test_base.py
@@ -24,6 +24,7 @@ from custom_components.lock_code_manager.exceptions import (
     DuplicateCodeError,
     LockDisconnected,
     LockOperationFailed,
+    ProviderNotImplementedError,
 )
 from custom_components.lock_code_manager.models import SlotCredential
 from custom_components.lock_code_manager.providers._base import BaseLock
@@ -111,6 +112,35 @@ async def test_base(hass: HomeAssistant):
             await lock.async_internal_set_usercode(1, "1234")
         with pytest.raises(NotImplementedError):
             await lock.async_internal_get_usercodes()
+
+
+async def test_unsubscribe_push_updates_suppresses_not_implemented(
+    hass: HomeAssistant,
+) -> None:
+    """Test unsubscribe_push_updates swallows ProviderNotImplementedError.
+
+    Providers that don't override teardown_push_subscription raise
+    ProviderNotImplementedError from the base default.  The public
+    unsubscribe_push_updates() wrapper must suppress that error so callers
+    (e.g. async_setup teardown on reconnect) never see it propagate.
+    """
+    entity_reg = er.async_get(hass)
+    config_entry = MockConfigEntry(domain=DOMAIN)
+    config_entry.add_to_hass(hass)
+    lock_entity = entity_reg.async_get_or_create(
+        "lock",
+        "test",
+        "test_lock_no_push",
+        config_entry=config_entry,
+    )
+    lock = BaseLock(hass, dr.async_get(hass), entity_reg, config_entry, lock_entity)
+
+    # teardown_push_subscription raises ProviderNotImplementedError by default
+    with pytest.raises(ProviderNotImplementedError):
+        lock.teardown_push_subscription()
+
+    # The public wrapper must not propagate it
+    lock.unsubscribe_push_updates()  # must not raise
 
 
 async def test_config_entry_state_change_resubscribes(


### PR DESCRIPTION
## Proposed change

`ZHALock.async_setup()` called `teardown_push_subscription()` directly instead of going through the public `unsubscribe_push_updates()` wrapper defined in `_base.py`.

The wrapper is decorated `@final` and wraps the inner call in `contextlib.suppress(ProviderNotImplementedError)`. The base default for `teardown_push_subscription()` raises `ProviderNotImplementedError` — meaning any provider that doesn't override it (or any future subclass) would surface that exception to callers. In ZHA's re-setup path (called on reconnect), this could propagate unexpectedly.

The fix replaces the one direct call at `providers/zha.py:123` with `self.unsubscribe_push_updates()`. A new unit test in `tests/providers/test_base.py` asserts that the wrapper silently swallows `ProviderNotImplementedError` when `teardown_push_subscription()` is not overridden.

No other provider files contained direct calls to `teardown_push_subscription()` outside of their own override definitions.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue:
- This PR is related to issue:

## Test plan

- [ ] `uv run pytest -q` — 970 tests pass
- [ ] `prek run --files custom_components/lock_code_manager/providers/zha.py tests/providers/test_base.py` — all hooks pass
- [ ] New test `test_unsubscribe_push_updates_suppresses_not_implemented` in `tests/providers/test_base.py` directly validates the wrapper behavior