### PR TITLE
test(zwave_js): modernize provider test suite (fixtures, helpers, boilerplate)

### DIFF
--- a/tests/providers/zwave_js/conftest.py
+++ b/tests/providers/zwave_js/conftest.py
@@ -30,6 +30,8 @@ from custom_components.lock_code_manager.const import (
 from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers.zwave_js import ZWaveJSLock
 
+from .helpers import _PROVIDER_MODULE
+
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
 
@@ -302,9 +304,6 @@ def e2e_zwave_lock(
 # ---------------------------------------------------------------------------
 # Shared provider fixtures (used by both test_provider.py and test_events.py)
 # ---------------------------------------------------------------------------
-
-# Module path where provider functions are imported (for patching in tests).
-_PROVIDER_MODULE = "custom_components.lock_code_manager.providers.zwave_js"
 
 
 @pytest.fixture(name="zwave_js_lock")

--- a/tests/providers/zwave_js/conftest.py
+++ b/tests/providers/zwave_js/conftest.py
@@ -12,6 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
+from zwave_js_server.const import CommandClass
 from zwave_js_server.model.driver import Driver
 from zwave_js_server.model.node import Node
 from zwave_js_server.version import VersionInfo
@@ -19,13 +20,14 @@ from zwave_js_server.version import VersionInfo
 from homeassistant.components.zwave_js.const import DOMAIN as ZWAVE_JS_DOMAIN
 from homeassistant.const import CONF_ENABLED, CONF_NAME, CONF_PIN
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from custom_components.lock_code_manager.const import (
     CONF_LOCKS,
     CONF_SLOTS,
     DOMAIN,
 )
+from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers.zwave_js import ZWaveJSLock
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
@@ -295,3 +297,161 @@ def e2e_zwave_lock(
 ) -> ZWaveJSLock:
     """Extract the ZWaveJSLock from the LCM config entry."""
     return get_zwave_lock(hass, lcm_config_entry, lock_entity)
+
+
+# ---------------------------------------------------------------------------
+# Shared provider fixtures (used by both test_provider.py and test_events.py)
+# ---------------------------------------------------------------------------
+
+# Module path where provider functions are imported (for patching in tests).
+_PROVIDER_MODULE = "custom_components.lock_code_manager.providers.zwave_js"
+
+
+@pytest.fixture(name="zwave_js_lock")
+async def zwave_js_lock_fixture(
+    hass: HomeAssistant,
+    zwave_integration: MockConfigEntry,
+    lock_entity: er.RegistryEntry,
+    lock_schlage_be469: Node,
+) -> ZWaveJSLock:
+    """Create a ZWaveJSLock instance (User Code CC V1) for testing."""
+    return ZWaveJSLock(
+        hass=hass,
+        dev_reg=dr.async_get(hass),
+        ent_reg=er.async_get(hass),
+        lock_config_entry=zwave_integration,
+        lock=lock_entity,
+    )
+
+
+@pytest.fixture(name="zwave_js_lock_v2")
+async def zwave_js_lock_v2_fixture(
+    hass: HomeAssistant,
+    zwave_integration: MockConfigEntry,
+    lock_entity: er.RegistryEntry,
+    lock_schlage_be469_v2: Node,
+) -> ZWaveJSLock:
+    """Create a ZWaveJSLock with User Code CC V2 for testing."""
+    return ZWaveJSLock(
+        hass=hass,
+        dev_reg=dr.async_get(hass),
+        ent_reg=er.async_get(hass),
+        lock_config_entry=zwave_integration,
+        lock=lock_entity,
+    )
+
+
+@pytest.fixture(name="mock_get_usercode_from_node", autouse=True)
+def mock_get_usercode_from_node_fixture():
+    """
+    Mock get_usercode_from_node for all tests.
+
+    V1 set/clear calls get_usercode_from_node to poll the slot from the device.
+    In tests, the node has no real Z-Wave JS server connection, so we mock the
+    function. Individual tests can access the mock via the parameter name.
+    """
+    with patch(
+        f"{_PROVIDER_MODULE}.get_usercode_from_node",
+        new_callable=AsyncMock,
+    ) as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_coordinator():
+    """
+    Return a factory for mock coordinators preloaded with slot state.
+
+    Replaces the repeated ``MagicMock(); .data = {...}; lock.coordinator = ...``
+    pattern. Call with a slot->SlotCredential dict; assign the result to
+    ``lock.coordinator``.
+    """
+
+    def _make(data: dict[int, SlotCredential] | None = None) -> MagicMock:
+        coordinator = MagicMock()
+        coordinator.data = data or {}
+        return coordinator
+
+    return _make
+
+
+@pytest.fixture
+async def simple_lcm_config_entry(
+    hass: HomeAssistant,
+    lock_entity: er.RegistryEntry,
+) -> MockConfigEntry:
+    """
+    Register a lightweight LCM config entry managing slots 1 and 2.
+
+    Mirrors the Matter provider's ``simple_lcm_config_entry``: it only adds slot
+    configuration data so ``managed_slots`` is populated on the provider. It does
+    NOT go through ``async_setup_internal`` — method-level tests that need
+    managed slots use this instead of the setup/unload lifecycle boilerplate.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_LOCKS: [lock_entity.entity_id],
+            CONF_SLOTS: {
+                1: {CONF_NAME: "slot1", CONF_PIN: "9999", CONF_ENABLED: True},
+                2: {CONF_NAME: "slot2", CONF_PIN: "1234", CONF_ENABLED: True},
+            },
+        },
+        unique_id="test_zwave_js_simple_lcm",
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+@pytest.fixture
+def mock_zwave_usercodes(zwave_client: MagicMock):
+    """
+    Mock Z-Wave JS usercode functions with mutable state.
+
+    Both ``get_usercodes`` and ``get_usercode`` read from a shared mutable
+    ``codes`` dict. The client's ``async_send_command`` is wrapped so that
+    set / clear Z-Wave commands automatically update ``codes``, preventing
+    the coordinator refresh from overwriting optimistic push updates with
+    stale data.
+
+    Yields ``(mock_get_usercodes, mock_get_usercode, codes)`` where *codes*
+    is ``dict[int, dict]`` keyed by slot number.
+    """
+    codes: dict[int, dict] = {}
+
+    original_side_effect = zwave_client.async_send_command.side_effect
+
+    async def _send_command_with_codes(message, require_schema=None):
+        if message.get("command") == "node.set_value":
+            vid = message.get("valueId", {})
+            if vid.get("commandClass") == CommandClass.USER_CODE:
+                slot = vid.get("propertyKey")
+                if slot is not None:
+                    prop = vid.get("property")
+                    if prop == "userIdStatus":
+                        # Clear operation
+                        codes[slot] = {
+                            "code_slot": slot,
+                            "in_use": False,
+                            "usercode": "",
+                        }
+                    elif prop == "userCode":
+                        # Set operation
+                        codes[slot] = {
+                            "code_slot": slot,
+                            "in_use": True,
+                            "usercode": str(message["value"]),
+                        }
+        return await original_side_effect(message, require_schema)
+
+    with (
+        patch(f"{_PROVIDER_MODULE}.get_usercodes") as mock_all,
+        patch(f"{_PROVIDER_MODULE}.get_usercode") as mock_one,
+    ):
+        mock_all.side_effect = lambda node: list(codes.values())
+        mock_one.side_effect = lambda node, slot: codes.get(
+            slot, {"code_slot": slot, "in_use": False, "usercode": ""}
+        )
+        zwave_client.async_send_command.side_effect = _send_command_with_codes
+        yield mock_all, mock_one, codes
+        zwave_client.async_send_command.side_effect = original_side_effect

--- a/tests/providers/zwave_js/helpers.py
+++ b/tests/providers/zwave_js/helpers.py
@@ -1,4 +1,4 @@
-"""Z-Wave JS provider test helpers — event factories and entity-id lookups."""
+"""Shared Z-Wave JS provider test helpers: patch paths, event factories, entity lookups."""
 
 from __future__ import annotations
 
@@ -11,6 +11,9 @@ from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
 
 from custom_components.lock_code_manager.const import DOMAIN
+
+# Module path where provider functions are imported (used as a patch target).
+_PROVIDER_MODULE = "custom_components.lock_code_manager.providers.zwave_js"
 
 
 def async_capture_events(

--- a/tests/providers/zwave_js/helpers.py
+++ b/tests/providers/zwave_js/helpers.py
@@ -1,0 +1,60 @@
+"""Z-Wave JS provider test helpers — event factories and entity-id lookups."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from zwave_js_server.event import Event as ZwaveEvent
+
+from homeassistant.const import CONF_ENABLED
+from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
+
+from custom_components.lock_code_manager.const import DOMAIN
+
+
+def async_capture_events(
+    hass: HomeAssistant, event_name: str
+) -> list[Event[dict[str, Any]]]:
+    """Capture events of the given type on the hass event bus."""
+    events: list[Event[dict[str, Any]]] = []
+
+    @callback
+    def capture_events(event: Event[dict[str, Any]]) -> None:
+        events.append(event)
+
+    hass.bus.async_listen(event_name, capture_events)
+    return events
+
+
+def make_duplicate_code_event(node_id: int, user_id: int | None = None) -> ZwaveEvent:
+    """Create a duplicate-code Access Control notification ZwaveEvent."""
+    params: dict[str, Any] = {}
+    if user_id is not None:
+        params["userId"] = user_id
+    return ZwaveEvent(
+        type="notification",
+        data={
+            "source": "node",
+            "event": "notification",
+            "nodeId": node_id,
+            "endpointIndex": 0,
+            "ccId": 113,
+            "args": {
+                "type": 6,  # ACCESS_CONTROL
+                "event": 15,  # NEW_USER_CODE_NOT_ADDED_DUE_TO_DUPLICATE_CODE
+                "label": "Access Control",
+                "eventLabel": "New user code not added due to duplicate code",
+                "parameters": params,
+            },
+        },
+    )
+
+
+def get_enabled_switch_entity_id(hass: HomeAssistant, entry_id: str, slot: int) -> str:
+    """Return the enabled-switch entity ID for a slot, asserting it exists."""
+    ent_reg = er.async_get(hass)
+    uid = f"{entry_id}|{slot}|{CONF_ENABLED}"
+    entity_id = ent_reg.async_get_entity_id("switch", DOMAIN, uid)
+    assert entity_id, f"Switch entity not found for slot {slot}"
+    return entity_id

--- a/tests/providers/zwave_js/test_events.py
+++ b/tests/providers/zwave_js/test_events.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -79,105 +79,6 @@ def _make_duplicate_code_event(node_id: int, user_id: int | None = None) -> Zwav
             },
         },
     )
-
-
-# ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
-
-
-@pytest.fixture(autouse=True)
-def mock_get_usercode_from_node():
-    """
-    Mock get_usercode_from_node for all tests.
-
-    V1 set/clear calls get_usercode_from_node to poll the slot from the device.
-    In tests, the node doesn't have a real Z-Wave JS server connection, so we
-    mock the function. Individual tests can access the mock via parameter name.
-    """
-    with patch(
-        "custom_components.lock_code_manager.providers.zwave_js.get_usercode_from_node",
-        new_callable=AsyncMock,
-    ) as mock:
-        yield mock
-
-
-@pytest.fixture(name="zwave_js_lock")
-async def zwave_js_lock_fixture(
-    hass: HomeAssistant,
-    zwave_integration: MockConfigEntry,
-    lock_entity: er.RegistryEntry,
-    lock_schlage_be469: Node,
-) -> ZWaveJSLock:
-    """Create a ZWaveJSLock instance for testing."""
-    dev_reg = dr.async_get(hass)
-    ent_reg = er.async_get(hass)
-
-    return ZWaveJSLock(
-        hass=hass,
-        dev_reg=dev_reg,
-        ent_reg=ent_reg,
-        lock_config_entry=zwave_integration,
-        lock=lock_entity,
-    )
-
-
-@pytest.fixture
-def mock_zwave_usercodes(zwave_client: MagicMock):
-    """
-    Mock Z-Wave JS usercode functions with mutable state.
-
-    Both ``get_usercodes`` and ``get_usercode`` read from a shared mutable
-    ``codes`` dict.  The client's ``async_send_command`` is wrapped so that
-    set / clear Z-Wave commands automatically update ``codes``, preventing
-    the coordinator refresh from overwriting optimistic push updates with
-    stale data.
-
-    Yields ``(mock_get_usercodes, mock_get_usercode, codes)`` where *codes*
-    is ``dict[int, dict]`` keyed by slot number.
-    """
-    codes: dict[int, dict] = {}
-
-    original_side_effect = zwave_client.async_send_command.side_effect
-
-    async def _send_command_with_codes(message, require_schema=None):
-        if message.get("command") == "node.set_value":
-            vid = message.get("valueId", {})
-            if vid.get("commandClass") == CommandClass.USER_CODE:
-                slot = vid.get("propertyKey")
-                if slot is not None:
-                    prop = vid.get("property")
-                    if prop == "userIdStatus":
-                        # Clear operation
-                        codes[slot] = {
-                            "code_slot": slot,
-                            "in_use": False,
-                            "usercode": "",
-                        }
-                    elif prop == "userCode":
-                        # Set operation
-                        codes[slot] = {
-                            "code_slot": slot,
-                            "in_use": True,
-                            "usercode": str(message["value"]),
-                        }
-        return await original_side_effect(message, require_schema)
-
-    with (
-        patch(
-            "custom_components.lock_code_manager.providers.zwave_js.get_usercodes",
-        ) as mock_all,
-        patch(
-            "custom_components.lock_code_manager.providers.zwave_js.get_usercode",
-        ) as mock_one,
-    ):
-        mock_all.side_effect = lambda node: list(codes.values())
-        mock_one.side_effect = lambda node, slot: codes.get(
-            slot, {"code_slot": slot, "in_use": False, "usercode": ""}
-        )
-        zwave_client.async_send_command.side_effect = _send_command_with_codes
-        yield mock_all, mock_one, codes
-        zwave_client.async_send_command.side_effect = original_side_effect
 
 
 async def _setup_lcm_entry(

--- a/tests/providers/zwave_js/test_events.py
+++ b/tests/providers/zwave_js/test_events.py
@@ -179,14 +179,9 @@ async def test_subscribe_push_no_crash_on_node_error(
 async def test_event_filter_matches_correct_node(
     hass: HomeAssistant,
     zwave_js_lock: ZWaveJSLock,
-    zwave_integration: MockConfigEntry,
     lock_schlage_be469: Node,
 ) -> None:
     """Test that event filter matches events for the correct node."""
-    lcm_entry = MockConfigEntry(domain=DOMAIN, data={CONF_LOCKS: [], CONF_SLOTS: {}})
-    lcm_entry.add_to_hass(hass)
-    await zwave_js_lock.async_setup_internal(lcm_entry)
-
     dev_reg = dr.async_get(hass)
     device = dev_reg.async_get(zwave_js_lock.lock.device_id)
     assert device is not None
@@ -205,8 +200,6 @@ async def test_event_filter_matches_correct_node(
         "device_id": zwave_js_lock.lock.device_id,
     }
     assert zwave_js_lock._zwave_js_event_filter(event_data_wrong_node) is False
-
-    await zwave_js_lock.async_unload(False)
 
 
 # ---------------------------------------------------------------------------
@@ -311,7 +304,6 @@ async def test_notification_event_keypad_unlock_fires_lock_state_changed(
 async def test_push_update_masked_code_sends_unknown(
     hass: HomeAssistant,
     zwave_js_lock: ZWaveJSLock,
-    zwave_integration: MockConfigEntry,
     lock_schlage_be469: Node,
 ) -> None:
     """
@@ -320,16 +312,6 @@ async def test_push_update_masked_code_sends_unknown(
     When a push update arrives with a masked code (all asterisks) and the slot
     is in use, the coordinator should receive SlotCredential.unreadable().
     """
-    lcm_entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            CONF_LOCKS: [zwave_js_lock.lock.entity_id],
-            CONF_SLOTS: {"2": {}},
-        },
-    )
-    lcm_entry.add_to_hass(hass)
-    await zwave_js_lock.async_setup_internal(lcm_entry)
-
     # Set up a mock coordinator (push_update is synchronous)
     mock_coordinator = MagicMock()
     mock_coordinator.data = {}
@@ -367,20 +349,9 @@ async def test_push_update_masked_code_sends_unknown(
 async def test_push_update_falsy_value_sends_empty(
     hass: HomeAssistant,
     zwave_js_lock: ZWaveJSLock,
-    zwave_integration: MockConfigEntry,
     lock_schlage_be469: Node,
 ) -> None:
     """Test that push updates with falsy values send SlotCredential.empty()."""
-    lcm_entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            CONF_LOCKS: [zwave_js_lock.lock.entity_id],
-            CONF_SLOTS: {"2": {}},
-        },
-    )
-    lcm_entry.add_to_hass(hass)
-    await zwave_js_lock.async_setup_internal(lcm_entry)
-
     mock_coordinator = MagicMock()
     mock_coordinator.data = {2: SlotCredential.known("1234")}
     zwave_js_lock.coordinator = mock_coordinator
@@ -410,20 +381,9 @@ async def test_push_update_falsy_value_sends_empty(
 async def test_push_update_all_zeros_not_in_use_sends_empty(
     hass: HomeAssistant,
     zwave_js_lock: ZWaveJSLock,
-    zwave_integration: MockConfigEntry,
     lock_schlage_be469: Node,
 ) -> None:
     """Test that all-zeros with slot_in_use=False sends SlotCredential.empty()."""
-    lcm_entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            CONF_LOCKS: [zwave_js_lock.lock.entity_id],
-            CONF_SLOTS: {"2": {}},
-        },
-    )
-    lcm_entry.add_to_hass(hass)
-    await zwave_js_lock.async_setup_internal(lcm_entry)
-
     mock_coordinator = MagicMock()
     mock_coordinator.data = {2: SlotCredential.known("1234")}
     zwave_js_lock.coordinator = mock_coordinator
@@ -455,20 +415,9 @@ async def test_push_update_all_zeros_not_in_use_sends_empty(
 async def test_push_update_duplicate_value_skipped(
     hass: HomeAssistant,
     zwave_js_lock: ZWaveJSLock,
-    zwave_integration: MockConfigEntry,
     lock_schlage_be469: Node,
 ) -> None:
     """Test that duplicate push updates are silently skipped."""
-    lcm_entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            CONF_LOCKS: [zwave_js_lock.lock.entity_id],
-            CONF_SLOTS: {"2": {}},
-        },
-    )
-    lcm_entry.add_to_hass(hass)
-    await zwave_js_lock.async_setup_internal(lcm_entry)
-
     mock_coordinator = MagicMock()
     mock_coordinator.data = {2: SlotCredential.known("1234")}  # Already has this value
     zwave_js_lock.coordinator = mock_coordinator
@@ -499,20 +448,9 @@ async def test_push_update_duplicate_value_skipped(
 async def test_push_update_masked_code_with_unknown_in_use_sends_unknown(
     hass: HomeAssistant,
     zwave_js_lock: ZWaveJSLock,
-    zwave_integration: MockConfigEntry,
     lock_schlage_be469: Node,
 ) -> None:
     """Test that masked codes with slot_in_use=None still send UNREADABLE_CODE."""
-    lcm_entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            CONF_LOCKS: [zwave_js_lock.lock.entity_id],
-            CONF_SLOTS: {"2": {}},
-        },
-    )
-    lcm_entry.add_to_hass(hass)
-    await zwave_js_lock.async_setup_internal(lcm_entry)
-
     mock_coordinator = MagicMock()
     mock_coordinator.data = {}
     zwave_js_lock.coordinator = mock_coordinator
@@ -550,7 +488,6 @@ async def test_push_update_masked_code_with_unknown_in_use_sends_unknown(
 async def test_push_update_user_id_status_available_clears_slot(
     hass: HomeAssistant,
     zwave_js_lock: ZWaveJSLock,
-    zwave_integration: MockConfigEntry,
     lock_schlage_be469: Node,
 ) -> None:
     """
@@ -560,16 +497,6 @@ async def test_push_update_user_id_status_available_clears_slot(
     it means the slot has been cleared. This should update the coordinator
     to mark the slot as empty.
     """
-    lcm_entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            CONF_LOCKS: [zwave_js_lock.lock.entity_id],
-            CONF_SLOTS: {"2": {}},
-        },
-    )
-    lcm_entry.add_to_hass(hass)
-    await zwave_js_lock.async_setup_internal(lcm_entry)
-
     # Set up a mock coordinator with existing data
     mock_coordinator = MagicMock()
     mock_coordinator.data = {2: SlotCredential.known("1234")}  # Slot has a PIN
@@ -598,13 +525,11 @@ async def test_push_update_user_id_status_available_clears_slot(
     mock_coordinator.push_update.assert_called_once_with({2: SlotCredential.empty()})
 
     zwave_js_lock.unsubscribe_push_updates()
-    await zwave_js_lock.async_unload(False)
 
 
 async def test_push_update_user_id_status_available_skipped_when_already_empty(
     hass: HomeAssistant,
     zwave_js_lock: ZWaveJSLock,
-    zwave_integration: MockConfigEntry,
     lock_schlage_be469: Node,
 ) -> None:
     """
@@ -613,16 +538,6 @@ async def test_push_update_user_id_status_available_skipped_when_already_empty(
     If the coordinator already shows the slot as empty, we shouldn't
     push another update.
     """
-    lcm_entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            CONF_LOCKS: [zwave_js_lock.lock.entity_id],
-            CONF_SLOTS: {"2": {}},
-        },
-    )
-    lcm_entry.add_to_hass(hass)
-    await zwave_js_lock.async_setup_internal(lcm_entry)
-
     # Set up a mock coordinator - slot already empty
     mock_coordinator = MagicMock()
     mock_coordinator.data = {2: SlotCredential.empty()}  # Slot already empty
@@ -650,13 +565,11 @@ async def test_push_update_user_id_status_available_skipped_when_already_empty(
     mock_coordinator.push_update.assert_not_called()
 
     zwave_js_lock.unsubscribe_push_updates()
-    await zwave_js_lock.async_unload(False)
 
 
 async def test_push_update_user_id_status_enabled_ignored(
     hass: HomeAssistant,
     zwave_js_lock: ZWaveJSLock,
-    zwave_integration: MockConfigEntry,
     lock_schlage_be469: Node,
 ) -> None:
     """
@@ -665,16 +578,6 @@ async def test_push_update_user_id_status_enabled_ignored(
     We only care about AVAILABLE status for clearing slots.
     ENABLED status doesn't tell us the PIN value.
     """
-    lcm_entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            CONF_LOCKS: [zwave_js_lock.lock.entity_id],
-            CONF_SLOTS: {"2": {}},
-        },
-    )
-    lcm_entry.add_to_hass(hass)
-    await zwave_js_lock.async_setup_internal(lcm_entry)
-
     # Set up a mock coordinator
     mock_coordinator = MagicMock()
     mock_coordinator.data = {2: SlotCredential.empty()}
@@ -702,13 +605,11 @@ async def test_push_update_user_id_status_enabled_ignored(
     mock_coordinator.push_update.assert_not_called()
 
     zwave_js_lock.unsubscribe_push_updates()
-    await zwave_js_lock.async_unload(False)
 
 
 async def test_push_update_user_id_status_available_ignored_when_slot_expects_pin(
     hass: HomeAssistant,
     zwave_js_lock: ZWaveJSLock,
-    zwave_integration: MockConfigEntry,
     lock_schlage_be469: Node,
 ) -> None:
     """
@@ -717,16 +618,6 @@ async def test_push_update_user_id_status_available_ignored_when_slot_expects_pi
     This prevents sync loops where the lock sends stale AVAILABLE status
     after a code was successfully set.
     """
-    lcm_entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            CONF_LOCKS: [zwave_js_lock.lock.entity_id],
-            CONF_SLOTS: {"2": {}},
-        },
-    )
-    lcm_entry.add_to_hass(hass)
-    await zwave_js_lock.async_setup_internal(lcm_entry)
-
     # Set up a mock coordinator with existing PIN
     mock_coordinator = MagicMock()
     mock_coordinator.data = {2: SlotCredential.known("1234")}  # Slot has a PIN
@@ -757,13 +648,11 @@ async def test_push_update_user_id_status_available_ignored_when_slot_expects_pi
     mock_coordinator.push_update.assert_not_called()
 
     zwave_js_lock.unsubscribe_push_updates()
-    await zwave_js_lock.async_unload(False)
 
 
 async def test_push_update_user_id_status_available_clears_when_slot_inactive(
     hass: HomeAssistant,
     zwave_js_lock: ZWaveJSLock,
-    zwave_integration: MockConfigEntry,
     lock_schlage_be469: Node,
 ) -> None:
     """
@@ -772,16 +661,6 @@ async def test_push_update_user_id_status_available_clears_when_slot_inactive(
     When the slot is inactive (active=OFF), AVAILABLE status should clear
     the coordinator as expected.
     """
-    lcm_entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            CONF_LOCKS: [zwave_js_lock.lock.entity_id],
-            CONF_SLOTS: {"2": {}},
-        },
-    )
-    lcm_entry.add_to_hass(hass)
-    await zwave_js_lock.async_setup_internal(lcm_entry)
-
     # Set up a mock coordinator with existing PIN
     mock_coordinator = MagicMock()
     mock_coordinator.data = {2: SlotCredential.known("1234")}  # Slot has a PIN
@@ -812,7 +691,6 @@ async def test_push_update_user_id_status_available_clears_when_slot_inactive(
     mock_coordinator.push_update.assert_called_once_with({2: SlotCredential.empty()})
 
     zwave_js_lock.unsubscribe_push_updates()
-    await zwave_js_lock.async_unload(False)
 
 
 # ---------------------------------------------------------------------------
@@ -971,20 +849,9 @@ async def test_duplicate_code_notification_ignored_when_user_id_mismatches(
 async def test_set_in_progress_cleared_on_value_update(
     hass: HomeAssistant,
     zwave_js_lock: ZWaveJSLock,
-    zwave_integration: MockConfigEntry,
     lock_schlage_be469: Node,
 ) -> None:
     """Test that a push value update for the in-progress slot clears the field."""
-    lcm_entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            CONF_LOCKS: [zwave_js_lock.lock.entity_id],
-            CONF_SLOTS: {"2": {}},
-        },
-    )
-    lcm_entry.add_to_hass(hass)
-    await zwave_js_lock.async_setup(lcm_entry)
-
     mock_coordinator = MagicMock()
     mock_coordinator.data = {2: SlotCredential.empty()}
     zwave_js_lock.coordinator = mock_coordinator
@@ -1013,7 +880,6 @@ async def test_set_in_progress_cleared_on_value_update(
     assert zwave_js_lock._set_in_progress_code_slot is None
 
     zwave_js_lock.unsubscribe_push_updates()
-    await zwave_js_lock.async_unload(False)
 
 
 async def test_internal_set_usercode_raises_duplicate_for_rejected_slot(

--- a/tests/providers/zwave_js/test_events.py
+++ b/tests/providers/zwave_js/test_events.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -17,7 +16,7 @@ from zwave_js_server.event import Event as ZwaveEvent
 from zwave_js_server.model.node import Node
 
 from homeassistant.const import CONF_ENABLED, CONF_NAME, CONF_PIN, STATE_ON
-from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.issue_registry import async_get as async_get_issue_registry
 
@@ -38,47 +37,15 @@ from custom_components.lock_code_manager.domain.models import (
 )
 from custom_components.lock_code_manager.providers.zwave_js import ZWaveJSLock
 
+from .helpers import (
+    async_capture_events,
+    get_enabled_switch_entity_id,
+    make_duplicate_code_event,
+)
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-
-def async_capture_events(
-    hass: HomeAssistant, event_name: str
-) -> list[Event[dict[str, Any]]]:
-    """Create a helper that captures events."""
-    events: list[Event[dict[str, Any]]] = []
-
-    @callback
-    def capture_events(event: Event[dict[str, Any]]) -> None:
-        events.append(event)
-
-    hass.bus.async_listen(event_name, capture_events)
-    return events
-
-
-def _make_duplicate_code_event(node_id: int, user_id: int | None = None) -> ZwaveEvent:
-    """Create a duplicate code notification ZwaveEvent."""
-    params: dict[str, Any] = {}
-    if user_id is not None:
-        params["userId"] = user_id
-    return ZwaveEvent(
-        type="notification",
-        data={
-            "source": "node",
-            "event": "notification",
-            "nodeId": node_id,
-            "endpointIndex": 0,
-            "ccId": 113,
-            "args": {
-                "type": 6,  # ACCESS_CONTROL
-                "event": 15,  # NEW_USER_CODE_NOT_ADDED_DUE_TO_DUPLICATE_CODE
-                "label": "Access Control",
-                "eventLabel": "New user code not added due to duplicate code",
-                "parameters": params,
-            },
-        },
-    )
 
 
 async def _setup_lcm_entry(
@@ -107,15 +74,6 @@ async def _setup_lcm_entry(
     await hass.config_entries.async_setup(lcm_entry.entry_id)
     await hass.async_block_till_done()
     return lcm_entry
-
-
-def _get_enabled_switch_entity_id(hass: HomeAssistant, entry_id: str, slot: int) -> str:
-    """Get the enabled switch entity ID for a slot."""
-    ent_reg = er.async_get(hass)
-    uid = f"{entry_id}|{slot}|{CONF_ENABLED}"
-    entity_id = ent_reg.async_get_entity_id("switch", DOMAIN, uid)
-    assert entity_id, f"Switch entity not found for slot {slot}"
-    return entity_id
 
 
 # ---------------------------------------------------------------------------
@@ -883,7 +841,7 @@ async def test_duplicate_code_notification_marks_rejected(
     lock_instance._set_in_progress_code_slot = 2
 
     lock_schlage_be469.receive_event(
-        _make_duplicate_code_event(lock_schlage_be469.node_id, user_id=2)
+        make_duplicate_code_event(lock_schlage_be469.node_id, user_id=2)
     )
     await hass.async_block_till_done()
 
@@ -916,7 +874,7 @@ async def test_duplicate_code_notification_no_user_id_marks_rejected(
     lock_instance._set_in_progress_code_slot = 3
 
     lock_schlage_be469.receive_event(
-        _make_duplicate_code_event(lock_schlage_be469.node_id)
+        make_duplicate_code_event(lock_schlage_be469.node_id)
     )
     await hass.async_block_till_done()
 
@@ -940,12 +898,12 @@ async def test_duplicate_code_notification_ignored_when_not_in_progress(
         {"2": {CONF_NAME: "test", CONF_PIN: "1234", CONF_ENABLED: True}},
         mock_zwave_usercodes,
     )
-    switch_entity_id = _get_enabled_switch_entity_id(hass, lcm_entry.entry_id, 2)
+    switch_entity_id = get_enabled_switch_entity_id(hass, lcm_entry.entry_id, 2)
     assert hass.states.get(switch_entity_id).state == STATE_ON
 
     # Do NOT set _set_in_progress_code_slot (external trigger)
     lock_schlage_be469.receive_event(
-        _make_duplicate_code_event(lock_schlage_be469.node_id, user_id=2)
+        make_duplicate_code_event(lock_schlage_be469.node_id, user_id=2)
     )
     await hass.async_block_till_done()
 
@@ -981,8 +939,8 @@ async def test_duplicate_code_notification_ignored_when_user_id_mismatches(
         },
         mock_zwave_usercodes,
     )
-    switch_2 = _get_enabled_switch_entity_id(hass, lcm_entry.entry_id, 2)
-    switch_3 = _get_enabled_switch_entity_id(hass, lcm_entry.entry_id, 3)
+    switch_2 = get_enabled_switch_entity_id(hass, lcm_entry.entry_id, 2)
+    switch_3 = get_enabled_switch_entity_id(hass, lcm_entry.entry_id, 3)
 
     runtime_data: LockCodeManagerConfigEntryRuntimeData = lcm_entry.runtime_data
     lock_instance = runtime_data.locks[lock_entity.entity_id]
@@ -991,7 +949,7 @@ async def test_duplicate_code_notification_ignored_when_user_id_mismatches(
     lock_instance._set_in_progress_code_slot = 2
 
     lock_schlage_be469.receive_event(
-        _make_duplicate_code_event(lock_schlage_be469.node_id, user_id=3)
+        make_duplicate_code_event(lock_schlage_be469.node_id, user_id=3)
     )
     await hass.async_block_till_done()
 

--- a/tests/providers/zwave_js/test_provider.py
+++ b/tests/providers/zwave_js/test_provider.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -22,6 +22,9 @@ from custom_components.lock_code_manager.const import (
 from custom_components.lock_code_manager.domain.exceptions import LockDisconnected
 from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers.zwave_js import ZWaveJSLock
+
+# Module path where provider functions are imported (for patching in tests).
+_PROVIDER_MODULE = "custom_components.lock_code_manager.providers.zwave_js"
 
 # Properties tests
 
@@ -130,44 +133,24 @@ async def test_is_integration_not_connected_when_not_loaded(
 
 
 async def test_set_usercode_skips_when_unchanged(
-    hass: HomeAssistant,
     zwave_js_lock: ZWaveJSLock,
-    zwave_integration: MockConfigEntry,
 ) -> None:
     """Test that set_usercode returns False when code is already set."""
-    lcm_entry = MockConfigEntry(domain=DOMAIN, data={CONF_LOCKS: [], CONF_SLOTS: {}})
-    lcm_entry.add_to_hass(hass)
-    await zwave_js_lock.async_setup_internal(lcm_entry)
-
     # Slot 2 already has "1234" in the fixture
     result = await zwave_js_lock.async_set_usercode(2, "1234", "Test User")
 
     assert result is False
 
-    await zwave_js_lock.async_unload(False)
-
 
 async def test_set_usercode_skips_when_code_matches(
-    hass: HomeAssistant,
     zwave_js_lock: ZWaveJSLock,
-    zwave_integration: MockConfigEntry,
 ) -> None:
     """Test that set_usercode returns False when cached code matches the target PIN."""
-    lcm_entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            CONF_LOCKS: [zwave_js_lock.lock.entity_id],
-            CONF_SLOTS: {"2": {}},
-        },
-    )
-    lcm_entry.add_to_hass(hass)
-    await zwave_js_lock.async_setup_internal(lcm_entry)
-
     # Mock the cache to return the same code we're trying to set
     matching_slot = {"code_slot": 2, "usercode": "5678", "in_use": True}
 
     with patch(
-        "custom_components.lock_code_manager.providers.zwave_js.get_usercode",
+        f"{_PROVIDER_MODULE}.get_usercode",
         return_value=matching_slot,
     ):
         result = await zwave_js_lock.async_set_usercode(2, "5678", "Test User")
@@ -175,13 +158,9 @@ async def test_set_usercode_skips_when_code_matches(
         # Should skip the set operation since code already matches
         assert result is False
 
-    await zwave_js_lock.async_unload(False)
-
 
 async def test_set_usercode_proceeds_when_masked(
-    hass: HomeAssistant,
     zwave_js_lock: ZWaveJSLock,
-    zwave_integration: MockConfigEntry,
 ) -> None:
     """
     Test that set_usercode proceeds when code is masked (all asterisks).
@@ -189,21 +168,11 @@ async def test_set_usercode_proceeds_when_masked(
     Some locks (like Yale) return masked PINs (****) instead of actual codes.
     Since we cannot compare masked codes, the set operation should always proceed.
     """
-    lcm_entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            CONF_LOCKS: [zwave_js_lock.lock.entity_id],
-            CONF_SLOTS: {"2": {}},
-        },
-    )
-    lcm_entry.add_to_hass(hass)
-    await zwave_js_lock.async_setup_internal(lcm_entry)
-
     # Mock the cache to return a masked code
     masked_slot = {"code_slot": 2, "usercode": "****", "in_use": True}
 
     with patch(
-        "custom_components.lock_code_manager.providers.zwave_js.get_usercode",
+        f"{_PROVIDER_MODULE}.get_usercode",
         return_value=masked_slot,
     ):
         result = await zwave_js_lock.async_set_usercode(2, "5678", "Test User")
@@ -211,13 +180,9 @@ async def test_set_usercode_proceeds_when_masked(
         # Should proceed since masked codes cannot be compared
         assert result is True
 
-    await zwave_js_lock.async_unload(False)
-
 
 async def test_set_usercode_proceeds_on_cache_failure(
-    hass: HomeAssistant,
     zwave_js_lock: ZWaveJSLock,
-    zwave_integration: MockConfigEntry,
 ) -> None:
     """
     Test that set_usercode proceeds when the cache lookup raises.
@@ -225,68 +190,45 @@ async def test_set_usercode_proceeds_on_cache_failure(
     A stale or missing cache entry must not block the set operation —
     the bare-except in the cache short-circuit guards against this.
     """
-    lcm_entry = MockConfigEntry(domain=DOMAIN, data={CONF_LOCKS: [], CONF_SLOTS: {}})
-    lcm_entry.add_to_hass(hass)
-    await zwave_js_lock.async_setup_internal(lcm_entry)
-
     with patch(
-        "custom_components.lock_code_manager.providers.zwave_js.get_usercode",
+        f"{_PROVIDER_MODULE}.get_usercode",
         side_effect=ValueError("cache miss"),
     ):
         result = await zwave_js_lock.async_set_usercode(4, "5678", "Test User")
 
         assert result is True
 
-    await zwave_js_lock.async_unload(False)
-
 
 async def test_clear_usercode_skips_when_already_cleared(
-    hass: HomeAssistant,
     zwave_js_lock: ZWaveJSLock,
-    zwave_integration: MockConfigEntry,
 ) -> None:
     """Test that clear_usercode returns False when slot is already empty."""
-    lcm_entry = MockConfigEntry(domain=DOMAIN, data={CONF_LOCKS: [], CONF_SLOTS: {}})
-    lcm_entry.add_to_hass(hass)
-    await zwave_js_lock.async_setup_internal(lcm_entry)
-
     # Slot 3 is already empty in the fixture
     result = await zwave_js_lock.async_clear_usercode(3)
 
     assert result is False
 
-    await zwave_js_lock.async_unload(False)
-
 
 async def test_clear_usercode_proceeds_on_cache_failure(
-    hass: HomeAssistant,
     zwave_js_lock: ZWaveJSLock,
-    zwave_integration: MockConfigEntry,
 ) -> None:
     """
     Test that clear_usercode proceeds when the cache lookup raises.
 
     Mirrors test_set_usercode_proceeds_on_cache_failure for the clear path.
     """
-    lcm_entry = MockConfigEntry(domain=DOMAIN, data={CONF_LOCKS: [], CONF_SLOTS: {}})
-    lcm_entry.add_to_hass(hass)
-    await zwave_js_lock.async_setup_internal(lcm_entry)
-
     with patch(
-        "custom_components.lock_code_manager.providers.zwave_js.get_usercode",
+        f"{_PROVIDER_MODULE}.get_usercode",
         side_effect=ValueError("cache miss"),
     ):
         result = await zwave_js_lock.async_clear_usercode(2)
 
         assert result is True
 
-    await zwave_js_lock.async_unload(False)
-
 
 async def test_set_usercode_optimistic_update(
-    hass: HomeAssistant,
     zwave_js_lock: ZWaveJSLock,
-    zwave_integration: MockConfigEntry,
+    mock_coordinator,
 ) -> None:
     """
     Test that set_usercode performs optimistic coordinator update.
@@ -300,61 +242,43 @@ async def test_set_usercode_optimistic_update(
     the optimistic update, there's a race condition where coordinator refresh
     reads stale cache data.
     """
-    lcm_entry = MockConfigEntry(domain=DOMAIN, data={CONF_LOCKS: [], CONF_SLOTS: {}})
-    lcm_entry.add_to_hass(hass)
-    await zwave_js_lock.async_setup_internal(lcm_entry)
-
     # Set up a mock coordinator with stale data (simulating the race condition)
-    mock_coordinator = MagicMock()
-    mock_coordinator.data = {
-        4: SlotCredential.empty()
-    }  # Slot appears empty in stale cache
-    zwave_js_lock.coordinator = mock_coordinator
+    zwave_js_lock.coordinator = mock_coordinator(
+        {4: SlotCredential.empty()}
+    )  # Slot appears empty in stale cache
 
     result = await zwave_js_lock.async_set_usercode(4, "5678", "Test User")
 
     assert result is True
     # Verify optimistic update was called with new PIN
-    mock_coordinator.push_update.assert_called_once_with(
+    zwave_js_lock.coordinator.push_update.assert_called_once_with(
         {4: SlotCredential.known("5678")}
     )
 
-    await zwave_js_lock.async_unload(False)
-
 
 async def test_set_usercode_optimistic_update_prevents_stale_read(
-    hass: HomeAssistant,
     zwave_js_lock: ZWaveJSLock,
-    zwave_integration: MockConfigEntry,
+    mock_coordinator,
 ) -> None:
     """Test that optimistic update prevents sync loops from stale cache reads."""
-    lcm_entry = MockConfigEntry(domain=DOMAIN, data={CONF_LOCKS: [], CONF_SLOTS: {}})
-    lcm_entry.add_to_hass(hass)
-    await zwave_js_lock.async_setup_internal(lcm_entry)
-
     # Simulate stale cache: coordinator thinks slot is empty
-    mock_coordinator = MagicMock()
-    mock_coordinator.data = {4: SlotCredential.empty()}
-    zwave_js_lock.coordinator = mock_coordinator
+    zwave_js_lock.coordinator = mock_coordinator({4: SlotCredential.empty()})
 
     await zwave_js_lock.async_set_usercode(4, "9999")
 
     # The optimistic update should have been called
-    mock_coordinator.push_update.assert_called_once_with(
+    zwave_js_lock.coordinator.push_update.assert_called_once_with(
         {4: SlotCredential.known("9999")}
     )
 
     # Simulate what push_update does - update coordinator data
-    mock_coordinator.data[4] = SlotCredential.known("9999")
-    assert mock_coordinator.data[4] == SlotCredential.known("9999")
-
-    await zwave_js_lock.async_unload(False)
+    zwave_js_lock.coordinator.data[4] = SlotCredential.known("9999")
+    assert zwave_js_lock.coordinator.data[4] == SlotCredential.known("9999")
 
 
 async def test_clear_usercode_optimistic_update(
-    hass: HomeAssistant,
     zwave_js_lock: ZWaveJSLock,
-    zwave_integration: MockConfigEntry,
+    mock_coordinator,
 ) -> None:
     """
     Test that clear_usercode performs optimistic coordinator update.
@@ -363,35 +287,28 @@ async def test_clear_usercode_optimistic_update(
     with SlotCredential.empty(). This prevents sync loops where the binary sensor reads
     stale cached data showing the old PIN and triggers repeated clear attempts.
     """
-    lcm_entry = MockConfigEntry(domain=DOMAIN, data={CONF_LOCKS: [], CONF_SLOTS: {}})
-    lcm_entry.add_to_hass(hass)
-    await zwave_js_lock.async_setup_internal(lcm_entry)
-
     # Set up a mock coordinator with stale data (still shows old PIN)
-    mock_coordinator = MagicMock()
-    mock_coordinator.data = {
-        2: SlotCredential.known("1234")
-    }  # Stale: slot still shows PIN
-    zwave_js_lock.coordinator = mock_coordinator
+    zwave_js_lock.coordinator = mock_coordinator(
+        {2: SlotCredential.known("1234")}
+    )  # Stale: slot still shows PIN
 
     result = await zwave_js_lock.async_clear_usercode(2)
 
     assert result is True
     # Verify optimistic update was called with SlotCredential.empty()
-    mock_coordinator.push_update.assert_called_once_with({2: SlotCredential.empty()})
-
-    await zwave_js_lock.async_unload(False)
+    zwave_js_lock.coordinator.push_update.assert_called_once_with(
+        {2: SlotCredential.empty()}
+    )
 
 
 # V1 cache poll tests
 
 
 async def test_v1_set_usercode_polls_slot(
-    hass: HomeAssistant,
     zwave_js_lock: ZWaveJSLock,
-    zwave_integration: MockConfigEntry,
     lock_schlage_be469: Node,
     mock_get_usercode_from_node,
+    mock_coordinator,
 ) -> None:
     """
     Test that V1 set_usercode polls the slot from the device after set.
@@ -400,71 +317,44 @@ async def test_v1_set_usercode_polls_slot(
     operation. Polling the slot forces the cache to update before the
     coordinator reads it, preventing sync loops.
     """
-    lcm_entry = MockConfigEntry(domain=DOMAIN, data={CONF_LOCKS: [], CONF_SLOTS: {}})
-    lcm_entry.add_to_hass(hass)
-    await zwave_js_lock.async_setup_internal(lcm_entry)
-
-    mock_coordinator = MagicMock()
-    mock_coordinator.data = {4: SlotCredential.empty()}
-    zwave_js_lock.coordinator = mock_coordinator
+    zwave_js_lock.coordinator = mock_coordinator({4: SlotCredential.empty()})
 
     await zwave_js_lock.async_set_usercode(4, "5678", "Test User")
 
     mock_get_usercode_from_node.assert_called_once_with(lock_schlage_be469, 4)
 
-    await zwave_js_lock.async_unload(False)
-
 
 async def test_v1_clear_usercode_polls_slot(
-    hass: HomeAssistant,
     zwave_js_lock: ZWaveJSLock,
-    zwave_integration: MockConfigEntry,
     lock_schlage_be469: Node,
     mock_get_usercode_from_node,
+    mock_coordinator,
 ) -> None:
     """Test that V1 clear_usercode polls the slot from the device after clear."""
-    lcm_entry = MockConfigEntry(domain=DOMAIN, data={CONF_LOCKS: [], CONF_SLOTS: {}})
-    lcm_entry.add_to_hass(hass)
-    await zwave_js_lock.async_setup_internal(lcm_entry)
-
-    mock_coordinator = MagicMock()
-    mock_coordinator.data = {2: SlotCredential.known("1234")}
-    zwave_js_lock.coordinator = mock_coordinator
+    zwave_js_lock.coordinator = mock_coordinator({2: SlotCredential.known("1234")})
 
     await zwave_js_lock.async_clear_usercode(2)
 
     mock_get_usercode_from_node.assert_called_once_with(lock_schlage_be469, 2)
 
-    await zwave_js_lock.async_unload(False)
-
 
 async def test_v2_set_usercode_does_not_poll_slot(
-    hass: HomeAssistant,
     zwave_js_lock_v2: ZWaveJSLock,
-    zwave_integration: MockConfigEntry,
     mock_get_usercode_from_node,
+    mock_coordinator,
 ) -> None:
     """Test that V2 set_usercode does NOT poll the slot (cache updates reliably)."""
-    lcm_entry = MockConfigEntry(domain=DOMAIN, data={CONF_LOCKS: [], CONF_SLOTS: {}})
-    lcm_entry.add_to_hass(hass)
-    await zwave_js_lock_v2.async_setup_internal(lcm_entry)
-
-    mock_coordinator = MagicMock()
-    mock_coordinator.data = {4: SlotCredential.empty()}
-    zwave_js_lock_v2.coordinator = mock_coordinator
+    zwave_js_lock_v2.coordinator = mock_coordinator({4: SlotCredential.empty()})
 
     await zwave_js_lock_v2.async_set_usercode(4, "5678", "Test User")
 
     mock_get_usercode_from_node.assert_not_called()
 
-    await zwave_js_lock_v2.async_unload(False)
-
 
 async def test_v1_set_usercode_poll_failure_raises_lock_disconnected(
-    hass: HomeAssistant,
     zwave_js_lock: ZWaveJSLock,
-    zwave_integration: MockConfigEntry,
     mock_get_usercode_from_node,
+    mock_coordinator,
 ) -> None:
     """
     Test that a V1 set poll failure raises LockDisconnected.
@@ -473,13 +363,7 @@ async def test_v1_set_usercode_poll_failure_raises_lock_disconnected(
     should be wrapped as LockDisconnected so it routes into the retry path
     instead of the generic exception handler that would suspend the lock.
     """
-    lcm_entry = MockConfigEntry(domain=DOMAIN, data={CONF_LOCKS: [], CONF_SLOTS: {}})
-    lcm_entry.add_to_hass(hass)
-    await zwave_js_lock.async_setup_internal(lcm_entry)
-
-    mock_coordinator = MagicMock()
-    mock_coordinator.data = {4: SlotCredential.empty()}
-    zwave_js_lock.coordinator = mock_coordinator
+    zwave_js_lock.coordinator = mock_coordinator({4: SlotCredential.empty()})
 
     mock_get_usercode_from_node.side_effect = FailedZWaveCommand(
         "msg_id", 202, "Node presumed dead"
@@ -488,14 +372,11 @@ async def test_v1_set_usercode_poll_failure_raises_lock_disconnected(
     with pytest.raises(LockDisconnected, match="Post-set verification poll failed"):
         await zwave_js_lock.async_set_usercode(4, "5678", "Test User")
 
-    await zwave_js_lock.async_unload(False)
-
 
 async def test_v1_clear_usercode_poll_failure_raises_lock_disconnected(
-    hass: HomeAssistant,
     zwave_js_lock: ZWaveJSLock,
-    zwave_integration: MockConfigEntry,
     mock_get_usercode_from_node,
+    mock_coordinator,
 ) -> None:
     """
     Test that a V1 clear poll failure raises LockDisconnected.
@@ -504,13 +385,7 @@ async def test_v1_clear_usercode_poll_failure_raises_lock_disconnected(
     should be wrapped as LockDisconnected so it routes into the retry path
     instead of the generic exception handler that would suspend the lock.
     """
-    lcm_entry = MockConfigEntry(domain=DOMAIN, data={CONF_LOCKS: [], CONF_SLOTS: {}})
-    lcm_entry.add_to_hass(hass)
-    await zwave_js_lock.async_setup_internal(lcm_entry)
-
-    mock_coordinator = MagicMock()
-    mock_coordinator.data = {2: SlotCredential.known("1234")}
-    zwave_js_lock.coordinator = mock_coordinator
+    zwave_js_lock.coordinator = mock_coordinator({2: SlotCredential.known("1234")})
 
     mock_get_usercode_from_node.side_effect = FailedZWaveCommand(
         "msg_id", 202, "Node presumed dead"
@@ -519,14 +394,11 @@ async def test_v1_clear_usercode_poll_failure_raises_lock_disconnected(
     with pytest.raises(LockDisconnected, match="Post-clear verification poll failed"):
         await zwave_js_lock.async_clear_usercode(2)
 
-    await zwave_js_lock.async_unload(False)
-
 
 async def test_v1_set_usercode_poll_non_zwave_error_propagates(
-    hass: HomeAssistant,
     zwave_js_lock: ZWaveJSLock,
-    zwave_integration: MockConfigEntry,
     mock_get_usercode_from_node,
+    mock_coordinator,
 ) -> None:
     """
     Non-Z-Wave errors from V1 post-set poll propagate uncaught.
@@ -535,49 +407,30 @@ async def test_v1_set_usercode_poll_non_zwave_error_propagates(
     exceptions (programming errors) should propagate so the sync
     manager's generic handler can suspend the lock and surface the bug.
     """
-    lcm_entry = MockConfigEntry(domain=DOMAIN, data={CONF_LOCKS: [], CONF_SLOTS: {}})
-    lcm_entry.add_to_hass(hass)
-    await zwave_js_lock.async_setup_internal(lcm_entry)
-
-    mock_coordinator = MagicMock()
-    mock_coordinator.data = {4: SlotCredential.empty()}
-    zwave_js_lock.coordinator = mock_coordinator
+    zwave_js_lock.coordinator = mock_coordinator({4: SlotCredential.empty()})
 
     mock_get_usercode_from_node.side_effect = RuntimeError("unexpected bug")
 
     with pytest.raises(RuntimeError, match="unexpected bug"):
         await zwave_js_lock.async_set_usercode(4, "5678", "Test User")
 
-    await zwave_js_lock.async_unload(False)
-
 
 async def test_v1_clear_usercode_poll_non_zwave_error_propagates(
-    hass: HomeAssistant,
     zwave_js_lock: ZWaveJSLock,
-    zwave_integration: MockConfigEntry,
     mock_get_usercode_from_node,
+    mock_coordinator,
 ) -> None:
     """Non-Z-Wave errors from V1 post-clear poll propagate uncaught."""
-    lcm_entry = MockConfigEntry(domain=DOMAIN, data={CONF_LOCKS: [], CONF_SLOTS: {}})
-    lcm_entry.add_to_hass(hass)
-    await zwave_js_lock.async_setup_internal(lcm_entry)
-
-    mock_coordinator = MagicMock()
-    mock_coordinator.data = {2: SlotCredential.known("1234")}
-    zwave_js_lock.coordinator = mock_coordinator
+    zwave_js_lock.coordinator = mock_coordinator({2: SlotCredential.known("1234")})
 
     mock_get_usercode_from_node.side_effect = RuntimeError("unexpected bug")
 
     with pytest.raises(RuntimeError, match="unexpected bug"):
         await zwave_js_lock.async_clear_usercode(2)
 
-    await zwave_js_lock.async_unload(False)
-
 
 async def test_set_usercode_no_coordinator(
-    hass: HomeAssistant,
     zwave_js_lock: ZWaveJSLock,
-    zwave_integration: MockConfigEntry,
 ) -> None:
     """
     Test that set_usercode handles missing coordinator gracefully.
@@ -585,38 +438,24 @@ async def test_set_usercode_no_coordinator(
     The coordinator check is defensive - in normal operation it always exists
     after setup. This test verifies the guard clause works.
     """
-    lcm_entry = MockConfigEntry(domain=DOMAIN, data={CONF_LOCKS: [], CONF_SLOTS: {}})
-    lcm_entry.add_to_hass(hass)
-    await zwave_js_lock.async_setup_internal(lcm_entry)
-
-    # Remove coordinator to test defensive check
+    # Remove coordinator to test defensive check (explicit for clarity)
     zwave_js_lock.coordinator = None
 
     # Should not raise even without coordinator
     result = await zwave_js_lock.async_set_usercode(4, "5678")
     assert result is True
 
-    await zwave_js_lock.async_unload(False)
-
 
 async def test_clear_usercode_no_coordinator(
-    hass: HomeAssistant,
     zwave_js_lock: ZWaveJSLock,
-    zwave_integration: MockConfigEntry,
 ) -> None:
     """Test that clear_usercode handles missing coordinator gracefully."""
-    lcm_entry = MockConfigEntry(domain=DOMAIN, data={CONF_LOCKS: [], CONF_SLOTS: {}})
-    lcm_entry.add_to_hass(hass)
-    await zwave_js_lock.async_setup_internal(lcm_entry)
-
-    # Remove coordinator to test defensive check
+    # Remove coordinator to test defensive check (explicit for clarity)
     zwave_js_lock.coordinator = None
 
     # Should not raise even without coordinator
     result = await zwave_js_lock.async_clear_usercode(2)
     assert result is True
-
-    await zwave_js_lock.async_unload(False)
 
 
 # Setup/unload tests
@@ -665,7 +504,6 @@ async def test_unload_cleans_up_push_subscription(
 async def test_hard_refresh_calls_refresh_cc_values(
     hass: HomeAssistant,
     zwave_js_lock: ZWaveJSLock,
-    zwave_integration: MockConfigEntry,
     lock_schlage_be469: Node,
 ) -> None:
     """Test that hard refresh calls the node's refresh method."""
@@ -677,7 +515,6 @@ async def test_hard_refresh_calls_refresh_cc_values(
         },
     )
     lcm_entry.add_to_hass(hass)
-    await zwave_js_lock.async_setup_internal(lcm_entry)
 
     with patch.object(
         lock_schlage_be469,
@@ -689,8 +526,6 @@ async def test_hard_refresh_calls_refresh_cc_values(
         mock_refresh.assert_called_once_with(CommandClass.USER_CODE)
         assert isinstance(codes, dict)
 
-    await zwave_js_lock.async_unload(False)
-
 
 # Masked usercode tests
 
@@ -698,7 +533,6 @@ async def test_hard_refresh_calls_refresh_cc_values(
 async def test_get_usercodes_masked_pin_unmanaged_slot_returns_masked_value(
     hass: HomeAssistant,
     zwave_js_lock: ZWaveJSLock,
-    zwave_integration: MockConfigEntry,
 ) -> None:
     """
     Test mixed slots: managed with real code vs unmanaged with masked code.
@@ -719,7 +553,6 @@ async def test_get_usercodes_masked_pin_unmanaged_slot_returns_masked_value(
         },
     )
     lcm_entry.add_to_hass(hass)
-    await zwave_js_lock.async_setup_internal(lcm_entry)
 
     # Mock the cache to include a slot with a masked PIN that isn't managed by LCM
     masked_slots = [
@@ -745,13 +578,10 @@ async def test_get_usercodes_masked_pin_unmanaged_slot_returns_masked_value(
         # Slot 5 returns an unreadable credential (masked code, so sync logic knows a PIN exists)
         assert codes[5] is SlotCredential.unreadable()
 
-    await zwave_js_lock.async_unload(False)
-
 
 async def test_get_usercodes_masked_pin_returns_unknown(
     hass: HomeAssistant,
     zwave_js_lock: ZWaveJSLock,
-    zwave_integration: MockConfigEntry,
 ) -> None:
     """
     Test that masked PINs return SlotCredential.unreadable().
@@ -767,7 +597,6 @@ async def test_get_usercodes_masked_pin_returns_unknown(
         },
     )
     lcm_entry.add_to_hass(hass)
-    await zwave_js_lock.async_setup_internal(lcm_entry)
 
     # Mock the cache to have a masked PIN on a managed slot
     masked_slots = [
@@ -782,13 +611,10 @@ async def test_get_usercodes_masked_pin_returns_unknown(
         # Masked PIN should be returned as SlotCredential.unreadable()
         assert codes[2] is SlotCredential.unreadable()
 
-    await zwave_js_lock.async_unload(False)
-
 
 async def test_get_usercodes_empty_usercode_in_use_skipped(
     hass: HomeAssistant,
     zwave_js_lock: ZWaveJSLock,
-    zwave_integration: MockConfigEntry,
 ) -> None:
     """Test that in_use=True with empty usercode is skipped (partially populated cache)."""
     lcm_entry = MockConfigEntry(
@@ -799,7 +625,6 @@ async def test_get_usercodes_empty_usercode_in_use_skipped(
         },
     )
     lcm_entry.add_to_hass(hass)
-    await zwave_js_lock.async_setup_internal(lcm_entry)
 
     # Slot 2: in_use=True but empty usercode (cache not populated yet)
     # Slot 3: normal code
@@ -815,8 +640,6 @@ async def test_get_usercodes_empty_usercode_in_use_skipped(
         assert 2 not in codes
         # Slot 3 should have its code
         assert codes[3] == SlotCredential.known("5678")
-
-    await zwave_js_lock.async_unload(False)
 
 
 # code_slot_in_use tests
@@ -838,7 +661,7 @@ async def test_code_slot_in_use(
 ) -> None:
     """Test code_slot_in_use for various return values and exceptions."""
     with patch(
-        "custom_components.lock_code_manager.providers.zwave_js.get_usercode",
+        f"{_PROVIDER_MODULE}.get_usercode",
         **mock_config,
     ):
         assert zwave_js_lock.code_slot_in_use(1) is expected

--- a/tests/providers/zwave_js/test_provider.py
+++ b/tests/providers/zwave_js/test_provider.py
@@ -23,8 +23,7 @@ from custom_components.lock_code_manager.domain.exceptions import LockDisconnect
 from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers.zwave_js import ZWaveJSLock
 
-# Module path where provider functions are imported (for patching in tests).
-_PROVIDER_MODULE = "custom_components.lock_code_manager.providers.zwave_js"
+from .helpers import _PROVIDER_MODULE
 
 # Properties tests
 

--- a/tests/providers/zwave_js/test_provider.py
+++ b/tests/providers/zwave_js/test_provider.py
@@ -13,7 +13,6 @@ from zwave_js_server.model.node import Node
 from homeassistant.components.zwave_js.const import DOMAIN as ZWAVE_JS_DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from custom_components.lock_code_manager.const import (
     CONF_LOCKS,
@@ -23,62 +22,6 @@ from custom_components.lock_code_manager.const import (
 from custom_components.lock_code_manager.domain.exceptions import LockDisconnected
 from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers.zwave_js import ZWaveJSLock
-
-
-@pytest.fixture(name="zwave_js_lock")
-async def zwave_js_lock_fixture(
-    hass: HomeAssistant,
-    zwave_integration: MockConfigEntry,
-    lock_entity: er.RegistryEntry,
-    lock_schlage_be469: Node,
-) -> ZWaveJSLock:
-    """Create a ZWaveJSLock instance for testing."""
-    dev_reg = dr.async_get(hass)
-    ent_reg = er.async_get(hass)
-
-    return ZWaveJSLock(
-        hass=hass,
-        dev_reg=dev_reg,
-        ent_reg=ent_reg,
-        lock_config_entry=zwave_integration,
-        lock=lock_entity,
-    )
-
-
-@pytest.fixture(autouse=True)
-def mock_get_usercode_from_node():
-    """
-    Mock get_usercode_from_node for all tests.
-
-    V1 set/clear calls get_usercode_from_node to poll the slot from the device.
-    In tests, the node doesn't have a real Z-Wave JS server connection, so we
-    mock the function. Individual tests can access the mock via parameter name.
-    """
-    with patch(
-        "custom_components.lock_code_manager.providers.zwave_js.get_usercode_from_node",
-        new_callable=AsyncMock,
-    ) as mock:
-        yield mock
-
-
-@pytest.fixture(name="zwave_js_lock_v2")
-async def zwave_js_lock_v2_fixture(
-    hass: HomeAssistant,
-    zwave_integration: MockConfigEntry,
-    lock_entity: er.RegistryEntry,
-    lock_schlage_be469_v2: Node,
-) -> ZWaveJSLock:
-    """Create a ZWaveJSLock with User Code CC V2 for testing."""
-    dev_reg = dr.async_get(hass)
-    ent_reg = er.async_get(hass)
-    return ZWaveJSLock(
-        hass=hass,
-        dev_reg=dev_reg,
-        ent_reg=ent_reg,
-        lock_config_entry=zwave_integration,
-        lock=lock_entity,
-    )
-
 
 # Properties tests
 


### PR DESCRIPTION
## Proposed change

Modernizes the Z-Wave JS provider test suite to match the patterns established by the (completed) Matter provider test refactor. **Pure test refactor — no production code changes; behavior is identical, same 76 tests pass throughout.**

- **Fixture consolidation:** `zwave_js_lock`, `zwave_js_lock_v2`, the autouse `mock_get_usercode_from_node`, and `mock_zwave_usercodes` were duplicated in *both* `test_provider.py` and `test_events.py`; they now live once in `conftest.py`, alongside new `mock_coordinator` factory and `simple_lcm_config_entry` fixtures and a `_PROVIDER_MODULE` patch constant.
- **Helpers extraction:** event factories (`make_duplicate_code_event`, `async_capture_events`, `get_enabled_switch_entity_id`) moved into a new `tests/providers/zwave_js/helpers.py` (mirrors the Matter `helpers.py`).
- **Boilerplate removal:** dropped the repeated `async_setup_internal`/`async_unload` + inline mock-coordinator setup from method/handler tests that don't exercise the lifecycle, while preserving it in the genuine setup/unload/subscription tests (those asserting on `_listeners`/`_push_unsubs` or using real LCM entities).

Net ~289 fewer lines. This is the green baseline the upcoming Z-Wave unified-`accessControl` rewrite (a later PR) will rewrite against, keeping that PR's test diff small and clearly attributable.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- Part of the credential-management refactor series (the `project_test_refactor_plan` "zwave_js next" item). Test-only; 76 zwave_js provider tests pass, full provider suite (425) green.
