### PR TITLE
refactor(layout): move domain logic into domain/

### DIFF
--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -93,9 +93,9 @@ from .domain.services import (
     async_set_slot_condition,
     async_set_usercode,
 )
+from .domain.slot_coordinator import SlotEntityCoordinator
 from .models import LockCodeManagerConfigEntry, LockCodeManagerConfigEntryRuntimeData
 from .providers import BaseLock
-from .slot_manager import SlotEntityCoordinator
 from .websocket import async_setup as async_websocket_setup
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/lock_code_manager/binary_sensor.py
+++ b/custom_components/lock_code_manager/binary_sensor.py
@@ -12,11 +12,11 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import ATTR_ACTIVE, ATTR_IN_SYNC, ATTR_SYNC_STATUS
-from .coordinator import LockUsercodeUpdateCoordinator
+from .domain.coordinator import LockUsercodeUpdateCoordinator
+from .domain.sync import SlotSyncManager
 from .entity import BaseLockCodeManagerCodeSlotPerLockEntity, BaseLockCodeManagerEntity
 from .models import LockCodeManagerConfigEntry
 from .providers import BaseLock
-from .sync import SlotSyncManager
 from .util import get_slot_coordinator
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/lock_code_manager/domain/coordinator.py
+++ b/custom_components/lock_code_manager/domain/coordinator.py
@@ -21,20 +21,20 @@ from homeassistant.helpers.issue_registry import (
 )
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import (
+from ..const import (
     BACKOFF_FAILURE_THRESHOLD,
     BACKOFF_INITIAL_SECONDS,
     BACKOFF_MAX_SECONDS,
     DOMAIN,
     POLL_FAILURE_ALERT_THRESHOLD,
 )
-from .domain.exceptions import LockCodeManagerError
-from .domain.queries import get_entry_config
-from .domain.resilience import CircuitBreaker
-from .models import SlotCredential
+from ..models import SlotCredential
+from .exceptions import LockCodeManagerError
+from .queries import get_entry_config
+from .resilience import CircuitBreaker
 
 if TYPE_CHECKING:
-    from .providers import BaseLock
+    from ..providers import BaseLock
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/lock_code_manager/domain/exceptions.py
+++ b/custom_components/lock_code_manager/domain/exceptions.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 from homeassistant.exceptions import HomeAssistantError
 
 if TYPE_CHECKING:
-    from .providers import BaseLock
+    from ..providers import BaseLock
 
 
 class LockCodeManagerError(HomeAssistantError):

--- a/custom_components/lock_code_manager/domain/slot_coordinator.py
+++ b/custom_components/lock_code_manager/domain/slot_coordinator.py
@@ -40,12 +40,12 @@ from homeassistant.helpers.issue_registry import (
     async_delete_issue,
 )
 
-from .const import ATTR_IN_SYNC, DOMAIN, EVENT_PIN_USED
-from .domain.config import EntryConfig
-from .domain.queries import get_entry_config
+from ..const import ATTR_IN_SYNC, DOMAIN, EVENT_PIN_USED
+from .config import EntryConfig
+from .queries import get_entry_config
 
 if TYPE_CHECKING:
-    from .models import LockCodeManagerConfigEntry
+    from ..models import LockCodeManagerConfigEntry
     from .sync import SlotSyncManager
 
 

--- a/custom_components/lock_code_manager/domain/sync.py
+++ b/custom_components/lock_code_manager/domain/sync.py
@@ -44,7 +44,7 @@ from homeassistant.helpers.issue_registry import (
     async_delete_issue,
 )
 
-from .const import (
+from ..const import (
     ATTR_ACTIVE,
     ATTR_CODE,
     DOMAIN,
@@ -52,16 +52,16 @@ from .const import (
     SYNC_ATTEMPT_WINDOW,
     TICK_INTERVAL,
 )
-from .domain.config import build_slot_unique_id
-from .domain.exceptions import CodeRejectedError, LockDisconnected, LockOperationFailed
-from .domain.resilience import CircuitBreaker
-from .models import SlotCredential, SyncState
-from .util import async_disable_slot
+from ..models import SlotCredential, SyncState
+from ..util import async_disable_slot
+from .config import build_slot_unique_id
+from .exceptions import CodeRejectedError, LockDisconnected, LockOperationFailed
+from .resilience import CircuitBreaker
 
 if TYPE_CHECKING:
+    from ..models import LockCodeManagerConfigEntry
+    from ..providers import BaseLock
     from .coordinator import LockUsercodeUpdateCoordinator
-    from .models import LockCodeManagerConfigEntry
-    from .providers import BaseLock
 
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/lock_code_manager/entity.py
+++ b/custom_components/lock_code_manager/entity.py
@@ -27,9 +27,9 @@ from .const import (
 )
 from .domain.config import build_slot_unique_id
 from .domain.queries import get_entry_config
+from .domain.slot_coordinator import SlotEntityCoordinator
 from .models import LockCodeManagerConfigEntry
 from .providers import BaseLock
-from .slot_manager import SlotEntityCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/lock_code_manager/models.py
+++ b/custom_components/lock_code_manager/models.py
@@ -19,9 +19,9 @@ from .callbacks import EntityCallbackRegistry
 from .domain.config import EntryConfig
 
 if TYPE_CHECKING:
+    from .domain.slot_coordinator import SlotEntityCoordinator
+    from .domain.sync import SlotSyncManager
     from .providers import BaseLock
-    from .slot_manager import SlotEntityCoordinator
-    from .sync import SlotSyncManager
 
 
 class SyncState(StrEnum):

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -38,8 +38,8 @@ from ..const import (
     DOMAIN,
     EVENT_LOCK_STATE_CHANGED,
 )
-from ..coordinator import LockUsercodeUpdateCoordinator
 from ..domain.config import build_slot_unique_id
+from ..domain.coordinator import LockUsercodeUpdateCoordinator
 from ..domain.exceptions import (
     DuplicateCodeError,
     LockCodeManagerError,

--- a/custom_components/lock_code_manager/sensor.py
+++ b/custom_components/lock_code_manager/sensor.py
@@ -10,7 +10,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import ATTR_CODE
-from .coordinator import LockUsercodeUpdateCoordinator
+from .domain.coordinator import LockUsercodeUpdateCoordinator
 from .entity import BaseLockCodeManagerCodeSlotPerLockEntity
 from .models import LockCodeManagerConfigEntry
 from .providers import BaseLock

--- a/custom_components/lock_code_manager/switch.py
+++ b/custom_components/lock_code_manager/switch.py
@@ -11,9 +11,9 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from .domain.slot_coordinator import PinRequiredError
 from .entity import BaseLockCodeManagerEntity
 from .models import LockCodeManagerConfigEntry
-from .slot_manager import PinRequiredError
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/lock_code_manager/util.py
+++ b/custom_components/lock_code_manager/util.py
@@ -16,7 +16,7 @@ from .const import DOMAIN
 from .domain.config import build_slot_unique_id
 
 if TYPE_CHECKING:
-    from .coordinator import LockUsercodeUpdateCoordinator
+    from .domain.coordinator import LockUsercodeUpdateCoordinator
     from .models import LockCodeManagerConfigEntry
     from .providers import BaseLock
 

--- a/tests/providers/test_base.py
+++ b/tests/providers/test_base.py
@@ -81,11 +81,11 @@ async def test_base(hass: HomeAssistant):
     # the abstract methods needed for a real refresh.
     with (
         patch(
-            "custom_components.lock_code_manager.coordinator."
+            "custom_components.lock_code_manager.domain.coordinator."
             "LockUsercodeUpdateCoordinator.async_config_entry_first_refresh"
         ),
         patch(
-            "custom_components.lock_code_manager.coordinator."
+            "custom_components.lock_code_manager.domain.coordinator."
             "LockUsercodeUpdateCoordinator.async_refresh"
         ),
     ):
@@ -650,7 +650,7 @@ async def test_setup_defers_push_subscription_when_entry_not_loaded(
     # Mock coordinator refreshes
     with (
         patch(
-            "custom_components.lock_code_manager.coordinator."
+            "custom_components.lock_code_manager.domain.coordinator."
             "LockUsercodeUpdateCoordinator.async_config_entry_first_refresh"
         ),
     ):
@@ -695,11 +695,11 @@ async def test_async_setup_internal_creates_coordinator_when_setup_fails(
             side_effect=LockDisconnected("provider unavailable"),
         ),
         patch(
-            "custom_components.lock_code_manager.coordinator."
+            "custom_components.lock_code_manager.domain.coordinator."
             "LockUsercodeUpdateCoordinator.async_config_entry_first_refresh"
         ),
         patch(
-            "custom_components.lock_code_manager.coordinator."
+            "custom_components.lock_code_manager.domain.coordinator."
             "LockUsercodeUpdateCoordinator.async_refresh"
         ),
     ):

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -42,7 +42,7 @@ from custom_components.lock_code_manager.const import (
     SYNC_ATTEMPT_WINDOW,
     TICK_INTERVAL,
 )
-from custom_components.lock_code_manager.coordinator import (
+from custom_components.lock_code_manager.domain.coordinator import (
     LockUsercodeUpdateCoordinator,
 )
 from custom_components.lock_code_manager.domain.exceptions import (

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -19,7 +19,7 @@ from custom_components.lock_code_manager.const import (
     DOMAIN,
     POLL_FAILURE_ALERT_THRESHOLD,
 )
-from custom_components.lock_code_manager.coordinator import (
+from custom_components.lock_code_manager.domain.coordinator import (
     LockUsercodeUpdateCoordinator,
 )
 from custom_components.lock_code_manager.domain.exceptions import LockDisconnected
@@ -262,11 +262,11 @@ async def test_subscribe_push_updates_called_during_setup(
     # Mock coordinator refreshes
     with (
         patch(
-            "custom_components.lock_code_manager.coordinator."
+            "custom_components.lock_code_manager.domain.coordinator."
             "LockUsercodeUpdateCoordinator.async_config_entry_first_refresh"
         ),
         patch(
-            "custom_components.lock_code_manager.coordinator."
+            "custom_components.lock_code_manager.domain.coordinator."
             "LockUsercodeUpdateCoordinator.async_refresh"
         ),
     ):
@@ -284,11 +284,11 @@ async def test_unsubscribe_push_updates_called_during_unload(
     # Setup first
     with (
         patch(
-            "custom_components.lock_code_manager.coordinator."
+            "custom_components.lock_code_manager.domain.coordinator."
             "LockUsercodeUpdateCoordinator.async_config_entry_first_refresh"
         ),
         patch(
-            "custom_components.lock_code_manager.coordinator."
+            "custom_components.lock_code_manager.domain.coordinator."
             "LockUsercodeUpdateCoordinator.async_refresh"
         ),
     ):
@@ -312,11 +312,11 @@ async def test_subscribe_push_not_called_for_non_push_lock(
     # Mock coordinator refreshes
     with (
         patch(
-            "custom_components.lock_code_manager.coordinator."
+            "custom_components.lock_code_manager.domain.coordinator."
             "LockUsercodeUpdateCoordinator.async_config_entry_first_refresh"
         ),
         patch(
-            "custom_components.lock_code_manager.coordinator."
+            "custom_components.lock_code_manager.domain.coordinator."
             "LockUsercodeUpdateCoordinator.async_refresh"
         ),
     ):

--- a/tests/test_slot_coordinator.py
+++ b/tests/test_slot_coordinator.py
@@ -41,7 +41,7 @@ from custom_components.lock_code_manager.const import (
     DOMAIN,
 )
 from custom_components.lock_code_manager.domain.queries import get_entry_config
-from custom_components.lock_code_manager.slot_manager import (
+from custom_components.lock_code_manager.domain.slot_coordinator import (
     PinRequiredError,
     SlotEntityCoordinator,
 )
@@ -632,7 +632,7 @@ async def test_active_toggle_enable_survives_repair_issue_delete_failure(
 
     boom = RuntimeError("issue registry boom")
     with patch(
-        "custom_components.lock_code_manager.slot_manager.async_delete_issue",
+        "custom_components.lock_code_manager.domain.slot_coordinator.async_delete_issue",
         side_effect=boom,
     ):
         with caplog.at_level(logging.ERROR):

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -26,8 +26,8 @@ from custom_components.lock_code_manager.domain.exceptions import (
     LockDisconnected,
     LockOperationFailed,
 )
+from custom_components.lock_code_manager.domain.sync import SlotState, SlotSyncManager
 from custom_components.lock_code_manager.models import SlotCredential, SyncState
-from custom_components.lock_code_manager.sync import SlotState, SlotSyncManager
 
 from .common import (
     LOCK_1_ENTITY_ID,
@@ -309,7 +309,7 @@ class TestDisableSlotExceptionHandling:
         assert manager._slot_breaker.failure_count == 5
 
         with patch(
-            "custom_components.lock_code_manager.sync.async_disable_slot",
+            "custom_components.lock_code_manager.domain.sync.async_disable_slot",
             new_callable=AsyncMock,
             side_effect=RuntimeError("service call failed"),
         ):
@@ -342,7 +342,7 @@ class TestDisableSlotExceptionHandling:
             manager._slot_breaker.record_failure()
 
         with patch(
-            "custom_components.lock_code_manager.sync.async_disable_slot",
+            "custom_components.lock_code_manager.domain.sync.async_disable_slot",
             new_callable=AsyncMock,
             return_value=True,
         ):


### PR DESCRIPTION
## Proposed change

Step 3 of the `domain/` reorganization plan. Moves the three modules that own LCM's runtime behavior into `domain/`:

| Before | After |
|---|---|
| `coordinator.py` | `domain/coordinator.py` |
| `sync.py` | `domain/sync.py` |
| `slot_manager.py` | `domain/slot_coordinator.py` (renamed) |

The rename of `slot_manager.py` → `slot_coordinator.py` matches the `SlotEntityCoordinator` class inside. The old name suggested CRUD slot management; the actual content is per-slot intent dispatch on behalf of the read-only entity views from #1191.

`tests/test_slot_manager.py` → `tests/test_slot_coordinator.py` to track the canonical name.

### Relative-import shifts within moved files

| Old (at root) | New (in domain/) |
|---|---|
| `from .const` | `from ..const` |
| `from .models` | `from ..models` |
| `from .util` | `from ..util` |
| `from .domain.X` | `from .X` (sibling) |
| `from .providers` (TYPE_CHECKING) | `from ..providers` |

### Drive-by fix

Also corrected a pre-existing latent bug in `domain/exceptions.py`: its `TYPE_CHECKING` `from .providers import BaseLock` was wrong relative-path-wise after Step 1's move (would have looked for `domain/providers/`) but never crashed because the import ran only under type-checking, not at runtime. Now correctly `..providers`.

### External impact

External importers and string-based test mocks (e.g. `custom_components.lock_code_manager.coordinator.X` → `custom_components.lock_code_manager.domain.coordinator.X`) updated to new paths.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

Follow-up to #1197. Remaining domain reorg step:
- **Step 4**: move `models.py`, `callbacks.py`, `util.py` to `domain/`; fix `models.py → callbacks.py` directional weirdness as a sibling import

After Step 4, the integration root will be HA-platform shims, `entity.py`, integration plumbing (`__init__.py`, `config_flow.py`, `websocket.py`, `diagnostics.py`, `repairs.py`), `const.py`, plus the `providers/` and `domain/` subpackages.

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Test plan

- [x] Full pytest suite (964 passed, baseline preserved)
- [x] prek (ruff, pydocstyle, mypy, flake8) all green
- [x] No residual references to old module paths (verified via grep on relative imports AND string mocks)

🤖 Generated with [Claude Code](https://claude.ai/code)