### PR TITLE
test: add async_advance_time helper for background-task tick chains

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Generator
+from datetime import timedelta
 from typing import Any
 from unittest.mock import patch
 
@@ -11,6 +12,7 @@ from pytest_homeassistant_custom_component.common import (
     MockConfigEntry,
     MockModule,
     MockPlatform,
+    async_fire_time_changed,
     mock_config_flow,
     mock_integration,
     mock_platform,
@@ -24,6 +26,7 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
 
 from custom_components.lock_code_manager.const import DOMAIN
 from custom_components.lock_code_manager.domain.models import SyncState
@@ -261,3 +264,20 @@ async def async_trigger_sync_tick_for_manager(
         sync_manager._state = SyncState.OUT_OF_SYNC
     await sync_manager._async_tick()
     await hass.async_block_till_done()
+
+
+async def async_advance_time(hass: HomeAssistant, delta: timedelta) -> None:
+    """
+    Advance HA's mock clock by ``delta`` and settle pending work.
+
+    Replaces the brittle ``async_fire_time_changed + async_block_till_done``
+    pair. ``async_track_time_interval`` (used for the sync tick and the
+    coordinator update interval) schedules its callback as a background
+    task via ``async_run_hass_job(..., background=True)``. The default
+    ``async_block_till_done`` only waits for foreground tasks, so chains
+    spawned by a timer-fired tick can outlive the wait and leak across
+    assertions. This helper passes ``wait_background_tasks=True`` to
+    cover them.
+    """
+    async_fire_time_changed(hass, dt_util.utcnow() + delta)
+    await hass.async_block_till_done(wait_background_tasks=True)

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -7,10 +7,7 @@ import logging
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from pytest_homeassistant_custom_component.common import (
-    MockConfigEntry,
-    async_fire_time_changed,
-)
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.components.text import (
@@ -65,6 +62,7 @@ from .common import (
     MockLCMLock,
 )
 from .conftest import (
+    async_advance_time,
     async_initial_tick,
     async_trigger_sync_tick,
     async_trigger_sync_tick_for_manager,
@@ -80,8 +78,7 @@ async def _async_force_sync_cycle(
     """Trigger a coordinator refresh and follow-up entity update."""
     await coordinator.async_refresh()
     await hass.async_block_till_done()
-    async_fire_time_changed(hass, dt_util.utcnow() + coordinator.update_interval)
-    await hass.async_block_till_done()
+    await async_advance_time(hass, coordinator.update_interval)
 
 
 async def test_binary_sensor_entity(
@@ -1201,8 +1198,7 @@ async def test_coordinator_poll_detects_external_change_and_syncs(
     assert coordinator.data[1] == SlotCredential.known("9999")
 
     # Fire the tick timer to let the sync manager detect the mismatch
-    async_fire_time_changed(hass, dt_util.utcnow() + TICK_INTERVAL * 2)
-    await hass.async_block_till_done()
+    await async_advance_time(hass, TICK_INTERVAL * 2)
 
     # Sync manager should have called set_usercode to restore "1234"
     assert len(service_calls.get("set_usercode", [])) == 1
@@ -1212,8 +1208,7 @@ async def test_coordinator_poll_detects_external_change_and_syncs(
     assert lock_provider.codes[1] == "1234"
 
     # Fire another tick for the sync manager to verify it is back in sync
-    async_fire_time_changed(hass, dt_util.utcnow() + TICK_INTERVAL * 3)
-    await hass.async_block_till_done()
+    await async_advance_time(hass, TICK_INTERVAL * 3)
 
     state = hass.states.get(in_sync_entity)
     assert state.state == STATE_ON, "Should be back in sync after correction"
@@ -1274,8 +1269,7 @@ async def test_push_update_triggers_sync_state_change_on_binary_sensor(
     # Fire a tick to let the sync manager correct it
     # Also update the mock lock codes so set_usercode can work
     lock_provider.codes[1] = "wrong"
-    async_fire_time_changed(hass, dt_util.utcnow() + TICK_INTERVAL * 2)
-    await hass.async_block_till_done()
+    await async_advance_time(hass, TICK_INTERVAL * 2)
 
     # Sync manager should have restored the configured PIN
     assert len(service_calls.get("set_usercode", [])) == 1
@@ -1283,8 +1277,7 @@ async def test_push_update_triggers_sync_state_change_on_binary_sensor(
     assert lock_provider.codes[1] == "1234"
 
     # Fire another tick to verify back in sync
-    async_fire_time_changed(hass, dt_util.utcnow() + TICK_INTERVAL * 3)
-    await hass.async_block_till_done()
+    await async_advance_time(hass, TICK_INTERVAL * 3)
 
     state = hass.states.get(in_sync_entity)
     assert state.state == STATE_ON, "Should be back in sync after tick"
@@ -1390,8 +1383,7 @@ async def test_drift_check_detects_external_change_and_triggers_sync(
     assert coordinator.data[1] == SlotCredential.known("5555")
 
     # Fire tick to let the sync manager detect and correct
-    async_fire_time_changed(hass, dt_util.utcnow() + TICK_INTERVAL * 2)
-    await hass.async_block_till_done()
+    await async_advance_time(hass, TICK_INTERVAL * 2)
 
     # Sync manager should have restored the configured PIN
     assert len(service_calls.get("set_usercode", [])) == 1
@@ -1399,11 +1391,79 @@ async def test_drift_check_detects_external_change_and_triggers_sync(
     assert lock_provider.codes[1] == "1234"
 
     # Verify back in sync
-    async_fire_time_changed(hass, dt_util.utcnow() + TICK_INTERVAL * 3)
-    await hass.async_block_till_done()
+    await async_advance_time(hass, TICK_INTERVAL * 3)
 
     state = hass.states.get(in_sync_entity)
     assert state.state == STATE_ON, "Should be in sync after drift correction"
+
+    await hass.config_entries.async_unload(config_entry.entry_id)
+
+
+async def test_async_advance_time_drains_background_tick_chain(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+) -> None:
+    """``async_advance_time`` settles a background tick whose mocks yield.
+
+    ``async_track_time_interval`` (used by the sync tick and coordinator
+    update) runs its callback as a background task. The bare
+    ``async_fire_time_changed + async_block_till_done`` pair does not
+    wait for background tasks, so any tick whose chain spans more than
+    one event-loop turn can outlive the wait. This is masked today only
+    because the default mock returns synchronously; the moment a mock
+    or a real provider yields, the bare pattern stops settling. This
+    test forces the issue by patching the connection check to yield,
+    and asserts ``async_advance_time`` still settles correctly.
+    """
+    config = {
+        CONF_LOCKS: [LOCK_1_ENTITY_ID],
+        CONF_SLOTS: {1: {CONF_NAME: "t1", CONF_PIN: "1234", CONF_ENABLED: True}},
+    }
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data=config, unique_id="advance_time_test", title="Test"
+    )
+    config_entry.add_to_hass(hass)
+
+    # Reproducing the race requires several mock methods to yield so the
+    # tick chain spans more than one event-loop turn -- a single yield
+    # happens to slip through the bare ``block_till_done``.
+    real_set = MockLCMLock.async_set_usercode
+    real_get = MockLCMLock.async_get_usercodes
+    real_connected = MockLCMLock.async_is_integration_connected
+
+    async def _yielding_set(self: MockLCMLock, *args, **kwargs) -> bool:
+        await asyncio.sleep(0)
+        return await real_set(self, *args, **kwargs)
+
+    async def _yielding_get(self: MockLCMLock) -> dict:
+        await asyncio.sleep(0)
+        return await real_get(self)
+
+    async def _yielding_connected(self: MockLCMLock) -> bool:
+        await asyncio.sleep(0)
+        return await real_connected(self)
+
+    with (
+        patch.object(MockLCMLock, "async_set_usercode", _yielding_set),
+        patch.object(MockLCMLock, "async_get_usercodes", _yielding_get),
+        patch.object(
+            MockLCMLock, "async_is_integration_connected", _yielding_connected
+        ),
+    ):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+        in_sync_entity = "binary_sensor.test_1_code_slot_1_in_sync"
+        await async_initial_tick(hass, in_sync_entity)
+
+        lock_provider = config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
+        lock_provider.service_calls.get("set_usercode", []).clear()
+        lock_provider.codes[1] = "9999"
+        await lock_provider.coordinator.async_refresh()
+        await hass.async_block_till_done()
+
+        await async_advance_time(hass, TICK_INTERVAL * 2)
+
+        assert len(lock_provider.service_calls["set_usercode"]) == 1
 
     await hass.config_entries.async_unload(config_entry.entry_id)
 
@@ -1459,8 +1519,7 @@ async def test_sync_manager_handles_code_sensor_unknown_state_on_startup(
     await hass.async_block_till_done()
 
     # Trigger a tick so the sync manager can process the new data
-    async_fire_time_changed(hass, dt_util.utcnow() + TICK_INTERVAL * 2)
-    await hass.async_block_till_done()
+    await async_advance_time(hass, TICK_INTERVAL * 2)
 
     # Sync manager should have transitioned out of LOADING
     assert mgr._state is not SyncState.LOADING, (


### PR DESCRIPTION
## Proposed change

The bare `async_fire_time_changed(...) + async_block_till_done()` pair that the binary-sensor tests use to drive timer-fired ticks is brittle. `async_track_time_interval` (which schedules both the sync tick and the coordinator update interval) runs its callback via `hass.async_run_hass_job(..., background=True)` — so the tick task is a **background** task. The default `async_block_till_done` only awaits foreground tasks (`wait_background_tasks=False`); it returns before the tick's chained awaits complete. The existing 3 \"external change → tick → sync\" tests in `test_binary_sensor.py` pass today only because the synchronous mock methods complete in fewer event-loop turns than the bare wait happens to allow. The moment any mock or real provider call (Z-Wave JS, Matter, Schlage HTTP) genuinely yields, those tests stop settling reliably.

This PR adds a small helper that wraps the correct call:

```python
async def async_advance_time(hass: HomeAssistant, delta: timedelta) -> None:
    async_fire_time_changed(hass, dt_util.utcnow() + delta)
    await hass.async_block_till_done(wait_background_tasks=True)
```

…and refactors the 9 existing usage sites in `test_binary_sensor.py` to use it. Net diff is small and behavior-preserving for the existing suite.

### Regression test

`test_async_advance_time_drains_background_tick_chain` patches three `MockLCMLock` methods (`async_set_usercode`, `async_get_usercodes`, `async_is_integration_connected`) to `await asyncio.sleep(0)` on entry — enough event-loop turns to expose the race — and asserts that `async_advance_time` still settles. Verified to fail when the helper drops `wait_background_tasks=True`.

### Why this matters

Discovered while empirically probing for hidden races (a follow-up from #1214). Yielding mocks broke 3 tests; the diagnosis tracked back to this helper-shape gap, not to a real production bug. Documenting the gotcha in one place and providing the right shape prevents future tests from rediscovering it.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue:
- This PR is related to issue: #1213, #1214