### PR TITLE
feat: add cross-platform User/Credential domain model

### DIFF
--- a/custom_components/lock_code_manager/domain/credentials.py
+++ b/custom_components/lock_code_manager/domain/credentials.py
@@ -34,3 +34,28 @@ class CredentialType(StrEnum):
     FACE = "face"
     PASSWORD = "password"
     NFC = "nfc"  # Near Field Communication tag.
+
+
+class UserType(StrEnum):
+    """
+    How a user is constrained on the lock.
+
+    Modeled minimally for now. ``UNRESTRICTED`` matches the Matter and Z-Wave
+    "normal" user with no schedule restrictions, which is the only kind Lock
+    Code Manager manages today. Additional kinds (for example schedule- or
+    duress-restricted users) can be appended without breaking callers.
+    """
+
+    UNRESTRICTED = "unrestricted"
+
+
+class CredentialRule(StrEnum):
+    """
+    How many credentials a user must present to operate the lock.
+
+    Modeled minimally for now. ``SINGLE`` means one credential is sufficient,
+    matching today's one-PIN-per-user reality. Multi-credential rules can be
+    appended later without breaking callers.
+    """
+
+    SINGLE = "single"

--- a/custom_components/lock_code_manager/domain/credentials.py
+++ b/custom_components/lock_code_manager/domain/credentials.py
@@ -1,0 +1,36 @@
+"""
+Cross-platform User and Credential domain model.
+
+A first-class internal abstraction over the per-platform credential
+vocabularies (the Z-Wave User Credential Command Class and the Matter
+DoorLock cluster). The model is shaped so the current one-managed-slot to
+one-user to one-Personal-Identification-Number-credential projection is a
+thin pure function, while a future "user is the unit, multiple credentials"
+world only needs to append to ``User.credentials`` -- no field changes.
+
+These are pure, immutable value types. They do not import Home Assistant and
+do not change ``SlotCredential``, which remains the coordinator's currency.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class CredentialType(StrEnum):
+    """
+    Kind of credential a user presents to a lock.
+
+    Only ``PIN`` is exercised today. The remaining members are reserved so a
+    future expansion to multiple credential kinds is additive: they map
+    cleanly to both the Z-Wave User Credential Command Class and the Matter
+    DoorLock cluster credential-type vocabularies. ``PIN`` deliberately
+    serializes to the lowercase wire value the providers already send.
+    """
+
+    PIN = "pin"
+    RFID = "rfid"  # Radio Frequency Identification tag/card.
+    FINGERPRINT = "fingerprint"
+    FACE = "face"
+    PASSWORD = "password"
+    NFC = "nfc"  # Near Field Communication tag.

--- a/custom_components/lock_code_manager/domain/credentials.py
+++ b/custom_components/lock_code_manager/domain/credentials.py
@@ -8,8 +8,10 @@ one-user to one-Personal-Identification-Number-credential projection is a
 thin pure function, while a future "user is the unit, multiple credentials"
 world only needs to append to ``User.credentials`` -- no field changes.
 
-These are pure, immutable value types. They do not import Home Assistant and
-do not change ``SlotCredential``, which remains the coordinator's currency.
+These are pure value types with no Home Assistant dependencies. The credential
+and capability types are immutable; ``User`` is a mutable aggregate of immutable
+credentials. They do not change ``SlotCredential``, which remains the
+coordinator's currency.
 """
 
 from __future__ import annotations
@@ -17,6 +19,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from enum import StrEnum
+from types import MappingProxyType
 from typing import NamedTuple
 
 from .models import SlotCredential
@@ -202,6 +205,14 @@ class LockCapabilities:
     supports_user_management: bool
     max_users: int
     credential_types: Mapping[CredentialType, CredentialTypeCapability]
+
+    def __post_init__(self) -> None:
+        """Snapshot credential_types so the value object cannot be mutated later."""
+        object.__setattr__(
+            self,
+            "credential_types",
+            MappingProxyType(dict(self.credential_types)),
+        )
 
     def capability_for(
         self, credential_type: CredentialType

--- a/custom_components/lock_code_manager/domain/credentials.py
+++ b/custom_components/lock_code_manager/domain/credentials.py
@@ -14,6 +14,7 @@ do not change ``SlotCredential``, which remains the coordinator's currency.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import NamedTuple
@@ -167,3 +168,47 @@ class User:
             ),
             None,
         )
+
+
+@dataclass(frozen=True, slots=True)
+class CredentialTypeCapability:
+    """
+    Per-credential-type limits advertised by a lock.
+
+    ``num_slots`` is the number of slots the lock exposes for this credential
+    type, ``min_length`` / ``max_length`` bound an acceptable value, and
+    ``supports_learn`` is True when the lock can enroll the credential at the
+    device (for example a fingerprint learn flow) rather than being told the
+    value.
+    """
+
+    num_slots: int
+    min_length: int
+    max_length: int
+    supports_learn: bool
+
+
+@dataclass(frozen=True, slots=True)
+class LockCapabilities:
+    """
+    What a lock can do, as a platform-neutral snapshot.
+
+    ``supports_user_management`` mirrors the providers' existing gate;
+    ``max_users`` is the total number of users the lock can hold; and
+    ``credential_types`` maps each supported ``CredentialType`` to its
+    per-type limits. A type absent from the mapping is unsupported.
+    """
+
+    supports_user_management: bool
+    max_users: int
+    credential_types: Mapping[CredentialType, CredentialTypeCapability]
+
+    def capability_for(
+        self, credential_type: CredentialType
+    ) -> CredentialTypeCapability | None:
+        """Return the per-type limits for ``credential_type``, else ``None``."""
+        return self.credential_types.get(credential_type)
+
+    def supports(self, credential_type: CredentialType) -> bool:
+        """Return True when the lock advertises ``credential_type``."""
+        return credential_type in self.credential_types

--- a/custom_components/lock_code_manager/domain/credentials.py
+++ b/custom_components/lock_code_manager/domain/credentials.py
@@ -14,7 +14,7 @@ do not change ``SlotCredential``, which remains the coordinator's currency.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import NamedTuple
 
@@ -126,3 +126,44 @@ class CredentialRef(NamedTuple):
     user_id: int
     type: CredentialType
     slot: int
+
+
+@dataclass(slots=True)
+class User:
+    """
+    A lock user and the credentials they present.
+
+    Modeled so the future "user is the unit, multiple credentials" world is
+    additive: today every user carries a single Personal Identification
+    Number credential, but ``credentials`` is already a list and the rule and
+    type fields already exist. ``credentials`` is mutable (a list), so this
+    aggregate is intentionally not frozen; the contained ``Credential``
+    values are themselves immutable.
+    """
+
+    user_id: int
+    name: str | None = None
+    user_type: UserType = UserType.UNRESTRICTED
+    active: bool = True
+    credential_rule: CredentialRule = CredentialRule.SINGLE
+    credentials: list[Credential] = field(default_factory=list)
+
+    @property
+    def pin_credentials(self) -> list[Credential]:
+        """Return this user's Personal Identification Number credentials."""
+        return [
+            credential
+            for credential in self.credentials
+            if credential.type is CredentialType.PIN
+        ]
+
+    def credential_for(self, credential_type: CredentialType) -> Credential | None:
+        """Return the first credential of ``credential_type``, else ``None``."""
+        return next(
+            (
+                credential
+                for credential in self.credentials
+                if credential.type is credential_type
+            ),
+            None,
+        )

--- a/custom_components/lock_code_manager/domain/credentials.py
+++ b/custom_components/lock_code_manager/domain/credentials.py
@@ -212,3 +212,48 @@ class LockCapabilities:
     def supports(self, credential_type: CredentialType) -> bool:
         """Return True when the lock advertises ``credential_type``."""
         return credential_type in self.credential_types
+
+
+def credential_from_slot(slot: int, state: SlotCredential) -> Credential:
+    """
+    Build the Personal Identification Number credential for a managed slot.
+
+    The new model relates to the coordinator's ``SlotCredential`` by a
+    one-to-one projection: a managed slot index becomes a PIN ``Credential``
+    at the same index, reusing the ``SlotCredential`` verbatim as its state.
+    """
+    return Credential(type=CredentialType.PIN, slot=slot, state=state)
+
+
+def slot_credential_of(credential: Credential) -> SlotCredential:
+    """
+    Project a Personal Identification Number credential back to a SlotCredential.
+
+    This is the inverse of ``credential_from_slot`` and is identity on the
+    state, so the coordinator can keep consuming ``SlotCredential`` unchanged.
+    It rejects non-PIN credentials because only PIN projects one-to-one onto a
+    managed slot today.
+    """
+    if credential.type is not CredentialType.PIN:
+        raise ValueError(
+            f"Only PIN credentials project to a slot, got {credential.type}"
+        )
+    return credential.state
+
+
+def user_from_slot(slot: int, state: SlotCredential, name: str | None = None) -> User:
+    """
+    Build the single-credential user for a managed slot.
+
+    Realizes today's one-managed-slot to one-user to one-PIN-credential
+    projection: the user identifier shares the slot index, the user owns
+    exactly one PIN credential at that index, and the user is active exactly
+    when the slot holds a code. A future multi-credential world only appends
+    to ``credentials`` -- no field changes here.
+    """
+    return User(
+        user_id=slot,
+        name=name,
+        active=state.is_present,
+        credentials=[credential_from_slot(slot, state)],
+    )

--- a/custom_components/lock_code_manager/domain/credentials.py
+++ b/custom_components/lock_code_manager/domain/credentials.py
@@ -14,7 +14,10 @@ do not change ``SlotCredential``, which remains the coordinator's currency.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from enum import StrEnum
+
+from .models import SlotCredential
 
 
 class CredentialType(StrEnum):
@@ -59,3 +62,52 @@ class CredentialRule(StrEnum):
     """
 
     SINGLE = "single"
+
+
+# CredentialState is the read-state of a credential value: known(value),
+# unreadable (write-only code present), or empty. It deliberately reuses
+# SlotCredential's existing semantics rather than duplicating them, so the
+# coordinator's currency and the new model never drift. Construct states via
+# SlotCredential.known(value) / .unreadable() / .empty().
+CredentialState = SlotCredential
+
+
+@dataclass(frozen=True, slots=True)
+class Credential:
+    """
+    One credential instance addressed within a user.
+
+    Pairs the credential ``type`` and its lock ``slot`` index with a reused
+    ``CredentialState`` (a ``SlotCredential``). The read-state accessors
+    delegate to that state so there is one source of truth for empty /
+    write-only / readable. Treat as an immutable value; consume via the
+    accessors rather than reaching into ``state``.
+    """
+
+    type: CredentialType
+    slot: int
+    state: CredentialState
+
+    @property
+    def is_empty(self) -> bool:
+        """Return True when the credential's slot holds no code."""
+        return self.state.is_empty
+
+    @property
+    def is_present(self) -> bool:
+        """Return True when the credential's slot holds a code."""
+        return self.state.is_present
+
+    @property
+    def is_readable(self) -> bool:
+        """Return True when the credential exposes a comparable value."""
+        return self.state.is_readable
+
+    @property
+    def readable_pin(self) -> str | None:
+        """Return the value when readable, otherwise ``None``."""
+        return self.state.readable_pin
+
+    def matches(self, pin: str) -> bool:
+        """Return True when this credential is readable and equals ``pin``."""
+        return self.state.matches(pin)

--- a/custom_components/lock_code_manager/domain/credentials.py
+++ b/custom_components/lock_code_manager/domain/credentials.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import StrEnum
+from typing import NamedTuple
 
 from .models import SlotCredential
 
@@ -111,3 +112,17 @@ class Credential:
     def matches(self, pin: str) -> bool:
         """Return True when this credential is readable and equals ``pin``."""
         return self.state.matches(pin)
+
+
+class CredentialRef(NamedTuple):
+    """
+    Stable address for a single credential.
+
+    A lightweight ``(user_id, type, slot)`` tuple used to point at a
+    credential without carrying its state. Hashable, so it works as a
+    dictionary key or set member when correlating credentials across reads.
+    """
+
+    user_id: int
+    type: CredentialType
+    slot: int

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -231,3 +231,74 @@ class TestLockCapabilities:
         )
         with pytest.raises((AttributeError, TypeError)):
             caps.max_users = 5  # type: ignore[misc]
+
+
+from custom_components.lock_code_manager.domain.credentials import (  # noqa: E402
+    credential_from_slot,
+    slot_credential_of,
+    user_from_slot,
+)
+
+
+class TestProjectionHelpers:
+    """Pure 1:1:1 projection between a managed slot and the User/Credential model."""
+
+    @pytest.mark.parametrize(
+        "state",
+        [
+            SlotCredential.known("1234"),
+            SlotCredential.unreadable(),
+            SlotCredential.empty(),
+        ],
+    )
+    def test_credential_from_slot_shares_index_and_state(
+        self, state: SlotCredential
+    ) -> None:
+        cred = credential_from_slot(5, state)
+        assert cred.type is CredentialType.PIN
+        assert cred.slot == 5
+        # The SlotCredential is reused verbatim as the credential state.
+        assert cred.state is state
+
+    @pytest.mark.parametrize(
+        "state",
+        [
+            SlotCredential.known("1234"),
+            SlotCredential.unreadable(),
+            SlotCredential.empty(),
+        ],
+    )
+    def test_slot_credential_of_round_trips(self, state: SlotCredential) -> None:
+        cred = credential_from_slot(5, state)
+        # Projecting the PIN credential back to a SlotCredential is identity.
+        assert slot_credential_of(cred) is state
+
+    def test_slot_credential_of_rejects_non_pin(self) -> None:
+        rfid = Credential(
+            type=CredentialType.RFID, slot=5, state=SlotCredential.unreadable()
+        )
+        with pytest.raises(ValueError):
+            slot_credential_of(rfid)
+
+    def test_user_from_slot_is_single_pin_user_sharing_index(self) -> None:
+        state = SlotCredential.known("1234")
+        user = user_from_slot(5, state)
+        assert user.user_id == 5
+        assert user.user_type is UserType.UNRESTRICTED
+        assert user.credential_rule is CredentialRule.SINGLE
+        # Active mirrors presence: an empty slot is an inactive user today.
+        assert user.active is True
+        assert len(user.credentials) == 1
+        cred = user.credentials[0]
+        assert cred.type is CredentialType.PIN
+        assert cred.slot == 5
+        assert cred.state is state
+
+    def test_user_from_slot_empty_is_inactive(self) -> None:
+        user = user_from_slot(5, SlotCredential.empty())
+        assert user.active is False
+        assert user.credentials[0].is_empty
+
+    def test_user_from_slot_accepts_optional_name(self) -> None:
+        user = user_from_slot(5, SlotCredential.known("1234"), name="alice")
+        assert user.name == "alice"

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -2,7 +2,21 @@
 
 import pytest
 
-from custom_components.lock_code_manager.domain.credentials import CredentialType
+from custom_components.lock_code_manager.domain.credentials import (
+    Credential,
+    CredentialRef,
+    CredentialRule,
+    CredentialState,
+    CredentialType,
+    CredentialTypeCapability,
+    LockCapabilities,
+    User,
+    UserType,
+    credential_from_slot,
+    slot_credential_of,
+    user_from_slot,
+)
+from custom_components.lock_code_manager.domain.models import SlotCredential
 
 
 class TestCredentialType:
@@ -36,12 +50,6 @@ class TestCredentialType:
         }
 
 
-from custom_components.lock_code_manager.domain.credentials import (  # noqa: E402
-    CredentialRule,
-    UserType,
-)
-
-
 class TestUserType:
     """UserType is modeled minimally; UNRESTRICTED is the default we use today."""
 
@@ -62,15 +70,6 @@ class TestCredentialRule:
 
     def test_members(self) -> None:
         assert set(CredentialRule.__members__) == {"SINGLE"}
-
-
-from custom_components.lock_code_manager.domain.credentials import (  # noqa: E402
-    Credential,
-    CredentialState,
-)
-from custom_components.lock_code_manager.domain.models import (  # noqa: E402
-    SlotCredential,
-)
 
 
 class TestCredentialStateAlias:
@@ -119,11 +118,6 @@ class TestCredential:
             cred.slot = 4  # type: ignore[misc]
 
 
-from custom_components.lock_code_manager.domain.credentials import (  # noqa: E402
-    CredentialRef,
-)
-
-
 class TestCredentialRef:
     """CredentialRef addresses a credential as (user_id, type, slot)."""
 
@@ -141,9 +135,6 @@ class TestCredentialRef:
         b = CredentialRef(user_id=1, type=CredentialType.PIN, slot=1)
         assert a == b
         assert len({a, b}) == 1
-
-
-from custom_components.lock_code_manager.domain.credentials import User  # noqa: E402
 
 
 class TestUser:
@@ -191,12 +182,6 @@ class TestUser:
         assert user.credential_for(CredentialType.RFID) is None
 
 
-from custom_components.lock_code_manager.domain.credentials import (  # noqa: E402
-    CredentialTypeCapability,
-    LockCapabilities,
-)
-
-
 class TestLockCapabilities:
     """LockCapabilities describes user management and per-type slot limits."""
 
@@ -231,13 +216,6 @@ class TestLockCapabilities:
         )
         with pytest.raises((AttributeError, TypeError)):
             caps.max_users = 5  # type: ignore[misc]
-
-
-from custom_components.lock_code_manager.domain.credentials import (  # noqa: E402
-    credential_from_slot,
-    slot_credential_of,
-    user_from_slot,
-)
 
 
 class TestProjectionHelpers:

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -117,3 +117,27 @@ class TestCredential:
         cred = Credential(type=CredentialType.PIN, slot=3, state=SlotCredential.empty())
         with pytest.raises((AttributeError, TypeError)):
             cred.slot = 4  # type: ignore[misc]
+
+
+from custom_components.lock_code_manager.domain.credentials import (  # noqa: E402
+    CredentialRef,
+)
+
+
+class TestCredentialRef:
+    """CredentialRef addresses a credential as (user_id, type, slot)."""
+
+    def test_field_order_and_values(self) -> None:
+        ref = CredentialRef(user_id=3, type=CredentialType.PIN, slot=3)
+        assert ref.user_id == 3
+        assert ref.type == CredentialType.PIN
+        assert ref.slot == 3
+        # NamedTuple positional order is part of the contract.
+        assert tuple(ref) == (3, CredentialType.PIN, 3)
+
+    def test_is_hashable_and_value_equal(self) -> None:
+        # Usable as a dict key / set member for addressing.
+        a = CredentialRef(user_id=1, type=CredentialType.PIN, slot=1)
+        b = CredentialRef(user_id=1, type=CredentialType.PIN, slot=1)
+        assert a == b
+        assert len({a, b}) == 1

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -34,3 +34,31 @@ class TestCredentialType:
             "PASSWORD",
             "NFC",
         }
+
+
+from custom_components.lock_code_manager.domain.credentials import (  # noqa: E402
+    CredentialRule,
+    UserType,
+)
+
+
+class TestUserType:
+    """UserType is modeled minimally; UNRESTRICTED is the default we use today."""
+
+    def test_unrestricted_present_and_is_str(self) -> None:
+        assert UserType.UNRESTRICTED == "unrestricted"
+        assert isinstance(UserType.UNRESTRICTED, str)
+
+    def test_members(self) -> None:
+        assert set(UserType.__members__) == {"UNRESTRICTED"}
+
+
+class TestCredentialRule:
+    """CredentialRule is modeled minimally; SINGLE is the rule we use today."""
+
+    def test_single_present_and_is_str(self) -> None:
+        assert CredentialRule.SINGLE == "single"
+        assert isinstance(CredentialRule.SINGLE, str)
+
+    def test_members(self) -> None:
+        assert set(CredentialRule.__members__) == {"SINGLE"}

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -189,3 +189,45 @@ class TestUser:
         user = User(user_id=3, credentials=[empty_pin])
         assert user.credential_for(CredentialType.PIN) is empty_pin
         assert user.credential_for(CredentialType.RFID) is None
+
+
+from custom_components.lock_code_manager.domain.credentials import (  # noqa: E402
+    CredentialTypeCapability,
+    LockCapabilities,
+)
+
+
+class TestLockCapabilities:
+    """LockCapabilities describes user management and per-type slot limits."""
+
+    def test_per_type_capability_fields(self) -> None:
+        cap = CredentialTypeCapability(
+            num_slots=30, min_length=4, max_length=8, supports_learn=False
+        )
+        assert cap.num_slots == 30
+        assert cap.min_length == 4
+        assert cap.max_length == 8
+        assert cap.supports_learn is False
+
+    def test_capabilities_expose_per_type_lookup(self) -> None:
+        pin_cap = CredentialTypeCapability(
+            num_slots=30, min_length=4, max_length=8, supports_learn=False
+        )
+        caps = LockCapabilities(
+            supports_user_management=True,
+            max_users=30,
+            credential_types={CredentialType.PIN: pin_cap},
+        )
+        assert caps.supports_user_management is True
+        assert caps.max_users == 30
+        assert caps.capability_for(CredentialType.PIN) is pin_cap
+        assert caps.capability_for(CredentialType.RFID) is None
+        assert caps.supports(CredentialType.PIN)
+        assert not caps.supports(CredentialType.RFID)
+
+    def test_capabilities_are_frozen(self) -> None:
+        caps = LockCapabilities(
+            supports_user_management=False, max_users=0, credential_types={}
+        )
+        with pytest.raises((AttributeError, TypeError)):
+            caps.max_users = 5  # type: ignore[misc]

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -217,6 +217,21 @@ class TestLockCapabilities:
         with pytest.raises((AttributeError, TypeError)):
             caps.max_users = 5  # type: ignore[misc]
 
+    def test_credential_types_is_snapshotted(self) -> None:
+        # A snapshot value object must not reflect later mutation of the
+        # caller's dict, and its stored mapping must itself be read-only.
+        pin_cap = CredentialTypeCapability(
+            num_slots=30, min_length=4, max_length=8, supports_learn=False
+        )
+        source = {CredentialType.PIN: pin_cap}
+        caps = LockCapabilities(
+            supports_user_management=True, max_users=30, credential_types=source
+        )
+        source[CredentialType.RFID] = pin_cap
+        assert not caps.supports(CredentialType.RFID)
+        with pytest.raises(TypeError):
+            caps.credential_types[CredentialType.RFID] = pin_cap  # type: ignore[index]
+
 
 class TestProjectionHelpers:
     """Pure 1:1:1 projection between a managed slot and the User/Credential model."""

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -62,3 +62,58 @@ class TestCredentialRule:
 
     def test_members(self) -> None:
         assert set(CredentialRule.__members__) == {"SINGLE"}
+
+
+from custom_components.lock_code_manager.domain.credentials import (  # noqa: E402
+    Credential,
+    CredentialState,
+)
+from custom_components.lock_code_manager.domain.models import (  # noqa: E402
+    SlotCredential,
+)
+
+
+class TestCredentialStateAlias:
+    """CredentialState is a thin reuse of SlotCredential, not a new dataclass."""
+
+    def test_credential_state_is_slot_credential(self) -> None:
+        # Aliasing guarantees there is a single implementation of the three
+        # read-states (known / unreadable / empty) shared with the coordinator.
+        assert CredentialState is SlotCredential
+
+
+class TestCredential:
+    """A Credential pairs a type and slot with a reused SlotCredential state."""
+
+    def test_known_pin_is_readable_and_present(self) -> None:
+        cred = Credential(
+            type=CredentialType.PIN, slot=3, state=SlotCredential.known("1234")
+        )
+        assert cred.is_present
+        assert cred.is_readable
+        assert not cred.is_empty
+        assert cred.readable_pin == "1234"
+        assert cred.matches("1234")
+        assert not cred.matches("0000")
+
+    def test_unreadable_is_present_not_readable(self) -> None:
+        cred = Credential(
+            type=CredentialType.PIN, slot=3, state=SlotCredential.unreadable()
+        )
+        assert cred.is_present
+        assert not cred.is_readable
+        assert not cred.is_empty
+        assert cred.readable_pin is None
+        assert not cred.matches("1234")
+
+    def test_empty_is_neither_present_nor_readable(self) -> None:
+        cred = Credential(type=CredentialType.PIN, slot=3, state=SlotCredential.empty())
+        assert cred.is_empty
+        assert not cred.is_present
+        assert not cred.is_readable
+        assert cred.readable_pin is None
+
+    def test_is_frozen(self) -> None:
+        cred = Credential(type=CredentialType.PIN, slot=3, state=SlotCredential.empty())
+        with pytest.raises((AttributeError, TypeError)):
+            cred.slot = 4  # type: ignore[misc]

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,0 +1,36 @@
+"""Tests for the cross-platform User/Credential domain model."""
+
+import pytest
+
+from custom_components.lock_code_manager.domain.credentials import CredentialType
+
+
+class TestCredentialType:
+    """CredentialType wire values must match the live provider vocabulary."""
+
+    def test_pin_wire_value_is_lowercase_pin(self) -> None:
+        # The Matter and Z-Wave providers send the literal string "pin".
+        assert CredentialType.PIN == "pin"
+        assert CredentialType.PIN.value == "pin"
+
+    def test_is_str_enum(self) -> None:
+        # StrEnum members compare and serialize as their string value.
+        assert isinstance(CredentialType.PIN, str)
+
+    @pytest.mark.parametrize(
+        "member",
+        ["PIN", "RFID", "FINGERPRINT", "FACE", "PASSWORD", "NFC"],
+    )
+    def test_reserved_future_members_present(self, member: str) -> None:
+        # Reserved so a future multi-credential expansion is purely additive.
+        assert member in CredentialType.__members__
+
+    def test_no_unexpected_members(self) -> None:
+        assert set(CredentialType.__members__) == {
+            "PIN",
+            "RFID",
+            "FINGERPRINT",
+            "FACE",
+            "PASSWORD",
+            "NFC",
+        }

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -141,3 +141,51 @@ class TestCredentialRef:
         b = CredentialRef(user_id=1, type=CredentialType.PIN, slot=1)
         assert a == b
         assert len({a, b}) == 1
+
+
+from custom_components.lock_code_manager.domain.credentials import User  # noqa: E402
+
+
+class TestUser:
+    """A User owns a list of credentials; defaults model today's single user."""
+
+    def test_defaults_are_minimal(self) -> None:
+        user = User(user_id=3)
+        assert user.user_id == 3
+        assert user.name is None
+        assert user.user_type is UserType.UNRESTRICTED
+        assert user.active is True
+        assert user.credential_rule is CredentialRule.SINGLE
+        assert user.credentials == []
+
+    def test_each_user_gets_its_own_credentials_list(self) -> None:
+        # A mutable default must not be shared across instances.
+        a = User(user_id=1)
+        b = User(user_id=2)
+        assert a.credentials is not b.credentials
+
+    def test_holds_credentials(self) -> None:
+        cred = Credential(
+            type=CredentialType.PIN, slot=3, state=SlotCredential.known("1234")
+        )
+        user = User(user_id=3, name="alice", credentials=[cred])
+        assert user.credentials == [cred]
+        assert user.name == "alice"
+
+    def test_pin_credentials_filters_by_type(self) -> None:
+        pin = Credential(
+            type=CredentialType.PIN, slot=3, state=SlotCredential.known("1234")
+        )
+        rfid = Credential(
+            type=CredentialType.RFID, slot=3, state=SlotCredential.unreadable()
+        )
+        user = User(user_id=3, credentials=[pin, rfid])
+        assert user.pin_credentials == [pin]
+
+    def test_credential_for_returns_first_match_or_none(self) -> None:
+        empty_pin = Credential(
+            type=CredentialType.PIN, slot=3, state=SlotCredential.empty()
+        )
+        user = User(user_id=3, credentials=[empty_pin])
+        assert user.credential_for(CredentialType.PIN) is empty_pin
+        assert user.credential_for(CredentialType.RFID) is None


### PR DESCRIPTION
## Proposed change

Introduces a cross-platform **User → Credential** domain model as a first-class internal abstraction, modeled on the shared shape of the Z-Wave User Credential Command Class and the Matter DoorLock cluster. This is **purely additive** — one new module (`domain/credentials.py`) plus its unit tests. No provider, coordinator, or `BaseLock` code changes.

New types:
- `CredentialType` (StrEnum) — `PIN` is the only one exercised today; `RFID/FINGERPRINT/FACE/PASSWORD/NFC` are reserved so a future multi-credential expansion is additive. `PIN` serializes to the lowercase `"pin"` wire value the providers already send.
- `UserType` / `CredentialRule` — modeled minimally (`UNRESTRICTED` / `SINGLE`).
- `CredentialState` — a thin reuse (alias) of the existing `SlotCredential`, so the coordinator's currency and the new model never drift (single source of truth for known/unreadable/empty).
- `Credential`, `User`, `CredentialRef`, `CredentialTypeCapability`, `LockCapabilities`.
- Pure 1:1:1 projection helpers (`credential_from_slot` / `slot_credential_of` / `user_from_slot`) — **not yet wired into any provider or coordinator**.

The model is shaped so today's one-managed-slot ↔ one-user ↔ one-PIN-credential projection is a thin pure function, while a future "user is the unit, multiple credentials" world only appends to `User.credentials` — no field changes. `SlotCredential` keeps its name, module, and every method.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- Part of the credential-management refactor (migrating providers onto the unified Z-Wave `accessControl` API + Matter user/credential helpers). This PR lands only the shared domain types; later PRs wire them into `BaseLock` and the providers.
- 38 new unit tests; existing suite unaffected (`SlotCredential` and all existing behavior untouched).
