### PR TITLE
perf: parallelize per-lock setup in _async_setup_new_locks

### DIFF
--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -773,8 +773,8 @@ async def _async_setup_new_locks(
         entry_title,
         locks_to_add,
     )
-    added_locks: list[BaseLock] = []
-    for lock_entity_id in locks_to_add:
+
+    async def _setup_one_lock(lock_entity_id: str) -> BaseLock:
         existing_lock = _find_shared_lock_instance(hass, config_entry, lock_entity_id)
         if existing_lock is not None:
             _LOGGER.debug(
@@ -783,34 +783,59 @@ async def _async_setup_new_locks(
                 entry_title,
                 existing_lock,
             )
-            lock = runtime_data.locks[lock_entity_id] = existing_lock
-            await lock.async_wait_for_setup()
-        else:
-            lock = runtime_data.locks[lock_entity_id] = async_create_lock_instance(
-                hass,
-                dr.async_get(hass),
-                ent_reg,
-                config_entry,
-                lock_entity_id,
-            )
-            _LOGGER.debug(
-                "%s (%s): Creating lock instance for lock %s",
+            runtime_data.locks[lock_entity_id] = existing_lock
+            await existing_lock.async_wait_for_setup()
+            return existing_lock
+
+        lock = runtime_data.locks[lock_entity_id] = async_create_lock_instance(
+            hass,
+            dr.async_get(hass),
+            ent_reg,
+            config_entry,
+            lock_entity_id,
+        )
+        _LOGGER.debug(
+            "%s (%s): Creating lock instance for lock %s",
+            entry_id,
+            entry_title,
+            lock,
+        )
+        await lock.async_setup_internal(config_entry)
+        return lock
+
+    # Set up locks concurrently. Each lock's initial usercode fetch can take
+    # seconds (Z-Wave node poll, Schlage HTTP, Matter device read); serial
+    # setup meant lock N+1 only began once lock N finished. return_exceptions
+    # isolates per-lock failures so one bad lock does not block the others.
+    setup_results = await asyncio.gather(
+        *(_setup_one_lock(lock_entity_id) for lock_entity_id in locks_to_add),
+        return_exceptions=True,
+    )
+
+    added_locks: list[BaseLock] = []
+    for lock_entity_id, result in zip(locks_to_add, setup_results, strict=True):
+        if isinstance(result, BaseException):
+            _LOGGER.error(
+                "%s (%s): Failed to set up lock %s: %s",
                 entry_id,
                 entry_title,
-                lock,
+                lock_entity_id,
+                result,
+                exc_info=result,
             )
-            await lock.async_setup_internal(config_entry)
+            runtime_data.locks.pop(lock_entity_id, None)
+            continue
 
-        added_locks.append(lock)
+        added_locks.append(result)
 
-        if not await lock.async_internal_is_integration_connected():
+        if not await result.async_internal_is_integration_connected():
             _LOGGER.debug(
                 "%s (%s): Lock %s is not connected yet. Entities will be created "
                 "but will be unavailable until the lock comes online. This is normal "
                 "during startup if Z-Wave JS is still initializing.",
                 entry_id,
                 entry_title,
-                lock.lock.entity_id,
+                result.lock.entity_id,
             )
 
         for slot_num in new_config.slots:
@@ -821,7 +846,7 @@ async def _async_setup_new_locks(
                 lock_entity_id,
                 slot_num,
             )
-            callbacks.invoke_lock_slot_adders(lock, slot_num, ent_reg)
+            callbacks.invoke_lock_slot_adders(result, slot_num, ent_reg)
 
     if added_locks:
         callbacks.invoke_lock_added_handlers(added_locks)


### PR DESCRIPTION
## Proposed change

The serial `for`-loop in `_async_setup_new_locks` awaited `async_setup_internal()` per lock, so each lock's initial usercode fetch (Z-Wave node poll, Schlage HTTP, Matter device read — seconds each) had to complete before the next lock began. With N locks, cold-start time was approximately the **sum** of all initial-fetch durations.

This PR wraps the per-lock setup in an inner async function and dispatches them all via `asyncio.gather`, so initial fetches overlap. Each provider already has its own rate-limiting; there is no contention argument for serial.

### Failure-isolation semantic change

`return_exceptions=True` isolates per-lock failures: a single bad lock no longer aborts the loop, the others still set up successfully. Failures are logged at ERROR with the exception chain preserved (`exc_info=result`) and the partial `runtime_data` entry is rolled back so a failed lock does not leave a half-initialized `BaseLock` instance behind.

This is a deliberate semantic improvement over the prior fail-fast behavior, which made one slow/disconnected lock block the rest of a multi-lock entry from coming up.

### Determinism

Order of `added_locks` follows `locks_to_add` (via `zip(strict=True)` pairing of inputs and results) rather than completion order, so downstream `invoke_lock_added_handlers` sees a deterministic order matching the config.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Code quality improvements to existing code or addition of tests

## Test plan

- [x] Full pytest suite (954 passed, baseline preserved)
- [x] prek (ruff, pydocstyle, flake8, mypy) all green
- [x] Manually traced the failure-isolation path: gather returns a mix of BaseException and BaseLock; the loop logs+pops on the former, processes the latter

🤖 Generated with [Claude Code](https://claude.ai/code)