### PR TITLE
feat: add deobfuscate_log service to reverse masked PIN tokens

### DIFF
--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -61,6 +61,7 @@ from .const import (
     ATTR_LENGTH,
     ATTR_LOCK_ENTITY_ID,
     ATTR_SLOT,
+    ATTR_TEXT,
     ATTR_USERCODE,
     CONDITION_ENTITY_DOMAINS,
     CONF_CALENDAR,
@@ -70,6 +71,7 @@ from .const import (
     PLATFORMS,
     SERVICE_CLEAR_SLOT_CONDITION,
     SERVICE_CLEAR_USERCODE,
+    SERVICE_DEOBFUSCATE_LOG,
     SERVICE_GENERATE_PIN,
     SERVICE_HARD_REFRESH_USERCODES,
     SERVICE_SET_SLOT_CONDITION,
@@ -98,6 +100,7 @@ from .domain.services import (
     async_set_usercode,
 )
 from .domain.slot_coordinator import SlotEntityCoordinator
+from .domain.util import build_pin_deobfuscation_map, deobfuscate_pins
 from .providers import BaseLock
 from .websocket import async_setup as async_websocket_setup
 
@@ -466,6 +469,33 @@ async def async_setup(hass: HomeAssistant, config: Config) -> bool:
                 ),
             }
         ),
+        supports_response=SupportsResponse.ONLY,
+    )
+
+    async def _deobfuscate_log(call: ServiceCall) -> ServiceResponse:
+        """Reverse mask_pin() tokens in pasted log text against the current config."""
+        instance_id = hass.data.get(DOMAIN, {}).get("instance_id", "")
+        if not instance_id:
+            raise HomeAssistantError(
+                "Lock Code Manager is not fully set up yet; try again in a moment"
+            )
+        entries = hass.config_entries.async_loaded_entries(DOMAIN)
+        table = build_pin_deobfuscation_map(entries, instance_id)
+        deobfuscated, summary = deobfuscate_pins(call.data[ATTR_TEXT], table)
+        # Sentinel banner so users see at a glance that the response contains
+        # plaintext PINs and must not be pasted into a public issue.
+        wrapped = (
+            "=== BEGIN DEOBFUSCATED — DO NOT SHARE ===\n"
+            f"{deobfuscated}\n"
+            "=== END DEOBFUSCATED ==="
+        )
+        return {"deobfuscated_text": wrapped, "summary": summary}
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_DEOBFUSCATE_LOG,
+        _deobfuscate_log,
+        schema=vol.Schema({vol.Required(ATTR_TEXT): cv.string}),
         supports_response=SupportsResponse.ONLY,
     )
 

--- a/custom_components/lock_code_manager/const.py
+++ b/custom_components/lock_code_manager/const.py
@@ -20,6 +20,9 @@ SERVICE_CLEAR_USERCODE = "clear_usercode"
 SERVICE_SET_SLOT_CONDITION = "set_slot_condition"
 SERVICE_CLEAR_SLOT_CONDITION = "clear_slot_condition"
 SERVICE_GENERATE_PIN = "generate_pin"
+SERVICE_DEOBFUSCATE_LOG = "deobfuscate_log"
+
+ATTR_TEXT = "text"
 
 ATTR_ENTITIES_ADDED_TRACKER = "entities_added_tracker"
 ATTR_ENTITIES_REMOVED_TRACKER = "entities_removed_tracker"

--- a/custom_components/lock_code_manager/domain/util.py
+++ b/custom_components/lock_code_manager/domain/util.py
@@ -57,9 +57,11 @@ def build_pin_deobfuscation_map(
     PIN is empty are skipped because ``mask_pin`` returns ``<empty>`` for
     them and that's not a token we need to reverse.
 
-    Different ``(slot, pin)`` pairs always produce different tokens (slot
-    is part of the salt), so the resulting map has one entry per
-    configured slot with a PIN.
+    Slot is part of the salt, so different ``(slot, pin)`` pairs produce
+    different tokens with overwhelming probability — CRC32 has a 32-bit
+    output so collisions are mathematically possible but vanishingly
+    unlikely at any plausible slot count. The resulting map has one
+    entry per configured slot with a PIN.
     """
     table: dict[str, str] = {}
     for entry in entries:

--- a/custom_components/lock_code_manager/domain/util.py
+++ b/custom_components/lock_code_manager/domain/util.py
@@ -2,17 +2,21 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 import logging
+import re
+from typing import Any
 import zlib
 
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN, SERVICE_TURN_OFF
-from homeassistant.const import ATTR_ENTITY_ID, CONF_ENABLED
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ATTR_ENTITY_ID, CONF_ENABLED, CONF_PIN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 
 from ..const import DOMAIN
-from .config import build_slot_unique_id
+from .config import EntryConfig, build_slot_unique_id
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -34,6 +38,69 @@ def mask_pin(
         return "<empty>"
     salt = f"{instance_id}:{slot_num}:{pin}"
     return f"pin#{zlib.crc32(salt.encode()) & 0xFFFFFFFF:08x}"
+
+
+# Token format emitted by ``mask_pin``: literal "pin#" followed by 8 lowercase
+# hex chars. Anchored by word boundary on the right so a longer hex string
+# isn't truncated and reported as a match.
+_PIN_TOKEN_RE = re.compile(r"pin#[0-9a-f]{8}\b")
+
+
+def build_pin_deobfuscation_map(
+    entries: Iterable[ConfigEntry], instance_id: str
+) -> dict[str, str]:
+    """
+    Build a ``{masked_token: plaintext_pin}`` lookup for every configured PIN.
+
+    Reads each entry's options-or-data view via ``EntryConfig`` so it works
+    whether or not the entry has been migrated to options yet. Slots whose
+    PIN is empty are skipped because ``mask_pin`` returns ``<empty>`` for
+    them and that's not a token we need to reverse.
+
+    Different ``(slot, pin)`` pairs always produce different tokens (slot
+    is part of the salt), so the resulting map has one entry per
+    configured slot with a PIN.
+    """
+    table: dict[str, str] = {}
+    for entry in entries:
+        config = EntryConfig.from_entry(entry)
+        for slot_num, slot_config in config.slots.items():
+            pin = slot_config.get(CONF_PIN)
+            if not pin:
+                continue
+            table[mask_pin(pin, slot_num, instance_id)] = pin
+    return table
+
+
+def deobfuscate_pins(text: str, table: dict[str, str]) -> tuple[str, dict[str, Any]]:
+    """
+    Replace ``pin#xxxxxxxx`` tokens in ``text`` using ``table``.
+
+    Tokens not in the table are left verbatim so the output stays
+    paste-compatible with the original log (useful when only some PINs
+    have been rotated since the log was written). The summary lists the
+    distinct unmatched tokens so the caller can see what didn't resolve
+    without scanning the text.
+    """
+    counts = {"total": 0, "matched": 0}
+    unmatched: set[str] = set()
+
+    def _replace(match: re.Match[str]) -> str:
+        token = match.group(0)
+        counts["total"] += 1
+        if token in table:
+            counts["matched"] += 1
+            return table[token]
+        unmatched.add(token)
+        return token
+
+    deobfuscated = _PIN_TOKEN_RE.sub(_replace, text)
+    summary: dict[str, Any] = {
+        "total": counts["total"],
+        "matched": counts["matched"],
+        "unmatched_tokens": sorted(unmatched),
+    }
+    return deobfuscated, summary
 
 
 async def async_disable_slot(

--- a/custom_components/lock_code_manager/icons.json
+++ b/custom_components/lock_code_manager/icons.json
@@ -43,6 +43,7 @@
   "services": {
     "clear_slot_condition": "mdi:calendar-remove",
     "clear_usercode": "mdi:key-remove",
+    "deobfuscate_log": "mdi:incognito-off",
     "generate_pin": "mdi:dice-multiple",
     "hard_refresh_usercodes": "mdi:refresh",
     "set_slot_condition": "mdi:calendar-edit",

--- a/custom_components/lock_code_manager/services.yaml
+++ b/custom_components/lock_code_manager/services.yaml
@@ -87,3 +87,11 @@ generate_pin:
           max: 12
           step: 1
           mode: box
+
+deobfuscate_log:
+  fields:
+    text:
+      required: true
+      selector:
+        text:
+          multiline: true

--- a/custom_components/lock_code_manager/strings.json
+++ b/custom_components/lock_code_manager/strings.json
@@ -162,6 +162,16 @@
           "name": "Length"
         }
       }
+    },
+    "deobfuscate_log": {
+      "name": "Deobfuscate log",
+      "description": "Replace mask_pin tokens (pin#xxxxxxxx) in pasted log text with the plaintext PINs configured in any loaded Lock Code Manager entry. WARNING: the response contains plaintext PINs \u2014 do not paste it into public issues, forums, or any shared channel.",
+      "fields": {
+        "text": {
+          "name": "Text",
+          "description": "The log text to deobfuscate. Paste raw log lines or a full log file."
+        }
+      }
     }
   },
   "issues": {

--- a/custom_components/lock_code_manager/translations/en.json
+++ b/custom_components/lock_code_manager/translations/en.json
@@ -162,6 +162,16 @@
           "name": "Length"
         }
       }
+    },
+    "deobfuscate_log": {
+      "name": "Deobfuscate log",
+      "description": "Replace mask_pin tokens (pin#xxxxxxxx) in pasted log text with the plaintext PINs configured in any loaded Lock Code Manager entry. WARNING: the response contains plaintext PINs \u2014 do not paste it into public issues, forums, or any shared channel.",
+      "fields": {
+        "text": {
+          "name": "Text",
+          "description": "The log text to deobfuscate. Paste raw log lines or a full log file."
+        }
+      }
     }
   },
   "issues": {

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -16,15 +16,18 @@ from custom_components.lock_code_manager.const import (
     ATTR_LENGTH,
     ATTR_LOCK_ENTITY_ID,
     ATTR_SLOT,
+    ATTR_TEXT,
     ATTR_USERCODE,
     DOMAIN,
     SERVICE_CLEAR_SLOT_CONDITION,
     SERVICE_CLEAR_USERCODE,
+    SERVICE_DEOBFUSCATE_LOG,
     SERVICE_GENERATE_PIN,
     SERVICE_SET_SLOT_CONDITION,
     SERVICE_SET_USERCODE,
 )
 from custom_components.lock_code_manager.domain.pin_generator import is_unsafe_pin
+from custom_components.lock_code_manager.domain.util import mask_pin
 
 from .common import LOCK_1_ENTITY_ID
 
@@ -369,3 +372,46 @@ async def test_generate_pin_service_rejects_invalid_length(
             blocking=True,
             return_response=True,
         )
+
+
+async def test_deobfuscate_log_service_round_trips_configured_pins(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+) -> None:
+    """deobfuscate_log replaces tokens for currently-configured PINs and wraps with sentinels."""
+    instance_id = hass.data[DOMAIN]["instance_id"]
+    # BASE_CONFIG has slot 1 with PIN "1234" and slot 2 with PIN "5678".
+    token_slot_1 = mask_pin("1234", 1, instance_id)
+    token_slot_2 = mask_pin("5678", 2, instance_id)
+    log_excerpt = (
+        f"Setting usercode on lock.test_1 slot 1 (pin={token_slot_1})\n"
+        f"Setting usercode on lock.test_2 slot 2 (pin={token_slot_2})\n"
+        "Unrelated line with no token\n"
+        "Stale token from a rotated PIN: pin#deadbeef"
+    )
+
+    response = await hass.services.async_call(
+        DOMAIN,
+        SERVICE_DEOBFUSCATE_LOG,
+        {ATTR_TEXT: log_excerpt},
+        blocking=True,
+        return_response=True,
+    )
+
+    assert response is not None
+    text = response["deobfuscated_text"]
+    assert "1234" in text
+    assert "5678" in text
+    assert token_slot_1 not in text
+    assert token_slot_2 not in text
+    # Stale token is preserved verbatim so the output remains comparable to the input.
+    assert "pin#deadbeef" in text
+    assert "BEGIN DEOBFUSCATED" in text and "END DEOBFUSCATED" in text
+
+    summary = response["summary"]
+    assert summary == {
+        "total": 3,
+        "matched": 2,
+        "unmatched_tokens": ["pin#deadbeef"],
+    }

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -11,6 +11,8 @@ from homeassistant.helpers.issue_registry import async_get as async_get_issue_re
 from custom_components.lock_code_manager.const import DOMAIN
 from custom_components.lock_code_manager.domain.util import (
     async_disable_slot,
+    build_pin_deobfuscation_map,
+    deobfuscate_pins,
     mask_pin,
 )
 
@@ -84,6 +86,82 @@ async def test_async_disable_slot_creates_repair_issue(
     assert issue is not None
     assert issue.severity == "warning"
     assert issue.is_fixable is True
+
+
+def test_deobfuscate_pins_replaces_known_tokens():
+    """Known tokens get replaced; unknown tokens are left verbatim."""
+    pin = "1234"
+    token = mask_pin(pin, 1, INSTANCE_ID)
+    unknown_token = "pin#deadbeef"
+    text = f"Setting usercode on lock.front_door slot 1 (pin={token}) and also {unknown_token}"
+
+    deobfuscated, summary = deobfuscate_pins(text, {token: pin})
+
+    assert pin in deobfuscated
+    assert token not in deobfuscated
+    assert unknown_token in deobfuscated
+    assert summary == {"total": 2, "matched": 1, "unmatched_tokens": [unknown_token]}
+
+
+def test_deobfuscate_pins_no_tokens_in_text():
+    """Empty summary when the input has no pin# tokens at all."""
+    text = "Nothing to deobfuscate here"
+    deobfuscated, summary = deobfuscate_pins(text, {})
+    assert deobfuscated == text
+    assert summary == {"total": 0, "matched": 0, "unmatched_tokens": []}
+
+
+def test_deobfuscate_pins_counts_each_occurrence():
+    """Same token appearing multiple times is replaced each time and counted as multiple."""
+    pin = "5678"
+    token = mask_pin(pin, 2, INSTANCE_ID)
+    text = f"first {token} second {token} third {token}"
+
+    deobfuscated, summary = deobfuscate_pins(text, {token: pin})
+
+    assert deobfuscated.count(pin) == 3
+    assert summary["total"] == 3
+    assert summary["matched"] == 3
+    assert summary["unmatched_tokens"] == []
+
+
+def test_deobfuscate_pins_unmatched_tokens_deduplicated():
+    """Repeated unmatched tokens appear once in the summary list."""
+    text = "pin#aaaaaaaa once, pin#aaaaaaaa twice, pin#bbbbbbbb"
+
+    _deobfuscated, summary = deobfuscate_pins(text, {})
+
+    assert summary["total"] == 3
+    assert summary["matched"] == 0
+    assert summary["unmatched_tokens"] == ["pin#aaaaaaaa", "pin#bbbbbbbb"]
+
+
+def test_deobfuscate_pins_does_not_match_partial_tokens():
+    """Tokens shorter or longer than 8 hex chars are not matched."""
+    text = "pin#abc pin#abcdefgh pin#abcdef0123456789"
+
+    deobfuscated, summary = deobfuscate_pins(text, {})
+
+    # First is too short (3 chars), second has 'g' (non-hex), third is too long.
+    # None should be counted.
+    assert summary["total"] == 0
+    assert deobfuscated == text
+
+
+async def test_build_pin_deobfuscation_map_uses_configured_pins(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """Map covers every slot with a non-empty PIN and matches mask_pin output."""
+    entries = hass.config_entries.async_loaded_entries(DOMAIN)
+    table = build_pin_deobfuscation_map(entries, INSTANCE_ID)
+
+    # BASE_CONFIG has slot 1 (pin 1234) and slot 2 (pin 5678) — both should
+    # round-trip through mask_pin to the same tokens this builds.
+    assert table[mask_pin("1234", 1, INSTANCE_ID)] == "1234"
+    assert table[mask_pin("5678", 2, INSTANCE_ID)] == "5678"
+    assert len(table) == 2
 
 
 async def test_async_disable_slot_no_issue_without_reason(


### PR DESCRIPTION
## Proposed change

`mask_pin()` emits `pin#xxxxxxxx` tokens in log lines so users can share logs without leaking PINs. The reverse direction is also useful for **local** debugging — a user pasting their own logs to see which slot a warning actually refers to. This PR adds a service that does exactly that.

### Service: `lock_code_manager.deobfuscate_log`

**Input**:
- `text` (required, multiline string) — pasted log content

**Output (`SupportsResponse.ONLY`)**:
- `deobfuscated_text` — input with every `pin#xxxxxxxx` token whose plaintext is in the current configuration replaced by the real PIN, wrapped in `=== BEGIN DEOBFUSCATED — DO NOT SHARE ===` / `=== END DEOBFUSCATED ===` sentinels so users notice the response contains plaintext PINs before pasting it anywhere shared
- `summary` — `{total, matched, unmatched_tokens}`

### How it works

`build_pin_deobfuscation_map` iterates every loaded LCM config entry, reads its slot config via the existing `EntryConfig` view, and computes `mask_pin(pin, slot_num, instance_id)` for every slot with a non-empty PIN. The result is a `{token: pin}` dict the service uses for substitution. CRC32 is fast — building the map for hundreds of slots takes microseconds.

`deobfuscate_pins` scans for `pin#[0-9a-f]{8}\b` (word-boundary anchored so a longer hex string isn't truncated and falsely matched) and substitutes. **Unmatched tokens are left verbatim** so the output stays paste-compatible with the original log; the summary lists them.

### Security note

The masking uses **CRC32**, not a cryptographic hash. This service doesn't change the threat model — an attacker who knows the salt format can already brute-force 4-12 digit PINs against the tokens in milliseconds. The service is for the legitimate user's own debugging, and the sentinel banner + service description make clear the response must not be pasted into public issues.

### Tests

- `test_deobfuscate_pins_replaces_known_tokens` — known matched, unknown preserved, summary correct
- `test_deobfuscate_pins_no_tokens_in_text` — empty summary when no tokens
- `test_deobfuscate_pins_counts_each_occurrence` — same token replaced multiple times, counted
- `test_deobfuscate_pins_unmatched_tokens_deduplicated` — distinct unmatched in summary
- `test_deobfuscate_pins_does_not_match_partial_tokens` — wrong-length and non-hex rejected
- `test_build_pin_deobfuscation_map_uses_configured_pins` — map matches mask_pin output for `BASE_CONFIG`
- `test_deobfuscate_log_service_round_trips_configured_pins` — end-to-end through the service registry

All 963 tests pass.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue:
- This PR is related to issue: