### PR TITLE
refactor(layout): move models/callbacks/util into domain/ (final step)

### DIFF
--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -80,6 +80,10 @@ from .const import (
 )
 from .domain.config import EntryConfig
 from .domain.locks import async_create_lock_instance, get_locks_from_targets
+from .domain.models import (
+    LockCodeManagerConfigEntry,
+    LockCodeManagerConfigEntryRuntimeData,
+)
 from .domain.pin_generator import (
     DEFAULT_PIN_LENGTH,
     MAX_PIN_LENGTH,
@@ -94,7 +98,6 @@ from .domain.services import (
     async_set_usercode,
 )
 from .domain.slot_coordinator import SlotEntityCoordinator
-from .models import LockCodeManagerConfigEntry, LockCodeManagerConfigEntryRuntimeData
 from .providers import BaseLock
 from .websocket import async_setup as async_websocket_setup
 

--- a/custom_components/lock_code_manager/binary_sensor.py
+++ b/custom_components/lock_code_manager/binary_sensor.py
@@ -13,11 +13,11 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import ATTR_ACTIVE, ATTR_IN_SYNC, ATTR_SYNC_STATUS
 from .domain.coordinator import LockUsercodeUpdateCoordinator
+from .domain.models import LockCodeManagerConfigEntry
 from .domain.sync import SlotSyncManager
+from .domain.util import get_slot_coordinator
 from .entity import BaseLockCodeManagerCodeSlotPerLockEntity, BaseLockCodeManagerEntity
-from .models import LockCodeManagerConfigEntry
 from .providers import BaseLock
-from .util import get_slot_coordinator
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -35,8 +35,8 @@ from .const import (
 )
 from .domain.config import EntryConfig
 from .domain.exceptions import LockCodeManagerError
+from .domain.models import SlotCredential
 from .domain.queries import get_entry_config
-from .models import SlotCredential
 from .providers import INTEGRATIONS_CLASS_MAP
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/lock_code_manager/diagnostics.py
+++ b/custom_components/lock_code_manager/diagnostics.py
@@ -9,10 +9,10 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .const import DOMAIN
+from .domain.models import SlotCode, SlotCredential
 from .domain.queries import get_entry_config
-from .models import SlotCode, SlotCredential
+from .domain.util import mask_pin
 from .providers._base import BaseLock
-from .util import mask_pin
 
 
 def _get_instance_id(hass: HomeAssistant) -> str:

--- a/custom_components/lock_code_manager/domain/callbacks.py
+++ b/custom_components/lock_code_manager/domain/callbacks.py
@@ -16,7 +16,7 @@ from homeassistant.core import callback
 from homeassistant.helpers import entity_registry as er
 
 if TYPE_CHECKING:
-    from .providers import BaseLock
+    from ..providers import BaseLock
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/lock_code_manager/domain/coordinator.py
+++ b/custom_components/lock_code_manager/domain/coordinator.py
@@ -28,8 +28,8 @@ from ..const import (
     DOMAIN,
     POLL_FAILURE_ALERT_THRESHOLD,
 )
-from ..models import SlotCredential
 from .exceptions import LockCodeManagerError
+from .models import SlotCredential
 from .queries import get_entry_config
 from .resilience import CircuitBreaker
 

--- a/custom_components/lock_code_manager/domain/models.py
+++ b/custom_components/lock_code_manager/domain/models.py
@@ -16,12 +16,12 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 
 from .callbacks import EntityCallbackRegistry
-from .domain.config import EntryConfig
+from .config import EntryConfig
 
 if TYPE_CHECKING:
-    from .domain.slot_coordinator import SlotEntityCoordinator
-    from .domain.sync import SlotSyncManager
-    from .providers import BaseLock
+    from ..providers import BaseLock
+    from .slot_coordinator import SlotEntityCoordinator
+    from .sync import SlotSyncManager
 
 
 class SyncState(StrEnum):

--- a/custom_components/lock_code_manager/domain/slot_coordinator.py
+++ b/custom_components/lock_code_manager/domain/slot_coordinator.py
@@ -45,7 +45,7 @@ from .config import EntryConfig
 from .queries import get_entry_config
 
 if TYPE_CHECKING:
-    from ..models import LockCodeManagerConfigEntry
+    from .models import LockCodeManagerConfigEntry
     from .sync import SlotSyncManager
 
 

--- a/custom_components/lock_code_manager/domain/sync.py
+++ b/custom_components/lock_code_manager/domain/sync.py
@@ -52,16 +52,16 @@ from ..const import (
     SYNC_ATTEMPT_WINDOW,
     TICK_INTERVAL,
 )
-from ..models import SlotCredential, SyncState
-from ..util import async_disable_slot
 from .config import build_slot_unique_id
 from .exceptions import CodeRejectedError, LockDisconnected, LockOperationFailed
+from .models import SlotCredential, SyncState
 from .resilience import CircuitBreaker
+from .util import async_disable_slot
 
 if TYPE_CHECKING:
-    from ..models import LockCodeManagerConfigEntry
     from ..providers import BaseLock
     from .coordinator import LockUsercodeUpdateCoordinator
+    from .models import LockCodeManagerConfigEntry
 
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/lock_code_manager/domain/util.py
+++ b/custom_components/lock_code_manager/domain/util.py
@@ -12,13 +12,13 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 
-from .const import DOMAIN
-from .domain.config import build_slot_unique_id
+from ..const import DOMAIN
+from .config import build_slot_unique_id
 
 if TYPE_CHECKING:
-    from .domain.coordinator import LockUsercodeUpdateCoordinator
+    from ..providers import BaseLock
+    from .coordinator import LockUsercodeUpdateCoordinator
     from .models import LockCodeManagerConfigEntry
-    from .providers import BaseLock
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/lock_code_manager/entity.py
+++ b/custom_components/lock_code_manager/entity.py
@@ -26,9 +26,9 @@ from .const import (
     DOMAIN,
 )
 from .domain.config import build_slot_unique_id
+from .domain.models import LockCodeManagerConfigEntry
 from .domain.queries import get_entry_config
 from .domain.slot_coordinator import SlotEntityCoordinator
-from .models import LockCodeManagerConfigEntry
 from .providers import BaseLock
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/lock_code_manager/event.py
+++ b/custom_components/lock_code_manager/event.py
@@ -12,8 +12,8 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import EVENT_LOCK_STATE_CHANGED, EVENT_PIN_USED
+from .domain.models import LockCodeManagerConfigEntry
 from .entity import BaseLockCodeManagerEntity
-from .models import LockCodeManagerConfigEntry
 from .providers import BaseLock
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -47,9 +47,9 @@ from ..domain.exceptions import (
     LockOperationFailed,
     ProviderNotImplementedError,
 )
+from ..domain.models import SlotCredential
 from ..domain.queries import find_entry_for_lock_slot, get_managed_slots
-from ..models import SlotCredential
-from ..util import mask_pin
+from ..domain.util import mask_pin
 from .const import LOGGER
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/lock_code_manager/providers/akuvox.py
+++ b/custom_components/lock_code_manager/providers/akuvox.py
@@ -25,7 +25,7 @@ from ..domain.exceptions import (
     LockDisconnected,
     LockOperationFailed,
 )
-from ..models import SlotCredential
+from ..domain.models import SlotCredential
 from ._base import BaseLock
 from ._util import make_tagged_name as _make_tagged_name, parse_tag as _parse_tag
 from .const import LOGGER

--- a/custom_components/lock_code_manager/providers/matter.py
+++ b/custom_components/lock_code_manager/providers/matter.py
@@ -39,7 +39,7 @@ from ..domain.exceptions import (
     LockCodeManagerProviderError,
     LockDisconnected,
 )
-from ..models import SlotCredential
+from ..domain.models import SlotCredential
 from ._base import BaseLock
 from ._util import parse_slot_num
 from .const import LOGGER

--- a/custom_components/lock_code_manager/providers/schlage.py
+++ b/custom_components/lock_code_manager/providers/schlage.py
@@ -31,7 +31,7 @@ from ..domain.exceptions import (
     LockDisconnected,
     LockOperationFailed,
 )
-from ..models import SlotCredential
+from ..domain.models import SlotCredential
 from ._base import BaseLock
 from ._util import make_tagged_name as _make_tagged_name, parse_tag as _parse_tag
 from .const import LOGGER

--- a/custom_components/lock_code_manager/providers/virtual.py
+++ b/custom_components/lock_code_manager/providers/virtual.py
@@ -10,7 +10,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.storage import Store
 
 from ..const import DOMAIN
-from ..models import SlotCredential
+from ..domain.models import SlotCredential
 from ._base import BaseLock
 from ._util import parse_slot_num
 

--- a/custom_components/lock_code_manager/providers/zha.py
+++ b/custom_components/lock_code_manager/providers/zha.py
@@ -25,7 +25,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import callback
 
 from ..domain.exceptions import CodeRejectedError, LockDisconnected
-from ..models import SlotCredential
+from ..domain.models import SlotCredential
 from ._base import BaseLock
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/lock_code_manager/providers/zigbee2mqtt.py
+++ b/custom_components/lock_code_manager/providers/zigbee2mqtt.py
@@ -20,7 +20,7 @@ from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
 
 from ..domain.exceptions import LockDisconnected, LockOperationFailed
-from ..models import SlotCredential
+from ..domain.models import SlotCredential
 from ._base import BaseLock
 from ._util import parse_slot_num
 from .const import LOGGER

--- a/custom_components/lock_code_manager/providers/zwave_js.py
+++ b/custom_components/lock_code_manager/providers/zwave_js.py
@@ -55,7 +55,7 @@ from homeassistant.const import ATTR_DEVICE_ID, ATTR_ENTITY_ID
 from homeassistant.core import Event, callback
 
 from ..domain.exceptions import LockDisconnected
-from ..models import SlotCredential
+from ..domain.models import SlotCredential
 from ._base import BaseLock
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/lock_code_manager/sensor.py
+++ b/custom_components/lock_code_manager/sensor.py
@@ -11,10 +11,10 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import ATTR_CODE
 from .domain.coordinator import LockUsercodeUpdateCoordinator
+from .domain.models import LockCodeManagerConfigEntry
+from .domain.util import get_slot_coordinator
 from .entity import BaseLockCodeManagerCodeSlotPerLockEntity
-from .models import LockCodeManagerConfigEntry
 from .providers import BaseLock
-from .util import get_slot_coordinator
 
 
 async def async_setup_entry(

--- a/custom_components/lock_code_manager/switch.py
+++ b/custom_components/lock_code_manager/switch.py
@@ -11,9 +11,9 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from .domain.models import LockCodeManagerConfigEntry
 from .domain.slot_coordinator import PinRequiredError
 from .entity import BaseLockCodeManagerEntity
-from .models import LockCodeManagerConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/lock_code_manager/text.py
+++ b/custom_components/lock_code_manager/text.py
@@ -10,8 +10,8 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from .domain.models import LockCodeManagerConfigEntry
 from .entity import BaseLockCodeManagerEntity
-from .models import LockCodeManagerConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/lock_code_manager/websocket.py
+++ b/custom_components/lock_code_manager/websocket.py
@@ -96,6 +96,7 @@ from .const import (
     EVENT_PIN_USED,
 )
 from .domain.locks import get_managed_locks
+from .domain.models import SlotCode, SlotCredential
 from .domain.queries import get_entry_config, get_managed_slots
 from .domain.services import (
     async_clear_slot_condition,
@@ -103,7 +104,6 @@ from .domain.services import (
     async_set_slot_condition,
     async_set_usercode,
 )
-from .models import SlotCode, SlotCredential
 from .providers import BaseLock
 
 _LOGGER = logging.getLogger(__name__)

--- a/tests/common.py
+++ b/tests/common.py
@@ -19,7 +19,7 @@ from custom_components.lock_code_manager.const import (
     CONF_SLOTS,
     DOMAIN,
 )
-from custom_components.lock_code_manager.models import SlotCredential
+from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers import BaseLock
 
 LOCK_1_ENTITY_ID = "lock.test_1"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,7 +26,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.setup import async_setup_component
 
 from custom_components.lock_code_manager.const import DOMAIN
-from custom_components.lock_code_manager.models import SyncState
+from custom_components.lock_code_manager.domain.models import SyncState
 from custom_components.lock_code_manager.providers import INTEGRATIONS_CLASS_MAP
 from custom_components.lock_code_manager.providers._base import BaseLock
 

--- a/tests/providers/akuvox/test_e2e.py
+++ b/tests/providers/akuvox/test_e2e.py
@@ -9,7 +9,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from custom_components.lock_code_manager.models import SlotCredential
+from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers.akuvox import (
     AKUVOX_DOMAIN,
     AkuvoxLock,

--- a/tests/providers/akuvox/test_provider.py
+++ b/tests/providers/akuvox/test_provider.py
@@ -18,7 +18,7 @@ from custom_components.lock_code_manager.domain.exceptions import (
     LockDisconnected,
     LockOperationFailed,
 )
-from custom_components.lock_code_manager.models import SlotCredential
+from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers.akuvox import (
     AKUVOX_DOMAIN,
     AkuvoxLock,

--- a/tests/providers/matter/test_e2e.py
+++ b/tests/providers/matter/test_e2e.py
@@ -9,7 +9,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from custom_components.lock_code_manager.models import SlotCredential
+from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers.matter import MatterLock
 
 # Module path where lock_helpers functions are imported in the provider

--- a/tests/providers/matter/test_provider.py
+++ b/tests/providers/matter/test_provider.py
@@ -20,7 +20,7 @@ from custom_components.lock_code_manager.domain.exceptions import (
     LockCodeManagerProviderError,
     LockDisconnected,
 )
-from custom_components.lock_code_manager.models import SlotCredential
+from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers.matter import (
     MatterLock,
     SetCredentialFailedError,

--- a/tests/providers/schlage/test_e2e.py
+++ b/tests/providers/schlage/test_e2e.py
@@ -9,7 +9,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from custom_components.lock_code_manager.models import SlotCredential
+from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers.schlage import (
     SCHLAGE_DOMAIN,
     SchlageLock,

--- a/tests/providers/schlage/test_provider.py
+++ b/tests/providers/schlage/test_provider.py
@@ -17,7 +17,7 @@ from custom_components.lock_code_manager.domain.exceptions import (
     LockDisconnected,
     LockOperationFailed,
 )
-from custom_components.lock_code_manager.models import SlotCredential
+from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers.schlage import (
     SCHLAGE_DOMAIN,
     SchlageLock,

--- a/tests/providers/test_base.py
+++ b/tests/providers/test_base.py
@@ -26,7 +26,7 @@ from custom_components.lock_code_manager.domain.exceptions import (
     LockOperationFailed,
     ProviderNotImplementedError,
 )
-from custom_components.lock_code_manager.models import SlotCredential
+from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers._base import BaseLock
 from tests.common import BASE_CONFIG, LOCK_1_ENTITY_ID, MockLCMLock
 

--- a/tests/providers/virtual/test_e2e.py
+++ b/tests/providers/virtual/test_e2e.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from homeassistant.core import HomeAssistant
 
-from custom_components.lock_code_manager.models import SlotCredential
+from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers.virtual import VirtualLock
 
 from .conftest import VIRTUAL_LOCK_ENTITY_ID

--- a/tests/providers/virtual/test_provider.py
+++ b/tests/providers/virtual/test_provider.py
@@ -1,6 +1,6 @@
 """Test the Virtual lock platform."""
 
-from custom_components.lock_code_manager.models import SlotCredential
+from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers.virtual import VirtualLock
 
 

--- a/tests/providers/zha/test_provider.py
+++ b/tests/providers/zha/test_provider.py
@@ -16,7 +16,7 @@ from custom_components.lock_code_manager.domain.exceptions import (
     CodeRejectedError,
     LockDisconnected,
 )
-from custom_components.lock_code_manager.models import SlotCredential
+from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers.zha import (
     ZHALock,
 )

--- a/tests/providers/zigbee2mqtt/test_e2e.py
+++ b/tests/providers/zigbee2mqtt/test_e2e.py
@@ -8,7 +8,7 @@ import pytest
 
 from homeassistant.core import HomeAssistant
 
-from custom_components.lock_code_manager.models import SlotCredential
+from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers.zigbee2mqtt import (
     Zigbee2MQTTLock,
 )

--- a/tests/providers/zigbee2mqtt/test_payload.py
+++ b/tests/providers/zigbee2mqtt/test_payload.py
@@ -10,7 +10,7 @@ import pytest
 
 from homeassistant.core import HomeAssistant
 
-from custom_components.lock_code_manager.models import SlotCredential
+from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers.zigbee2mqtt import (
     Zigbee2MQTTLock,
     _mqtt_payload_pin_has_code_value,

--- a/tests/providers/zigbee2mqtt/test_provider.py
+++ b/tests/providers/zigbee2mqtt/test_provider.py
@@ -17,7 +17,7 @@ from custom_components.lock_code_manager.domain.exceptions import (
     LockDisconnected,
     LockOperationFailed,
 )
-from custom_components.lock_code_manager.models import SlotCredential
+from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers.zigbee2mqtt import (
     Zigbee2MQTTLock,
 )

--- a/tests/providers/zwave_js/test_e2e.py
+++ b/tests/providers/zwave_js/test_e2e.py
@@ -16,7 +16,7 @@ from custom_components.lock_code_manager.const import (
     ATTR_CODE_SLOT,
     EVENT_LOCK_STATE_CHANGED,
 )
-from custom_components.lock_code_manager.models import SlotCredential
+from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers.zwave_js import ZWaveJSLock
 
 

--- a/tests/providers/zwave_js/test_events.py
+++ b/tests/providers/zwave_js/test_events.py
@@ -32,7 +32,7 @@ from custom_components.lock_code_manager.const import (
     EVENT_LOCK_STATE_CHANGED,
 )
 from custom_components.lock_code_manager.domain.exceptions import DuplicateCodeError
-from custom_components.lock_code_manager.models import (
+from custom_components.lock_code_manager.domain.models import (
     LockCodeManagerConfigEntryRuntimeData,
     SlotCredential,
 )

--- a/tests/providers/zwave_js/test_provider.py
+++ b/tests/providers/zwave_js/test_provider.py
@@ -21,7 +21,7 @@ from custom_components.lock_code_manager.const import (
     DOMAIN,
 )
 from custom_components.lock_code_manager.domain.exceptions import LockDisconnected
-from custom_components.lock_code_manager.models import SlotCredential
+from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers.zwave_js import ZWaveJSLock
 
 

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -49,7 +49,7 @@ from custom_components.lock_code_manager.domain.exceptions import (
     DuplicateCodeError,
     LockCodeManagerError,
 )
-from custom_components.lock_code_manager.models import SlotCredential, SyncState
+from custom_components.lock_code_manager.domain.models import SlotCredential, SyncState
 
 from .common import (
     BASE_CONFIG,

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from custom_components.lock_code_manager.callbacks import EntityCallbackRegistry
+from custom_components.lock_code_manager.domain.callbacks import EntityCallbackRegistry
 
 
 @pytest.fixture

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -25,7 +25,7 @@ from custom_components.lock_code_manager.domain.exceptions import (
     LockCodeManagerError,
     LockDisconnected,
 )
-from custom_components.lock_code_manager.models import SlotCredential
+from custom_components.lock_code_manager.domain.models import SlotCredential
 
 from .common import BASE_CONFIG, LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -23,7 +23,7 @@ from custom_components.lock_code_manager.domain.coordinator import (
     LockUsercodeUpdateCoordinator,
 )
 from custom_components.lock_code_manager.domain.exceptions import LockDisconnected
-from custom_components.lock_code_manager.models import SlotCredential
+from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers.virtual import VirtualLock
 
 from .common import MockLCMLock, MockLCMPushLock

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -42,7 +42,7 @@ from custom_components.lock_code_manager.const import (
     SERVICE_HARD_REFRESH_USERCODES,
     STRATEGY_PATH,
 )
-from custom_components.lock_code_manager.models import SlotCredential, SyncState
+from custom_components.lock_code_manager.domain.models import SlotCredential, SyncState
 from custom_components.lock_code_manager.repairs import (
     AcknowledgeRepairFlow,
     async_create_fix_flow,

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -4,7 +4,7 @@ import logging
 
 from homeassistant.core import HomeAssistant
 
-from custom_components.lock_code_manager.models import SlotCredential
+from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers import BaseLock
 
 from .common import LOCK_1_ENTITY_ID

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -26,8 +26,8 @@ from custom_components.lock_code_manager.domain.exceptions import (
     LockDisconnected,
     LockOperationFailed,
 )
+from custom_components.lock_code_manager.domain.models import SlotCredential, SyncState
 from custom_components.lock_code_manager.domain.sync import SlotState, SlotSyncManager
-from custom_components.lock_code_manager.models import SlotCredential, SyncState
 
 from .common import (
     LOCK_1_ENTITY_ID,

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -9,7 +9,7 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.issue_registry import async_get as async_get_issue_registry
 
 from custom_components.lock_code_manager.const import DOMAIN
-from custom_components.lock_code_manager.util import (
+from custom_components.lock_code_manager.domain.util import (
     async_disable_slot,
     mask_pin,
 )

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -65,7 +65,7 @@ from custom_components.lock_code_manager.const import (
     CONF_SLOTS,
 )
 from custom_components.lock_code_manager.domain.exceptions import DuplicateCodeError
-from custom_components.lock_code_manager.models import SlotCredential
+from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers import BaseLock
 from custom_components.lock_code_manager.websocket import (
     SlotEntities,


### PR DESCRIPTION
## Proposed change

Step 4 of the `domain/` reorganization plan — the final move. Relocates the last three LCM-internal modules into the `domain/` subpackage:

| Before | After |
|---|---|
| `models.py` | `domain/models.py` |
| `callbacks.py` | `domain/callbacks.py` |
| `util.py` | `domain/util.py` |

### Fixes the directional weirdness

`models.py` previously imported `callbacks.py` at the root level — a value type pulling on entity-lifecycle infrastructure (the auditor's note). Now they're siblings in `domain/` and the import resolves locally.

### After this PR — final integration root

```
custom_components/lock_code_manager/
├── HA platform discovery shims (can't move per HA loader contract):
│   binary_sensor.py, event.py, sensor.py, switch.py, text.py
├── HA-layer entity bases:
│   entity.py
├── Integration plumbing:
│   __init__.py, config_flow.py, diagnostics.py, repairs.py, websocket.py
├── const.py
├── providers/  (unchanged)
└── domain/     (everything LCM-internal)
```

The boundary between "things HA discovers/calls" and "things LCM owns" is now visible from the filesystem.

### Mechanical changes

- 30+ external importers updated (every provider, every entity, root files, tests)
- String-based test mocks (`custom_components.lock_code_manager.models.X` etc.) retargeted to new paths
- Existing `domain/*.py` files that referenced `..models` / `..util` flipped to sibling `.models` / `.util` imports

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

Final step in the domain/ reorganization series: #1195 → #1196 → #1197 → #1198 → (this PR).

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Test plan

- [x] Full pytest suite (964 passed, baseline preserved across all 5 PRs in the series)
- [x] prek (ruff, pydocstyle, mypy, flake8) all green
- [x] No residual references to old module paths
- [x] Integration root now contains only HA-mandated modules

🤖 Generated with [Claude Code](https://claude.ai/code)