### PR TITLE
build(deps): align dev/test pins with Home Assistant 2026.6.1

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,19 +1,19 @@
 -r requirements_lint.txt
 -r requirements_test.txt
-aioesphomeapi==45.0.4
-aiofiles==25.1.0
+aioesphomeapi==45.3.1
+aiofiles==24.1.0
 aiousbwatcher==1.1.2
 colorlog==6.10.1
-debugpy==1.8.21
-ha-silabs-firmware-client>=0.3.0
-homeassistant>=2026.5.4
-matter-python-client==0.8.0
+debugpy==1.8.17
+ha-silabs-firmware-client==0.3.0
+homeassistant>=2026.6.1
+matter-python-client==0.7.1
 pyserial==3.5
 pyudev==0.24.4
-universal-silabs-flasher>=1.1.0
+universal-silabs-flasher==1.1.0
 usb-devices>=0.5.1
 uv
-zeroconf==0.148.0
-zha>=1.3.1,<1.4
+zeroconf==0.149.16
+zha==1.4.1
 zigpy>=1.4.1
-zwave-js-server-python==0.72.0
+zwave-js-server-python==0.71.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,3 +1,3 @@
 pylint-strict-informational>=0.1
 pytest>=9.0.3
-pytest-homeassistant-custom-component==0.13.333
+pytest-homeassistant-custom-component==0.13.337


### PR DESCRIPTION
## Proposed change

Bumps Home Assistant to **2026.6.1** in the dev floor and updates `pytest-homeassistant-custom-component` to the matching **0.13.337** release. Pinned libraries in `requirements_dev.txt` are re-aligned with what HA 2026.6.1 ships in `homeassistant/package_constraints.txt` / `requirements_all.txt`, so the dev environment again mirrors core's constraints exactly.

| Pin | Before | After |
| --- | --- | --- |
| `homeassistant` (floor) | `>=2026.5.4` | `>=2026.6.1` |
| `pytest-homeassistant-custom-component` | `==0.13.333` | `==0.13.337` |
| `aioesphomeapi` | `==45.0.4` | `==45.3.1` |
| `aiofiles` | `==25.1.0` | `==24.1.0` ⬇ |
| `debugpy` | `==1.8.21` | `==1.8.17` ⬇ |
| `ha-silabs-firmware-client` | `>=0.3.0` | `==0.3.0` |
| `matter-python-client` | `==0.8.0` | `==0.7.1` ⬇ |
| `universal-silabs-flasher` | `>=1.1.0` | `==1.1.0` |
| `zeroconf` | `==0.148.0` | `==0.149.16` |
| `zha` | `>=1.3.1,<1.4` | `==1.4.1` |
| `zwave-js-server-python` | `==0.72.0` | `==0.71.0` ⬇ |

### Why some libs go *down*

After #1155 trimmed the Dependabot `homeassistant` group to just `homeassistant` + `pytest-homeassistant-custom-component`, the other libs started receiving their own standalone Dependabot bumps and drifted **ahead** of what HA core actually pins. Since `pytest-homeassistant-custom-component` transitively installs HA — which carries its own `package_constraints.txt` — the dev venv was already resolving down to HA's versions in practice (e.g. `zwave-js-server-python==0.71.0` and `matter-python-client==0.7.1` were already installed despite the file claiming `0.72.0`/`0.8.0`). This PR makes the source-of-truth files honest.

`pyserial`, `pyudev`, `usb-devices`, and `zigpy` are intentionally left alone — they aren't pinned anywhere in HA core (they come in transitively via `zha` / `matter-python-client` / `usb-devices`), so there's no canonical HA-derived target to align to.

`hacs.json` stays at `2026.6.0` (just bumped in #1221) — the credential-management APIs this whole chain is preparing for landed in 2026.6.0, so the HACS floor doesn't need to move with each patch.

## Verification

- `uv pip install -r requirements_dev.txt -r requirements_test.txt` resolves cleanly with no conflicts.
- `pytest`: **963 passed in 35.73s** on HA 2026.6.1.
- 168 deprecation warnings observed during `tests/providers/zha/test_provider.py` originate inside `homeassistant/components/usb/utils.py` (HA passing `description=` instead of `product=` to itself) — HA-internal noise, unchanged by this PR.

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: follows up #1221 (HACS floor bump) in preparation for using HA 2026.6's credential management APIs

🤖 Generated with [Claude Code](https://claude.com/claude-code)