### PR TITLE
chore: bump HACS minimum Home Assistant version to 2026.6.0

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -2,6 +2,6 @@
   "name": "Lock Code Manager",
   "zip_release": true,
   "filename": "lock_code_manager.zip",
-  "homeassistant": "2026.5.0",
+  "homeassistant": "2026.6.0",
   "render_readme": true
 }


### PR DESCRIPTION
# Breaking change

Users still running Home Assistant **2026.5.x** will no longer receive new releases of Lock Code Manager through HACS. To continue receiving updates, upgrade Home Assistant to **2026.6.0** or newer.

## Proposed change

Bump the `homeassistant` minimum in `hacs.json` from `2026.5.0` to `2026.6.0`.

This is preparation for adopting the new credential management APIs that landed in Home Assistant 2026.6.0. Pinning the HACS floor up-front lets the integration code call those APIs unconditionally in follow-up PRs without runtime version checks or compatibility shims.

No integration code changes in this PR — only the HACS gate moves.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

🤖 Generated with [Claude Code](https://claude.com/claude-code)