### PR TITLE
fix: create per-slot coordinators before per-lock entity setup

### DIFF
--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -964,6 +964,17 @@ async def async_update_listener(
             hass, config_entry, lock_entity_id=lock_entity_id, remove_permanently=True
         )
 
+    # Create per-slot coordinators for new slots BEFORE setting up new
+    # locks. _async_setup_new_locks awaits per-lock connection checks,
+    # giving the event loop opportunities to drain entity-add tasks it
+    # scheduled for prior locks; those per-lock entities (`code`,
+    # `in_sync`) look up the slot coordinator in async_added_to_hass and
+    # would warn if it did not yet exist.
+    for slot_num in slots_to_add:
+        coordinator = SlotEntityCoordinator(hass, config_entry, slot_num)
+        runtime_data.slot_coordinators[slot_num] = coordinator
+        coordinator.async_start()
+
     if locks_to_add:
         await _async_setup_new_locks(
             hass, config_entry, locks_to_add, new_config, callbacks, ent_reg
@@ -978,9 +989,6 @@ async def async_update_listener(
             entry_title,
             slot_num,
         )
-        coordinator = SlotEntityCoordinator(hass, config_entry, slot_num)
-        runtime_data.slot_coordinators[slot_num] = coordinator
-        coordinator.async_start()
         callbacks.invoke_standard_adders(slot_num, ent_reg)
 
         for lock_entity_id, lock in runtime_data.locks.items():

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -53,6 +53,7 @@ from .common import (
     LOCK_1_ENTITY_ID,
     LOCK_2_ENTITY_ID,
     SLOT_1_IN_SYNC_ENTITY,
+    MockLCMLock,
 )
 from .conftest import (
     async_initial_tick,
@@ -639,6 +640,46 @@ async def test_coordinator_exists_after_setup(
     runtime_data = lock_code_manager_config_entry.runtime_data
     for lock in runtime_data.locks.values():
         assert lock.coordinator is not None
+
+
+async def test_no_slot_coordinator_warning_during_initial_setup(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Regression test for issue #1213.
+
+    Before the fix, per-lock entities (``code`` sensor, ``in_sync`` binary
+    sensor) were scheduled by ``_async_setup_new_locks`` while the slot
+    coordinators had not yet been created. The await on
+    ``async_internal_is_integration_connected`` between locks let the event
+    loop drain the entity-add tasks for prior locks, whose
+    ``async_added_to_hass`` then warned about the missing coordinator.
+
+    The race requires the connection check to actually yield to the event
+    loop -- the default mock returns synchronously and so cannot reproduce
+    it. We patch it to force an ``asyncio.sleep(0)`` yield, which is what
+    real provider calls (Z-Wave JS, Matter) do.
+    """
+
+    async def _yielding_is_connected(self: MockLCMLock) -> bool:
+        await asyncio.sleep(0)
+        return self._connected
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data=BASE_CONFIG, unique_id="Issue 1213"
+    )
+    config_entry.add_to_hass(hass)
+    caplog.set_level(logging.WARNING)
+    with patch.object(
+        MockLCMLock, "async_is_integration_connected", _yielding_is_connected
+    ):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert "No slot coordinator" not in caplog.text
+
+    await hass.config_entries.async_unload(config_entry.entry_id)
 
 
 @pytest.mark.parametrize("config", [{}])


### PR DESCRIPTION
## Proposed change

PR #1191 introduced `SlotEntityCoordinator` and a requirement that entities resolve it from `runtime_data.slot_coordinators` in `async_added_to_hass`. The `slots_to_add` loop in `async_update_listener` created the coordinator before invoking standard slot adders, but `_async_setup_new_locks` runs **earlier on the same path** and schedules per-lock `code` (sensor) and `in_sync` (binary sensor) entities for every slot. Its per-lock `await result.async_internal_is_integration_connected()` gives the event loop a chance to drain the entity-add tasks scheduled for already-processed locks before control returns to the slot loop that creates the coordinators. The per-lock entities' `async_added_to_hass` then runs with `runtime_data.slot_coordinators` still empty and emits:

```
WARNING ... No slot coordinator for slot N when adding entity in_sync
WARNING ... No slot coordinator for slot N when adding entity code
```

This is exactly what @AA6CG hit at startup with 4 locks: on first load the diff sees all locks and all slots as "added," so both paths fire on the same call.

This PR hoists coordinator creation for `slots_to_add` ahead of `_async_setup_new_locks` so per-lock entities scheduled there can resolve their coordinator. `SlotEntityCoordinator.__init__` / `async_start` are lock-independent (they only subscribe to the condition entity and compute derived active state), so creating them earlier is safe.

### Test

The default `MockLCMLock.async_is_integration_connected` returns without yielding, so the existing test fixtures cannot reproduce the race. The new regression test patches it to `asyncio.sleep(0)` to mimic real provider behavior (Z-Wave JS, Matter) and asserts no `No slot coordinator` warning is logged. Verified to fail on the previous code and pass with this fix.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #1213
- This PR is related to issue: