### PR TITLE
refactor: remove four vestigial single-caller helpers

### DIFF
--- a/custom_components/lock_code_manager/binary_sensor.py
+++ b/custom_components/lock_code_manager/binary_sensor.py
@@ -15,7 +15,6 @@ from .const import ATTR_ACTIVE, ATTR_IN_SYNC, ATTR_SYNC_STATUS
 from .domain.coordinator import LockUsercodeUpdateCoordinator
 from .domain.models import LockCodeManagerConfigEntry
 from .domain.sync import SlotSyncManager
-from .domain.util import get_slot_coordinator
 from .entity import BaseLockCodeManagerCodeSlotPerLockEntity, BaseLockCodeManagerEntity
 from .providers import BaseLock
 
@@ -46,7 +45,7 @@ async def async_setup_entry(
         lock: BaseLock, slot_num: int, ent_reg: er.EntityRegistry
     ):
         """Add code slot sensor entities for slot."""
-        coordinator = get_slot_coordinator(config_entry, lock, slot_num)
+        coordinator = lock.coordinator
         if coordinator is None:
             return
         async_add_entities(

--- a/custom_components/lock_code_manager/domain/queries.py
+++ b/custom_components/lock_code_manager/domain/queries.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator, Mapping
-from typing import Any
+from collections.abc import Iterator
 
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.core import HomeAssistant
@@ -76,14 +75,6 @@ def iter_loaded_lcm_entries(hass: HomeAssistant) -> Iterator[ConfigEntry]:
         )
         if entry.state is ConfigEntryState.LOADED
     )
-
-
-def get_slot_config(config_entry: ConfigEntry, slot_num: int) -> Mapping[str, Any]:
-    """Get slot config, raising if not found."""
-    config = get_entry_config(config_entry)
-    if not config.has_slot(slot_num):
-        raise ServiceValidationError(f"Slot {slot_num} not found in config entry")
-    return config.slot(slot_num)
 
 
 def get_loaded_config_entry(hass: HomeAssistant, config_entry_id: str) -> ConfigEntry:

--- a/custom_components/lock_code_manager/domain/resilience.py
+++ b/custom_components/lock_code_manager/domain/resilience.py
@@ -56,10 +56,6 @@ class CircuitBreaker:
             self._first_failure = now
         self._failure_count += 1
 
-    def record_success(self) -> None:
-        """Record a success, clearing all failure state."""
-        self.reset()
-
     def reset(self) -> None:
         """Clear all failure state."""
         self._failure_count = 0

--- a/custom_components/lock_code_manager/domain/services.py
+++ b/custom_components/lock_code_manager/domain/services.py
@@ -9,7 +9,7 @@ from homeassistant.helpers import entity_registry as er
 
 from ..const import EXCLUDED_CONDITION_PLATFORMS
 from .locks import get_managed_lock
-from .queries import get_entry_config, get_loaded_config_entry, get_slot_config
+from .queries import get_entry_config, get_loaded_config_entry
 
 
 async def async_set_usercode(
@@ -38,7 +38,9 @@ async def async_set_slot_condition(
 ) -> None:
     """Set a condition entity for a slot."""
     config_entry = get_loaded_config_entry(hass, config_entry_id)
-    get_slot_config(config_entry, slot)
+    config = get_entry_config(config_entry)
+    if not config.has_slot(slot):
+        raise ServiceValidationError(f"Slot {slot} not found in config entry")
 
     # Verify entity exists
     if not hass.states.get(entity_id):
@@ -55,9 +57,7 @@ async def async_set_slot_condition(
             "Unsupported-Condition-Entity-Integrations"
         )
 
-    new_config = get_entry_config(config_entry).with_slot_field_set(
-        slot, CONF_ENTITY_ID, entity_id
-    )
+    new_config = config.with_slot_field_set(slot, CONF_ENTITY_ID, entity_id)
     hass.config_entries.async_update_entry(config_entry, options=new_config.to_dict())
 
 
@@ -66,9 +66,9 @@ async def async_clear_slot_condition(
 ) -> None:
     """Clear the condition entity from a slot."""
     config_entry = get_loaded_config_entry(hass, config_entry_id)
-    get_slot_config(config_entry, slot)
+    config = get_entry_config(config_entry)
+    if not config.has_slot(slot):
+        raise ServiceValidationError(f"Slot {slot} not found in config entry")
 
-    new_config = get_entry_config(config_entry).with_slot_field_removed(
-        slot, CONF_ENTITY_ID
-    )
+    new_config = config.with_slot_field_removed(slot, CONF_ENTITY_ID)
     hass.config_entries.async_update_entry(config_entry, options=new_config.to_dict())

--- a/custom_components/lock_code_manager/domain/util.py
+++ b/custom_components/lock_code_manager/domain/util.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
 import zlib
 
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN, SERVICE_TURN_OFF
@@ -15,35 +14,7 @@ from homeassistant.helpers.issue_registry import IssueSeverity, async_create_iss
 from ..const import DOMAIN
 from .config import build_slot_unique_id
 
-if TYPE_CHECKING:
-    from ..providers import BaseLock
-    from .coordinator import LockUsercodeUpdateCoordinator
-    from .models import LockCodeManagerConfigEntry
-
 _LOGGER = logging.getLogger(__name__)
-
-
-def get_slot_coordinator(
-    config_entry: LockCodeManagerConfigEntry,
-    lock: BaseLock,
-    slot_num: int,
-) -> LockUsercodeUpdateCoordinator | None:
-    """
-    Return the lock's coordinator, or None if it is not yet available.
-
-    When the coordinator is missing a warning is logged so the slot
-    entities are simply skipped rather than raising during setup.
-    """
-    coordinator = lock.coordinator
-    if coordinator is None:
-        _LOGGER.warning(
-            "%s (%s): Coordinator missing for lock %s when adding slot %s entities",
-            config_entry.entry_id,
-            config_entry.title,
-            lock.lock.entity_id,
-            slot_num,
-        )
-    return coordinator
 
 
 def mask_pin(

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -347,15 +347,6 @@ class BaseLock:
             self.hass.data.get(DOMAIN, {}).get("instance_id", ""),
         )
 
-    @staticmethod
-    def is_masked_or_empty(code: str | SlotCredential | None) -> bool:
-        """Return whether a code is masked or empty (not comparable)."""
-        if code is None:
-            return True
-        if isinstance(code, SlotCredential):
-            return not code.is_readable
-        return code == "*" * len(code)
-
     @final
     @callback
     def _push_credential_update(

--- a/custom_components/lock_code_manager/providers/schlage.py
+++ b/custom_components/lock_code_manager/providers/schlage.py
@@ -201,7 +201,8 @@ class SchlageLock(BaseLock):
                 )
                 continue
 
-            if self.is_masked_or_empty(pin):
+            # Empty or all-asterisk (masked) PINs are untaggable.
+            if pin == "*" * len(pin):
                 LOGGER.debug(
                     "Lock %s: skipping untaggable code '%s' (PIN is masked or empty)",
                     self.lock.entity_id,

--- a/custom_components/lock_code_manager/sensor.py
+++ b/custom_components/lock_code_manager/sensor.py
@@ -12,7 +12,6 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import ATTR_CODE
 from .domain.coordinator import LockUsercodeUpdateCoordinator
 from .domain.models import LockCodeManagerConfigEntry
-from .domain.util import get_slot_coordinator
 from .entity import BaseLockCodeManagerCodeSlotPerLockEntity
 from .providers import BaseLock
 
@@ -29,7 +28,7 @@ async def async_setup_entry(
         lock: BaseLock, slot_num: int, ent_reg: er.EntityRegistry
     ) -> None:
         """Add code slot sensor entities for slot."""
-        coordinator = get_slot_coordinator(config_entry, lock, slot_num)
+        coordinator = lock.coordinator
         if coordinator is None:
             return
         async_add_entities(

--- a/tests/providers/test_base.py
+++ b/tests/providers/test_base.py
@@ -925,30 +925,6 @@ async def test_execute_rate_limited_raises_when_device_not_available(
 
 
 # =============================================================================
-# is_masked_or_empty tests
-# =============================================================================
-
-
-@pytest.mark.parametrize(
-    ("code", "expected"),
-    [
-        (None, True),
-        ("", True),
-        ("****", True),
-        ("*", True),
-        (SlotCredential.empty(), True),
-        (SlotCredential.unreadable(), True),
-        ("1234", False),
-        ("12*4", False),
-        ("0", False),
-    ],
-)
-def test_is_masked_or_empty(code, expected: bool):
-    """Test BaseLock.is_masked_or_empty for various inputs."""
-    assert BaseLock.is_masked_or_empty(code) is expected
-
-
-# =============================================================================
 # _check_duplicate_code tests
 # =============================================================================
 

--- a/tests/test_resilience.py
+++ b/tests/test_resilience.py
@@ -53,12 +53,6 @@ class TestConsecutiveBackoffPolicy:
         assert not breaker.tripped
         assert breaker.backoff_delay == timedelta(0)
 
-    def test_record_success_is_reset(self) -> None:
-        breaker = self._breaker()
-        breaker.record_failure()
-        breaker.record_success()
-        assert breaker.failure_count == 0
-
 
 class TestWindowedTripPolicy:
     """Slot-level config: threshold within a sliding window, no backoff."""


### PR DESCRIPTION
## Proposed change

Second-pass over-abstraction audit findings from after the `domain/` reorganization series (#1195-#1199). Four helpers had no real abstraction value; all four are removed.

### 1. `CircuitBreaker.record_success` — dead-equivalent API

`domain/resilience.py`. Aliased `reset()` with **zero production callers**. The only consumer was its own test (`test_record_success_is_reset`) — which existed solely to verify the alias delegated to `reset()`. Removed the method and the test.

### 2. `BaseLock.is_masked_or_empty` — vestigial type-union staticmethod

`providers/_base.py`. Accepted a `str | SlotCredential | None` union from before the `SlotCredential` migration. One production caller (`schlage.py:204`) only ever passes a raw `str` from the Schlage API response. Inlined as `pin == "*" * len(pin)` (matches both empty string and all-asterisk masked codes — equivalent to the original method's str-branch). Removed the method and its parametrized test.

### 3. `get_slot_coordinator` — thin guard with redundant warning

`domain/util.py`. Wrapped `lock.coordinator` with a None-guard and warning log. Two callers (`sensor.py`, `binary_sensor.py`) followed identical patterns. The warning is defensive and essentially unreachable now that `async_setup_internal` guarantees coordinator creation before entity platform setup. Inlined as a direct `lock.coordinator` read with the same None-skip guard; dropped the warning rather than add a `logging` import to `sensor.py` just to preserve it. *(This was flagged in the first audit too but deferred at the time.)*

### 4. `get_slot_config` — return value discarded by both callers

`domain/queries.py`. Two callers in `services.py`, both **discarded the return value** — the function only existed for its `ServiceValidationError` side-effect. Each caller already needed a `get_entry_config` call afterward, so the helper caused a redundant `get_entry_config` walk per service invocation. Folded the `has_slot` check into the caller's existing `get_entry_config` call (one walk now instead of two), then removed the function.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

Net -82 lines across the integration; minus 10 tests (the `record_success` and parametrized `is_masked_or_empty` test cases — they tested helpers that no longer exist).

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Test plan

- [x] Full pytest suite (954 passed = baseline 964 − 10 deleted tests for removed helpers)
- [x] prek (ruff, pydocstyle, mypy, flake8) all green
- [x] Behavior preservation: `schlage.py` inline matches original method's str-branch semantics for both empty and all-asterisk codes; `services.py` validation logic is identical, just with one fewer `get_entry_config` call

🤖 Generated with [Claude Code](https://claude.ai/code)