### PR TITLE
refactor: inline three single-caller abstractions

### DIFF
--- a/custom_components/lock_code_manager/coordinator.py
+++ b/custom_components/lock_code_manager/coordinator.py
@@ -106,10 +106,6 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator[dict[int, SlotCredenti
             return SlotCredential.empty()
         return SlotCredential.known(pin)
 
-    def slot_expects_pin(self, slot_num: int) -> bool:
-        """Return whether LCM expects a PIN on this slot (enabled with PIN)."""
-        return self.desired_credential(slot_num).is_present
-
     @staticmethod
     def _normalize_keys(
         data: dict[Any, SlotCredential],

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -542,7 +542,54 @@ class BaseLock:
             self._setup_succeeded = True
 
         try:
-            await self._async_setup_internal(config_entry)
+            lock_entity_id = self.lock.entity_id
+            # Track the provider's config entry (e.g., zwave_js) so we can resubscribe
+            # when that integration reloads or reconnects.
+            self._setup_config_entry_state_listener()
+
+            # Reuse existing coordinator or create new one
+            if self.coordinator is not None:
+                self.hass.async_create_task(
+                    self.coordinator.async_request_refresh(),
+                    f"Refresh coordinator for {lock_entity_id}",
+                )
+            else:
+                self.coordinator = LockUsercodeUpdateCoordinator(
+                    self.hass, self, config_entry
+                )
+                if config_entry.state == ConfigEntryState.SETUP_IN_PROGRESS:
+                    try:
+                        await self.coordinator.async_config_entry_first_refresh()
+                    except (ConfigEntryNotReady, UpdateFailed) as err:
+                        LOGGER.warning(
+                            "Failed to fetch initial data for lock %s: %s. "
+                            "Entities will be created but unavailable until lock is ready.",
+                            lock_entity_id,
+                            err,
+                        )
+                else:
+                    await self.coordinator.async_refresh()
+                    if not self.coordinator.last_update_success:
+                        LOGGER.warning(
+                            "Failed to fetch initial data for lock %s: %s. "
+                            "Entities will be created but unavailable until lock is ready.",
+                            lock_entity_id,
+                            self.coordinator.last_exception,
+                        )
+
+                # Subscribe to push updates after coordinator is ready. If the provider's
+                # config entry isn't loaded yet, defer and let the state listener resubscribe.
+                if self.supports_push:
+                    if (
+                        self.lock_config_entry
+                        and self.lock_config_entry.state != ConfigEntryState.LOADED
+                    ):
+                        LOGGER.debug(
+                            "Lock %s: deferring push subscription until config entry is loaded",
+                            lock_entity_id,
+                        )
+                    else:
+                        self.subscribe_push_updates()
         finally:
             self._setup_complete.set()
 
@@ -588,57 +635,6 @@ class BaseLock:
             await self.coordinator.async_request_refresh()
         if self.supports_push:
             self.subscribe_push_updates()
-
-    @final
-    async def _async_setup_internal(self, config_entry: ConfigEntry) -> None:
-        """Set up lock and coordinator."""
-        lock_entity_id = self.lock.entity_id
-        # Track the provider's config entry (e.g., zwave_js) so we can resubscribe
-        # when that integration reloads or reconnects.
-        self._setup_config_entry_state_listener()
-
-        # Reuse existing coordinator or create new one
-        if self.coordinator is not None:
-            self.hass.async_create_task(
-                self.coordinator.async_request_refresh(),
-                f"Refresh coordinator for {lock_entity_id}",
-            )
-            return
-
-        self.coordinator = LockUsercodeUpdateCoordinator(self.hass, self, config_entry)
-        if config_entry.state == ConfigEntryState.SETUP_IN_PROGRESS:
-            try:
-                await self.coordinator.async_config_entry_first_refresh()
-            except (ConfigEntryNotReady, UpdateFailed) as err:
-                LOGGER.warning(
-                    "Failed to fetch initial data for lock %s: %s. "
-                    "Entities will be created but unavailable until lock is ready.",
-                    lock_entity_id,
-                    err,
-                )
-        else:
-            await self.coordinator.async_refresh()
-            if not self.coordinator.last_update_success:
-                LOGGER.warning(
-                    "Failed to fetch initial data for lock %s: %s. "
-                    "Entities will be created but unavailable until lock is ready.",
-                    lock_entity_id,
-                    self.coordinator.last_exception,
-                )
-
-        # Subscribe to push updates after coordinator is ready. If the provider's
-        # config entry isn't loaded yet, defer and let the state listener resubscribe.
-        if self.supports_push:
-            if (
-                self.lock_config_entry
-                and self.lock_config_entry.state != ConfigEntryState.LOADED
-            ):
-                LOGGER.debug(
-                    "Lock %s: deferring push subscription until config entry is loaded",
-                    lock_entity_id,
-                )
-            else:
-                self.subscribe_push_updates()
 
     async def async_setup(self, config_entry: ConfigEntry) -> None:
         """
@@ -784,7 +780,7 @@ class BaseLock:
             return
         # Skip during SETUP_IN_PROGRESS: the setup path handles the initial
         # subscription, and a parallel subscribe here would race with
-        # coordinator creation in _async_setup_internal.
+        # coordinator creation in async_setup_internal.
         if lock_entry.state != ConfigEntryState.LOADED:
             return
         if self._last_connection_up is False and is_up:

--- a/custom_components/lock_code_manager/providers/zwave_js.py
+++ b/custom_components/lock_code_manager/providers/zwave_js.py
@@ -159,12 +159,6 @@ class ZWaveJSLock(BaseLock):
         except KeyError, ValueError:
             return None
 
-    def _slot_expects_pin(self, code_slot: int) -> bool:
-        """Return True if this slot is enabled and has a PIN configured."""
-        if not self.coordinator:
-            return False
-        return self.coordinator.slot_expects_pin(code_slot)
-
     @callback
     def _handle_usercode_status_update(self, code_slot: int, status: Any) -> None:
         """Handle userIdStatus value update for a code slot."""
@@ -172,7 +166,10 @@ class ZWaveJSLock(BaseLock):
             # Ignore AVAILABLE status if Lock Code Manager expects a PIN on this
             # slot. Some locks send stale AVAILABLE events after a code was set,
             # which would cause infinite sync loops.
-            if self._slot_expects_pin(code_slot):
+            if (
+                self.coordinator
+                and self.coordinator.desired_credential(code_slot).is_present
+            ):
                 _LOGGER.debug(
                     "Lock %s: ignoring userIdStatus=AVAILABLE for slot %s "
                     "(LCM expects PIN on this slot)",

--- a/custom_components/lock_code_manager/sync.py
+++ b/custom_components/lock_code_manager/sync.py
@@ -102,7 +102,7 @@ class SlotSyncManager:
     manager.sync_status for display.
 
     State mutation rules:
-        - ``_request_sync_check`` transitions IN_SYNC -> OUT_OF_SYNC or
+        - ``request_sync_check`` transitions IN_SYNC -> OUT_OF_SYNC or
           SUSPENDED -> OUT_OF_SYNC for immediate UI feedback.
         - ``_async_tick_impl`` is the single authoritative place for all
           other state transitions, circuit breaker, sync operations,
@@ -553,19 +553,7 @@ class SlotSyncManager:
         self._state_writer(self.in_sync)
 
     @callback
-    def request_sync_check(self) -> None:
-        """
-        Public no-arg wrapper over ``_request_sync_check``.
-
-        ``_request_sync_check`` accepts ``*_args`` so it can serve as a
-        coordinator/state-change listener; callers that want to nudge sync
-        directly should not have to pretend to be a listener. Routing
-        through it keeps the state-transition rules in one place.
-        """
-        self._request_sync_check()
-
-    @callback
-    def _request_sync_check(self, *_args: Any) -> None:
+    def request_sync_check(self, *_args: Any) -> None:
         """
         Request a sync check on the next tick.
 
@@ -623,7 +611,7 @@ class SlotSyncManager:
         if not self._tracked_entity_ids or (
             event.data["entity_id"] in self._tracked_entity_ids
         ):
-            self._request_sync_check()
+            self.request_sync_check()
 
     async def _async_tick(self, _now: datetime | None = None) -> None:
         """Periodic reconciliation tick."""
@@ -638,7 +626,7 @@ class SlotSyncManager:
         self._tick_tasks.add(task)
         try:
             # Try upgrading before the state check — catch-all mode may prevent
-            # _request_sync_check from firing for entities not yet tracked
+            # request_sync_check from firing for entities not yet tracked
             self._try_upgrade_state_tracking()
 
             if self._state in (
@@ -661,7 +649,7 @@ class SlotSyncManager:
         changes.
         """
         # Consume any external reset requests before reading breaker state.
-        # ``_request_sync_check`` cannot reset the breaker directly because
+        # ``request_sync_check`` cannot reset the breaker directly because
         # it can fire while a tick is awaiting ``_perform_sync``, and a
         # mid-flight reset would clear failure state the tick is about to
         # read. Coalescing many requests into one reset is intentional.
@@ -753,7 +741,7 @@ class SlotSyncManager:
                 f"Fix the issue and re-enable the slot.",
             )
             # After disable, the slot active switch turns off. The next
-            # _request_sync_check will see the slot as in-sync (no code
+            # request_sync_check will see the slot as in-sync (no code
             # desired, no code on lock). Set to OUT_OF_SYNC so the next
             # tick resolves to IN_SYNC.
             self._state = SyncState.OUT_OF_SYNC
@@ -846,7 +834,7 @@ class SlotSyncManager:
     def _setup_coordinator_listener(self) -> None:
         """Subscribe to coordinator updates."""
         self._coordinator_unsub = self._coordinator.async_add_listener(
-            self._request_sync_check
+            self.request_sync_check
         )
 
     @callback
@@ -873,7 +861,7 @@ class SlotSyncManager:
         self._state_tracking_unsub = async_track_state_change_event(
             self._hass,
             self._tracked_entity_ids,
-            self._request_sync_check,
+            self.request_sync_check,
         )
         self._tracking_all_states = False
         _LOGGER.debug(
@@ -898,7 +886,7 @@ class SlotSyncManager:
             self._state_tracking_unsub = async_track_state_change_event(
                 self._hass,
                 self._tracked_entity_ids,
-                self._request_sync_check,
+                self.request_sync_check,
             )
             self._tracking_all_states = False
         else:

--- a/tests/providers/zwave_js/test_events.py
+++ b/tests/providers/zwave_js/test_events.py
@@ -714,7 +714,7 @@ async def test_push_update_user_id_status_available_clears_slot(
     # Set up a mock coordinator with existing data
     mock_coordinator = MagicMock()
     mock_coordinator.data = {2: SlotCredential.known("1234")}  # Slot has a PIN
-    mock_coordinator.slot_expects_pin.return_value = False  # No expected PIN
+    mock_coordinator.desired_credential.return_value = SlotCredential.empty()
     zwave_js_lock.coordinator = mock_coordinator
 
     # Subscribe to push updates
@@ -876,25 +876,26 @@ async def test_push_update_user_id_status_available_ignored_when_slot_expects_pi
     # Subscribe to push updates
     zwave_js_lock.subscribe_push_updates()
 
-    # Mock _slot_expects_pin to return True (LCM expects a PIN on this slot)
-    with patch.object(zwave_js_lock, "_slot_expects_pin", return_value=True):
-        # Simulate userIdStatus=AVAILABLE event (stale status from lock)
-        event = ZwaveEvent(
-            type="value updated",
-            data={
-                "args": {
-                    "commandClass": CommandClass.USER_CODE,
-                    "property": LOCK_USERCODE_STATUS_PROPERTY,
-                    "propertyKey": 2,
-                    "newValue": CodeSlotStatus.AVAILABLE,
-                },
-            },
-        )
-        lock_schlage_be469.emit("value updated", event.data)
-        await hass.async_block_till_done()
+    # LCM expects a PIN on this slot
+    mock_coordinator.desired_credential.return_value = SlotCredential.known("1234")
 
-        # Coordinator should NOT be updated (AVAILABLE ignored)
-        mock_coordinator.push_update.assert_not_called()
+    # Simulate userIdStatus=AVAILABLE event (stale status from lock)
+    event = ZwaveEvent(
+        type="value updated",
+        data={
+            "args": {
+                "commandClass": CommandClass.USER_CODE,
+                "property": LOCK_USERCODE_STATUS_PROPERTY,
+                "propertyKey": 2,
+                "newValue": CodeSlotStatus.AVAILABLE,
+            },
+        },
+    )
+    lock_schlage_be469.emit("value updated", event.data)
+    await hass.async_block_till_done()
+
+    # Coordinator should NOT be updated (AVAILABLE ignored)
+    mock_coordinator.push_update.assert_not_called()
 
     zwave_js_lock.unsubscribe_push_updates()
     await zwave_js_lock.async_unload(False)
@@ -930,27 +931,26 @@ async def test_push_update_user_id_status_available_clears_when_slot_inactive(
     # Subscribe to push updates
     zwave_js_lock.subscribe_push_updates()
 
-    # Mock _slot_expects_pin to return False (slot is inactive)
-    with patch.object(zwave_js_lock, "_slot_expects_pin", return_value=False):
-        # Simulate userIdStatus=AVAILABLE event
-        event = ZwaveEvent(
-            type="value updated",
-            data={
-                "args": {
-                    "commandClass": CommandClass.USER_CODE,
-                    "property": LOCK_USERCODE_STATUS_PROPERTY,
-                    "propertyKey": 2,
-                    "newValue": CodeSlotStatus.AVAILABLE,
-                },
-            },
-        )
-        lock_schlage_be469.emit("value updated", event.data)
-        await hass.async_block_till_done()
+    # Slot is inactive (no PIN expected)
+    mock_coordinator.desired_credential.return_value = SlotCredential.empty()
 
-        # Coordinator SHOULD be updated (slot cleared)
-        mock_coordinator.push_update.assert_called_once_with(
-            {2: SlotCredential.empty()}
-        )
+    # Simulate userIdStatus=AVAILABLE event
+    event = ZwaveEvent(
+        type="value updated",
+        data={
+            "args": {
+                "commandClass": CommandClass.USER_CODE,
+                "property": LOCK_USERCODE_STATUS_PROPERTY,
+                "propertyKey": 2,
+                "newValue": CodeSlotStatus.AVAILABLE,
+            },
+        },
+    )
+    lock_schlage_be469.emit("value updated", event.data)
+    await hass.async_block_till_done()
+
+    # Coordinator SHOULD be updated (slot cleared)
+    mock_coordinator.push_update.assert_called_once_with({2: SlotCredential.empty()})
 
     zwave_js_lock.unsubscribe_push_updates()
     await zwave_js_lock.async_unload(False)

--- a/tests/providers/zwave_js/test_provider.py
+++ b/tests/providers/zwave_js/test_provider.py
@@ -12,7 +12,6 @@ from zwave_js_server.model.node import Node
 
 from homeassistant.components.zwave_js.const import DOMAIN as ZWAVE_JS_DOMAIN
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import CONF_ENABLED, CONF_PIN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
@@ -900,63 +899,6 @@ async def test_code_slot_in_use(
         **mock_config,
     ):
         assert zwave_js_lock.code_slot_in_use(1) is expected
-
-
-# _slot_expects_pin tests
-
-
-@pytest.mark.parametrize(
-    ("slot_config", "expected"),
-    [
-        ({CONF_PIN: "1234", CONF_ENABLED: True}, True),
-        ({CONF_PIN: "1234", CONF_ENABLED: False}, False),
-        ({CONF_PIN: "", CONF_ENABLED: True}, False),
-        ({CONF_ENABLED: True}, False),
-    ],
-)
-async def test_slot_expects_pin_by_config(
-    hass: HomeAssistant,
-    zwave_js_lock: ZWaveJSLock,
-    zwave_integration: MockConfigEntry,
-    slot_config: dict,
-    expected: bool,
-) -> None:
-    """Test _slot_expects_pin based on coordinator.slot_expects_pin from config entry."""
-    lcm_entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            CONF_LOCKS: [zwave_js_lock.lock.entity_id],
-            CONF_SLOTS: {"2": slot_config},
-        },
-    )
-    lcm_entry.add_to_hass(hass)
-    await zwave_js_lock.async_setup_internal(lcm_entry)
-
-    assert zwave_js_lock._slot_expects_pin(2) is expected
-
-    await zwave_js_lock.async_unload(False)
-
-
-async def test_slot_expects_pin_returns_false_for_unmanaged_slot(
-    hass: HomeAssistant,
-    zwave_js_lock: ZWaveJSLock,
-    zwave_integration: MockConfigEntry,
-) -> None:
-    """Test _slot_expects_pin returns False for unmanaged slot."""
-    lcm_entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            CONF_LOCKS: [zwave_js_lock.lock.entity_id],
-            CONF_SLOTS: {"1": {}},  # Only slot 1 managed
-        },
-    )
-    lcm_entry.add_to_hass(hass)
-    await zwave_js_lock.async_setup_internal(lcm_entry)
-
-    # Slot 99 is not managed
-    assert zwave_js_lock._slot_expects_pin(99) is False
-
-    await zwave_js_lock.async_unload(False)
 
 
 # Device availability tests

--- a/tests/test_slot_manager.py
+++ b/tests/test_slot_manager.py
@@ -441,28 +441,6 @@ async def test_slot_remove_then_readd_creates_fresh_coordinator(
     assert original_slot_2_coordinator._started is False
 
 
-async def test_request_sync_check_public_wrapper_delegates(
-    hass: HomeAssistant,
-    mock_lock_config_entry,
-    lock_code_manager_config_entry,
-):
-    """The public ``request_sync_check`` forwards to the private handler.
-
-    The wrapper exists so callers that aren't listener-shaped don't have
-    to pretend to be one (``_request_sync_check`` accepts ``*_args`` to
-    serve as a state-change listener). A regression that bypasses the
-    private handler would lose the centralized state-transition rules.
-    """
-    runtime_data = lock_code_manager_config_entry.runtime_data
-    assert runtime_data.sync_managers
-    manager = next(iter(runtime_data.sync_managers))
-
-    with patch.object(manager, "_request_sync_check") as private:
-        manager.request_sync_check()
-
-    private.assert_called_once_with()
-
-
 async def test_active_binary_sensor_does_not_self_track_state(
     hass: HomeAssistant,
     mock_lock_config_entry,

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -578,7 +578,7 @@ class TestSyncStateMachine:
         assert manager._state is SyncState.IN_SYNC
 
         manager._coordinator.data[1] = SlotCredential.empty()
-        manager._request_sync_check()
+        manager.request_sync_check()
         assert manager._state is SyncState.OUT_OF_SYNC
 
     async def test_out_of_sync_to_synced_after_successful_sync(
@@ -596,7 +596,7 @@ class TestSyncStateMachine:
         assert manager._state is SyncState.IN_SYNC
 
         manager._coordinator.data[1] = SlotCredential.empty()
-        manager._request_sync_check()
+        manager.request_sync_check()
         assert manager._state is SyncState.OUT_OF_SYNC
 
         await async_trigger_sync_tick(hass, SLOT_1_IN_SYNC_ENTITY, set_dirty=False)
@@ -705,7 +705,7 @@ class TestSyncStateMachine:
 
         # Lock recovers: breaker resets, so the next sync check resumes.
         manager._coordinator._lock_breaker.reset()
-        manager._request_sync_check()
+        manager.request_sync_check()
 
         assert manager._state is SyncState.OUT_OF_SYNC
 
@@ -723,7 +723,7 @@ class TestSyncStateMachine:
             manager._coordinator._lock_breaker.record_failure()
         manager._state = SyncState.SUSPENDED
 
-        manager._request_sync_check()
+        manager.request_sync_check()
         assert manager._state is SyncState.SUSPENDED
 
     async def test_code_rejected_still_disables_slot(
@@ -947,14 +947,14 @@ class TestSyncStateMachine:
 
         # A sync check with the same desired target must not resume the slot —
         # this is the key fix: it no longer hot-loops on a reachable lock.
-        manager._request_sync_check()
+        manager.request_sync_check()
         assert manager._state is SyncState.SUSPENDED
 
         # Simulate the desired target changing (e.g. the user edits the PIN):
         # the recorded target now differs from the resolved state, so the slot
         # resumes.
         manager._code_suspend_target = (STATE_ON, "0000")
-        manager._request_sync_check()
+        manager.request_sync_check()
         assert manager._state is SyncState.OUT_OF_SYNC
         assert manager._code_suspend_target is None
 
@@ -1252,10 +1252,10 @@ class TestBreakerTickSoleMutatorInvariant:
             # and is now awaiting the set. Fire callbacks that would, under
             # the old contract, have called reset() directly.
             manager._state = SyncState.IN_SYNC
-            manager._request_sync_check()
+            manager.request_sync_check()
             manager._state = SyncState.SUSPENDED
             manager._code_suspend_target = ("on", "1234")
-            manager._request_sync_check()
+            manager.request_sync_check()
 
             # Mutators must not have fired from the callback path.
             assert reset_spy.call_count == 0
@@ -1343,7 +1343,7 @@ class TestBreakerTickSoleMutatorInvariant:
         with patch.object(
             manager._slot_breaker, "reset", wraps=manager._slot_breaker.reset
         ) as reset_spy:
-            manager._request_sync_check()
+            manager.request_sync_check()
 
         assert manager._state is SyncState.OUT_OF_SYNC
         assert manager._breaker_reset_requested is True
@@ -1370,7 +1370,7 @@ class TestBreakerTickSoleMutatorInvariant:
         with patch.object(
             manager._slot_breaker, "reset", wraps=manager._slot_breaker.reset
         ) as reset_spy:
-            manager._request_sync_check()
+            manager.request_sync_check()
 
         assert manager._state is SyncState.OUT_OF_SYNC
         assert manager._breaker_reset_requested is True
@@ -1401,7 +1401,7 @@ class TestBreakerTickSoleMutatorInvariant:
         with patch.object(
             manager._slot_breaker, "reset", wraps=manager._slot_breaker.reset
         ) as reset_spy:
-            manager._request_sync_check()
+            manager.request_sync_check()
 
         assert manager._state is SyncState.OUT_OF_SYNC
         assert manager._breaker_reset_requested is True


### PR DESCRIPTION
## Proposed change

Three pieces of single-caller indirection identified by the over-abstraction audit. Each method hop added no behavior between caller and implementation.

**1. `LockUsercodeUpdateCoordinator.slot_expects_pin`** — one-line wrapper around `desired_credential(slot_num).is_present`. Only caller was `ZWaveJSLock._slot_expects_pin`, which itself just added a coordinator-null check that the other coordinator accessors handle inline. Removed both; `_handle_usercode_status_update` now reads `self.coordinator and self.coordinator.desired_credential(code_slot).is_present` directly.

**2. `SlotSyncManager.request_sync_check` wrapper** — existed so non-listener-shaped callers wouldn't have to pretend to be one (`_request_sync_check` accepts `*_args` to also serve as a state-change listener). Renamed `_request_sync_check` to `request_sync_check` (it already accepts both shapes) and dropped the wrapper.

**3. `BaseLock._async_setup_internal`** — private `@final` method called from exactly one place: `async_setup_internal`'s `try/finally`. Inlined into the finally block; the original `if/return; else_path` shape becomes a clean `if/else` where the new-coordinator path also handles push subscribe. `_setup_complete.set()` stays in `finally`.

### Deliberately NOT taken

A fourth audit finding (inline `SlotEntityCoordinator.async_request_name_update`) was rejected on review — it would have forced `text.py` to call `SlotEntityCoordinator._write_config_fields(...)` directly, reaching across the read-only-entities boundary established in #1191. The intent-dispatch surface is the value, not the behavior.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

Follow-up to #1193 (zha push-unsub bypass) — both surfaced by the post-#1192 over-abstraction audit.

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Test plan

- [x] Full pytest suite (963 passed; -6 from baseline 969 = tests for removed methods deleted)
- [x] prek (ruff, pydocstyle, mypy, flake8) all green
- [x] No behavior change — these are pure structural refactors

🤖 Generated with [Claude Code](https://claude.ai/code)