### PR TITLE
chore: fill in missing entity and service icons

### DIFF
--- a/custom_components/lock_code_manager/icons.json
+++ b/custom_components/lock_code_manager/icons.json
@@ -1,6 +1,13 @@
 {
   "entity": {
     "binary_sensor": {
+      "active": {
+        "default": "mdi:account-clock",
+        "state": {
+          "off": "mdi:account-off",
+          "on": "mdi:account-check"
+        }
+      },
       "in_sync": {
         "default": "mdi:sync-alert",
         "state": {
@@ -19,6 +26,11 @@
         "default": "mdi:lock-smart"
       }
     },
+    "switch": {
+      "enabled": {
+        "default": "mdi:account-key"
+      }
+    },
     "text": {
       "name": {
         "default": "mdi:rename"
@@ -29,6 +41,11 @@
     }
   },
   "services": {
-    "hard_refresh_usercodes": "mdi:refresh"
+    "clear_slot_condition": "mdi:calendar-remove",
+    "clear_usercode": "mdi:key-remove",
+    "generate_pin": "mdi:dice-multiple",
+    "hard_refresh_usercodes": "mdi:refresh",
+    "set_slot_condition": "mdi:calendar-edit",
+    "set_usercode": "mdi:key-plus"
   }
 }


### PR DESCRIPTION
## Proposed change

`icons.json` only covered `in_sync`, `pin_used`, `code`, `name`, `pin`, and the `hard_refresh_usercodes` service, leaving the `active` binary sensor, the `enabled` switch, and the other five services on default platform icons. Fill them in with semantic glyphs:

- **`binary_sensor.active`** — \`mdi:account-clock\` default with state map: \`account-check\` on, \`account-off\` off (matches the on/off flip already used for \`in_sync\`)
- **\`switch.enabled\`** — \`mdi:account-key\` (conveys \"slot grants access\" and pairs visually with the existing \`mdi:lock-smart\` on the code sensor)
- **\`set_usercode\` / \`clear_usercode\`** — \`key-plus\` / \`key-remove\`
- **\`set_slot_condition\` / \`clear_slot_condition\`** — \`calendar-edit\` / \`calendar-remove\`
- **\`generate_pin\`** — \`dice-multiple\`

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue:
- This PR is related to issue: