### PR TITLE
refactor(layout): split data.py into domain/{config,queries}

### DIFF
--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -78,13 +78,14 @@ from .const import (
     STRATEGY_PATH,
     Platform,
 )
-from .data import EntryConfig, get_entry_config
+from .domain.config import EntryConfig
 from .domain.pin_generator import (
     DEFAULT_PIN_LENGTH,
     MAX_PIN_LENGTH,
     MIN_PIN_LENGTH,
     generate_pin,
 )
+from .domain.queries import get_entry_config
 from .helpers import (
     async_clear_slot_condition,
     async_clear_usercode,

--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -33,8 +33,9 @@ from .const import (
     DOMAIN,
     EXCLUDED_CONDITION_PLATFORMS,
 )
-from .data import EntryConfig, get_entry_config
+from .domain.config import EntryConfig
 from .domain.exceptions import LockCodeManagerError
+from .domain.queries import get_entry_config
 from .models import SlotCredential
 from .providers import INTEGRATIONS_CLASS_MAP
 

--- a/custom_components/lock_code_manager/coordinator.py
+++ b/custom_components/lock_code_manager/coordinator.py
@@ -28,8 +28,8 @@ from .const import (
     DOMAIN,
     POLL_FAILURE_ALERT_THRESHOLD,
 )
-from .data import get_entry_config
 from .domain.exceptions import LockCodeManagerError
+from .domain.queries import get_entry_config
 from .domain.resilience import CircuitBreaker
 from .models import SlotCredential
 

--- a/custom_components/lock_code_manager/diagnostics.py
+++ b/custom_components/lock_code_manager/diagnostics.py
@@ -9,7 +9,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .const import DOMAIN
-from .data import get_entry_config
+from .domain.queries import get_entry_config
 from .models import SlotCode, SlotCredential
 from .providers._base import BaseLock
 from .util import mask_pin

--- a/custom_components/lock_code_manager/domain/config.py
+++ b/custom_components/lock_code_manager/domain/config.py
@@ -1,4 +1,4 @@
-"""Config entry data helpers for lock_code_manager."""
+"""Config entry data types for lock_code_manager."""
 
 from __future__ import annotations
 
@@ -8,9 +8,8 @@ from types import MappingProxyType
 from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
 
-from .const import CONF_LOCKS, CONF_SLOTS, DOMAIN
+from ..const import CONF_LOCKS, CONF_SLOTS
 
 _EMPTY_SLOTS: Mapping[int, Mapping[str, Any]] = MappingProxyType({})
 
@@ -186,53 +185,6 @@ class EntryConfig:
             CONF_LOCKS: list(self.locks),
             CONF_SLOTS: {k: dict(v) for k, v in self.slots.items()},
         }
-
-
-def get_entry_config(entry: ConfigEntry) -> EntryConfig:
-    """
-    Return the EntryConfig view of ``entry``.
-
-    Prefers the cached instance on ``entry.runtime_data.config`` (set by
-    the listener during setup and on every update) and falls back to
-    constructing fresh from the raw entry data. The fallback covers
-    iteration over ``hass.config_entries.async_entries(DOMAIN)`` which
-    may yield entries that haven't been loaded yet (or are mid-teardown)
-    and so don't have ``runtime_data`` populated.
-    """
-    cached = getattr(getattr(entry, "runtime_data", None), "config", None)
-    if isinstance(cached, EntryConfig):
-        return cached
-    return EntryConfig.from_entry(entry)
-
-
-def get_managed_slots(hass: HomeAssistant, lock_entity_id: str) -> set[int]:
-    """Return the set of slot numbers managed by any LCM config entry for a lock."""
-    return {
-        slot_num
-        for entry in hass.config_entries.async_entries(DOMAIN)
-        if (config := get_entry_config(entry)).has_lock(lock_entity_id)
-        for slot_num in config.slots
-    }
-
-
-def find_entry_for_lock_slot(
-    hass: HomeAssistant, lock_entity_id: str, code_slot: int | str
-) -> ConfigEntry | None:
-    """
-    Find the config entry that manages a specific lock + slot combination.
-
-    Returns None if no entry manages this lock/slot. There can be at most one
-    due to the config entry uniqueness constraint.
-    """
-    return next(
-        (
-            entry
-            for entry in hass.config_entries.async_entries(DOMAIN)
-            if (config := get_entry_config(entry)).has_lock(lock_entity_id)
-            and config.has_slot(code_slot)
-        ),
-        None,
-    )
 
 
 @dataclass(frozen=True, slots=True)

--- a/custom_components/lock_code_manager/domain/queries.py
+++ b/custom_components/lock_code_manager/domain/queries.py
@@ -1,0 +1,56 @@
+"""Query helpers that read across LCM config entries."""
+
+from __future__ import annotations
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from ..const import DOMAIN
+from .config import EntryConfig
+
+
+def get_entry_config(entry: ConfigEntry) -> EntryConfig:
+    """
+    Return the EntryConfig view of ``entry``.
+
+    Prefers the cached instance on ``entry.runtime_data.config`` (set by
+    the listener during setup and on every update) and falls back to
+    constructing fresh from the raw entry data. The fallback covers
+    iteration over ``hass.config_entries.async_entries(DOMAIN)`` which
+    may yield entries that haven't been loaded yet (or are mid-teardown)
+    and so don't have ``runtime_data`` populated.
+    """
+    cached = getattr(getattr(entry, "runtime_data", None), "config", None)
+    if isinstance(cached, EntryConfig):
+        return cached
+    return EntryConfig.from_entry(entry)
+
+
+def get_managed_slots(hass: HomeAssistant, lock_entity_id: str) -> set[int]:
+    """Return the set of slot numbers managed by any LCM config entry for a lock."""
+    return {
+        slot_num
+        for entry in hass.config_entries.async_entries(DOMAIN)
+        if (config := get_entry_config(entry)).has_lock(lock_entity_id)
+        for slot_num in config.slots
+    }
+
+
+def find_entry_for_lock_slot(
+    hass: HomeAssistant, lock_entity_id: str, code_slot: int | str
+) -> ConfigEntry | None:
+    """
+    Find the config entry that manages a specific lock + slot combination.
+
+    Returns None if no entry manages this lock/slot. There can be at most one
+    due to the config entry uniqueness constraint.
+    """
+    return next(
+        (
+            entry
+            for entry in hass.config_entries.async_entries(DOMAIN)
+            if (config := get_entry_config(entry)).has_lock(lock_entity_id)
+            and config.has_slot(code_slot)
+        ),
+        None,
+    )

--- a/custom_components/lock_code_manager/entity.py
+++ b/custom_components/lock_code_manager/entity.py
@@ -25,7 +25,8 @@ from .const import (
     ATTR_TO,
     DOMAIN,
 )
-from .data import build_slot_unique_id, get_entry_config
+from .domain.config import build_slot_unique_id
+from .domain.queries import get_entry_config
 from .models import LockCodeManagerConfigEntry
 from .providers import BaseLock
 from .slot_manager import SlotEntityCoordinator

--- a/custom_components/lock_code_manager/helpers.py
+++ b/custom_components/lock_code_manager/helpers.py
@@ -23,7 +23,7 @@ from homeassistant.helpers import (
 )
 
 from .const import DOMAIN, EXCLUDED_CONDITION_PLATFORMS
-from .data import get_entry_config
+from .domain.queries import get_entry_config
 from .providers import INTEGRATIONS_CLASS_MAP, BaseLock
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/lock_code_manager/models.py
+++ b/custom_components/lock_code_manager/models.py
@@ -16,7 +16,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 
 from .callbacks import EntityCallbackRegistry
-from .data import EntryConfig
+from .domain.config import EntryConfig
 
 if TYPE_CHECKING:
     from .providers import BaseLock

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -39,7 +39,7 @@ from ..const import (
     EVENT_LOCK_STATE_CHANGED,
 )
 from ..coordinator import LockUsercodeUpdateCoordinator
-from ..data import build_slot_unique_id, find_entry_for_lock_slot, get_managed_slots
+from ..domain.config import build_slot_unique_id
 from ..domain.exceptions import (
     DuplicateCodeError,
     LockCodeManagerError,
@@ -47,6 +47,7 @@ from ..domain.exceptions import (
     LockOperationFailed,
     ProviderNotImplementedError,
 )
+from ..domain.queries import find_entry_for_lock_slot, get_managed_slots
 from ..models import SlotCredential
 from ..util import mask_pin
 from .const import LOGGER

--- a/custom_components/lock_code_manager/slot_manager.py
+++ b/custom_components/lock_code_manager/slot_manager.py
@@ -41,7 +41,8 @@ from homeassistant.helpers.issue_registry import (
 )
 
 from .const import ATTR_IN_SYNC, DOMAIN, EVENT_PIN_USED
-from .data import EntryConfig, get_entry_config
+from .domain.config import EntryConfig
+from .domain.queries import get_entry_config
 
 if TYPE_CHECKING:
     from .models import LockCodeManagerConfigEntry

--- a/custom_components/lock_code_manager/sync.py
+++ b/custom_components/lock_code_manager/sync.py
@@ -52,7 +52,7 @@ from .const import (
     SYNC_ATTEMPT_WINDOW,
     TICK_INTERVAL,
 )
-from .data import build_slot_unique_id
+from .domain.config import build_slot_unique_id
 from .domain.exceptions import CodeRejectedError, LockDisconnected, LockOperationFailed
 from .domain.resilience import CircuitBreaker
 from .models import SlotCredential, SyncState

--- a/custom_components/lock_code_manager/util.py
+++ b/custom_components/lock_code_manager/util.py
@@ -13,7 +13,7 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 
 from .const import DOMAIN
-from .data import build_slot_unique_id
+from .domain.config import build_slot_unique_id
 
 if TYPE_CHECKING:
     from .coordinator import LockUsercodeUpdateCoordinator

--- a/custom_components/lock_code_manager/websocket.py
+++ b/custom_components/lock_code_manager/websocket.py
@@ -95,7 +95,7 @@ from .const import (
     DOMAIN,
     EVENT_PIN_USED,
 )
-from .data import get_entry_config, get_managed_slots
+from .domain.queries import get_entry_config, get_managed_slots
 from .helpers import (
     async_clear_slot_condition,
     async_clear_usercode,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,11 +11,11 @@ from custom_components.lock_code_manager.const import (
     CONF_SLOTS,
     DOMAIN,
 )
-from custom_components.lock_code_manager.data import (
+from custom_components.lock_code_manager.domain.config import (
     EntryConfig,
     EntryConfigDiff,
-    get_entry_config,
 )
+from custom_components.lock_code_manager.domain.queries import get_entry_config
 
 
 def _slot(pin: str = "1234") -> dict:

--- a/tests/test_slot_manager.py
+++ b/tests/test_slot_manager.py
@@ -40,7 +40,7 @@ from custom_components.lock_code_manager.const import (
     CONF_SLOTS,
     DOMAIN,
 )
-from custom_components.lock_code_manager.data import get_entry_config
+from custom_components.lock_code_manager.domain.queries import get_entry_config
 from custom_components.lock_code_manager.slot_manager import (
     PinRequiredError,
     SlotEntityCoordinator,


### PR DESCRIPTION
## Proposed change

Step 2a of the `domain/` reorganization plan. The `data.py` file had two jobs: pure data types and query helpers that walk `hass.config_entries`. Split along that fault line:

| Before (in `data.py`) | After |
|---|---|
| `_EMPTY_SLOTS`, `EntryConfig`, `EntryConfigDiff`, `build_slot_unique_id` | `domain/config.py` |
| `get_entry_config`, `get_managed_slots`, `find_entry_for_lock_slot` | `domain/queries.py` |

`domain/config.py` is now HA-free at the import level (no `homeassistant.core` import) — it's just typed views of entry data. `domain/queries.py` is the accessor layer: `get_entry_config` reads the cached `EntryConfig` off `runtime_data` with a `from_entry()` fallback; the cross-entry queries walk `hass.config_entries`.

Importers that pulled multiple symbols across the new boundary now split into two import lines (one per new location). 7 of the 14 callers needed this; the rest were single-symbol and translate cleanly.

`tests/test_data.py` → `tests/test_config.py` to match the new home of the types it tests.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

Follow-up to #1195. Next step in the series:
- **Step 2b**: split `helpers.py` — query helpers join `domain/queries.py`, service handlers become `domain/services.py`
- **Step 3**: move `coordinator.py`, `sync.py`, rename `slot_manager.py` → `domain/slot_coordinator.py`
- **Step 4**: move `models.py`, `callbacks.py`, `util.py`

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Test plan

- [x] Full pytest suite (964 passed, baseline preserved)
- [x] prek (ruff, pydocstyle, mypy, flake8) all green
- [x] No string-based references to the old module path

🤖 Generated with [Claude Code](https://claude.ai/code)