### PR TITLE
feat(zwave_js): migrate to unified access_control credential API

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -47,6 +47,71 @@ read/write, name-based, max 4 user PINs), SwitchBot, SmartThings
   sensor entities to coordinator (survives entity recreation during config
   updates).
 
+- **Expand sync "in sync" predicate to include user name + every managed
+  credential type** — Today sync compares PIN only. With names (User
+  Credential CC) and future credential types (PASSWORD, etc.), a slot
+  should be "out of sync" if any field — name, PIN, or any managed
+  non-PIN credential — drifts from config. Smart writes only the deltas:
+  name-only via `async_set_user`, credential-only via `async_set_credential`
+  per mismatching type, both via `_put_credential` for the create path.
+  Trivially-equal name comparison on User Code CC locks (both sides
+  None) keeps the same code path safe for legacy locks. Requires the
+  coordinator/sync state to carry `User` rather than `dict[int,
+  SlotCredential]` so name is visible to the sync predicate.
+
+- **Least-common-denominator capability aggregation across locks in a
+  config entry** — When a config entry covers multiple locks, aggregate
+  per-credential-type limits as the LCD so a single configured value
+  works on all of them. Rules per capability kind:
+  - Numeric bounds: `min_length = max(...)`, `max_length = min(...)`
+    across the locks that support the type. Skip locks where the
+    capability doesn't apply (e.g. User Code CC locks contribute
+    nothing to name-length aggregation because UC has no names).
+  - Type availability: any lock supports the type → the field appears
+    on the slot config; the sync layer per-lock decides whether to
+    write. When no lock supports the type, hide the field entirely.
+  - Boolean feature flags (e.g. `supports_learn` for RFID): AND across
+    the supporting locks.
+  Empty aggregate (e.g. PIN min > max because one lock requires <=6 and
+  another requires >=8) must be a hard config flow failure surfaced in
+  both the initial config flow and the option flow ("these locks have
+  incompatible PIN length requirements; split them into separate config
+  entries"). On lock add/remove, re-validate existing slot configs
+  against the recomputed aggregate and disable any slots whose stored
+  values fall outside the new bounds, with a clear repair-suggestion
+  notification. Enforce at the `text` entity level via `native_min` /
+  `native_max` for both PIN and name. Lands after the password
+  expansion + name-reconciliation sync work above.
+
+- **Multi-credential-type support: password (Option B architecture
+  decision)** — Z-Wave User Credential CC and Matter DoorLock both
+  expose `PASSWORD` natively; this is the first concrete second type
+  beyond PIN. Sequence-wise lands after the sync-state expansion above
+  and the LCD aggregation, since both are prerequisites for a coherent
+  multi-type UX.
+  The feature work: slot config schema becomes `{name, pin, password,
+  ...}` (slot per user, multiple credential types per slot);
+  capability-gated per slot by `max_user_name_length > 0` and at least
+  one lock advertising `credential_types[PASSWORD]`; sync layer
+  multiplexes the write/clear per type.
+  The architecture decision (Option B): the base orchestration already
+  carries Option A (parametric per-type projection via
+  `_project_users_to_slots(credential_type)`) so the seam supports
+  adding types additively. Open question is whether the
+  coordinator/entities also become type-scoped from the top — separate
+  slot entity trees per credential type — or whether a single slot
+  surfaces multiple type fields. Tied up with the lock-side slot
+  mapping: Z-Wave User Credential CC indexes (user_id,
+  credential_type, credential_slot) independently, so LCM "slot N"
+  could hold PIN at one lock-side index and PASSWORD at another.
+  Simplest is to enforce `lock_slot = user_id = LCM_slot_N` for every
+  credential type (matches the existing 1:1:1 invariant, may waste
+  lock-side slot capacity when types are sparsely used); richer is a
+  per-type mapping table (more flexibility, more state to track and
+  recover at setup). Decide the entity-tree shape and the slot-mapping
+  rule together when wiring password — they're one design question
+  with two surfaces.
+
 ## Code Quality
 
 - **Dual storage pattern** — Simplify `data` + `options` config entry pattern.

--- a/custom_components/lock_code_manager/domain/credentials.py
+++ b/custom_components/lock_code_manager/domain/credentials.py
@@ -237,18 +237,10 @@ class LockCapabilities:
     supports_user_management: bool
     max_users: int
     credential_types: Mapping[CredentialType, CredentialTypeCapability]
-    # Maximum user-name length the lock will store; 0 when the underlying
-    # API has no concept of named users (Z-Wave User Code CC) and the user
-    # IS the credential. The base orchestration uses
-    # ``supports_user_management and max_user_name_length > 0`` to decide
-    # whether to write a separate user record before a credential -- on
-    # locks where the user is implicit in the credential, ``async_set_user``
-    # is skipped entirely and the credential write creates the user
-    # implicitly. Default 0 keeps the field backward-compatible for
-    # callers that haven't been updated yet; new providers should set it
-    # explicitly. Matter providers hardcode 32 today because the Matter
-    # DoorLock cluster spec caps UserName at 32 bytes UTF-8 and the HA
-    # ``matter.lock_helpers`` does not yet surface the attribute.
+    # Maximum user-name length the lock will store; 0 means the lock has
+    # no concept of named users (e.g. Z-Wave User Code CC) and the user
+    # IS the credential. The base orchestration skips the separate user
+    # write when ``supports_user_management`` is False OR this is 0.
     max_user_name_length: int = 0
 
     def __post_init__(self) -> None:

--- a/custom_components/lock_code_manager/domain/credentials.py
+++ b/custom_components/lock_code_manager/domain/credentials.py
@@ -237,6 +237,19 @@ class LockCapabilities:
     supports_user_management: bool
     max_users: int
     credential_types: Mapping[CredentialType, CredentialTypeCapability]
+    # Maximum user-name length the lock will store; 0 when the underlying
+    # API has no concept of named users (Z-Wave User Code CC) and the user
+    # IS the credential. The base orchestration uses
+    # ``supports_user_management and max_user_name_length > 0`` to decide
+    # whether to write a separate user record before a credential -- on
+    # locks where the user is implicit in the credential, ``async_set_user``
+    # is skipped entirely and the credential write creates the user
+    # implicitly. Default 0 keeps the field backward-compatible for
+    # callers that haven't been updated yet; new providers should set it
+    # explicitly. Matter providers hardcode 32 today because the Matter
+    # DoorLock cluster spec caps UserName at 32 bytes UTF-8 and the HA
+    # ``matter.lock_helpers`` does not yet surface the attribute.
+    max_user_name_length: int = 0
 
     def __post_init__(self) -> None:
         """Snapshot credential_types so the value object cannot be mutated later."""

--- a/custom_components/lock_code_manager/domain/credentials.py
+++ b/custom_components/lock_code_manager/domain/credentials.py
@@ -152,25 +152,39 @@ class User:
     credential_rule: CredentialRule = CredentialRule.SINGLE
     credentials: list[Credential] = field(default_factory=list)
 
-    @property
-    def pin_credentials(self) -> list[Credential]:
-        """Return this user's Personal Identification Number credentials."""
+    def credentials_of_type(self, credential_type: CredentialType) -> list[Credential]:
+        """
+        Return this user's credentials of ``credential_type``.
+
+        Generic per-type accessor used by the base orchestration to project
+        users into a slot-shaped view for a given credential kind. Providers
+        store every type they can map (see each provider's ``async_get_users``);
+        this accessor is the seam where the integration narrows that store to
+        the type the caller cares about, which today is always Personal
+        Identification Number but is wired through here so that adding a
+        second supported type (Z-Wave User Credential CC also exposes
+        ``PASSWORD``) is a caller-side change, not a provider-side change.
+        """
         return [
             credential
             for credential in self.credentials
-            if credential.type is CredentialType.PIN
+            if credential.type is credential_type
         ]
+
+    @property
+    def pin_credentials(self) -> list[Credential]:
+        """
+        Return this user's Personal Identification Number credentials.
+
+        Thin alias for ``credentials_of_type(CredentialType.PIN)``; kept as
+        a property because most call sites are written against the PIN-only
+        world and read cleanly that way.
+        """
+        return self.credentials_of_type(CredentialType.PIN)
 
     def credential_for(self, credential_type: CredentialType) -> Credential | None:
         """Return the first credential of ``credential_type``, else ``None``."""
-        return next(
-            (
-                credential
-                for credential in self.credentials
-                if credential.type is credential_type
-            ),
-            None,
-        )
+        return next(iter(self.credentials_of_type(credential_type)), None)
 
 
 @dataclass(frozen=True, slots=True)

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -1028,6 +1028,35 @@ class BaseLock:
             self._capabilities_cache = await self.async_get_capabilities()
         return self._capabilities_cache
 
+    async def _supports_user_records(self) -> bool:
+        """
+        Return whether the lock exposes a separate user-record write path.
+
+        False covers both no-user-management locks and the implicit-user
+        case (e.g. Z-Wave User Code CC: the user IS the credential).
+        """
+        caps = await self._get_cached_capabilities()
+        return caps.supports_user_management and caps.max_user_name_length > 0
+
+    async def _truncate_user_name(self, name: str | None) -> str | None:
+        """
+        Truncate ``name`` to the lock's advertised user-name length.
+
+        Returns ``None`` when the lock has no concept of named users
+        (``max_user_name_length == 0``). A best-effort capabilities-fetch
+        failure also returns ``None`` rather than blocking the write --
+        the cache stays unset so the next call retries.
+        """
+        if name is None:
+            return None
+        try:
+            caps = await self._get_cached_capabilities()
+        except LockDisconnected, LockOperationFailed:
+            return None
+        if caps.max_user_name_length <= 0:
+            return None
+        return name[: caps.max_user_name_length]
+
     @final
     async def _put_credential(
         self,
@@ -1046,11 +1075,7 @@ class BaseLock:
         the slot-keyed coordinator can't reconcile. Returns True if the
         value changed.
         """
-        caps = await self._get_cached_capabilities()
-        needs_user_write = (
-            caps.supports_user_management and caps.max_user_name_length > 0
-        )
-        if needs_user_write:
+        if await self._supports_user_records():
             result = await self.async_set_user(user)
             credential_user_id = result.user_id
             rollback_user_id = result.user_id if result.created else None

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -44,6 +44,7 @@ from ..domain.credentials import (
     Credential,
     CredentialRef,
     CredentialType,
+    LockCapabilities,
     SetUserResult,
     User,
     credential_from_slot,
@@ -183,6 +184,15 @@ class BaseLock:
     # everything on teardown without each provider tracking its own field.
     _push_unsubs: list[Callable[[], None]] = field(
         default_factory=list, init=False, repr=False
+    )
+    # Cache for ``async_get_capabilities`` result; populated on first read
+    # via ``_get_cached_capabilities`` and used by the base orchestration
+    # (today: ``_put_credential`` chooses whether to write a user record).
+    # Lives for the provider instance's lifetime -- reload recreates the
+    # provider, naturally invalidating the cache after firmware/capability
+    # changes.
+    _capabilities_cache: LockCapabilities | None = field(
+        default=None, init=False, repr=False
     )
     _last_operation_time: float = field(default=0.0, init=False)
     _min_operation_delay: float = field(default=MIN_OPERATION_DELAY, init=False)
@@ -1011,6 +1021,24 @@ class BaseLock:
         return await self._project_users_to_slots(CredentialType.PIN)
 
     @final
+    async def _get_cached_capabilities(self) -> LockCapabilities:
+        """
+        Return the lock's capabilities, populating the cache on first call.
+
+        Provider-agnostic chokepoint for capability-driven base decisions
+        (today: whether ``_put_credential`` writes a user record before the
+        credential). The cache is per-instance and lives for the lifetime
+        of the provider, which is recreated on each integration reload --
+        so a firmware update or capability change is naturally picked up
+        the next time the integration loads. Errors propagate to the
+        caller so the same backoff/retry the provider already wraps
+        ``async_get_capabilities`` in keeps applying.
+        """
+        if self._capabilities_cache is None:
+            self._capabilities_cache = await self.async_get_capabilities()
+        return self._capabilities_cache
+
+    @final
     async def _put_credential(
         self,
         user: User,
@@ -1023,39 +1051,61 @@ class BaseLock:
         Run the create-on-first user lifecycle around a credential write.
 
         Native-user only (the slot adapters call the primitives directly for
-        slot-only providers). The owning user is created or updated first --
-        the Z-Wave set-credential command requires an existing user, and this
-        ordering also sidesteps the User-Code-Command-Class fallback quirk --
-        and its resolved identifier (which the integration may allocate) is
-        threaded into the credential write. Returns True if the value changed.
+        slot-only providers). On locks that expose a real user record --
+        ``supports_user_management`` AND ``max_user_name_length > 0`` --
+        the owning user is created or updated first and its resolved
+        identifier (which the integration may allocate) is threaded into
+        the credential write. On locks where the user is implicit in the
+        credential (Z-Wave User Code CC: the user IS the code and the
+        unified ``accessControl`` API's ``setUser`` cannot run before a
+        credential exists), the user write is skipped and the credential
+        write creates the implicit user. Returns True if the value
+        changed.
 
-        ``user`` carries the user record (identifier, name, active state) for
-        ``async_set_user``; ``credential`` is the specific credential to write.
-        They are independent arguments: the slot adapter's ``user`` happens to
-        also list this credential (an artifact of the one-to-one slot
-        projection), but only ``credential`` drives the write here.
+        ``user`` carries the user record (identifier, name, active state)
+        for ``async_set_user`` on the real-user path; ``credential`` is
+        the specific credential to write. They are independent arguments:
+        the slot adapter's ``user`` happens to also list this credential
+        (an artifact of the one-to-one slot projection), but only
+        ``credential`` drives the write here.
 
-        If the credential write fails, a user this call newly created is rolled
-        back so the lock is not left with a credential-less user (which the
-        slot-keyed coordinator cannot see and would never reconcile away). A
-        pre-existing user is left untouched -- it may still own other
-        credentials.
+        If the credential write fails, a user this call newly created is
+        rolled back so the lock is not left with a credential-less user
+        (which the slot-keyed coordinator cannot see and would never
+        reconcile away). A pre-existing user is left untouched -- it may
+        still own other credentials. On the no-user-write path there is
+        nothing to roll back -- the implicit user only exists while the
+        credential does.
         """
-        result = await self.async_set_user(user)
+        caps = await self._get_cached_capabilities()
+        needs_user_write = (
+            caps.supports_user_management and caps.max_user_name_length > 0
+        )
+        if needs_user_write:
+            result = await self.async_set_user(user)
+            credential_user_id = result.user_id
+            rollback_user_id = result.user_id if result.created else None
+        else:
+            # Implicit-user lock (e.g. Z-Wave User Code CC). The
+            # credential write creates the user implicitly; address the
+            # credential by the slot-shaped user identifier the seam
+            # already carries.
+            credential_user_id = user.user_id
+            rollback_user_id = None
         try:
             return await self.async_set_credential(
-                result.user_id, credential, name=name, source=source
+                credential_user_id, credential, name=name, source=source
             )
         except Exception:
-            if result.created:
+            if rollback_user_id is not None:
                 try:
-                    await self.async_delete_user(result.user_id)
+                    await self.async_delete_user(rollback_user_id)
                 except Exception as rollback_err:
                     LOGGER.warning(
                         "Lock %s: failed to roll back newly created user %s "
                         "after a failed credential write: %s",
                         self.lock.entity_id,
-                        result.user_id,
+                        rollback_user_id,
                         rollback_err,
                     )
             raise
@@ -1189,6 +1239,20 @@ class BaseLock:
         self._raise_not_implemented(
             "async_get_users",
             "Override to read users and credentials from the lock.",
+        )
+
+    async def async_get_capabilities(self) -> LockCapabilities:
+        """
+        Report the lock's user/credential capabilities.
+
+        Read by the base orchestration's ``_get_cached_capabilities``
+        helper to drive capability-gated behavior (today: whether
+        ``_put_credential`` writes a user record before the credential).
+        Providers that route through ``_put_credential`` must override.
+        """
+        self._raise_not_implemented(
+            "async_get_capabilities",
+            "Override to report the lock's user/credential capabilities.",
         )
 
     @final

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -51,8 +51,10 @@ from ..domain.credentials import (
     user_from_slot,
 )
 from ..domain.exceptions import (
+    CodeRejectedError,
     DuplicateCodeError,
     LockCodeManagerError,
+    LockCodeManagerProviderError,
     LockDisconnected,
     LockOperationFailed,
     ProviderNotImplementedError,
@@ -548,10 +550,23 @@ class BaseLock:
         """
         Set up lock and coordinator, signaling completion to waiters.
 
-        Provider ``async_setup()`` runs first so providers can initialize
-        any state the coordinator needs during its first refresh.
+        Validates the lock advertises the capabilities LCM needs
+        (``supports_user_management`` + PIN credentials) for native-user
+        providers; failures here are hard and propagate. Provider
+        ``async_setup()`` then runs so providers can initialize any state
+        the coordinator needs during its first refresh.
         """
         self._lcm_config_entry = config_entry
+        if self.supports_native_users:
+            caps = await self._get_cached_capabilities()
+            if not caps.supports_user_management:
+                raise LockCodeManagerProviderError(
+                    f"{self.lock.entity_id}: lock does not support user management"
+                )
+            if CredentialType.PIN not in caps.credential_types:
+                raise LockCodeManagerProviderError(
+                    f"{self.lock.entity_id}: lock does not advertise PIN credential support"
+                )
         try:
             await self.async_setup(config_entry)
         except (LockDisconnected, LockOperationFailed) as err:
@@ -1057,6 +1072,37 @@ class BaseLock:
             return None
         return name[: caps.max_user_name_length]
 
+    async def _assert_credential_type_supported(self, credential: Credential) -> None:
+        """
+        Raise ``CodeRejectedError`` if the lock doesn't advertise the type.
+
+        Capability-driven defense for ``async_set_credential``. Picks up
+        new types (e.g. PASSWORD) automatically once a lock starts
+        advertising them in ``credential_types`` -- no provider-side
+        change needed.
+        """
+        caps = await self._get_cached_capabilities()
+        if credential.type not in caps.credential_types:
+            raise CodeRejectedError(
+                code_slot=credential.slot,
+                lock_entity_id=self.lock.entity_id,
+                reason=f"unsupported credential type: {credential.type}",
+            )
+
+    async def _assert_credential_ref_supported(self, ref: CredentialRef) -> None:
+        """
+        Raise ``CodeRejectedError`` if the lock doesn't advertise the type.
+
+        Delete-path sibling of ``_assert_credential_type_supported``.
+        """
+        caps = await self._get_cached_capabilities()
+        if ref.type not in caps.credential_types:
+            raise CodeRejectedError(
+                code_slot=ref.slot,
+                lock_entity_id=self.lock.entity_id,
+                reason=f"unsupported credential type: {ref.type}",
+            )
+
     @final
     async def _put_credential(
         self,
@@ -1070,13 +1116,15 @@ class BaseLock:
         Run the create-on-first user lifecycle around a credential write.
 
         Native-user only (the slot adapters call the credential primitive
-        directly). Truncates ``user.name`` to the lock's advertised limit
-        before handing the user to the provider, so each provider's
+        directly). Asserts the lock advertises ``credential.type`` and
+        truncates ``user.name`` to the lock's advertised limit before
+        handing the user to the provider, so each provider's
         ``async_set_user`` can write the name verbatim. Rolls back a
         newly-created user when the credential write fails so the lock
         isn't left with a credential-less user the slot-keyed coordinator
         can't reconcile. Returns True if the value changed.
         """
+        await self._assert_credential_type_supported(credential)
         if await self._supports_user_records():
             truncated = await self._truncate_user_name(user.name)
             user_for_write = (
@@ -1111,17 +1159,20 @@ class BaseLock:
         """
         Run the delete-on-last user lifecycle around a credential delete.
 
-        Native-user only. Deletes the credential, then deletes ``owner`` when
-        that was its last credential (the invariant: a user exists if and only
-        if it owns at least one credential). The count is read from ``owner``,
-        a pre-deletion snapshot, so the decision does not depend on whether the
-        provider mutates the user during the delete. Returns True if changed.
+        Native-user only. Asserts the lock advertises ``ref.type``, then
+        deletes the credential. Deletes ``owner`` when that was its last
+        credential (the invariant: a user exists if and only if it owns
+        at least one credential). The count is read from ``owner``, a
+        pre-deletion snapshot, so the decision does not depend on whether
+        the provider mutates the user during the delete. Returns True if
+        changed.
 
         The credential delete is the operation that clears the slot, so a
         failure of the follow-up user delete is logged rather than raised: the
         slot is already cleared, and raising would only churn retries that
         re-resolve to no owner. The leftover empty user is surfaced in the log.
         """
+        await self._assert_credential_ref_supported(ref)
         was_only_credential = len(owner.credentials) <= 1
         changed = await self.async_delete_credential(ref)
         if changed and was_only_credential:

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -855,7 +855,7 @@ class BaseLock:
 
         Projects the slot to a single Personal Identification Number
         credential. Native-user providers run the create-on-first user
-        lifecycle via ``_put_credential``; slot-only providers write the
+        lifecycle via ``_set_credential``; slot-only providers write the
         credential directly, addressing it by slot. Returns True if the value
         changed, False if it was already set to this value -- and True when the
         provider cannot determine whether a change occurred, so the coordinator
@@ -867,7 +867,7 @@ class BaseLock:
             return await self.async_set_credential(
                 code_slot, credential, name=name, source=source
             )
-        return await self._put_credential(
+        return await self._set_credential(
             user_from_slot(code_slot, state, name),
             credential,
             name=name,
@@ -929,7 +929,7 @@ class BaseLock:
         credential may have been created on the lock by another controller, or
         the integration may have allocated a user identifier that differs from
         the slot. The owner is resolved from the lock's current users and the
-        delete-on-last user lifecycle runs via ``_drop_credential``. Returns
+        delete-on-last user lifecycle runs via ``_delete_credential``. Returns
         True if the value changed, False if it was already cleared -- and True
         when the provider cannot determine whether a change occurred, so the
         coordinator refreshes and verifies the actual state.
@@ -956,7 +956,7 @@ class BaseLock:
         ref = CredentialRef(
             user_id=owner.user_id, type=CredentialType.PIN, slot=code_slot
         )
-        return await self._drop_credential(owner, ref)
+        return await self._delete_credential(owner, ref)
 
     @final
     async def async_internal_clear_usercode(
@@ -1104,7 +1104,7 @@ class BaseLock:
             )
 
     @final
-    async def _put_credential(
+    async def _set_credential(
         self,
         user: User,
         credential: Credential,
@@ -1155,7 +1155,7 @@ class BaseLock:
             raise
 
     @final
-    async def _drop_credential(self, owner: User, ref: CredentialRef) -> bool:
+    async def _delete_credential(self, owner: User, ref: CredentialRef) -> bool:
         """
         Run the delete-on-last user lifecycle around a credential delete.
 

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Awaitable, Callable
 import contextlib
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import timedelta
 import logging
 import time
@@ -1070,13 +1070,19 @@ class BaseLock:
         Run the create-on-first user lifecycle around a credential write.
 
         Native-user only (the slot adapters call the credential primitive
-        directly). Rolls back a newly-created user when the credential
-        write fails so the lock isn't left with a credential-less user
-        the slot-keyed coordinator can't reconcile. Returns True if the
-        value changed.
+        directly). Truncates ``user.name`` to the lock's advertised limit
+        before handing the user to the provider, so each provider's
+        ``async_set_user`` can write the name verbatim. Rolls back a
+        newly-created user when the credential write fails so the lock
+        isn't left with a credential-less user the slot-keyed coordinator
+        can't reconcile. Returns True if the value changed.
         """
         if await self._supports_user_records():
-            result = await self.async_set_user(user)
+            truncated = await self._truncate_user_name(user.name)
+            user_for_write = (
+                user if truncated == user.name else replace(user, name=truncated)
+            )
+            result = await self.async_set_user(user_for_write)
             credential_user_id = result.user_id
             rollback_user_id = result.user_id if result.created else None
         else:

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -956,30 +956,59 @@ class BaseLock:
         if changed and self.coordinator and not self.supports_push:
             await self.coordinator.async_request_refresh()
 
-    async def async_get_usercodes(self) -> dict[int, SlotCredential]:
+    async def _project_users_to_slots(
+        self, credential_type: CredentialType
+    ) -> dict[int, SlotCredential]:
         """
-        Return slot -> ``SlotCredential`` by projecting the lock's users.
+        Project the lock's users to a slot -> ``SlotCredential`` map.
 
-        Every managed slot is present even when empty: the projection starts
-        from ``managed_slots`` mapped to ``SlotCredential.empty()`` and then
-        overlays the Personal Identification Number credentials read via
+        Every managed slot is present even when empty: the projection
+        starts from ``managed_slots`` mapped to ``SlotCredential.empty()``
+        and then overlays the credentials of ``credential_type`` read via
         ``async_get_users``. This preserves the slot-keyed contract the
-        coordinator, sync manager, and slot entities depend on -- a managed
-        slot missing from the map is treated as unavailable, not empty, so the
-        empty placeholders are load-bearing. Occupied slots the lock reports
-        that are not managed are surfaced too. Non-PIN credentials and the user
-        layer are dropped here: the seam keeps everything below it slot-shaped
-        this round.
+        coordinator, sync manager, and slot entities depend on -- a
+        managed slot missing from the map is treated as unavailable, not
+        empty, so the empty placeholders are load-bearing. Occupied slots
+        the lock reports that are not managed are surfaced too.
+        Credentials of other types are dropped here -- the seam keeps
+        everything below it slot-shaped and single-type this round.
+
+        This is the chokepoint for "the base class filters per credential
+        type before passing to the coordinator/entities" (Option A in the
+        design discussion). Adding a second supported type means calling
+        this helper from a second projection method -- providers store
+        every type they can map, so no provider changes are required.
+
+        TODO(option-b): when the integration adds a second supported
+        credential type (Z-Wave User Credential CC also exposes
+        ``PASSWORD``), revisit whether the coordinator/entities should
+        instead be type-scoped from the top -- one set of slot entities
+        per credential type -- rather than threading the type through a
+        single projection. The provider-side model is already ready for
+        that move; the open question is configuration / user experience
+        (do users configure "PIN slots 1-10" and "password slots 1-5"
+        separately, or is each slot polymorphic?).
         """
         codes = {slot: SlotCredential.empty() for slot in self.managed_slots}
         codes.update(
             {
                 credential.slot: credential.state
                 for user in await self.async_get_users()
-                for credential in user.pin_credentials
+                for credential in user.credentials_of_type(credential_type)
             }
         )
         return codes
+
+    async def async_get_usercodes(self) -> dict[int, SlotCredential]:
+        """
+        Return the slot -> ``SlotCredential`` map for Personal Identification Numbers.
+
+        Thin Personal-Identification-Number-shaped wrapper over
+        ``_project_users_to_slots``; preserved as a stable name because
+        the coordinator, sync manager, and slot entities are all
+        Personal Identification Number-scoped today.
+        """
+        return await self._project_users_to_slots(CredentialType.PIN)
 
     @final
     async def _put_credential(

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -1160,12 +1160,15 @@ class BaseLock:
         Run the delete-on-last user lifecycle around a credential delete.
 
         Native-user only. Asserts the lock advertises ``ref.type``, then
-        deletes the credential. Deletes ``owner`` when that was its last
-        credential (the invariant: a user exists if and only if it owns
-        at least one credential). The count is read from ``owner``, a
-        pre-deletion snapshot, so the decision does not depend on whether
-        the provider mutates the user during the delete. Returns True if
-        changed.
+        deletes the credential. On locks with separate user records
+        (mirroring ``_set_credential``'s gate), deletes ``owner`` when
+        that was its last credential -- the invariant being that a user
+        exists if and only if it owns at least one credential. On
+        implicit-user locks (e.g. Z-Wave User Code CC) the credential
+        delete already removed the user, so the cleanup call is skipped.
+        The count is read from ``owner``, a pre-deletion snapshot, so
+        the decision does not depend on whether the provider mutates the
+        user during the delete. Returns True if changed.
 
         The credential delete is the operation that clears the slot, so a
         failure of the follow-up user delete is logged rather than raised: the
@@ -1175,7 +1178,7 @@ class BaseLock:
         await self._assert_credential_ref_supported(ref)
         was_only_credential = len(owner.credentials) <= 1
         changed = await self.async_delete_credential(ref)
-        if changed and was_only_credential:
+        if changed and was_only_credential and await self._supports_user_records():
             try:
                 await self.async_delete_user(owner.user_id)
             except Exception as err:

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -185,12 +185,8 @@ class BaseLock:
     _push_unsubs: list[Callable[[], None]] = field(
         default_factory=list, init=False, repr=False
     )
-    # Cache for ``async_get_capabilities`` result; populated on first read
-    # via ``_get_cached_capabilities`` and used by the base orchestration
-    # (today: ``_put_credential`` chooses whether to write a user record).
-    # Lives for the provider instance's lifetime -- reload recreates the
-    # provider, naturally invalidating the cache after firmware/capability
-    # changes.
+    # Read via ``_get_cached_capabilities``; cleared by recreating the
+    # provider on integration reload.
     _capabilities_cache: LockCapabilities | None = field(
         default=None, init=False, repr=False
     )
@@ -1025,14 +1021,8 @@ class BaseLock:
         """
         Return the lock's capabilities, populating the cache on first call.
 
-        Provider-agnostic chokepoint for capability-driven base decisions
-        (today: whether ``_put_credential`` writes a user record before the
-        credential). The cache is per-instance and lives for the lifetime
-        of the provider, which is recreated on each integration reload --
-        so a firmware update or capability change is naturally picked up
-        the next time the integration loads. Errors propagate to the
-        caller so the same backoff/retry the provider already wraps
-        ``async_get_capabilities`` in keeps applying.
+        Cache lives for the provider instance's lifetime; reload
+        recreates the provider and naturally invalidates the cache.
         """
         if self._capabilities_cache is None:
             self._capabilities_cache = await self.async_get_capabilities()
@@ -1050,32 +1040,11 @@ class BaseLock:
         """
         Run the create-on-first user lifecycle around a credential write.
 
-        Native-user only (the slot adapters call the primitives directly for
-        slot-only providers). On locks that expose a real user record --
-        ``supports_user_management`` AND ``max_user_name_length > 0`` --
-        the owning user is created or updated first and its resolved
-        identifier (which the integration may allocate) is threaded into
-        the credential write. On locks where the user is implicit in the
-        credential (Z-Wave User Code CC: the user IS the code and the
-        unified ``accessControl`` API's ``setUser`` cannot run before a
-        credential exists), the user write is skipped and the credential
-        write creates the implicit user. Returns True if the value
-        changed.
-
-        ``user`` carries the user record (identifier, name, active state)
-        for ``async_set_user`` on the real-user path; ``credential`` is
-        the specific credential to write. They are independent arguments:
-        the slot adapter's ``user`` happens to also list this credential
-        (an artifact of the one-to-one slot projection), but only
-        ``credential`` drives the write here.
-
-        If the credential write fails, a user this call newly created is
-        rolled back so the lock is not left with a credential-less user
-        (which the slot-keyed coordinator cannot see and would never
-        reconcile away). A pre-existing user is left untouched -- it may
-        still own other credentials. On the no-user-write path there is
-        nothing to roll back -- the implicit user only exists while the
-        credential does.
+        Native-user only (the slot adapters call the credential primitive
+        directly). Rolls back a newly-created user when the credential
+        write fails so the lock isn't left with a credential-less user
+        the slot-keyed coordinator can't reconcile. Returns True if the
+        value changed.
         """
         caps = await self._get_cached_capabilities()
         needs_user_write = (
@@ -1086,10 +1055,6 @@ class BaseLock:
             credential_user_id = result.user_id
             rollback_user_id = result.user_id if result.created else None
         else:
-            # Implicit-user lock (e.g. Z-Wave User Code CC). The
-            # credential write creates the user implicitly; address the
-            # credential by the slot-shaped user identifier the seam
-            # already carries.
             credential_user_id = user.user_id
             rollback_user_id = None
         try:
@@ -1245,10 +1210,8 @@ class BaseLock:
         """
         Report the lock's user/credential capabilities.
 
-        Read by the base orchestration's ``_get_cached_capabilities``
-        helper to drive capability-gated behavior (today: whether
-        ``_put_credential`` writes a user record before the credential).
-        Providers that route through ``_put_credential`` must override.
+        Native-user providers must override; the base orchestration reads
+        this to decide whether to write a user record before a credential.
         """
         self._raise_not_implemented(
             "async_get_capabilities",

--- a/custom_components/lock_code_manager/providers/zwave_js.py
+++ b/custom_components/lock_code_manager/providers/zwave_js.py
@@ -218,10 +218,8 @@ class ZWaveJSLock(BaseLock):
                 raw_caps = await lock_helpers.async_get_credential_capabilities(
                     self.node
                 )
-                self._max_user_name_length = raw_caps.get(
-                    "max_user_name_length", 0
-                )
-            except (BaseZwaveJSServerError, HomeAssistantError):
+                self._max_user_name_length = raw_caps.get("max_user_name_length", 0)
+            except BaseZwaveJSServerError, HomeAssistantError:
                 # Capabilities fetch failed — proceed without a name guard
                 # so the write is not blocked by a read failure.
                 self._max_user_name_length = 0

--- a/custom_components/lock_code_manager/providers/zwave_js.py
+++ b/custom_components/lock_code_manager/providers/zwave_js.py
@@ -241,15 +241,15 @@ class ZWaveJSLock(BaseLock):
 
         ``created`` reflects whether the user existed BEFORE this call so
         the base orchestration can roll back a user only newly created
-        here. Names are truncated via the base helper.
+        here. Receives ``user`` with a name already truncated to the
+        lock's advertised limit by the base orchestration.
         """
-        user_name = await self._truncate_user_name(user.name)
         try:
             existing = await self.node.access_control.get_user_cached(user.user_id)
             result = await lock_helpers.async_set_user(
                 self.node,
                 user_id=user.user_id,
-                user_name=user_name,
+                user_name=user.name,
                 active=user.active,
             )
         except BaseZwaveJSServerError as err:

--- a/custom_components/lock_code_manager/providers/zwave_js.py
+++ b/custom_components/lock_code_manager/providers/zwave_js.py
@@ -96,6 +96,10 @@ class ZWaveJSLock(BaseLock):
     # subscriptions: registered in ``async_setup``, released in
     # ``async_unload``).
     _listeners: list[Callable[[], None]] = field(init=False, default_factory=list)
+    # Cached max user name length from lock_helpers capabilities. Populated
+    # lazily on first async_set_user call (or by async_get_capabilities).
+    # ``None`` means "not yet queried"; the value is always an int once set.
+    _max_user_name_length: int | None = field(init=False, default=None)
 
     @property
     def node(self) -> Node:
@@ -140,8 +144,13 @@ class ZWaveJSLock(BaseLock):
 
     async def async_get_users(self) -> list[User]:
         """Read users and their PIN credentials (with values) from the lock."""
-        users = await self.node.access_control.get_users_cached()
-        credentials = await self.node.access_control.get_all_credentials_cached()
+        try:
+            users = await self.node.access_control.get_users_cached()
+            credentials = await self.node.access_control.get_all_credentials_cached()
+        except BaseZwaveJSServerError as err:
+            raise LockDisconnected(f"get users failed: {err}") from err
+        except HomeAssistantError as err:
+            raise LockOperationFailed(f"get users failed: {err}") from err
         pins_by_user: dict[int, list[Credential]] = {}
         for cred in credentials:
             if cred.type is not UserCredentialType.PIN_CODE:
@@ -165,7 +174,14 @@ class ZWaveJSLock(BaseLock):
 
     async def async_get_capabilities(self) -> LockCapabilities:
         """Report the lock's user/credential capabilities."""
-        caps = await lock_helpers.async_get_credential_capabilities(self.node)
+        try:
+            caps = await lock_helpers.async_get_credential_capabilities(self.node)
+        except BaseZwaveJSServerError as err:
+            raise LockDisconnected(f"get capabilities failed: {err}") from err
+        except HomeAssistantError as err:
+            raise LockOperationFailed(f"get capabilities failed: {err}") from err
+        # Cache max name length for async_set_user name validation.
+        self._max_user_name_length = caps.get("max_user_name_length", 0)
         pin = caps["supported_credential_types"].get(_PIN_TYPE_STR)
         credential_types = (
             {
@@ -194,12 +210,37 @@ class ZWaveJSLock(BaseLock):
         here), not from the helper's return value, so the base orchestration
         can roll back a user this call newly created.
         """
+        # Resolve the max user name length. If async_get_capabilities has
+        # not yet been called (or the cache is stale), fetch capabilities
+        # so the name is always validated against the lock's actual limit.
+        if self._max_user_name_length is None:
+            try:
+                raw_caps = await lock_helpers.async_get_credential_capabilities(
+                    self.node
+                )
+                self._max_user_name_length = raw_caps.get(
+                    "max_user_name_length", 0
+                )
+            except (BaseZwaveJSServerError, HomeAssistantError):
+                # Capabilities fetch failed — proceed without a name guard
+                # so the write is not blocked by a read failure.
+                self._max_user_name_length = 0
+        max_name_len: int = self._max_user_name_length or 0
+        # Enforce the lock's name length constraint:
+        # - max_name_len == 0: the lock does not support user names; omit it
+        # - name exceeds max_name_len: truncate to the allowed length
+        user_name = user.name
+        if user_name is not None:
+            if max_name_len == 0:
+                user_name = None
+            elif len(user_name) > max_name_len:
+                user_name = user_name[:max_name_len]
         try:
             existing = await self.node.access_control.get_user_cached(user.user_id)
             result = await lock_helpers.async_set_user(
                 self.node,
                 user_id=user.user_id,
-                user_name=user.name,
+                user_name=user_name,
                 active=user.active,
             )
         except BaseZwaveJSServerError as err:
@@ -226,6 +267,12 @@ class ZWaveJSLock(BaseLock):
         source: Literal["sync", "direct"],
     ) -> bool:
         """Write the Personal Identification Number credential under user_id; map device rejections."""
+        if credential.type is not CredentialType.PIN:
+            raise CodeRejectedError(
+                code_slot=credential.slot,
+                lock_entity_id=self.lock.entity_id,
+                reason=f"unsupported credential type: {credential.type}",
+            )
         pin = credential.readable_pin
         if pin is None:
             # The set path only ever carries a readable Personal Identification
@@ -265,6 +312,12 @@ class ZWaveJSLock(BaseLock):
 
     async def async_delete_credential(self, ref: CredentialRef) -> bool:
         """Delete the Personal Identification Number credential addressed by ref."""
+        if ref.type is not CredentialType.PIN:
+            raise CodeRejectedError(
+                code_slot=ref.slot,
+                lock_entity_id=self.lock.entity_id,
+                reason=f"unsupported credential type: {ref.type}",
+            )
         try:
             await lock_helpers.async_delete_credential(
                 self.node, ref.user_id, UserCredentialType.PIN_CODE, ref.slot

--- a/custom_components/lock_code_manager/providers/zwave_js.py
+++ b/custom_components/lock_code_manager/providers/zwave_js.py
@@ -1,8 +1,9 @@
 """
 Z-Wave JS lock provider.
 
-Handles push updates, duplicate code detection, and rate-limited set/clear operations.
-See ARCHITECTURE.md for the provider's role in the data flow.
+Handles push updates via access-control credential node events and operation
+notifications for lock/unlock state changes. See ARCHITECTURE.md for the
+provider's role in the data flow.
 """
 
 from __future__ import annotations
@@ -14,20 +15,13 @@ import logging
 from typing import Any, Literal
 
 from zwave_js_server.client import Client
-from zwave_js_server.const import CommandClass, NodeStatus
+from zwave_js_server.const import NodeStatus
 from zwave_js_server.const.command_class.access_control import UserCredentialType
-from zwave_js_server.const.command_class.lock import (
-    ATTR_IN_USE,
-    LOCK_USERCODE_PROPERTY,
-    LOCK_USERCODE_STATUS_PROPERTY,
-    CodeSlotStatus,
-)
 from zwave_js_server.const.command_class.notification import (
     AccessControlNotificationEvent,
     NotificationType,
 )
 from zwave_js_server.model.node import Node
-from zwave_js_server.util.lock import get_usercode
 
 from homeassistant.components.zwave_js import lock_helpers
 from homeassistant.components.zwave_js.const import (
@@ -96,7 +90,6 @@ class ZWaveJSLock(BaseLock):
     # subscriptions: registered in ``async_setup``, released in
     # ``async_unload``).
     _listeners: list[Callable[[], None]] = field(init=False, default_factory=list)
-    _set_in_progress_code_slot: int | None = field(init=False, default=None)
 
     @property
     def node(self) -> Node:
@@ -266,84 +259,9 @@ class ZWaveJSLock(BaseLock):
 
         return True, ""
 
-    # --- Legacy User Code CC push path (interim; replaced in PR 4 Task 4) ---
-    # The methods below (code_slot_in_use, _handle_usercode_*, the User Code CC
-    # value-event subscription in setup_push_subscription, and the
-    # _set_in_progress_code_slot duplicate-notification sniffing) still observe
-    # the legacy User Code CC value events. Task 4 replaces them with
-    # access-control credential node events; they are kept here only so the
-    # provider keeps receiving push updates until that lands.
-    def code_slot_in_use(self, code_slot: int) -> bool | None:
-        """Return whether a code slot is in use."""
-        try:
-            return get_usercode(self.node, code_slot)[ATTR_IN_USE]
-        except KeyError, ValueError:
-            return None
-
-    @callback
-    def _handle_usercode_status_update(self, code_slot: int, status: Any) -> None:
-        """Handle userIdStatus value update for a code slot."""
-        if status == CodeSlotStatus.AVAILABLE:
-            # Ignore AVAILABLE status if Lock Code Manager expects a PIN on this
-            # slot. Some locks send stale AVAILABLE events after a code was set,
-            # which would cause infinite sync loops.
-            if (
-                self.coordinator
-                and self.coordinator.desired_credential(code_slot).is_present
-            ):
-                _LOGGER.debug(
-                    "Lock %s: ignoring userIdStatus=AVAILABLE for slot %s "
-                    "(LCM expects PIN on this slot)",
-                    self.lock.entity_id,
-                    code_slot,
-                )
-                return
-
-            # Slot was cleared - update coordinator if needed
-            current = self.coordinator.data.get(code_slot) if self.coordinator else None
-            if self.coordinator and (current is None or not current.is_empty):
-                _LOGGER.debug(
-                    "Lock %s: slot %s userIdStatus=AVAILABLE, marking cleared",
-                    self.lock.entity_id,
-                    code_slot,
-                )
-                self._push_credential_update(code_slot, SlotCredential.empty())
-
-    @callback
-    def _handle_usercode_value_update(self, code_slot: int, new_value: Any) -> None:
-        """Handle userCode value update for a code slot."""
-        if not new_value:
-            resolved = SlotCredential.empty()
-        else:
-            value = str(new_value)
-            slot_in_use = self.code_slot_in_use(code_slot)
-            # Asymmetric in_use checks: masked codes count as unreadable even
-            # when in_use is None (some firmwares mask before reporting
-            # status), but all-zeros only counts as empty when in_use is
-            # explicitly False (zeros from a partially-loaded cache must
-            # not be misread as cleared).
-            if value == "*" * len(value) and slot_in_use is not False:
-                resolved = SlotCredential.unreadable()
-            elif value.strip("0") == "" and slot_in_use is False:
-                resolved = SlotCredential.empty()
-            else:
-                resolved = SlotCredential.known(value)
-
-        # Z-Wave JS sends duplicate events; skip if the value is unchanged.
-        if self.coordinator and self.coordinator.data.get(code_slot) == resolved:
-            return
-
-        _LOGGER.debug(
-            "Lock %s received push update for slot %s: %s",
-            self.lock.entity_id,
-            code_slot,
-            "****" if resolved.is_readable else f"({resolved.as_label()})",
-        )
-        self._push_credential_update(code_slot, resolved)
-
     @callback
     def setup_push_subscription(self) -> None:
-        """Subscribe to User Code CC value update events."""
+        """Subscribe to access-control credential change events."""
         if self._push_unsubs:
             return
 
@@ -352,44 +270,33 @@ class ZWaveJSLock(BaseLock):
             raise LockDisconnected(reason)
 
         @callback
-        def on_value_updated(event: dict[str, Any]) -> None:
-            """Handle value update events from Z-Wave JS."""
-            args: dict[str, Any] = event["args"]
-            if args.get("commandClass") != CommandClass.USER_CODE:
+        def on_credential_changed(event: dict[str, Any]) -> None:
+            """Handle credential added/modified events from the node."""
+            args = event["args"]  # CredentialChangedArgs (pre-parsed by the library)
+            if args.credential_type != UserCredentialType.PIN_CODE:
                 return
+            self._push_credential_update(
+                args.credential_slot, SlotCredential.unreadable()
+            )
 
-            property_name = args.get("property")
-            if property_name not in (
-                LOCK_USERCODE_PROPERTY,
-                LOCK_USERCODE_STATUS_PROPERTY,
-            ):
+        @callback
+        def on_credential_deleted(event: dict[str, Any]) -> None:
+            """Handle credential deleted events from the node."""
+            args = event["args"]  # CredentialDeletedArgs (pre-parsed by the library)
+            if args.credential_type != UserCredentialType.PIN_CODE:
                 return
-
-            code_slot = int(args["propertyKey"])
-
-            # Slot 0 is not a valid user code slot.
-            if code_slot == 0:
-                return
-
-            # Clear in-progress tracking only on userCode updates for the slot
-            # we were setting. userIdStatus updates don't confirm acceptance and
-            # could race with duplicate-code notifications.
-            if (
-                property_name == LOCK_USERCODE_PROPERTY
-                and code_slot == self._set_in_progress_code_slot
-            ):
-                self._set_in_progress_code_slot = None
-
-            if property_name == LOCK_USERCODE_STATUS_PROPERTY:
-                self._handle_usercode_status_update(code_slot, args.get("newValue"))
-            else:
-                self._handle_usercode_value_update(code_slot, args.get("newValue"))
+            self._push_credential_update(args.credential_slot, SlotCredential.empty())
 
         try:
-            unsub = self.node.on("value updated", on_value_updated)
+            for name, handler in (
+                ("credential added", on_credential_changed),
+                ("credential modified", on_credential_changed),
+                ("credential deleted", on_credential_deleted),
+            ):
+                self._register_push_unsub(self.node.on(name, handler))
         except ValueError as err:
+            self._clear_push_unsubs()
             raise LockDisconnected(f"node not ready: {err}") from err
-        self._register_push_unsub(unsub)
 
     @callback
     def teardown_push_subscription(self) -> None:
@@ -419,24 +326,6 @@ class ZWaveJSLock(BaseLock):
 
         params = evt.data.get(ATTR_PARAMETERS) or {}
         code_slot = params.get("userId", 0)
-
-        # Handle duplicate code rejection — only when LCM initiated the set.
-        # Mark the slot as rejected so the sync manager raises DuplicateCodeError
-        # on the next tick, routing through the standard CodeRejectedError flow
-        # (tracker reset, circuit breaker awareness, notification).
-        # Some Z-Wave lock firmwares report this notification with userId=0
-        # instead of the offending slot; treat 0 as referring to the slot
-        # we're currently setting.
-        if (
-            evt.data[ATTR_EVENT]
-            == AccessControlNotificationEvent.NEW_USER_CODE_NOT_ADDED_DUE_TO_DUPLICATE_CODE
-            and self._set_in_progress_code_slot is not None
-            and code_slot in (0, self._set_in_progress_code_slot)
-        ):
-            slot = self._set_in_progress_code_slot
-            self._set_in_progress_code_slot = None
-            self.mark_code_rejected(slot)
-            return
 
         self.async_fire_code_slot_event(
             code_slot=code_slot,

--- a/custom_components/lock_code_manager/providers/zwave_js.py
+++ b/custom_components/lock_code_manager/providers/zwave_js.py
@@ -21,6 +21,7 @@ from zwave_js_server.const.command_class.notification import (
     AccessControlNotificationEvent,
     NotificationType,
 )
+from zwave_js_server.exceptions import BaseZwaveJSServerError
 from zwave_js_server.model.node import Node
 
 from homeassistant.components.zwave_js import lock_helpers
@@ -50,7 +51,12 @@ from ..domain.credentials import (
     SetUserResult,
     User,
 )
-from ..domain.exceptions import CodeRejectedError, DuplicateCodeError, LockDisconnected
+from ..domain.exceptions import (
+    CodeRejectedError,
+    DuplicateCodeError,
+    LockDisconnected,
+    LockOperationFailed,
+)
 from ..domain.models import SlotCredential
 from ._base import BaseLock
 
@@ -107,6 +113,17 @@ class ZWaveJSLock(BaseLock):
     def connection_check_interval(self) -> timedelta | None:
         """Z-Wave JS exposes config entry state changes, so skip polling."""
         return None
+
+    @property
+    def hard_refresh_interval(self) -> timedelta | None:
+        """
+        Re-read all credentials hourly to recover from missed push events.
+
+        Credentials are normally kept current by the access-control node-event
+        push, but a missed or value-less event would otherwise strand a slot
+        (for example as unreadable). This periodic drift refresh is the backstop.
+        """
+        return timedelta(hours=1)
 
     @property
     def supports_native_users(self) -> bool:
@@ -177,18 +194,28 @@ class ZWaveJSLock(BaseLock):
         here), not from the helper's return value, so the base orchestration
         can roll back a user this call newly created.
         """
-        existing = await self.node.access_control.get_user_cached(user.user_id)
-        result = await lock_helpers.async_set_user(
-            self.node,
-            user_id=user.user_id,
-            user_name=user.name,
-            active=user.active,
-        )
+        try:
+            existing = await self.node.access_control.get_user_cached(user.user_id)
+            result = await lock_helpers.async_set_user(
+                self.node,
+                user_id=user.user_id,
+                user_name=user.name,
+                active=user.active,
+            )
+        except BaseZwaveJSServerError as err:
+            raise LockDisconnected(f"set user {user.user_id} failed: {err}") from err
+        except HomeAssistantError as err:
+            raise LockOperationFailed(f"set user {user.user_id} failed: {err}") from err
         return SetUserResult(user_id=result["user_id"], created=existing is None)
 
     async def async_delete_user(self, user_id: int) -> None:
         """Delete the lock user (cascades its credentials)."""
-        await lock_helpers.async_delete_user(self.node, user_id)
+        try:
+            await lock_helpers.async_delete_user(self.node, user_id)
+        except BaseZwaveJSServerError as err:
+            raise LockDisconnected(f"delete user {user_id} failed: {err}") from err
+        except HomeAssistantError as err:
+            raise LockOperationFailed(f"delete user {user_id} failed: {err}") from err
 
     async def async_set_credential(
         self,
@@ -217,6 +244,12 @@ class ZWaveJSLock(BaseLock):
                 pin,
                 credential_slot=credential.slot,
             )
+        except BaseZwaveJSServerError as err:
+            # Transient Z-Wave command failure (e.g. a sleeping/battery lock):
+            # route to the retry path rather than a slot suspension.
+            raise LockDisconnected(
+                f"set credential slot {credential.slot} failed: {err}"
+            ) from err
         except HomeAssistantError as err:
             if getattr(err, "translation_key", None) == "credential_rejected_duplicate":
                 raise DuplicateCodeError(
@@ -232,9 +265,18 @@ class ZWaveJSLock(BaseLock):
 
     async def async_delete_credential(self, ref: CredentialRef) -> bool:
         """Delete the Personal Identification Number credential addressed by ref."""
-        await lock_helpers.async_delete_credential(
-            self.node, ref.user_id, UserCredentialType.PIN_CODE, ref.slot
-        )
+        try:
+            await lock_helpers.async_delete_credential(
+                self.node, ref.user_id, UserCredentialType.PIN_CODE, ref.slot
+            )
+        except BaseZwaveJSServerError as err:
+            raise LockDisconnected(
+                f"delete credential slot {ref.slot} failed: {err}"
+            ) from err
+        except HomeAssistantError as err:
+            raise LockOperationFailed(
+                f"delete credential slot {ref.slot} failed: {err}"
+            ) from err
         return True
 
     def _get_client_state(self) -> tuple[bool, str]:
@@ -275,8 +317,12 @@ class ZWaveJSLock(BaseLock):
             args = event["args"]  # CredentialChangedArgs (pre-parsed by the library)
             if args.credential_type != UserCredentialType.PIN_CODE:
                 return
+            # The event carries the value when the lock includes it (e.g. an
+            # out-of-band keypad change), so push the readable state rather than
+            # always unreadable -- otherwise the slot would be stranded as
+            # unreadable until the next set/clear or hard refresh.
             self._push_credential_update(
-                args.credential_slot, SlotCredential.unreadable()
+                args.credential_slot, self._pin_state(args.data)
             )
 
         @callback

--- a/custom_components/lock_code_manager/providers/zwave_js.py
+++ b/custom_components/lock_code_manager/providers/zwave_js.py
@@ -9,6 +9,7 @@ provider's role in the data flow.
 from __future__ import annotations
 
 from collections.abc import Callable
+import contextlib
 from dataclasses import dataclass, field
 from datetime import timedelta
 import logging
@@ -82,6 +83,7 @@ _ZWAVE_TO_DOMAIN_CREDENTIAL_TYPE: dict[UserCredentialType, CredentialType] = {
     UserCredentialType.FACE_BIOMETRIC: CredentialType.FACE,
     UserCredentialType.FINGER_BIOMETRIC: CredentialType.FINGERPRINT,
 }
+
 
 # All known Access Control Notification CC events that indicate the lock is locked
 # or unlocked
@@ -220,7 +222,12 @@ class ZWaveJSLock(BaseLock):
             raise LockDisconnected(f"get capabilities failed: {err}") from err
         except HomeAssistantError as err:
             raise LockOperationFailed(f"get capabilities failed: {err}") from err
-        # Cache max name length for async_set_user name validation.
+        # Cache max name length for async_set_user's name truncation. The
+        # base orchestration also reads ``max_user_name_length`` via
+        # ``_get_cached_capabilities`` to decide whether ``_put_credential``
+        # should write a user record at all -- 0 means the lock surfaces
+        # User Code CC under the unified accessControl API, where the
+        # user is implicit in the credential.
         self._max_user_name_length = caps.get("max_user_name_length", 0)
         pin = caps["supported_credential_types"].get(_PIN_TYPE_STR)
         credential_types = (
@@ -239,6 +246,7 @@ class ZWaveJSLock(BaseLock):
             supports_user_management=caps["supports_user_management"],
             max_users=caps["max_users"],
             credential_types=credential_types,
+            max_user_name_length=self._max_user_name_length,
         )
 
     async def async_set_user(self, user: User) -> SetUserResult:
@@ -253,20 +261,15 @@ class ZWaveJSLock(BaseLock):
         # Resolve the max user name length. If async_get_capabilities has
         # not yet been called (or the cache is stale), fetch capabilities
         # so the name is always validated against the lock's actual limit.
+        # Note: the base's ``_put_credential`` only routes through
+        # ``async_set_user`` when ``supports_user_management`` is True and
+        # the lock advertises ``max_user_name_length > 0`` -- so by the
+        # time we get here we know the lock has real user records and
+        # names; the cache priming below just ensures the truncation
+        # bound is fresh on first call.
         if self._max_user_name_length is None:
-            try:
-                raw_caps = await lock_helpers.async_get_credential_capabilities(
-                    self.node
-                )
-            except BaseZwaveJSServerError, HomeAssistantError:
-                # Capabilities fetch failed — proceed for this call without
-                # a name guard, but leave the cache unset so the next call
-                # retries. Caching a 0 sentinel here would silently strip
-                # all user names for the lifetime of the provider instance
-                # after a single transient disconnect.
-                pass
-            else:
-                self._max_user_name_length = raw_caps.get("max_user_name_length")
+            with contextlib.suppress(LockDisconnected, LockOperationFailed):
+                await self.async_get_capabilities()
         max_name_len: int = self._max_user_name_length or 0
         # Enforce the lock's name length constraint:
         # - max_name_len == 0: the lock does not support user names; omit it
@@ -497,9 +500,24 @@ class ZWaveJSLock(BaseLock):
         """
         Set up lock by provider.
 
+        Prime the base capability cache so the orchestration's
+        ``_put_credential`` gate (write a user record only when the lock
+        has ``supports_user_management`` and ``max_user_name_length > 0``)
+        is resolved before the first write, and surface a clear typed
+        error if the lock exposes neither User Credential CC nor User
+        Code CC (i.e. the unified ``accessControl`` API is not available
+        at all -- effectively never for a real Z-Wave lock, but worth
+        catching cleanly rather than as an opaque attribute error
+        downstream).
+
         Idempotent: clears existing listeners before re-registering.
         """
         self._clear_listeners()
+        # Prime the capability cache via the base helper so subsequent
+        # ``_put_credential`` calls hit a warm cache. Failures surface as
+        # typed LCM errors and prevent integration setup -- a Z-Wave lock
+        # that exposes neither CC is not a lock LCM can manage.
+        await self._get_cached_capabilities()
         self._listeners.append(
             self.hass.bus.async_listen(
                 ZWAVE_JS_NOTIFICATION_EVENT,

--- a/custom_components/lock_code_manager/providers/zwave_js.py
+++ b/custom_components/lock_code_manager/providers/zwave_js.py
@@ -300,7 +300,7 @@ class ZWaveJSLock(BaseLock):
 
     @callback
     def teardown_push_subscription(self) -> None:
-        """Unsubscribe from value update events."""
+        """Unsubscribe from credential change events."""
         self._clear_push_unsubs()
 
     @callback

--- a/custom_components/lock_code_manager/providers/zwave_js.py
+++ b/custom_components/lock_code_manager/providers/zwave_js.py
@@ -66,6 +66,23 @@ _LOGGER = logging.getLogger(__name__)
 # in the supported_credential_types dict returned by async_get_credential_capabilities.
 _PIN_TYPE_STR = lock_helpers.CREDENTIAL_TYPE_MAP[UserCredentialType.PIN_CODE]
 
+# Z-Wave UserCredentialType -> domain CredentialType. The domain vocabulary
+# is intentionally narrower than the Z-Wave one: types with no domain
+# equivalent (BLE, UWB, DESFIRE, unspecified/eye/hand biometrics) are
+# omitted and silently dropped by async_get_users. The base orchestration
+# only acts on Personal Identification Number credentials today, but the
+# non-PIN types we can represent are surfaced so direct callers (and a
+# future expansion past PIN-only) see the full picture without another
+# read.
+_ZWAVE_TO_DOMAIN_CREDENTIAL_TYPE: dict[UserCredentialType, CredentialType] = {
+    UserCredentialType.PIN_CODE: CredentialType.PIN,
+    UserCredentialType.PASSWORD: CredentialType.PASSWORD,
+    UserCredentialType.RFID_CODE: CredentialType.RFID,
+    UserCredentialType.NFC: CredentialType.NFC,
+    UserCredentialType.FACE_BIOMETRIC: CredentialType.FACE,
+    UserCredentialType.FINGER_BIOMETRIC: CredentialType.FINGERPRINT,
+}
+
 # All known Access Control Notification CC events that indicate the lock is locked
 # or unlocked
 ACCESS_CONTROL_NOTIFICATION_TO_LOCKED = {
@@ -145,7 +162,20 @@ class ZWaveJSLock(BaseLock):
         return SlotCredential.known(data if isinstance(data, str) else data.decode())
 
     async def async_get_users(self) -> list[User]:
-        """Read users and their Personal Identification Number credentials from the lock."""
+        """
+        Read every user and all of their credentials from the lock.
+
+        Returns users carrying every credential type the domain model can
+        represent (Personal Identification Number, Radio Frequency
+        Identification, Near Field Communication, password, face,
+        fingerprint). The base orchestration filters to Personal
+        Identification Number at the slot-projection layer via
+        ``user.pin_credentials``, so this method does no type-specific
+        filtering -- direct callers see the full picture without an
+        extra read. Z-Wave credential types with no domain equivalent
+        (BLE, UWB, DESFIRE, unspecified/eye/hand biometrics) are
+        dropped.
+        """
         try:
             users = await self.node.access_control.get_users_cached()
             credentials = await self.node.access_control.get_all_credentials_cached()
@@ -153,26 +183,34 @@ class ZWaveJSLock(BaseLock):
             raise LockDisconnected(f"get users failed: {err}") from err
         except HomeAssistantError as err:
             raise LockOperationFailed(f"get users failed: {err}") from err
-        pins_by_user: dict[int, list[Credential]] = {}
-        for cred in credentials:
-            if cred.type is not UserCredentialType.PIN_CODE:
-                continue
-            pins_by_user.setdefault(cred.user_id, []).append(
-                Credential(
-                    type=CredentialType.PIN,
-                    slot=cred.slot,
-                    state=self._pin_state(cred.data),
-                )
-            )
-        return [
-            User(
+        users_by_id: dict[int, User] = {
+            user.user_id: User(
                 user_id=user.user_id,
                 name=user.user_name,
                 active=user.active,
-                credentials=pins_by_user.get(user.user_id, []),
             )
             for user in users
-        ]
+        }
+        for cred in credentials:
+            domain_type = _ZWAVE_TO_DOMAIN_CREDENTIAL_TYPE.get(cred.type)
+            owner = users_by_id.get(cred.user_id)
+            if domain_type is None or owner is None:
+                continue
+            # _pin_state decodes the Personal Identification Number value
+            # so the slot-projection sees a comparable string. For other
+            # credential types the data is opaque to Lock Code Manager
+            # (an RFID tag identifier, a biometric hash, ...), so they
+            # surface as unreadable -- "the slot is occupied" without
+            # revealing a value the integration would not act on anyway.
+            state = (
+                self._pin_state(cred.data)
+                if cred.type is UserCredentialType.PIN_CODE
+                else SlotCredential.unreadable()
+            )
+            owner.credentials.append(
+                Credential(type=domain_type, slot=cred.slot, state=state)
+            )
+        return list(users_by_id.values())
 
     async def async_get_capabilities(self) -> LockCapabilities:
         """Report the lock's user/credential capabilities."""

--- a/custom_components/lock_code_manager/providers/zwave_js.py
+++ b/custom_components/lock_code_manager/providers/zwave_js.py
@@ -9,7 +9,6 @@ provider's role in the data flow.
 from __future__ import annotations
 
 from collections.abc import Callable
-import contextlib
 from dataclasses import dataclass, field
 from datetime import timedelta
 import logging
@@ -115,10 +114,6 @@ class ZWaveJSLock(BaseLock):
     # subscriptions: registered in ``async_setup``, released in
     # ``async_unload``).
     _listeners: list[Callable[[], None]] = field(init=False, default_factory=list)
-    # Driven by ``async_get_capabilities``. ``None`` means "not yet
-    # queried" so a failed capabilities read retries on the next call
-    # instead of pinning a 0 sentinel that would silently drop names.
-    _max_user_name_length: int | None = field(init=False, default=None)
 
     @property
     def node(self) -> Node:
@@ -220,7 +215,6 @@ class ZWaveJSLock(BaseLock):
             raise LockDisconnected(f"get capabilities failed: {err}") from err
         except HomeAssistantError as err:
             raise LockOperationFailed(f"get capabilities failed: {err}") from err
-        self._max_user_name_length = caps.get("max_user_name_length", 0)
         pin = caps["supported_credential_types"].get(_PIN_TYPE_STR)
         credential_types = (
             {
@@ -238,7 +232,7 @@ class ZWaveJSLock(BaseLock):
             supports_user_management=caps["supports_user_management"],
             max_users=caps["max_users"],
             credential_types=credential_types,
-            max_user_name_length=self._max_user_name_length,
+            max_user_name_length=caps.get("max_user_name_length", 0),
         )
 
     async def async_set_user(self, user: User) -> SetUserResult:
@@ -247,24 +241,9 @@ class ZWaveJSLock(BaseLock):
 
         ``created`` reflects whether the user existed BEFORE this call so
         the base orchestration can roll back a user only newly created
-        here. Names are truncated to the lock's advertised limit.
+        here. Names are truncated via the base helper.
         """
-        # Prime the truncation bound on first call; failures fall through
-        # to the ``max_name_len or 0`` default so a read miss doesn't
-        # block the write.
-        if self._max_user_name_length is None:
-            with contextlib.suppress(LockDisconnected, LockOperationFailed):
-                await self.async_get_capabilities()
-        max_name_len: int = self._max_user_name_length or 0
-        # Enforce the lock's name length constraint:
-        # - max_name_len == 0: the lock does not support user names; omit it
-        # - name exceeds max_name_len: truncate to the allowed length
-        user_name = user.name
-        if user_name is not None:
-            if max_name_len == 0:
-                user_name = None
-            elif len(user_name) > max_name_len:
-                user_name = user_name[:max_name_len]
+        user_name = await self._truncate_user_name(user.name)
         try:
             existing = await self.node.access_control.get_user_cached(user.user_id)
             result = await lock_helpers.async_set_user(

--- a/custom_components/lock_code_manager/providers/zwave_js.py
+++ b/custom_components/lock_code_manager/providers/zwave_js.py
@@ -16,6 +16,7 @@ from typing import Any, Literal
 
 from zwave_js_server.client import Client
 from zwave_js_server.const import CommandClass, NodeStatus
+from zwave_js_server.const.command_class.access_control import UserCredentialType
 from zwave_js_server.const.command_class.lock import (
     ATTR_CODE_SLOT,
     ATTR_IN_USE,
@@ -36,6 +37,7 @@ from zwave_js_server.util.lock import (
     get_usercodes,
 )
 
+from homeassistant.components.zwave_js import lock_helpers
 from homeassistant.components.zwave_js.const import (
     ATTR_EVENT,
     ATTR_EVENT_LABEL,
@@ -54,11 +56,22 @@ from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import ATTR_DEVICE_ID, ATTR_ENTITY_ID
 from homeassistant.core import Event, callback
 
+from ..domain.credentials import (
+    Credential,
+    CredentialType,
+    CredentialTypeCapability,
+    LockCapabilities,
+    User,
+)
 from ..domain.exceptions import LockDisconnected
 from ..domain.models import SlotCredential
 from ._base import BaseLock
 
 _LOGGER = logging.getLogger(__name__)
+
+# String key used by lock_helpers for Personal Identification Number credentials
+# in the supported_credential_types dict returned by async_get_credential_capabilities.
+_PIN_TYPE_STR = lock_helpers.CREDENTIAL_TYPE_MAP[UserCredentialType.PIN_CODE]
 
 # All known Access Control Notification CC events that indicate the lock is locked
 # or unlocked
@@ -129,6 +142,62 @@ class ZWaveJSLock(BaseLock):
     def connection_check_interval(self) -> timedelta | None:
         """Z-Wave JS exposes config entry state changes, so skip polling."""
         return None
+
+    @property
+    def supports_native_users(self) -> bool:
+        """Return True: this provider implements the credential primitives."""
+        return True
+
+    def _pin_state(self, data: object) -> SlotCredential:
+        """Project Z-Wave credential data to a SlotCredential (readable when present)."""
+        return SlotCredential.known(str(data)) if data else SlotCredential.unreadable()
+
+    async def async_get_users(self) -> list[User]:
+        """Read users and their PIN credentials (with values) from the lock."""
+        users = await self.node.access_control.get_users_cached()
+        credentials = await self.node.access_control.get_all_credentials_cached()
+        pins_by_user: dict[int, list[Credential]] = {}
+        for cred in credentials:
+            if cred.type is not UserCredentialType.PIN_CODE:
+                continue
+            pins_by_user.setdefault(cred.user_id, []).append(
+                Credential(
+                    type=CredentialType.PIN,
+                    slot=cred.slot,
+                    state=self._pin_state(cred.data),
+                )
+            )
+        return [
+            User(
+                user_id=user.user_id,
+                name=user.user_name,
+                active=user.active,
+                credentials=pins_by_user.get(user.user_id, []),
+            )
+            for user in users
+        ]
+
+    async def async_get_capabilities(self) -> LockCapabilities:
+        """Report the lock's user/credential capabilities."""
+        caps = await lock_helpers.async_get_credential_capabilities(self.node)
+        pin = caps["supported_credential_types"].get(_PIN_TYPE_STR)
+        credential_types = (
+            {
+                CredentialType.PIN: CredentialTypeCapability(
+                    num_slots=pin["num_slots"],
+                    min_length=pin["min_length"],
+                    max_length=pin["max_length"],
+                    supports_learn=pin["supports_learn"],
+                )
+            }
+            if pin
+            else {}
+        )
+        return LockCapabilities(
+            supports_user_management=caps["supports_user_management"],
+            max_users=caps["max_users"],
+            credential_types=credential_types,
+        )
 
     def _get_client_state(self) -> tuple[bool, str]:
         """Return whether the Z-Wave JS client is ready and a retry reason."""

--- a/custom_components/lock_code_manager/providers/zwave_js.py
+++ b/custom_components/lock_code_manager/providers/zwave_js.py
@@ -55,15 +55,18 @@ from homeassistant.components.zwave_js.models import ZwaveJSData
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import ATTR_DEVICE_ID, ATTR_ENTITY_ID
 from homeassistant.core import Event, callback
+from homeassistant.exceptions import HomeAssistantError
 
 from ..domain.credentials import (
     Credential,
+    CredentialRef,
     CredentialType,
     CredentialTypeCapability,
     LockCapabilities,
+    SetUserResult,
     User,
 )
-from ..domain.exceptions import LockDisconnected
+from ..domain.exceptions import CodeRejectedError, DuplicateCodeError, LockDisconnected
 from ..domain.models import SlotCredential
 from ._base import BaseLock
 
@@ -202,6 +205,58 @@ class ZWaveJSLock(BaseLock):
             max_users=caps["max_users"],
             credential_types=credential_types,
         )
+
+    async def async_set_user(self, user: User) -> SetUserResult:
+        """Create or update the lock user; report whether it was created."""
+        existing = await self.node.access_control.get_user_cached(user.user_id)
+        result = await lock_helpers.async_set_user(
+            self.node,
+            user_id=user.user_id,
+            user_name=user.name,
+            active=user.active,
+        )
+        return SetUserResult(user_id=result["user_id"], created=existing is None)
+
+    async def async_delete_user(self, user_id: int) -> None:
+        """Delete the lock user (cascades its credentials)."""
+        await lock_helpers.async_delete_user(self.node, user_id)
+
+    async def async_set_credential(
+        self,
+        user_id: int,
+        credential: Credential,
+        *,
+        name: str | None,
+        source: str,
+    ) -> bool:
+        """Write the Personal Identification Number credential under user_id; map device rejections."""
+        try:
+            await lock_helpers.async_set_credential(
+                self.node,
+                user_id,
+                UserCredentialType.PIN_CODE,
+                credential.readable_pin,
+                credential_slot=credential.slot,
+            )
+        except HomeAssistantError as err:
+            if getattr(err, "translation_key", None) == "credential_rejected_duplicate":
+                raise DuplicateCodeError(
+                    code_slot=credential.slot,
+                    lock_entity_id=self.lock.entity_id,
+                ) from err
+            raise CodeRejectedError(
+                code_slot=credential.slot,
+                lock_entity_id=self.lock.entity_id,
+                reason=str(err),
+            ) from err
+        return True
+
+    async def async_delete_credential(self, ref: CredentialRef) -> bool:
+        """Delete the Personal Identification Number credential addressed by ref."""
+        await lock_helpers.async_delete_credential(
+            self.node, ref.user_id, UserCredentialType.PIN_CODE, ref.slot
+        )
+        return True
 
     def _get_client_state(self) -> tuple[bool, str]:
         """Return whether the Z-Wave JS client is ready and a retry reason."""

--- a/custom_components/lock_code_manager/providers/zwave_js.py
+++ b/custom_components/lock_code_manager/providers/zwave_js.py
@@ -207,7 +207,14 @@ class ZWaveJSLock(BaseLock):
         )
 
     async def async_set_user(self, user: User) -> SetUserResult:
-        """Create or update the lock user; report whether it was created."""
+        """
+        Create or update the lock user; report whether it was created.
+
+        ``created`` is derived from a pre-write cache read of the explicit
+        ``user.user_id`` (which the helper always honors, never auto-allocating
+        here), not from the helper's return value, so the base orchestration
+        can roll back a user this call newly created.
+        """
         existing = await self.node.access_control.get_user_cached(user.user_id)
         result = await lock_helpers.async_set_user(
             self.node,
@@ -227,15 +234,25 @@ class ZWaveJSLock(BaseLock):
         credential: Credential,
         *,
         name: str | None,
-        source: str,
+        source: Literal["sync", "direct"],
     ) -> bool:
         """Write the Personal Identification Number credential under user_id; map device rejections."""
+        pin = credential.readable_pin
+        if pin is None:
+            # The set path only ever carries a readable Personal Identification
+            # Number; guard so an unreadable credential fails cleanly rather
+            # than passing None into the helper's str-only signature.
+            raise CodeRejectedError(
+                code_slot=credential.slot,
+                lock_entity_id=self.lock.entity_id,
+                reason="cannot write an unreadable credential",
+            )
         try:
             await lock_helpers.async_set_credential(
                 self.node,
                 user_id,
                 UserCredentialType.PIN_CODE,
-                credential.readable_pin,
+                pin,
                 credential_slot=credential.slot,
             )
         except HomeAssistantError as err:

--- a/custom_components/lock_code_manager/providers/zwave_js.py
+++ b/custom_components/lock_code_manager/providers/zwave_js.py
@@ -266,6 +266,13 @@ class ZWaveJSLock(BaseLock):
 
         return True, ""
 
+    # --- Legacy User Code CC push path (interim; replaced in PR 4 Task 4) ---
+    # The methods below (code_slot_in_use, _handle_usercode_*, the User Code CC
+    # value-event subscription in setup_push_subscription, and the
+    # _set_in_progress_code_slot duplicate-notification sniffing) still observe
+    # the legacy User Code CC value events. Task 4 replaces them with
+    # access-control credential node events; they are kept here only so the
+    # provider keeps receiving push updates until that lands.
     def code_slot_in_use(self, code_slot: int) -> bool | None:
         """Return whether a code slot is in use."""
         try:
@@ -499,5 +506,5 @@ class ZWaveJSLock(BaseLock):
             await self.node.access_control.get_users()
             await self.node.access_control.get_all_credentials()
         except Exception as err:
-            raise LockDisconnected from err
+            raise LockDisconnected(f"hard refresh failed: {err}") from err
         return await self.async_get_usercodes()

--- a/custom_components/lock_code_manager/providers/zwave_js.py
+++ b/custom_components/lock_code_manager/providers/zwave_js.py
@@ -276,12 +276,6 @@ class ZWaveJSLock(BaseLock):
         source: Literal["sync", "direct"],
     ) -> bool:
         """Write the Personal Identification Number credential under user_id; map device rejections."""
-        if credential.type is not CredentialType.PIN:
-            raise CodeRejectedError(
-                code_slot=credential.slot,
-                lock_entity_id=self.lock.entity_id,
-                reason=f"unsupported credential type: {credential.type}",
-            )
         pin = credential.readable_pin
         if pin is None:
             # The set path only ever carries a readable Personal Identification
@@ -321,12 +315,6 @@ class ZWaveJSLock(BaseLock):
 
     async def async_delete_credential(self, ref: CredentialRef) -> bool:
         """Delete the Personal Identification Number credential addressed by ref."""
-        if ref.type is not CredentialType.PIN:
-            raise CodeRejectedError(
-                code_slot=ref.slot,
-                lock_entity_id=self.lock.entity_id,
-                reason=f"unsupported credential type: {ref.type}",
-            )
         try:
             await lock_helpers.async_delete_credential(
                 self.node, ref.user_id, UserCredentialType.PIN_CODE, ref.slot
@@ -464,14 +452,10 @@ class ZWaveJSLock(BaseLock):
         """
         Set up lock by provider.
 
-        Probes capabilities so an unmanageable lock (neither User
-        Credential CC nor User Code CC under the unified
-        ``accessControl`` API) fails setup with a typed LCM error
-        instead of a downstream attribute error. Idempotent: clears
-        existing listeners before re-registering.
+        Idempotent: clears existing listeners before re-registering.
+        Capability validation runs in the base ``async_setup_internal``.
         """
         self._clear_listeners()
-        await self._get_cached_capabilities()
         self._listeners.append(
             self.hass.bus.async_listen(
                 ZWAVE_JS_NOTIFICATION_EVENT,

--- a/custom_components/lock_code_manager/providers/zwave_js.py
+++ b/custom_components/lock_code_manager/providers/zwave_js.py
@@ -98,7 +98,9 @@ class ZWaveJSLock(BaseLock):
     _listeners: list[Callable[[], None]] = field(init=False, default_factory=list)
     # Cached max user name length from lock_helpers capabilities. Populated
     # lazily on first async_set_user call (or by async_get_capabilities).
-    # ``None`` means "not yet queried"; the value is always an int once set.
+    # ``None`` means "not yet queried"; on capabilities-fetch failure the
+    # cache stays None so the next call retries (rather than getting stuck
+    # at a sentinel that would silently drop all user names).
     _max_user_name_length: int | None = field(init=False, default=None)
 
     @property
@@ -143,7 +145,7 @@ class ZWaveJSLock(BaseLock):
         return SlotCredential.known(data if isinstance(data, str) else data.decode())
 
     async def async_get_users(self) -> list[User]:
-        """Read users and their PIN credentials (with values) from the lock."""
+        """Read users and their Personal Identification Number credentials from the lock."""
         try:
             users = await self.node.access_control.get_users_cached()
             credentials = await self.node.access_control.get_all_credentials_cached()
@@ -218,11 +220,15 @@ class ZWaveJSLock(BaseLock):
                 raw_caps = await lock_helpers.async_get_credential_capabilities(
                     self.node
                 )
-                self._max_user_name_length = raw_caps.get("max_user_name_length", 0)
             except BaseZwaveJSServerError, HomeAssistantError:
-                # Capabilities fetch failed — proceed without a name guard
-                # so the write is not blocked by a read failure.
-                self._max_user_name_length = 0
+                # Capabilities fetch failed — proceed for this call without
+                # a name guard, but leave the cache unset so the next call
+                # retries. Caching a 0 sentinel here would silently strip
+                # all user names for the lifetime of the provider instance
+                # after a single transient disconnect.
+                pass
+            else:
+                self._max_user_name_length = raw_caps.get("max_user_name_length", 0)
         max_name_len: int = self._max_user_name_length or 0
         # Enforce the lock's name length constraint:
         # - max_name_len == 0: the lock does not support user names; omit it
@@ -491,6 +497,8 @@ class ZWaveJSLock(BaseLock):
         try:
             await self.node.access_control.get_users()
             await self.node.access_control.get_all_credentials()
-        except Exception as err:
+        except BaseZwaveJSServerError as err:
             raise LockDisconnected(f"hard refresh failed: {err}") from err
+        except HomeAssistantError as err:
+            raise LockOperationFailed(f"hard refresh failed: {err}") from err
         return await self.async_get_usercodes()

--- a/custom_components/lock_code_manager/providers/zwave_js.py
+++ b/custom_components/lock_code_manager/providers/zwave_js.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import timedelta
-import functools
 import logging
 from typing import Any, Literal
 
@@ -18,9 +17,7 @@ from zwave_js_server.client import Client
 from zwave_js_server.const import CommandClass, NodeStatus
 from zwave_js_server.const.command_class.access_control import UserCredentialType
 from zwave_js_server.const.command_class.lock import (
-    ATTR_CODE_SLOT,
     ATTR_IN_USE,
-    ATTR_USERCODE,
     LOCK_USERCODE_PROPERTY,
     LOCK_USERCODE_STATUS_PROPERTY,
     CodeSlotStatus,
@@ -29,13 +26,8 @@ from zwave_js_server.const.command_class.notification import (
     AccessControlNotificationEvent,
     NotificationType,
 )
-from zwave_js_server.exceptions import FailedZWaveCommand
 from zwave_js_server.model.node import Node
-from zwave_js_server.util.lock import (
-    get_usercode,
-    get_usercode_from_node,
-    get_usercodes,
-)
+from zwave_js_server.util.lock import get_usercode
 
 from homeassistant.components.zwave_js import lock_helpers
 from homeassistant.components.zwave_js.const import (
@@ -46,14 +38,12 @@ from homeassistant.components.zwave_js.const import (
     ATTR_PARAMETERS,
     ATTR_TYPE,
     DOMAIN as ZWAVE_JS_DOMAIN,
-    SERVICE_CLEAR_LOCK_USERCODE,
-    SERVICE_SET_LOCK_USERCODE,
     ZWAVE_JS_NOTIFICATION_EVENT,
 )
 from homeassistant.components.zwave_js.helpers import async_get_node_from_entity_id
 from homeassistant.components.zwave_js.models import ZwaveJSData
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
-from homeassistant.const import ATTR_DEVICE_ID, ATTR_ENTITY_ID
+from homeassistant.const import ATTR_DEVICE_ID
 from homeassistant.core import Event, callback
 from homeassistant.exceptions import HomeAssistantError
 
@@ -114,27 +104,6 @@ class ZWaveJSLock(BaseLock):
         return async_get_node_from_entity_id(
             self.hass, self.lock.entity_id, self.ent_reg
         )
-
-    @functools.cached_property
-    def _usercode_cc_version(self) -> int:
-        """Return the User Code CC version supported by this node."""
-        version = next(
-            (
-                cc.version
-                for cc in self.node.command_classes
-                if cc.id == CommandClass.USER_CODE
-            ),
-            0,
-        )
-        if version == 0:
-            _LOGGER.warning(
-                "Lock %s: User Code CC not found on node %s. This may "
-                "indicate an incomplete interview. Defaulting to V1 behavior",
-                self.lock.entity_id,
-                self.node.node_id,
-            )
-            return 1
-        return version
 
     @property
     def supports_push(self) -> bool:
@@ -525,173 +494,10 @@ class ZWaveJSLock(BaseLock):
             return False
 
     async def async_hard_refresh_codes(self) -> dict[int, SlotCredential]:
-        """Refresh the User Code CC cache from the device and return all codes."""
-        await self._async_refresh_usercode_cache()
+        """Re-read users AND credentials fresh from the device, then project to slots."""
+        try:
+            await self.node.access_control.get_users()
+            await self.node.access_control.get_all_credentials()
+        except Exception as err:
+            raise LockDisconnected from err
         return await self.async_get_usercodes()
-
-    async def _async_verify_write(
-        self, code_slot: int, operation: Literal["set", "clear"]
-    ) -> None:
-        """
-        Force-update the value cache after a set/clear on a V1 lock.
-
-        V1 locks don't reliably update the Z-Wave JS value cache after a write.
-        Poll the slot directly from the device to force-update the cache before
-        the coordinator reads it, preventing sync loops. Wrap failures as
-        LockDisconnected so they route to the retry path instead of leaking a
-        raw FailedZWaveCommand into the generic exception handler, which would
-        otherwise suspend the lock.
-        """
-        if self._usercode_cc_version >= 2:
-            return
-        try:
-            await get_usercode_from_node(self.node, code_slot)
-        except FailedZWaveCommand as err:
-            raise LockDisconnected(
-                f"Post-{operation} verification poll failed for "
-                f"{self.lock.entity_id} slot {code_slot}: {err}"
-            ) from err
-
-    async def async_set_usercode(
-        self,
-        code_slot: int,
-        usercode: str,
-        name: str | None = None,
-        source: Literal["sync", "direct"] = "direct",
-    ) -> bool:
-        """
-        Set a usercode on a code slot.
-
-        Returns True if the value was changed, False if already set to this value.
-        """
-        # Cache lookup short-circuits no-op writes. Bare-except is intentional:
-        # a stale or missing cache entry must not block the set operation.
-        try:
-            if (current := get_usercode(self.node, code_slot)).get("in_use"):
-                current_code = str(current.get("usercode", ""))
-                # Skip the duplicate check if the current code is masked.
-                if current_code != "*" * len(current_code) and usercode == current_code:
-                    _LOGGER.debug(
-                        "Lock %s slot %s already has this PIN, skipping set",
-                        self.lock.entity_id,
-                        code_slot,
-                    )
-                    return False
-        except Exception:
-            pass
-
-        self._set_in_progress_code_slot = code_slot
-        service_data = {
-            ATTR_ENTITY_ID: self.lock.entity_id,
-            ATTR_CODE_SLOT: code_slot,
-            ATTR_USERCODE: usercode,
-        }
-        await self.async_call_service(
-            ZWAVE_JS_DOMAIN, SERVICE_SET_LOCK_USERCODE, service_data
-        )
-        await self._async_verify_write(code_slot, "set")
-        # Optimistic update: the value cache updates asynchronously via push
-        # notification; push now to prevent sync loops from reading stale cache.
-        self._push_credential_update(code_slot, SlotCredential.known(usercode))
-        return True
-
-    async def async_clear_usercode(self, code_slot: int) -> bool:
-        """
-        Clear a usercode on a code slot.
-
-        Returns True if the value was changed, False if already cleared.
-        """
-        # Cache lookup short-circuits no-op clears. Bare-except is intentional:
-        # see async_set_usercode for rationale.
-        try:
-            current = get_usercode(self.node, code_slot)
-            if not current.get("in_use"):
-                _LOGGER.debug(
-                    "Lock %s slot %s already cleared, skipping clear",
-                    self.lock.entity_id,
-                    code_slot,
-                )
-                return False
-        except Exception:
-            pass
-
-        service_data = {
-            ATTR_ENTITY_ID: self.lock.entity_id,
-            ATTR_CODE_SLOT: code_slot,
-        }
-        await self.async_call_service(
-            ZWAVE_JS_DOMAIN, SERVICE_CLEAR_LOCK_USERCODE, service_data
-        )
-        await self._async_verify_write(code_slot, "clear")
-        # Optimistic update: see async_set_usercode for rationale.
-        self._push_credential_update(code_slot, SlotCredential.empty())
-        return True
-
-    def _get_usercodes_from_cache(self) -> list[dict[str, Any]]:
-        """Get usercodes from Z-Wave JS value DB cache."""
-        try:
-            return list(get_usercodes(self.node) or [])
-        except Exception as err:
-            raise LockDisconnected from err
-
-    async def _async_refresh_usercode_cache(self) -> None:
-        """Refresh usercode cache from the device."""
-        try:
-            await self.node.async_refresh_cc_values(CommandClass.USER_CODE)
-        except Exception as err:
-            raise LockDisconnected from err
-
-    async def async_get_usercodes(self) -> dict[int, SlotCredential]:
-        """Get dictionary of code slots and usercodes."""
-        code_slots = self.managed_slots
-        data: dict[int, SlotCredential] = {}
-
-        if not await self.async_is_integration_connected():
-            raise LockDisconnected
-
-        slots = self._get_usercodes_from_cache()
-        slots_by_num = {int(slot["code_slot"]): slot for slot in slots}
-
-        # If any managed slot is missing or has unknown in_use state, do one hard
-        # refresh. Call _async_refresh_usercode_cache directly (not
-        # async_hard_refresh_codes) to avoid recursion.
-        if any(
-            slot_num not in slots_by_num or slots_by_num[slot_num].get("in_use") is None
-            for slot_num in code_slots
-        ):
-            _LOGGER.debug(
-                "Lock %s has missing/unknown slots, performing hard refresh",
-                self.lock.entity_id,
-            )
-            await self._async_refresh_usercode_cache()
-            slots = self._get_usercodes_from_cache()
-            slots_by_num = {int(slot["code_slot"]): slot for slot in slots}
-
-        for slot in slots:
-            code_slot = int(slot["code_slot"])
-            usercode: str = slot["usercode"] or ""
-            in_use: bool | None = slot["in_use"]
-
-            if not in_use:
-                data[code_slot] = SlotCredential.empty()
-            elif not usercode:
-                # in_use but no code content (cache partially populated); skip
-                continue
-            elif usercode == "*" * len(usercode):
-                # Masked code (all asterisks with slot in use)
-                data[code_slot] = SlotCredential.unreadable()
-            else:
-                # Unmasked code
-                data[code_slot] = SlotCredential.known(usercode)
-
-        slots_with_pin = [s for s, v in data.items() if v.is_present]
-        slots_empty = [s for s, v in data.items() if v.is_empty]
-        _LOGGER.debug(
-            "Lock %s: %s slots with PIN %s, %s slots empty %s",
-            self.lock.entity_id,
-            len(slots_with_pin),
-            slots_with_pin,
-            len(slots_empty),
-            slots_empty,
-        )
-        return data

--- a/custom_components/lock_code_manager/providers/zwave_js.py
+++ b/custom_components/lock_code_manager/providers/zwave_js.py
@@ -115,11 +115,9 @@ class ZWaveJSLock(BaseLock):
     # subscriptions: registered in ``async_setup``, released in
     # ``async_unload``).
     _listeners: list[Callable[[], None]] = field(init=False, default_factory=list)
-    # Cached max user name length from lock_helpers capabilities. Populated
-    # lazily on first async_set_user call (or by async_get_capabilities).
-    # ``None`` means "not yet queried"; on capabilities-fetch failure the
-    # cache stays None so the next call retries (rather than getting stuck
-    # at a sentinel that would silently drop all user names).
+    # Driven by ``async_get_capabilities``. ``None`` means "not yet
+    # queried" so a failed capabilities read retries on the next call
+    # instead of pinning a 0 sentinel that would silently drop names.
     _max_user_name_length: int | None = field(init=False, default=None)
 
     @property
@@ -222,12 +220,6 @@ class ZWaveJSLock(BaseLock):
             raise LockDisconnected(f"get capabilities failed: {err}") from err
         except HomeAssistantError as err:
             raise LockOperationFailed(f"get capabilities failed: {err}") from err
-        # Cache max name length for async_set_user's name truncation. The
-        # base orchestration also reads ``max_user_name_length`` via
-        # ``_get_cached_capabilities`` to decide whether ``_put_credential``
-        # should write a user record at all -- 0 means the lock surfaces
-        # User Code CC under the unified accessControl API, where the
-        # user is implicit in the credential.
         self._max_user_name_length = caps.get("max_user_name_length", 0)
         pin = caps["supported_credential_types"].get(_PIN_TYPE_STR)
         credential_types = (
@@ -253,20 +245,13 @@ class ZWaveJSLock(BaseLock):
         """
         Create or update the lock user; report whether it was created.
 
-        ``created`` is derived from a pre-write cache read of the explicit
-        ``user.user_id`` (which the helper always honors, never auto-allocating
-        here), not from the helper's return value, so the base orchestration
-        can roll back a user this call newly created.
+        ``created`` reflects whether the user existed BEFORE this call so
+        the base orchestration can roll back a user only newly created
+        here. Names are truncated to the lock's advertised limit.
         """
-        # Resolve the max user name length. If async_get_capabilities has
-        # not yet been called (or the cache is stale), fetch capabilities
-        # so the name is always validated against the lock's actual limit.
-        # Note: the base's ``_put_credential`` only routes through
-        # ``async_set_user`` when ``supports_user_management`` is True and
-        # the lock advertises ``max_user_name_length > 0`` -- so by the
-        # time we get here we know the lock has real user records and
-        # names; the cache priming below just ensures the truncation
-        # bound is fresh on first call.
+        # Prime the truncation bound on first call; failures fall through
+        # to the ``max_name_len or 0`` default so a read miss doesn't
+        # block the write.
         if self._max_user_name_length is None:
             with contextlib.suppress(LockDisconnected, LockOperationFailed):
                 await self.async_get_capabilities()
@@ -500,23 +485,13 @@ class ZWaveJSLock(BaseLock):
         """
         Set up lock by provider.
 
-        Prime the base capability cache so the orchestration's
-        ``_put_credential`` gate (write a user record only when the lock
-        has ``supports_user_management`` and ``max_user_name_length > 0``)
-        is resolved before the first write, and surface a clear typed
-        error if the lock exposes neither User Credential CC nor User
-        Code CC (i.e. the unified ``accessControl`` API is not available
-        at all -- effectively never for a real Z-Wave lock, but worth
-        catching cleanly rather than as an opaque attribute error
-        downstream).
-
-        Idempotent: clears existing listeners before re-registering.
+        Probes capabilities so an unmanageable lock (neither User
+        Credential CC nor User Code CC under the unified
+        ``accessControl`` API) fails setup with a typed LCM error
+        instead of a downstream attribute error. Idempotent: clears
+        existing listeners before re-registering.
         """
         self._clear_listeners()
-        # Prime the capability cache via the base helper so subsequent
-        # ``_put_credential`` calls hit a warm cache. Failures surface as
-        # typed LCM errors and prevent integration setup -- a Z-Wave lock
-        # that exposes neither CC is not a lock LCM can manage.
         await self._get_cached_capabilities()
         self._listeners.append(
             self.hass.bus.async_listen(

--- a/custom_components/lock_code_manager/providers/zwave_js.py
+++ b/custom_components/lock_code_manager/providers/zwave_js.py
@@ -228,7 +228,7 @@ class ZWaveJSLock(BaseLock):
                 # after a single transient disconnect.
                 pass
             else:
-                self._max_user_name_length = raw_caps.get("max_user_name_length", 0)
+                self._max_user_name_length = raw_caps.get("max_user_name_length")
         max_name_len: int = self._max_user_name_length or 0
         # Enforce the lock's name length constraint:
         # - max_name_len == 0: the lock does not support user names; omit it

--- a/custom_components/lock_code_manager/providers/zwave_js.py
+++ b/custom_components/lock_code_manager/providers/zwave_js.py
@@ -148,9 +148,13 @@ class ZWaveJSLock(BaseLock):
         """Return True: this provider implements the credential primitives."""
         return True
 
-    def _pin_state(self, data: object) -> SlotCredential:
+    def _pin_state(self, data: str | bytes | None) -> SlotCredential:
         """Project Z-Wave credential data to a SlotCredential (readable when present)."""
-        return SlotCredential.known(str(data)) if data else SlotCredential.unreadable()
+        if not data:
+            return SlotCredential.unreadable()
+        # CredentialData.data is str | bytes; decode bytes so a Personal
+        # Identification Number is the digit string, not "b'1234'".
+        return SlotCredential.known(data if isinstance(data, str) else data.decode())
 
     async def async_get_users(self) -> list[User]:
         """Read users and their PIN credentials (with values) from the lock."""

--- a/tests/providers/test_seam.py
+++ b/tests/providers/test_seam.py
@@ -16,6 +16,8 @@ from custom_components.lock_code_manager.domain.credentials import (
     Credential,
     CredentialRef,
     CredentialType,
+    CredentialTypeCapability,
+    LockCapabilities,
     SetUserResult,
     User,
     credential_from_slot,
@@ -98,6 +100,23 @@ class _NativeStubLock(BaseLock):
 
     async def async_get_users(self) -> list[User]:
         return list(self._users.values())
+
+    async def async_get_capabilities(self) -> LockCapabilities:
+        # Real user records with names available — this is what gates
+        # ``_put_credential`` into the set-user-first path.
+        return LockCapabilities(
+            supports_user_management=True,
+            max_users=30,
+            credential_types={
+                CredentialType.PIN: CredentialTypeCapability(
+                    num_slots=30,
+                    min_length=4,
+                    max_length=8,
+                    supports_learn=False,
+                ),
+            },
+            max_user_name_length=16,
+        )
 
 
 class _DegenerateStubLock(BaseLock):

--- a/tests/providers/test_seam.py
+++ b/tests/providers/test_seam.py
@@ -25,6 +25,7 @@ from custom_components.lock_code_manager.domain.credentials import (
 )
 from custom_components.lock_code_manager.domain.exceptions import (
     CodeRejectedError,
+    LockCodeManagerProviderError,
     LockDisconnected,
     LockOperationFailed,
     ProviderNotImplementedError,
@@ -176,6 +177,68 @@ async def test_primitive_defaults_raise(hass: HomeAssistant) -> None:
         await lock.async_delete_credential(CredentialRef(1, CredentialType.PIN, 1))
     with pytest.raises(ProviderNotImplementedError):
         await lock.async_get_users()
+
+
+async def test_setup_internal_rejects_lock_without_pin_support(
+    hass: HomeAssistant,
+) -> None:
+    """A native-user lock missing PIN support fails setup with a typed error."""
+
+    class _NoPinLock(_NativeStubLock):
+        async def async_get_capabilities(self) -> LockCapabilities:
+            return LockCapabilities(
+                supports_user_management=True,
+                max_users=30,
+                credential_types={},  # no PIN
+                max_user_name_length=16,
+            )
+
+    lock = _make_lock(hass, _NoPinLock, "seam_setup_no_pin")
+    config_entry = MockConfigEntry(domain=DOMAIN)
+    config_entry.add_to_hass(hass)
+    with pytest.raises(LockCodeManagerProviderError, match="PIN credential"):
+        await lock.async_setup_internal(config_entry)
+
+
+async def test_setup_internal_rejects_lock_without_user_management(
+    hass: HomeAssistant,
+) -> None:
+    """A native-user lock missing user management fails setup with a typed error."""
+
+    class _NoUserMgmtLock(_NativeStubLock):
+        async def async_get_capabilities(self) -> LockCapabilities:
+            return LockCapabilities(
+                supports_user_management=False,
+                max_users=30,
+                credential_types={
+                    CredentialType.PIN: CredentialTypeCapability(
+                        num_slots=30,
+                        min_length=4,
+                        max_length=8,
+                        supports_learn=False,
+                    ),
+                },
+                max_user_name_length=16,
+            )
+
+    lock = _make_lock(hass, _NoUserMgmtLock, "seam_setup_no_user_mgmt")
+    config_entry = MockConfigEntry(domain=DOMAIN)
+    config_entry.add_to_hass(hass)
+    with pytest.raises(LockCodeManagerProviderError, match="user management"):
+        await lock.async_setup_internal(config_entry)
+
+
+async def test_setup_internal_skips_capability_check_for_slot_only_providers(
+    hass: HomeAssistant,
+) -> None:
+    """Slot-only providers don't have capabilities; base must not call them."""
+    lock = _make_lock(hass, _DegenerateStubLock, "seam_setup_degen")
+    config_entry = MockConfigEntry(domain=DOMAIN)
+    config_entry.add_to_hass(hass)
+    # The default async_get_capabilities raises ProviderNotImplementedError;
+    # if the base attempted to read caps, that error would propagate. The
+    # gate on supports_native_users keeps it from running.
+    await lock.async_setup_internal(config_entry)
 
 
 async def test_get_usercodes_projects_pin_credentials(hass: HomeAssistant) -> None:
@@ -431,6 +494,69 @@ async def test_truncate_user_name_returns_none_when_caps_fetch_fails(
         assert await lock._truncate_user_name("alice") is None
     # Cache stays unset so the next call retries.
     assert lock._capabilities_cache is None
+
+
+async def test_assert_credential_type_supported_accepts_advertised(
+    hass: HomeAssistant,
+) -> None:
+    """PIN is advertised by the stub → no raise."""
+    lock = _make_lock(hass, _NativeStubLock, "seam_assert_type_ok")
+    credential = credential_from_slot(1, SlotCredential.known("1234"))
+    # Should not raise.
+    await lock._assert_credential_type_supported(credential)
+
+
+async def test_assert_credential_type_supported_rejects_unadvertised(
+    hass: HomeAssistant,
+) -> None:
+    """A type the lock doesn't advertise → CodeRejectedError."""
+    lock = _make_lock(hass, _NativeStubLock, "seam_assert_type_reject")
+    credential = Credential(
+        type=CredentialType.RFID, slot=4, state=SlotCredential.known("AABB")
+    )
+    with pytest.raises(CodeRejectedError) as exc_info:
+        await lock._assert_credential_type_supported(credential)
+    assert exc_info.value.code_slot == 4
+    assert "unsupported credential type" in str(exc_info.value)
+
+
+async def test_assert_credential_ref_supported_rejects_unadvertised(
+    hass: HomeAssistant,
+) -> None:
+    """A ref of a type the lock doesn't advertise → CodeRejectedError."""
+    lock = _make_lock(hass, _NativeStubLock, "seam_assert_ref_reject")
+    ref = CredentialRef(user_id=1, type=CredentialType.RFID, slot=7)
+    with pytest.raises(CodeRejectedError) as exc_info:
+        await lock._assert_credential_ref_supported(ref)
+    assert exc_info.value.code_slot == 7
+    assert "unsupported credential type" in str(exc_info.value)
+
+
+async def test_put_credential_rejects_unsupported_credential_type(
+    hass: HomeAssistant,
+) -> None:
+    """``_put_credential`` asserts the type before any set call."""
+    lock = _make_lock(hass, _NativeStubLock, "seam_put_reject_type")
+    rfid_credential = Credential(
+        type=CredentialType.RFID, slot=2, state=SlotCredential.known("AABB")
+    )
+    user = User(user_id=2, credentials=[rfid_credential])
+    with pytest.raises(CodeRejectedError):
+        await lock._put_credential(user, rfid_credential, name=None, source="direct")
+    # No primitive was reached because the assertion fired first.
+    assert lock.calls == []
+
+
+async def test_drop_credential_rejects_unsupported_credential_type(
+    hass: HomeAssistant,
+) -> None:
+    """``_drop_credential`` asserts the ref's type before any delete call."""
+    lock = _make_lock(hass, _NativeStubLock, "seam_drop_reject_type")
+    owner = User(user_id=1, credentials=[])
+    ref = CredentialRef(user_id=1, type=CredentialType.RFID, slot=3)
+    with pytest.raises(CodeRejectedError):
+        await lock._drop_credential(owner, ref)
+    assert lock.calls == []
 
 
 async def test_set_usercode_native_user_first_and_threads_id(

--- a/tests/providers/test_seam.py
+++ b/tests/providers/test_seam.py
@@ -105,7 +105,7 @@ class _NativeStubLock(BaseLock):
 
     async def async_get_capabilities(self) -> LockCapabilities:
         # Real user records with names available — this is what gates
-        # ``_put_credential`` into the set-user-first path.
+        # ``_set_credential`` into the set-user-first path.
         return LockCapabilities(
             supports_user_management=True,
             max_users=30,
@@ -532,30 +532,30 @@ async def test_assert_credential_ref_supported_rejects_unadvertised(
     assert "unsupported credential type" in str(exc_info.value)
 
 
-async def test_put_credential_rejects_unsupported_credential_type(
+async def test_set_credential_rejects_unsupported_credential_type(
     hass: HomeAssistant,
 ) -> None:
-    """``_put_credential`` asserts the type before any set call."""
+    """``_set_credential`` asserts the type before any set call."""
     lock = _make_lock(hass, _NativeStubLock, "seam_put_reject_type")
     rfid_credential = Credential(
         type=CredentialType.RFID, slot=2, state=SlotCredential.known("AABB")
     )
     user = User(user_id=2, credentials=[rfid_credential])
     with pytest.raises(CodeRejectedError):
-        await lock._put_credential(user, rfid_credential, name=None, source="direct")
+        await lock._set_credential(user, rfid_credential, name=None, source="direct")
     # No primitive was reached because the assertion fired first.
     assert lock.calls == []
 
 
-async def test_drop_credential_rejects_unsupported_credential_type(
+async def test_delete_credential_rejects_unsupported_credential_type(
     hass: HomeAssistant,
 ) -> None:
-    """``_drop_credential`` asserts the ref's type before any delete call."""
+    """``_delete_credential`` asserts the ref's type before any delete call."""
     lock = _make_lock(hass, _NativeStubLock, "seam_drop_reject_type")
     owner = User(user_id=1, credentials=[])
     ref = CredentialRef(user_id=1, type=CredentialType.RFID, slot=3)
     with pytest.raises(CodeRejectedError):
-        await lock._drop_credential(owner, ref)
+        await lock._delete_credential(owner, ref)
     assert lock.calls == []
 
 

--- a/tests/providers/test_seam.py
+++ b/tests/providers/test_seam.py
@@ -598,6 +598,54 @@ async def test_clear_usercode_native_deletes_user_on_last_credential(
     assert 3 not in lock._users
 
 
+async def test_clear_usercode_implicit_user_skips_delete_user(
+    hass: HomeAssistant,
+) -> None:
+    """
+    Implicit-user lock (e.g. Z-Wave User Code CC) skips the cleanup
+    ``async_delete_user`` call after a credential delete.
+
+    The credential delete already removed the user implicitly, so the
+    base lifecycle has nothing to clean up. Without this gate the base
+    would log a spurious warning on every clear because the driver
+    reports the user as already gone. Mirrors ``_set_credential``'s
+    ``_supports_user_records()`` gate on the set side.
+    """
+
+    class _ImplicitUserStubLock(_NativeStubLock):
+        async def async_get_capabilities(self) -> LockCapabilities:
+            # supports_user_management True (hardcoded by the driver for
+            # all Z-Wave locks), max_user_name_length 0 (UC has no
+            # names) -- the implicit-user signal.
+            return LockCapabilities(
+                supports_user_management=True,
+                max_users=30,
+                credential_types={
+                    CredentialType.PIN: CredentialTypeCapability(
+                        num_slots=30,
+                        min_length=4,
+                        max_length=8,
+                        supports_learn=False,
+                    ),
+                },
+                max_user_name_length=0,
+            )
+
+    lock = _make_lock(hass, _ImplicitUserStubLock, "seam_clear_implicit_user")
+    # Directly seed an implicit user; on a real User Code CC lock the
+    # driver creates this record inside the credential-write call.
+    lock._users[3] = User(
+        user_id=3,
+        credentials=[credential_from_slot(3, SlotCredential.known("9999"))],
+    )
+
+    changed = await lock.async_clear_usercode(3)
+
+    assert changed is True
+    # delete_credential ran; delete_user did NOT.
+    assert lock.calls == [("delete_credential", 3, 3)]
+
+
 async def test_clear_usercode_degenerate_no_user_op(hass: HomeAssistant) -> None:
     """Slot-only clear deletes the credential and performs no user operation."""
     lock = _make_lock(hass, _DegenerateStubLock, "seam_clear_degen")

--- a/tests/providers/test_seam.py
+++ b/tests/providers/test_seam.py
@@ -242,6 +242,68 @@ async def test_get_usercodes_drops_non_pin_credentials(hass: HomeAssistant) -> N
     assert await lock.async_get_usercodes() == {1: SlotCredential.known("1234")}
 
 
+async def test_project_users_to_slots_is_type_parametric(
+    hass: HomeAssistant,
+) -> None:
+    """
+    The base projection helper isolates one credential type per call.
+
+    Option A wiring: ``async_get_usercodes`` is a thin Personal Identification
+    Number-shaped wrapper over ``_project_users_to_slots``; calling the helper
+    with a different ``CredentialType`` returns the slot view for that type.
+    Regression guard for the chokepoint -- if a future caller needs the
+    Radio Frequency Identification view, it goes through this same code path
+    rather than a parallel projection.
+    """
+    lock = _make_lock(hass, _NativeStubLock, "seam_project_typed")
+    lock._users = {
+        1: User(
+            user_id=1,
+            credentials=[
+                credential_from_slot(1, SlotCredential.known("1234")),
+                Credential(
+                    type=CredentialType.RFID,
+                    slot=2,
+                    state=SlotCredential.unreadable(),
+                ),
+                Credential(
+                    type=CredentialType.PASSWORD,
+                    slot=3,
+                    state=SlotCredential.known("hunter2"),
+                ),
+            ],
+        ),
+    }
+
+    with patch(
+        "custom_components.lock_code_manager.providers._base.get_managed_slots",
+        return_value={1, 2, 3},
+    ):
+        pin_slots = await lock._project_users_to_slots(CredentialType.PIN)
+        rfid_slots = await lock._project_users_to_slots(CredentialType.RFID)
+        password_slots = await lock._project_users_to_slots(CredentialType.PASSWORD)
+        # async_get_usercodes() is the PIN wrapper.
+        assert await lock.async_get_usercodes() == pin_slots
+
+    # Each projection only sees its own credential type; the managed-slot
+    # empty placeholders persist across all of them.
+    assert pin_slots == {
+        1: SlotCredential.known("1234"),
+        2: SlotCredential.empty(),
+        3: SlotCredential.empty(),
+    }
+    assert rfid_slots == {
+        1: SlotCredential.empty(),
+        2: SlotCredential.unreadable(),
+        3: SlotCredential.empty(),
+    }
+    assert password_slots == {
+        1: SlotCredential.empty(),
+        2: SlotCredential.empty(),
+        3: SlotCredential.known("hunter2"),
+    }
+
+
 async def test_set_usercode_native_user_first_and_threads_id(
     hass: HomeAssistant,
 ) -> None:

--- a/tests/providers/test_seam.py
+++ b/tests/providers/test_seam.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from typing import Literal
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -25,6 +25,7 @@ from custom_components.lock_code_manager.domain.credentials import (
 )
 from custom_components.lock_code_manager.domain.exceptions import (
     CodeRejectedError,
+    LockDisconnected,
     LockOperationFailed,
     ProviderNotImplementedError,
 )
@@ -321,6 +322,115 @@ async def test_project_users_to_slots_is_type_parametric(
         2: SlotCredential.empty(),
         3: SlotCredential.known("hunter2"),
     }
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Base capability-derived helpers
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _caps(
+    *, supports_user_management: bool, max_user_name_length: int
+) -> LockCapabilities:
+    return LockCapabilities(
+        supports_user_management=supports_user_management,
+        max_users=30,
+        credential_types={
+            CredentialType.PIN: CredentialTypeCapability(
+                num_slots=30,
+                min_length=4,
+                max_length=8,
+                supports_learn=False,
+            ),
+        },
+        max_user_name_length=max_user_name_length,
+    )
+
+
+async def test_supports_user_records_true_when_management_and_named(
+    hass: HomeAssistant,
+) -> None:
+    """``supports_user_management AND max_user_name_length > 0`` → True."""
+    lock = _make_lock(hass, _NativeStubLock, "seam_supports_users_true")
+    lock._capabilities_cache = _caps(
+        supports_user_management=True, max_user_name_length=16
+    )
+    assert await lock._supports_user_records() is True
+
+
+async def test_supports_user_records_false_when_max_name_length_zero(
+    hass: HomeAssistant,
+) -> None:
+    """Implicit-user lock (e.g. Z-Wave User Code CC) → False."""
+    lock = _make_lock(hass, _NativeStubLock, "seam_supports_users_uc")
+    lock._capabilities_cache = _caps(
+        supports_user_management=True, max_user_name_length=0
+    )
+    assert await lock._supports_user_records() is False
+
+
+async def test_supports_user_records_false_when_management_disabled(
+    hass: HomeAssistant,
+) -> None:
+    """A lock that doesn't expose user management → False."""
+    lock = _make_lock(hass, _NativeStubLock, "seam_supports_users_no_mgmt")
+    lock._capabilities_cache = _caps(
+        supports_user_management=False, max_user_name_length=16
+    )
+    assert await lock._supports_user_records() is False
+
+
+async def test_truncate_user_name_within_limit_is_unchanged(
+    hass: HomeAssistant,
+) -> None:
+    """A name within ``max_user_name_length`` passes through unchanged."""
+    lock = _make_lock(hass, _NativeStubLock, "seam_truncate_within")
+    lock._capabilities_cache = _caps(
+        supports_user_management=True, max_user_name_length=16
+    )
+    assert await lock._truncate_user_name("alice") == "alice"
+
+
+async def test_truncate_user_name_truncates_to_limit(hass: HomeAssistant) -> None:
+    """A name longer than ``max_user_name_length`` is truncated."""
+    lock = _make_lock(hass, _NativeStubLock, "seam_truncate_long")
+    lock._capabilities_cache = _caps(
+        supports_user_management=True, max_user_name_length=5
+    )
+    assert await lock._truncate_user_name("alexandra") == "alexa"
+
+
+async def test_truncate_user_name_returns_none_when_max_zero(
+    hass: HomeAssistant,
+) -> None:
+    """Locks without named users drop the name entirely."""
+    lock = _make_lock(hass, _NativeStubLock, "seam_truncate_zero")
+    lock._capabilities_cache = _caps(
+        supports_user_management=True, max_user_name_length=0
+    )
+    assert await lock._truncate_user_name("alice") is None
+
+
+async def test_truncate_user_name_none_input_is_none(hass: HomeAssistant) -> None:
+    """A ``None`` name stays ``None`` without touching the capability cache."""
+    lock = _make_lock(hass, _NativeStubLock, "seam_truncate_none")
+    # No capabilities cache primed; helper short-circuits on None input.
+    assert await lock._truncate_user_name(None) is None
+
+
+async def test_truncate_user_name_returns_none_when_caps_fetch_fails(
+    hass: HomeAssistant,
+) -> None:
+    """Caps-read failure falls back to None instead of blocking the write."""
+    lock = _make_lock(hass, _NativeStubLock, "seam_truncate_fail")
+    with patch.object(
+        type(lock),
+        "async_get_capabilities",
+        AsyncMock(side_effect=LockDisconnected("unreachable")),
+    ):
+        assert await lock._truncate_user_name("alice") is None
+    # Cache stays unset so the next call retries.
+    assert lock._capabilities_cache is None
 
 
 async def test_set_usercode_native_user_first_and_threads_id(

--- a/tests/providers/zwave_js/conftest.py
+++ b/tests/providers/zwave_js/conftest.py
@@ -477,7 +477,13 @@ def mock_lock_helpers():
 
 @pytest.fixture
 def mock_access_control(lock_schlage_be469: Node):
-    """Give the node a mock access_control with READ methods (Option B)."""
+    """
+    Give the node a mock access_control with READ methods (Option B).
+
+    ``access_control`` is a property on ``Node``, so this patches it at the
+    CLASS level for the fixture's scope -- every ``Node`` instance sees the
+    mock while the fixture is active, not just ``lock_schlage_be469``.
+    """
     ac = MagicMock()
     ac.get_user_cached = AsyncMock(return_value=None)
     ac.get_users_cached = AsyncMock(return_value=[])

--- a/tests/providers/zwave_js/conftest.py
+++ b/tests/providers/zwave_js/conftest.py
@@ -29,8 +29,6 @@ from custom_components.lock_code_manager.const import (
 from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers.zwave_js import ZWaveJSLock
 
-from .helpers import _PROVIDER_MODULE
-
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
 
@@ -407,30 +405,6 @@ async def simple_lcm_config_entry(
     )
     entry.add_to_hass(hass)
     return entry
-
-
-@pytest.fixture
-def mock_zwave_usercodes(zwave_client: MagicMock):
-    """
-    Mock Z-Wave JS usercode cache functions with mutable state.
-
-    ``get_usercode`` reads from a shared mutable ``codes`` dict. The client's
-    ``async_send_command`` is wrapped so that access_control commands return
-    an empty users/credentials list by default (tests override via
-    ``mock_access_control`` when they need specific credential data).
-
-    Yields ``(None, mock_get_usercode, codes)`` where ``None`` is a placeholder
-    for the removed ``get_usercodes`` mock (kept so call sites using tuple
-    unpacking as ``_mock_all, _mock_one, codes`` continue to work), and
-    *codes* is ``dict[int, dict]`` keyed by slot number.
-    """
-    codes: dict[int, dict] = {}
-
-    with patch(f"{_PROVIDER_MODULE}.get_usercode") as mock_one:
-        mock_one.side_effect = lambda node, slot: codes.get(
-            slot, {"code_slot": slot, "in_use": False, "usercode": ""}
-        )
-        yield None, mock_one, codes
 
 
 @pytest.fixture

--- a/tests/providers/zwave_js/conftest.py
+++ b/tests/providers/zwave_js/conftest.py
@@ -410,8 +410,23 @@ async def simple_lcm_config_entry(
 @pytest.fixture
 def mock_lock_helpers():
     """Patch the write/capability lock_helpers the provider calls."""
+    pin_type_str = "pin"
     mocks = {
-        "async_get_credential_capabilities": AsyncMock(),
+        "async_get_credential_capabilities": AsyncMock(return_value={
+            "supports_user_management": True,
+            "max_users": 30,
+            "supported_user_types": [],
+            "max_user_name_length": 10,
+            "supported_credential_rules": [],
+            "supported_credential_types": {
+                pin_type_str: {
+                    "num_slots": 30,
+                    "min_length": 4,
+                    "max_length": 8,
+                    "supports_learn": False,
+                }
+            },
+        }),
         "async_set_user": AsyncMock(return_value={"user_id": 1}),
         "async_delete_user": AsyncMock(),
         "async_set_credential": AsyncMock(

--- a/tests/providers/zwave_js/conftest.py
+++ b/tests/providers/zwave_js/conftest.py
@@ -454,3 +454,35 @@ def mock_zwave_usercodes(zwave_client: MagicMock):
         zwave_client.async_send_command.side_effect = _send_command_with_codes
         yield mock_all, mock_one, codes
         zwave_client.async_send_command.side_effect = original_side_effect
+
+
+@pytest.fixture
+def mock_lock_helpers():
+    """Patch the write/capability lock_helpers the provider calls."""
+    mocks = {
+        "async_get_credential_capabilities": AsyncMock(),
+        "async_set_user": AsyncMock(return_value={"user_id": 1}),
+        "async_delete_user": AsyncMock(),
+        "async_set_credential": AsyncMock(
+            return_value={"credential_slot": 1, "user_id": 1}
+        ),
+        "async_delete_credential": AsyncMock(),
+    }
+    with patch.multiple(
+        "custom_components.lock_code_manager.providers.zwave_js.lock_helpers",
+        **mocks,
+    ):
+        yield mocks
+
+
+@pytest.fixture
+def mock_access_control(lock_schlage_be469: Node):
+    """Give the node a mock access_control with READ methods (Option B)."""
+    ac = MagicMock()
+    ac.get_user_cached = AsyncMock(return_value=None)
+    ac.get_users_cached = AsyncMock(return_value=[])
+    ac.get_all_credentials_cached = AsyncMock(return_value=[])
+    ac.get_users = AsyncMock(return_value=[])
+    ac.get_all_credentials = AsyncMock(return_value=[])
+    with patch.object(type(lock_schlage_be469), "access_control", ac):
+        yield ac

--- a/tests/providers/zwave_js/conftest.py
+++ b/tests/providers/zwave_js/conftest.py
@@ -276,6 +276,8 @@ async def lcm_config_entry(
     hass: HomeAssistant,
     zwave_integration: MockConfigEntry,
     lock_entity: er.RegistryEntry,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
 ) -> MockConfigEntry:
     """
     Set up a full LCM config entry managing the Z-Wave JS lock.

--- a/tests/providers/zwave_js/conftest.py
+++ b/tests/providers/zwave_js/conftest.py
@@ -12,10 +12,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
+from zwave_js_server.const.command_class.access_control import UserCredentialType
 from zwave_js_server.model.driver import Driver
 from zwave_js_server.model.node import Node
 from zwave_js_server.version import VersionInfo
 
+from homeassistant.components.zwave_js import lock_helpers
 from homeassistant.components.zwave_js.const import DOMAIN as ZWAVE_JS_DOMAIN
 from homeassistant.const import CONF_ENABLED, CONF_NAME, CONF_PIN
 from homeassistant.core import HomeAssistant
@@ -412,7 +414,7 @@ async def simple_lcm_config_entry(
 @pytest.fixture
 def mock_lock_helpers():
     """Patch the write/capability lock_helpers the provider calls."""
-    pin_type_str = "pin"
+    pin_type_str = lock_helpers.CREDENTIAL_TYPE_MAP[UserCredentialType.PIN_CODE]
     mocks = {
         "async_get_credential_capabilities": AsyncMock(
             return_value={

--- a/tests/providers/zwave_js/conftest.py
+++ b/tests/providers/zwave_js/conftest.py
@@ -412,21 +412,23 @@ def mock_lock_helpers():
     """Patch the write/capability lock_helpers the provider calls."""
     pin_type_str = "pin"
     mocks = {
-        "async_get_credential_capabilities": AsyncMock(return_value={
-            "supports_user_management": True,
-            "max_users": 30,
-            "supported_user_types": [],
-            "max_user_name_length": 10,
-            "supported_credential_rules": [],
-            "supported_credential_types": {
-                pin_type_str: {
-                    "num_slots": 30,
-                    "min_length": 4,
-                    "max_length": 8,
-                    "supports_learn": False,
-                }
-            },
-        }),
+        "async_get_credential_capabilities": AsyncMock(
+            return_value={
+                "supports_user_management": True,
+                "max_users": 30,
+                "supported_user_types": [],
+                "max_user_name_length": 10,
+                "supported_credential_rules": [],
+                "supported_credential_types": {
+                    pin_type_str: {
+                        "num_slots": 30,
+                        "min_length": 4,
+                        "max_length": 8,
+                        "supports_learn": False,
+                    }
+                },
+            }
+        ),
         "async_set_user": AsyncMock(return_value={"user_id": 1}),
         "async_delete_user": AsyncMock(),
         "async_set_credential": AsyncMock(

--- a/tests/providers/zwave_js/conftest.py
+++ b/tests/providers/zwave_js/conftest.py
@@ -12,7 +12,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
-from zwave_js_server.const import CommandClass
 from zwave_js_server.model.driver import Driver
 from zwave_js_server.model.node import Node
 from zwave_js_server.version import VersionInfo
@@ -152,6 +151,30 @@ def mock_zwave_client_fixture(
                 return {"changed": False}
             if message["command"] == "endpoint.invoke_cc_api":
                 return {"response": None}
+            if message["command"] in (
+                "endpoint.access_control.get_users_cached",
+                "endpoint.access_control.get_users",
+            ):
+                return {"users": []}
+            if message["command"] in (
+                "endpoint.access_control.get_all_credentials_cached",
+                "endpoint.access_control.get_all_credentials",
+            ):
+                return {"credentials": []}
+            if message["command"] == "endpoint.access_control.get_user_cached":
+                return {"user": None}
+            if message["command"] == "endpoint.access_control.is_supported":
+                return {"supported": True}
+            if message["command"] in (
+                "endpoint.access_control.set_user",
+                "endpoint.access_control.delete_user",
+            ):
+                return {"result": {"success": True, "userId": message.get("userId", 1)}}
+            if message["command"] in (
+                "endpoint.access_control.set_credential",
+                "endpoint.access_control.delete_credential",
+            ):
+                return {"result": {"success": True}}
             return {"result": {"success": True, "status": 255}}
 
         client.async_send_command = AsyncMock(
@@ -340,22 +363,6 @@ async def zwave_js_lock_v2_fixture(
     )
 
 
-@pytest.fixture(name="mock_get_usercode_from_node", autouse=True)
-def mock_get_usercode_from_node_fixture():
-    """
-    Mock get_usercode_from_node for all tests.
-
-    V1 set/clear calls get_usercode_from_node to poll the slot from the device.
-    In tests, the node has no real Z-Wave JS server connection, so we mock the
-    function. Individual tests can access the mock via the parameter name.
-    """
-    with patch(
-        f"{_PROVIDER_MODULE}.get_usercode_from_node",
-        new_callable=AsyncMock,
-    ) as mock:
-        yield mock
-
-
 @pytest.fixture
 def mock_coordinator():
     """
@@ -405,55 +412,25 @@ async def simple_lcm_config_entry(
 @pytest.fixture
 def mock_zwave_usercodes(zwave_client: MagicMock):
     """
-    Mock Z-Wave JS usercode functions with mutable state.
+    Mock Z-Wave JS usercode cache functions with mutable state.
 
-    Both ``get_usercodes`` and ``get_usercode`` read from a shared mutable
-    ``codes`` dict. The client's ``async_send_command`` is wrapped so that
-    set / clear Z-Wave commands automatically update ``codes``, preventing
-    the coordinator refresh from overwriting optimistic push updates with
-    stale data.
+    ``get_usercode`` reads from a shared mutable ``codes`` dict. The client's
+    ``async_send_command`` is wrapped so that access_control commands return
+    an empty users/credentials list by default (tests override via
+    ``mock_access_control`` when they need specific credential data).
 
-    Yields ``(mock_get_usercodes, mock_get_usercode, codes)`` where *codes*
-    is ``dict[int, dict]`` keyed by slot number.
+    Yields ``(None, mock_get_usercode, codes)`` where ``None`` is a placeholder
+    for the removed ``get_usercodes`` mock (kept so call sites using tuple
+    unpacking as ``_mock_all, _mock_one, codes`` continue to work), and
+    *codes* is ``dict[int, dict]`` keyed by slot number.
     """
     codes: dict[int, dict] = {}
 
-    original_side_effect = zwave_client.async_send_command.side_effect
-
-    async def _send_command_with_codes(message, require_schema=None):
-        if message.get("command") == "node.set_value":
-            vid = message.get("valueId", {})
-            if vid.get("commandClass") == CommandClass.USER_CODE:
-                slot = vid.get("propertyKey")
-                if slot is not None:
-                    prop = vid.get("property")
-                    if prop == "userIdStatus":
-                        # Clear operation
-                        codes[slot] = {
-                            "code_slot": slot,
-                            "in_use": False,
-                            "usercode": "",
-                        }
-                    elif prop == "userCode":
-                        # Set operation
-                        codes[slot] = {
-                            "code_slot": slot,
-                            "in_use": True,
-                            "usercode": str(message["value"]),
-                        }
-        return await original_side_effect(message, require_schema)
-
-    with (
-        patch(f"{_PROVIDER_MODULE}.get_usercodes") as mock_all,
-        patch(f"{_PROVIDER_MODULE}.get_usercode") as mock_one,
-    ):
-        mock_all.side_effect = lambda node: list(codes.values())
+    with patch(f"{_PROVIDER_MODULE}.get_usercode") as mock_one:
         mock_one.side_effect = lambda node, slot: codes.get(
             slot, {"code_slot": slot, "in_use": False, "usercode": ""}
         )
-        zwave_client.async_send_command.side_effect = _send_command_with_codes
-        yield mock_all, mock_one, codes
-        zwave_client.async_send_command.side_effect = original_side_effect
+        yield None, mock_one, codes
 
 
 @pytest.fixture

--- a/tests/providers/zwave_js/helpers.py
+++ b/tests/providers/zwave_js/helpers.py
@@ -10,9 +10,6 @@ from homeassistant.helpers import entity_registry as er
 
 from custom_components.lock_code_manager.const import DOMAIN
 
-# Module path where provider functions are imported (used as a patch target).
-_PROVIDER_MODULE = "custom_components.lock_code_manager.providers.zwave_js"
-
 
 def async_capture_events(
     hass: HomeAssistant, event_name: str

--- a/tests/providers/zwave_js/helpers.py
+++ b/tests/providers/zwave_js/helpers.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from typing import Any
 
-from zwave_js_server.event import Event as ZwaveEvent
-
 from homeassistant.const import CONF_ENABLED
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
@@ -28,30 +26,6 @@ def async_capture_events(
 
     hass.bus.async_listen(event_name, capture_events)
     return events
-
-
-def make_duplicate_code_event(node_id: int, user_id: int | None = None) -> ZwaveEvent:
-    """Create a duplicate-code Access Control notification ZwaveEvent."""
-    params: dict[str, Any] = {}
-    if user_id is not None:
-        params["userId"] = user_id
-    return ZwaveEvent(
-        type="notification",
-        data={
-            "source": "node",
-            "event": "notification",
-            "nodeId": node_id,
-            "endpointIndex": 0,
-            "ccId": 113,
-            "args": {
-                "type": 6,  # ACCESS_CONTROL
-                "event": 15,  # NEW_USER_CODE_NOT_ADDED_DUE_TO_DUPLICATE_CODE
-                "label": "Access Control",
-                "eventLabel": "New user code not added due to duplicate code",
-                "parameters": params,
-            },
-        },
-    )
 
 
 def get_enabled_switch_entity_id(hass: HomeAssistant, entry_id: str, slot: int) -> str:

--- a/tests/providers/zwave_js/test_e2e.py
+++ b/tests/providers/zwave_js/test_e2e.py
@@ -5,8 +5,14 @@ from __future__ import annotations
 from typing import Any
 from unittest.mock import MagicMock
 
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 from zwave_js_server.const import CommandClass
+from zwave_js_server.const.command_class.access_control import (
+    UserCredentialType,
+    UserCredentialUserType,
+)
 from zwave_js_server.event import Event as ZwaveEvent
+from zwave_js_server.model.access_control import CredentialData, UserData
 from zwave_js_server.model.node import Node
 
 from homeassistant.core import Event, HomeAssistant, callback
@@ -14,6 +20,9 @@ from homeassistant.helpers import entity_registry as er
 
 from custom_components.lock_code_manager.const import (
     ATTR_CODE_SLOT,
+    CONF_LOCKS,
+    CONF_SLOTS,
+    DOMAIN,
     EVENT_LOCK_STATE_CHANGED,
 )
 from custom_components.lock_code_manager.domain.models import SlotCredential
@@ -66,72 +75,132 @@ class TestFullSetupLifecycle:
 
 
 class TestSetAndClearUsercodes:
-    """Verify set/clear operations send proper Z-Wave commands."""
+    """Verify set/clear operations invoke the unified access-control primitives."""
 
-    async def test_set_usercode(
+    async def test_set_usercode_calls_lock_helpers(
         self,
         hass: HomeAssistant,
-        e2e_zwave_lock: ZWaveJSLock,
-        zwave_client: MagicMock,
+        zwave_js_lock: ZWaveJSLock,
+        mock_access_control: MagicMock,
+        mock_lock_helpers: dict,
+        zwave_integration: MockConfigEntry,
     ) -> None:
-        """Set a code via the provider and verify the Z-Wave command was sent."""
-        zwave_client.async_send_command.reset_mock()
-        result = await e2e_zwave_lock.async_set_usercode(4, "5678", "Test User")
+        """Setting a code drives async_set_user then async_set_credential via lock_helpers."""
+        lcm_entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={
+                CONF_LOCKS: [zwave_js_lock.lock.entity_id],
+                CONF_SLOTS: {"4": {}},
+            },
+        )
+        lcm_entry.add_to_hass(hass)
+        zwave_js_lock._min_operation_delay = 0.0
+        mock_access_control.get_user_cached.return_value = None
+        mock_lock_helpers["async_set_user"].return_value = {"user_id": 4}
+
+        result = await zwave_js_lock.async_set_usercode(4, "5678", "Test User")
 
         assert result is True
-        assert zwave_client.async_send_command.call_count >= 1
+        mock_lock_helpers["async_set_user"].assert_called_once()
+        mock_lock_helpers["async_set_credential"].assert_called_once()
 
-    async def test_clear_usercode(
+    async def test_clear_usercode_calls_lock_helpers(
         self,
         hass: HomeAssistant,
-        e2e_zwave_lock: ZWaveJSLock,
-        zwave_client: MagicMock,
+        zwave_js_lock: ZWaveJSLock,
+        mock_access_control: MagicMock,
+        mock_lock_helpers: dict,
+        zwave_integration: MockConfigEntry,
     ) -> None:
-        """Clear a code via the provider and verify the Z-Wave command was sent."""
-        zwave_client.async_send_command.reset_mock()
-        result = await e2e_zwave_lock.async_clear_usercode(2)
+        """Clearing a slot resolves the owner then calls async_delete_credential."""
+        lcm_entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={
+                CONF_LOCKS: [zwave_js_lock.lock.entity_id],
+                CONF_SLOTS: {"2": {}},
+            },
+        )
+        lcm_entry.add_to_hass(hass)
+        zwave_js_lock._min_operation_delay = 0.0
+        mock_access_control.get_users_cached.return_value = [
+            UserData(
+                user_id=2,
+                active=True,
+                user_type=UserCredentialUserType.GENERAL,
+                user_name="bob",
+            ),
+        ]
+        mock_access_control.get_all_credentials_cached.return_value = [
+            CredentialData(
+                user_id=2,
+                type=UserCredentialType.PIN_CODE,
+                slot=2,
+                data="1234",
+            ),
+        ]
+
+        result = await zwave_js_lock.async_clear_usercode(2)
 
         assert result is True
-        assert zwave_client.async_send_command.call_count >= 1
-
-    async def test_set_usercode_optimistic_update(
-        self,
-        hass: HomeAssistant,
-        e2e_zwave_lock: ZWaveJSLock,
-    ) -> None:
-        """After set, the coordinator has the optimistic value."""
-        await e2e_zwave_lock.async_set_usercode(4, "5678", "Test User")
-
-        assert e2e_zwave_lock.coordinator.data.get(4) == SlotCredential.known("5678")
-
-    async def test_clear_usercode_optimistic_update(
-        self,
-        hass: HomeAssistant,
-        e2e_zwave_lock: ZWaveJSLock,
-    ) -> None:
-        """After clear, the coordinator has SlotCredential.empty()."""
-        await e2e_zwave_lock.async_clear_usercode(2)
-
-        assert e2e_zwave_lock.coordinator.data.get(2) is SlotCredential.empty()
+        mock_lock_helpers["async_delete_credential"].assert_called_once()
 
 
 class TestGetUsercodes:
-    """Verify reading usercodes from the Z-Wave JS value cache."""
+    """Verify reading usercodes from the access_control API."""
 
-    async def test_get_usercodes_returns_codes(
+    async def test_get_usercodes_returns_codes_from_access_control(
         self,
         hass: HomeAssistant,
-        e2e_zwave_lock: ZWaveJSLock,
+        zwave_js_lock: ZWaveJSLock,
+        mock_access_control: MagicMock,
+        mock_lock_helpers: dict,
+        zwave_integration: MockConfigEntry,
     ) -> None:
         """
-        Get usercodes returns the fixture's cached codes.
+        async_get_usercodes projects access_control users and credentials to slots.
 
-        The node fixture has slot 1="9999" (in_use), slot 2="1234" (in_use),
-        and slot 3=empty (not in_use).
+        The access_control fixture is seeded with two users at slots 1 and 2.
+        The result maps each slot to the readable Personal Identification Number.
         """
-        codes = await e2e_zwave_lock.async_get_usercodes()
+        lcm_entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={
+                CONF_LOCKS: [zwave_js_lock.lock.entity_id],
+                CONF_SLOTS: {"1": {}, "2": {}},
+            },
+        )
+        lcm_entry.add_to_hass(hass)
+        mock_access_control.get_users_cached.return_value = [
+            UserData(
+                user_id=1,
+                active=True,
+                user_type=UserCredentialUserType.GENERAL,
+                user_name="alice",
+            ),
+            UserData(
+                user_id=2,
+                active=True,
+                user_type=UserCredentialUserType.GENERAL,
+                user_name="bob",
+            ),
+        ]
+        mock_access_control.get_all_credentials_cached.return_value = [
+            CredentialData(
+                user_id=1,
+                type=UserCredentialType.PIN_CODE,
+                slot=1,
+                data="9999",
+            ),
+            CredentialData(
+                user_id=2,
+                type=UserCredentialType.PIN_CODE,
+                slot=2,
+                data="1234",
+            ),
+        ]
 
-        # Slots 1 and 2 are managed by the LCM config
+        codes = await zwave_js_lock.async_get_usercodes()
+
         assert codes[1] == SlotCredential.known("9999")
         assert codes[2] == SlotCredential.known("1234")
 

--- a/tests/providers/zwave_js/test_e2e.py
+++ b/tests/providers/zwave_js/test_e2e.py
@@ -6,7 +6,6 @@ from typing import Any
 from unittest.mock import MagicMock
 
 from pytest_homeassistant_custom_component.common import MockConfigEntry
-from zwave_js_server.const import CommandClass
 from zwave_js_server.const.command_class.access_control import (
     UserCredentialType,
     UserCredentialUserType,
@@ -246,28 +245,30 @@ class TestEvents:
         assert len(events) == 1
         assert events[0].data[ATTR_CODE_SLOT] == 1
 
-    async def test_push_value_update_reaches_coordinator(
+    async def test_push_credential_added_reaches_coordinator(
         self,
         hass: HomeAssistant,
         e2e_zwave_lock: ZWaveJSLock,
         lock_schlage_be469: Node,
     ) -> None:
-        """A Z-Wave value update event for a usercode updates the coordinator."""
+        """A credential-added node event for a Personal Identification Number updates the coordinator."""
         event = ZwaveEvent(
-            type="value updated",
+            type="credential added",
             data={
                 "source": "node",
-                "event": "value updated",
+                "event": "credential added",
                 "nodeId": lock_schlage_be469.node_id,
+                "endpointIndex": 0,
                 "args": {
-                    "commandClass": CommandClass.USER_CODE,
-                    "property": "userCode",
-                    "propertyKey": 1,
-                    "newValue": "4321",
+                    "userId": 1,
+                    "credentialType": UserCredentialType.PIN_CODE,
+                    "credentialSlot": 1,
                 },
             },
         )
         lock_schlage_be469.receive_event(event)
         await hass.async_block_till_done()
 
-        assert e2e_zwave_lock.coordinator.data.get(1) == SlotCredential.known("4321")
+        # Credential events push unreadable (the lock doesn't expose the Personal
+        # Identification Number value in the event; a coordinator refresh reads it).
+        assert e2e_zwave_lock.coordinator.data.get(1) == SlotCredential.unreadable()

--- a/tests/providers/zwave_js/test_events.py
+++ b/tests/providers/zwave_js/test_events.py
@@ -314,8 +314,16 @@ def _make_credential_added_event(
     credential_slot: int,
     credential_type: int = UserCredentialType.PIN_CODE,
     user_id: int = 1,
+    credential_data: str | None = None,
 ) -> ZwaveEvent:
     """Build a 'credential added' ZwaveEvent for a given slot."""
+    args: dict = {
+        "userId": user_id,
+        "credentialType": credential_type,
+        "credentialSlot": credential_slot,
+    }
+    if credential_data is not None:
+        args["data"] = credential_data
     return ZwaveEvent(
         type="credential added",
         data={
@@ -323,11 +331,7 @@ def _make_credential_added_event(
             "event": "credential added",
             "nodeId": node_id,
             "endpointIndex": 0,
-            "args": {
-                "userId": user_id,
-                "credentialType": credential_type,
-                "credentialSlot": credential_slot,
-            },
+            "args": args,
         },
     )
 
@@ -397,6 +401,32 @@ async def test_credential_added_pin_pushes_unreadable(
 
     mock_coordinator.push_update.assert_called_once_with(
         {2: SlotCredential.unreadable()}
+    )
+
+    zwave_js_lock.unsubscribe_push_updates()
+
+
+async def test_credential_added_pin_with_data_pushes_known(
+    hass: HomeAssistant,
+    zwave_js_lock: ZWaveJSLock,
+    lock_schlage_be469: Node,
+) -> None:
+    """A credential event that carries the value pushes the readable state."""
+    mock_coordinator = MagicMock()
+    mock_coordinator.data = {}
+    zwave_js_lock.coordinator = mock_coordinator
+
+    zwave_js_lock.subscribe_push_updates()
+
+    lock_schlage_be469.receive_event(
+        _make_credential_added_event(
+            lock_schlage_be469.node_id, credential_slot=2, credential_data="1234"
+        )
+    )
+    await hass.async_block_till_done()
+
+    mock_coordinator.push_update.assert_called_once_with(
+        {2: SlotCredential.known("1234")}
     )
 
     zwave_js_lock.unsubscribe_push_updates()

--- a/tests/providers/zwave_js/test_events.py
+++ b/tests/providers/zwave_js/test_events.py
@@ -39,6 +39,8 @@ async def test_subscribe_push_updates(
     zwave_js_lock: ZWaveJSLock,
     zwave_integration: MockConfigEntry,
     lock_schlage_be469: Node,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
 ) -> None:
     """Test subscribing to push updates."""
     lcm_entry = MockConfigEntry(domain=DOMAIN, data={CONF_LOCKS: [], CONF_SLOTS: {}})
@@ -60,6 +62,8 @@ async def test_subscribe_is_idempotent(
     hass: HomeAssistant,
     zwave_js_lock: ZWaveJSLock,
     zwave_integration: MockConfigEntry,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
 ) -> None:
     """Test that calling subscribe multiple times is safe."""
     lcm_entry = MockConfigEntry(domain=DOMAIN, data={CONF_LOCKS: [], CONF_SLOTS: {}})
@@ -80,6 +84,8 @@ async def test_subscribe_push_no_crash_on_client_not_ready(
     hass: HomeAssistant,
     zwave_js_lock: ZWaveJSLock,
     zwave_integration: MockConfigEntry,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
 ) -> None:
     """Test that push subscription handles client not ready without crashing."""
     lcm_entry = MockConfigEntry(domain=DOMAIN, data={CONF_LOCKS: [], CONF_SLOTS: {}})
@@ -106,6 +112,8 @@ async def test_subscribe_push_no_crash_on_node_error(
     zwave_js_lock: ZWaveJSLock,
     zwave_integration: MockConfigEntry,
     lock_schlage_be469: Node,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
 ) -> None:
     """Test that push subscription handles node.on error without crashing."""
     lcm_entry = MockConfigEntry(domain=DOMAIN, data={CONF_LOCKS: [], CONF_SLOTS: {}})
@@ -127,6 +135,8 @@ async def test_subscribe_push_cleans_up_partial_subscription_on_error(
     zwave_js_lock: ZWaveJSLock,
     zwave_integration: MockConfigEntry,
     lock_schlage_be469: Node,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
 ) -> None:
     """A failure partway through subscribing releases the unsubs already registered."""
     lcm_entry = MockConfigEntry(domain=DOMAIN, data={CONF_LOCKS: [], CONF_SLOTS: {}})
@@ -166,6 +176,8 @@ async def test_subscribe_registers_three_credential_listeners(
     zwave_js_lock: ZWaveJSLock,
     zwave_integration: MockConfigEntry,
     lock_schlage_be469: Node,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
 ) -> None:
     """Test that subscribing registers listeners for all three credential events."""
     lcm_entry = MockConfigEntry(domain=DOMAIN, data={CONF_LOCKS: [], CONF_SLOTS: {}})
@@ -188,6 +200,8 @@ async def test_event_filter_matches_correct_node(
     hass: HomeAssistant,
     zwave_js_lock: ZWaveJSLock,
     lock_schlage_be469: Node,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
 ) -> None:
     """Test that event filter matches events for the correct node."""
     dev_reg = dr.async_get(hass)
@@ -220,6 +234,8 @@ async def test_notification_event_keypad_lock_fires_lock_state_changed(
     zwave_js_lock: ZWaveJSLock,
     zwave_integration: MockConfigEntry,
     lock_schlage_be469: Node,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
 ) -> None:
     """Test that a keypad lock notification event fires EVENT_LOCK_STATE_CHANGED."""
     lcm_entry = MockConfigEntry(domain=DOMAIN, data={CONF_LOCKS: [], CONF_SLOTS: {}})
@@ -266,6 +282,8 @@ async def test_notification_event_keypad_unlock_fires_lock_state_changed(
     zwave_js_lock: ZWaveJSLock,
     zwave_integration: MockConfigEntry,
     lock_schlage_be469: Node,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
 ) -> None:
     """Test that a keypad unlock notification event fires EVENT_LOCK_STATE_CHANGED."""
     lcm_entry = MockConfigEntry(domain=DOMAIN, data={CONF_LOCKS: [], CONF_SLOTS: {}})
@@ -309,6 +327,8 @@ async def test_notification_event_non_access_control_ignored(
     zwave_js_lock: ZWaveJSLock,
     zwave_integration: MockConfigEntry,
     lock_schlage_be469: Node,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
 ) -> None:
     """A notification of a non Access Control type is ignored (no LCM event)."""
     lcm_entry = MockConfigEntry(domain=DOMAIN, data={CONF_LOCKS: [], CONF_SLOTS: {}})
@@ -425,6 +445,8 @@ async def test_credential_added_pin_pushes_unreadable(
     hass: HomeAssistant,
     zwave_js_lock: ZWaveJSLock,
     lock_schlage_be469: Node,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
 ) -> None:
     """Test that a 'credential added' event for a PIN pushes SlotCredential.unreadable()."""
     mock_coordinator = MagicMock()
@@ -449,6 +471,8 @@ async def test_credential_added_pin_with_data_pushes_known(
     hass: HomeAssistant,
     zwave_js_lock: ZWaveJSLock,
     lock_schlage_be469: Node,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
 ) -> None:
     """A credential event that carries the value pushes the readable state."""
     mock_coordinator = MagicMock()
@@ -475,6 +499,8 @@ async def test_credential_modified_pin_pushes_unreadable(
     hass: HomeAssistant,
     zwave_js_lock: ZWaveJSLock,
     lock_schlage_be469: Node,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
 ) -> None:
     """Test that a 'credential modified' event for a PIN pushes SlotCredential.unreadable()."""
     mock_coordinator = MagicMock()
@@ -499,6 +525,8 @@ async def test_credential_deleted_pin_pushes_empty(
     hass: HomeAssistant,
     zwave_js_lock: ZWaveJSLock,
     lock_schlage_be469: Node,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
 ) -> None:
     """Test that a 'credential deleted' event for a PIN pushes SlotCredential.empty()."""
     mock_coordinator = MagicMock()
@@ -521,6 +549,8 @@ async def test_credential_added_non_pin_ignored(
     hass: HomeAssistant,
     zwave_js_lock: ZWaveJSLock,
     lock_schlage_be469: Node,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
 ) -> None:
     """Test that 'credential added' for a non-PIN credential type is ignored."""
     mock_coordinator = MagicMock()
@@ -547,6 +577,8 @@ async def test_credential_deleted_non_pin_ignored(
     hass: HomeAssistant,
     zwave_js_lock: ZWaveJSLock,
     lock_schlage_be469: Node,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
 ) -> None:
     """Test that 'credential deleted' for a non-PIN credential type is ignored."""
     mock_coordinator = MagicMock()

--- a/tests/providers/zwave_js/test_events.py
+++ b/tests/providers/zwave_js/test_events.py
@@ -1,24 +1,16 @@
-"""Test Z-Wave JS event handling: push updates, notifications, and duplicate codes."""
+"""Test Z-Wave JS event handling: credential push updates and operation notifications."""
 
 from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
-from zwave_js_server.const import CommandClass
-from zwave_js_server.const.command_class.lock import (
-    LOCK_USERCODE_PROPERTY,
-    LOCK_USERCODE_STATUS_PROPERTY,
-    CodeSlotStatus,
-)
+from zwave_js_server.const.command_class.access_control import UserCredentialType
 from zwave_js_server.event import Event as ZwaveEvent
 from zwave_js_server.model.node import Node
 
-from homeassistant.const import CONF_ENABLED, CONF_NAME, CONF_PIN, STATE_ON
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr, entity_registry as er
-from homeassistant.helpers.issue_registry import async_get as async_get_issue_registry
+from homeassistant.helpers import device_registry as dr
 
 from custom_components.lock_code_manager.const import (
     ATTR_ACTION_TEXT,
@@ -30,51 +22,10 @@ from custom_components.lock_code_manager.const import (
     DOMAIN,
     EVENT_LOCK_STATE_CHANGED,
 )
-from custom_components.lock_code_manager.domain.exceptions import DuplicateCodeError
-from custom_components.lock_code_manager.domain.models import (
-    LockCodeManagerConfigEntryRuntimeData,
-    SlotCredential,
-)
+from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers.zwave_js import ZWaveJSLock
 
-from .helpers import (
-    async_capture_events,
-    get_enabled_switch_entity_id,
-    make_duplicate_code_event,
-)
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-async def _setup_lcm_entry(
-    hass: HomeAssistant,
-    lock_entity_id: str,
-    slots: dict[str, dict],
-    mock_zwave_usercodes: tuple[MagicMock, MagicMock, dict[int, dict]],
-) -> MockConfigEntry:
-    """Set up a full LCM config entry with real platform entities."""
-    _mock_all, _mock_one, codes = mock_zwave_usercodes
-
-    for k, v in slots.items():
-        pin = v.get(CONF_PIN, "")
-        in_use = bool(pin)
-        codes[int(k)] = {"code_slot": int(k), "usercode": pin, "in_use": in_use}
-
-    lcm_entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            CONF_LOCKS: [lock_entity_id],
-            CONF_SLOTS: slots,
-        },
-        unique_id=f"duplicate_code_test_{lock_entity_id}",
-    )
-    lcm_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(lcm_entry.entry_id)
-    await hass.async_block_till_done()
-    return lcm_entry
-
+from .helpers import async_capture_events
 
 # ---------------------------------------------------------------------------
 # Push subscription tests
@@ -171,6 +122,28 @@ async def test_subscribe_push_no_crash_on_node_error(
     await zwave_js_lock.async_unload(False)
 
 
+# Three subscriptions registered (credential added, modified, deleted)
+_EXPECTED_PUSH_UNSUB_COUNT = 3
+
+
+async def test_subscribe_registers_three_credential_listeners(
+    hass: HomeAssistant,
+    zwave_js_lock: ZWaveJSLock,
+    zwave_integration: MockConfigEntry,
+    lock_schlage_be469: Node,
+) -> None:
+    """Test that subscribing registers listeners for all three credential events."""
+    lcm_entry = MockConfigEntry(domain=DOMAIN, data={CONF_LOCKS: [], CONF_SLOTS: {}})
+    lcm_entry.add_to_hass(hass)
+    await zwave_js_lock.async_setup_internal(lcm_entry)
+
+    zwave_js_lock.subscribe_push_updates()
+    assert len(zwave_js_lock._push_unsubs) == _EXPECTED_PUSH_UNSUB_COUNT
+
+    zwave_js_lock.unsubscribe_push_updates()
+    await zwave_js_lock.async_unload(False)
+
+
 # ---------------------------------------------------------------------------
 # Event filter tests
 # ---------------------------------------------------------------------------
@@ -203,7 +176,7 @@ async def test_event_filter_matches_correct_node(
 
 
 # ---------------------------------------------------------------------------
-# Notification event tests
+# Notification event tests (operation events — lock/unlock)
 # ---------------------------------------------------------------------------
 
 
@@ -297,628 +270,197 @@ async def test_notification_event_keypad_unlock_fires_lock_state_changed(
 
 
 # ---------------------------------------------------------------------------
-# Push value update tests
+# Credential node event push tests
 # ---------------------------------------------------------------------------
 
 
-async def test_push_update_masked_code_sends_unknown(
-    hass: HomeAssistant,
-    zwave_js_lock: ZWaveJSLock,
-    lock_schlage_be469: Node,
-) -> None:
-    """
-    Test that push updates with masked codes send SlotCredential.unreadable().
-
-    When a push update arrives with a masked code (all asterisks) and the slot
-    is in use, the coordinator should receive SlotCredential.unreadable().
-    """
-    # Set up a mock coordinator (push_update is synchronous)
-    mock_coordinator = MagicMock()
-    mock_coordinator.data = {}
-    zwave_js_lock.coordinator = mock_coordinator
-
-    # Subscribe to push updates
-    zwave_js_lock.subscribe_push_updates()
-
-    # Mock code_slot_in_use to return True (slot has a code)
-    with patch.object(zwave_js_lock, "code_slot_in_use", return_value=True):
-        # Simulate a value update event with masked code
-        event = ZwaveEvent(
-            type="value updated",
-            data={
-                "source": "node",
-                "event": "value updated",
-                "nodeId": lock_schlage_be469.node_id,
-                "args": {
-                    "commandClass": CommandClass.USER_CODE,
-                    "property": "userCode",
-                    "propertyKey": 2,
-                    "newValue": "****",
-                },
-            },
-        )
-        lock_schlage_be469.receive_event(event)
-        await hass.async_block_till_done()
-
-        # Coordinator should receive SlotCredential.unreadable() for masked codes
-        mock_coordinator.push_update.assert_called_once_with(
-            {2: SlotCredential.unreadable()}
-        )
-
-
-async def test_push_update_falsy_value_sends_empty(
-    hass: HomeAssistant,
-    zwave_js_lock: ZWaveJSLock,
-    lock_schlage_be469: Node,
-) -> None:
-    """Test that push updates with falsy values send SlotCredential.empty()."""
-    mock_coordinator = MagicMock()
-    mock_coordinator.data = {2: SlotCredential.known("1234")}
-    zwave_js_lock.coordinator = mock_coordinator
-    zwave_js_lock.subscribe_push_updates()
-
-    # Simulate a value update with empty string (falsy)
-    event = ZwaveEvent(
-        type="value updated",
+def _make_credential_added_event(
+    node_id: int,
+    credential_slot: int,
+    credential_type: int = UserCredentialType.PIN_CODE,
+    user_id: int = 1,
+) -> ZwaveEvent:
+    """Build a 'credential added' ZwaveEvent for a given slot."""
+    return ZwaveEvent(
+        type="credential added",
         data={
             "source": "node",
-            "event": "value updated",
-            "nodeId": lock_schlage_be469.node_id,
+            "event": "credential added",
+            "nodeId": node_id,
+            "endpointIndex": 0,
             "args": {
-                "commandClass": CommandClass.USER_CODE,
-                "property": "userCode",
-                "propertyKey": 2,
-                "newValue": "",
+                "userId": user_id,
+                "credentialType": credential_type,
+                "credentialSlot": credential_slot,
             },
         },
     )
-    lock_schlage_be469.receive_event(event)
-    await hass.async_block_till_done()
-
-    mock_coordinator.push_update.assert_called_once_with({2: SlotCredential.empty()})
 
 
-async def test_push_update_all_zeros_not_in_use_sends_empty(
-    hass: HomeAssistant,
-    zwave_js_lock: ZWaveJSLock,
-    lock_schlage_be469: Node,
-) -> None:
-    """Test that all-zeros with slot_in_use=False sends SlotCredential.empty()."""
-    mock_coordinator = MagicMock()
-    mock_coordinator.data = {2: SlotCredential.known("1234")}
-    zwave_js_lock.coordinator = mock_coordinator
-    zwave_js_lock.subscribe_push_updates()
-
-    with patch.object(zwave_js_lock, "code_slot_in_use", return_value=False):
-        event = ZwaveEvent(
-            type="value updated",
-            data={
-                "source": "node",
-                "event": "value updated",
-                "nodeId": lock_schlage_be469.node_id,
-                "args": {
-                    "commandClass": CommandClass.USER_CODE,
-                    "property": "userCode",
-                    "propertyKey": 2,
-                    "newValue": "0000",
-                },
+def _make_credential_modified_event(
+    node_id: int,
+    credential_slot: int,
+    credential_type: int = UserCredentialType.PIN_CODE,
+    user_id: int = 1,
+) -> ZwaveEvent:
+    """Build a 'credential modified' ZwaveEvent for a given slot."""
+    return ZwaveEvent(
+        type="credential modified",
+        data={
+            "source": "node",
+            "event": "credential modified",
+            "nodeId": node_id,
+            "endpointIndex": 0,
+            "args": {
+                "userId": user_id,
+                "credentialType": credential_type,
+                "credentialSlot": credential_slot,
             },
-        )
-        lock_schlage_be469.receive_event(event)
-        await hass.async_block_till_done()
-
-        mock_coordinator.push_update.assert_called_once_with(
-            {2: SlotCredential.empty()}
-        )
+        },
+    )
 
 
-async def test_push_update_duplicate_value_skipped(
-    hass: HomeAssistant,
-    zwave_js_lock: ZWaveJSLock,
-    lock_schlage_be469: Node,
-) -> None:
-    """Test that duplicate push updates are silently skipped."""
-    mock_coordinator = MagicMock()
-    mock_coordinator.data = {2: SlotCredential.known("1234")}  # Already has this value
-    zwave_js_lock.coordinator = mock_coordinator
-    zwave_js_lock.subscribe_push_updates()
-
-    with patch.object(zwave_js_lock, "code_slot_in_use", return_value=True):
-        event = ZwaveEvent(
-            type="value updated",
-            data={
-                "source": "node",
-                "event": "value updated",
-                "nodeId": lock_schlage_be469.node_id,
-                "args": {
-                    "commandClass": CommandClass.USER_CODE,
-                    "property": "userCode",
-                    "propertyKey": 2,
-                    "newValue": "1234",
-                },
+def _make_credential_deleted_event(
+    node_id: int,
+    credential_slot: int,
+    credential_type: int = UserCredentialType.PIN_CODE,
+    user_id: int = 1,
+) -> ZwaveEvent:
+    """Build a 'credential deleted' ZwaveEvent for a given slot."""
+    return ZwaveEvent(
+        type="credential deleted",
+        data={
+            "source": "node",
+            "event": "credential deleted",
+            "nodeId": node_id,
+            "endpointIndex": 0,
+            "args": {
+                "userId": user_id,
+                "credentialType": credential_type,
+                "credentialSlot": credential_slot,
             },
-        )
-        lock_schlage_be469.receive_event(event)
-        await hass.async_block_till_done()
-
-        # push_update should NOT be called (duplicate)
-        mock_coordinator.push_update.assert_not_called()
+        },
+    )
 
 
-async def test_push_update_masked_code_with_unknown_in_use_sends_unknown(
+async def test_credential_added_pin_pushes_unreadable(
     hass: HomeAssistant,
     zwave_js_lock: ZWaveJSLock,
     lock_schlage_be469: Node,
 ) -> None:
-    """Test that masked codes with slot_in_use=None still send UNREADABLE_CODE."""
+    """Test that a 'credential added' event for a PIN pushes SlotCredential.unreadable()."""
     mock_coordinator = MagicMock()
     mock_coordinator.data = {}
     zwave_js_lock.coordinator = mock_coordinator
+
     zwave_js_lock.subscribe_push_updates()
 
-    # slot_in_use returns None (indeterminate) — should still treat masked as UNREADABLE_CODE
-    with patch.object(zwave_js_lock, "code_slot_in_use", return_value=None):
-        event = ZwaveEvent(
-            type="value updated",
-            data={
-                "source": "node",
-                "event": "value updated",
-                "nodeId": lock_schlage_be469.node_id,
-                "args": {
-                    "commandClass": CommandClass.USER_CODE,
-                    "property": "userCode",
-                    "propertyKey": 2,
-                    "newValue": "****",
-                },
-            },
+    lock_schlage_be469.receive_event(
+        _make_credential_added_event(lock_schlage_be469.node_id, credential_slot=2)
+    )
+    await hass.async_block_till_done()
+
+    mock_coordinator.push_update.assert_called_once_with(
+        {2: SlotCredential.unreadable()}
+    )
+
+    zwave_js_lock.unsubscribe_push_updates()
+
+
+async def test_credential_modified_pin_pushes_unreadable(
+    hass: HomeAssistant,
+    zwave_js_lock: ZWaveJSLock,
+    lock_schlage_be469: Node,
+) -> None:
+    """Test that a 'credential modified' event for a PIN pushes SlotCredential.unreadable()."""
+    mock_coordinator = MagicMock()
+    mock_coordinator.data = {}
+    zwave_js_lock.coordinator = mock_coordinator
+
+    zwave_js_lock.subscribe_push_updates()
+
+    lock_schlage_be469.receive_event(
+        _make_credential_modified_event(lock_schlage_be469.node_id, credential_slot=3)
+    )
+    await hass.async_block_till_done()
+
+    mock_coordinator.push_update.assert_called_once_with(
+        {3: SlotCredential.unreadable()}
+    )
+
+    zwave_js_lock.unsubscribe_push_updates()
+
+
+async def test_credential_deleted_pin_pushes_empty(
+    hass: HomeAssistant,
+    zwave_js_lock: ZWaveJSLock,
+    lock_schlage_be469: Node,
+) -> None:
+    """Test that a 'credential deleted' event for a PIN pushes SlotCredential.empty()."""
+    mock_coordinator = MagicMock()
+    mock_coordinator.data = {5: SlotCredential.unreadable()}
+    zwave_js_lock.coordinator = mock_coordinator
+
+    zwave_js_lock.subscribe_push_updates()
+
+    lock_schlage_be469.receive_event(
+        _make_credential_deleted_event(lock_schlage_be469.node_id, credential_slot=5)
+    )
+    await hass.async_block_till_done()
+
+    mock_coordinator.push_update.assert_called_once_with({5: SlotCredential.empty()})
+
+    zwave_js_lock.unsubscribe_push_updates()
+
+
+async def test_credential_added_non_pin_ignored(
+    hass: HomeAssistant,
+    zwave_js_lock: ZWaveJSLock,
+    lock_schlage_be469: Node,
+) -> None:
+    """Test that 'credential added' for a non-PIN credential type is ignored."""
+    mock_coordinator = MagicMock()
+    mock_coordinator.data = {}
+    zwave_js_lock.coordinator = mock_coordinator
+
+    zwave_js_lock.subscribe_push_updates()
+
+    # Use a non-PIN credential type (e.g. RFID = 2)
+    lock_schlage_be469.receive_event(
+        _make_credential_added_event(
+            lock_schlage_be469.node_id,
+            credential_slot=2,
+            credential_type=2,  # not PIN_CODE (1)
         )
-        lock_schlage_be469.receive_event(event)
-        await hass.async_block_till_done()
+    )
+    await hass.async_block_till_done()
 
-        mock_coordinator.push_update.assert_called_once_with(
-            {2: SlotCredential.unreadable()}
+    mock_coordinator.push_update.assert_not_called()
+
+    zwave_js_lock.unsubscribe_push_updates()
+
+
+async def test_credential_deleted_non_pin_ignored(
+    hass: HomeAssistant,
+    zwave_js_lock: ZWaveJSLock,
+    lock_schlage_be469: Node,
+) -> None:
+    """Test that 'credential deleted' for a non-PIN credential type is ignored."""
+    mock_coordinator = MagicMock()
+    mock_coordinator.data = {4: SlotCredential.unreadable()}
+    zwave_js_lock.coordinator = mock_coordinator
+
+    zwave_js_lock.subscribe_push_updates()
+
+    lock_schlage_be469.receive_event(
+        _make_credential_deleted_event(
+            lock_schlage_be469.node_id,
+            credential_slot=4,
+            credential_type=2,  # not PIN_CODE (1)
         )
-
-
-# ---------------------------------------------------------------------------
-# userIdStatus push update tests
-# ---------------------------------------------------------------------------
-
-
-async def test_push_update_user_id_status_available_clears_slot(
-    hass: HomeAssistant,
-    zwave_js_lock: ZWaveJSLock,
-    lock_schlage_be469: Node,
-) -> None:
-    """
-    Test that userIdStatus=AVAILABLE push update clears the slot.
-
-    When the lock sends a userIdStatus update with AVAILABLE status,
-    it means the slot has been cleared. This should update the coordinator
-    to mark the slot as empty.
-    """
-    # Set up a mock coordinator with existing data
-    mock_coordinator = MagicMock()
-    mock_coordinator.data = {2: SlotCredential.known("1234")}  # Slot has a PIN
-    mock_coordinator.desired_credential.return_value = SlotCredential.empty()
-    zwave_js_lock.coordinator = mock_coordinator
-
-    # Subscribe to push updates
-    zwave_js_lock.subscribe_push_updates()
-
-    # Simulate userIdStatus=AVAILABLE event (slot cleared)
-    event = ZwaveEvent(
-        type="value updated",
-        data={
-            "args": {
-                "commandClass": CommandClass.USER_CODE,
-                "property": LOCK_USERCODE_STATUS_PROPERTY,
-                "propertyKey": 2,
-                "newValue": CodeSlotStatus.AVAILABLE,
-            },
-        },
     )
-    lock_schlage_be469.emit("value updated", event.data)
     await hass.async_block_till_done()
 
-    # Coordinator should be updated with SlotCredential.empty()
-    mock_coordinator.push_update.assert_called_once_with({2: SlotCredential.empty()})
-
-    zwave_js_lock.unsubscribe_push_updates()
-
-
-async def test_push_update_user_id_status_available_skipped_when_already_empty(
-    hass: HomeAssistant,
-    zwave_js_lock: ZWaveJSLock,
-    lock_schlage_be469: Node,
-) -> None:
-    """
-    Test that userIdStatus=AVAILABLE is skipped when slot already empty.
-
-    If the coordinator already shows the slot as empty, we shouldn't
-    push another update.
-    """
-    # Set up a mock coordinator - slot already empty
-    mock_coordinator = MagicMock()
-    mock_coordinator.data = {2: SlotCredential.empty()}  # Slot already empty
-    zwave_js_lock.coordinator = mock_coordinator
-
-    # Subscribe to push updates
-    zwave_js_lock.subscribe_push_updates()
-
-    # Simulate userIdStatus=AVAILABLE event
-    event = ZwaveEvent(
-        type="value updated",
-        data={
-            "args": {
-                "commandClass": CommandClass.USER_CODE,
-                "property": LOCK_USERCODE_STATUS_PROPERTY,
-                "propertyKey": 2,
-                "newValue": CodeSlotStatus.AVAILABLE,
-            },
-        },
-    )
-    lock_schlage_be469.emit("value updated", event.data)
-    await hass.async_block_till_done()
-
-    # Coordinator should NOT be updated (already empty)
     mock_coordinator.push_update.assert_not_called()
 
     zwave_js_lock.unsubscribe_push_updates()
-
-
-async def test_push_update_user_id_status_enabled_ignored(
-    hass: HomeAssistant,
-    zwave_js_lock: ZWaveJSLock,
-    lock_schlage_be469: Node,
-) -> None:
-    """
-    Test that userIdStatus=ENABLED push updates are ignored.
-
-    We only care about AVAILABLE status for clearing slots.
-    ENABLED status doesn't tell us the PIN value.
-    """
-    # Set up a mock coordinator
-    mock_coordinator = MagicMock()
-    mock_coordinator.data = {2: SlotCredential.empty()}
-    zwave_js_lock.coordinator = mock_coordinator
-
-    # Subscribe to push updates
-    zwave_js_lock.subscribe_push_updates()
-
-    # Simulate userIdStatus=ENABLED event
-    event = ZwaveEvent(
-        type="value updated",
-        data={
-            "args": {
-                "commandClass": CommandClass.USER_CODE,
-                "property": LOCK_USERCODE_STATUS_PROPERTY,
-                "propertyKey": 2,
-                "newValue": CodeSlotStatus.ENABLED,
-            },
-        },
-    )
-    lock_schlage_be469.emit("value updated", event.data)
-    await hass.async_block_till_done()
-
-    # Coordinator should NOT be updated
-    mock_coordinator.push_update.assert_not_called()
-
-    zwave_js_lock.unsubscribe_push_updates()
-
-
-async def test_push_update_user_id_status_available_ignored_when_slot_expects_pin(
-    hass: HomeAssistant,
-    zwave_js_lock: ZWaveJSLock,
-    lock_schlage_be469: Node,
-) -> None:
-    """
-    Test that userIdStatus=AVAILABLE is ignored when slot expects a PIN.
-
-    This prevents sync loops where the lock sends stale AVAILABLE status
-    after a code was successfully set.
-    """
-    # Set up a mock coordinator with existing PIN
-    mock_coordinator = MagicMock()
-    mock_coordinator.data = {2: SlotCredential.known("1234")}  # Slot has a PIN
-    zwave_js_lock.coordinator = mock_coordinator
-
-    # Subscribe to push updates
-    zwave_js_lock.subscribe_push_updates()
-
-    # LCM expects a PIN on this slot
-    mock_coordinator.desired_credential.return_value = SlotCredential.known("1234")
-
-    # Simulate userIdStatus=AVAILABLE event (stale status from lock)
-    event = ZwaveEvent(
-        type="value updated",
-        data={
-            "args": {
-                "commandClass": CommandClass.USER_CODE,
-                "property": LOCK_USERCODE_STATUS_PROPERTY,
-                "propertyKey": 2,
-                "newValue": CodeSlotStatus.AVAILABLE,
-            },
-        },
-    )
-    lock_schlage_be469.emit("value updated", event.data)
-    await hass.async_block_till_done()
-
-    # Coordinator should NOT be updated (AVAILABLE ignored)
-    mock_coordinator.push_update.assert_not_called()
-
-    zwave_js_lock.unsubscribe_push_updates()
-
-
-async def test_push_update_user_id_status_available_clears_when_slot_inactive(
-    hass: HomeAssistant,
-    zwave_js_lock: ZWaveJSLock,
-    lock_schlage_be469: Node,
-) -> None:
-    """
-    Test that userIdStatus=AVAILABLE clears slot when LCM doesn't expect a PIN.
-
-    When the slot is inactive (active=OFF), AVAILABLE status should clear
-    the coordinator as expected.
-    """
-    # Set up a mock coordinator with existing PIN
-    mock_coordinator = MagicMock()
-    mock_coordinator.data = {2: SlotCredential.known("1234")}  # Slot has a PIN
-    zwave_js_lock.coordinator = mock_coordinator
-
-    # Subscribe to push updates
-    zwave_js_lock.subscribe_push_updates()
-
-    # Slot is inactive (no PIN expected)
-    mock_coordinator.desired_credential.return_value = SlotCredential.empty()
-
-    # Simulate userIdStatus=AVAILABLE event
-    event = ZwaveEvent(
-        type="value updated",
-        data={
-            "args": {
-                "commandClass": CommandClass.USER_CODE,
-                "property": LOCK_USERCODE_STATUS_PROPERTY,
-                "propertyKey": 2,
-                "newValue": CodeSlotStatus.AVAILABLE,
-            },
-        },
-    )
-    lock_schlage_be469.emit("value updated", event.data)
-    await hass.async_block_till_done()
-
-    # Coordinator SHOULD be updated (slot cleared)
-    mock_coordinator.push_update.assert_called_once_with({2: SlotCredential.empty()})
-
-    zwave_js_lock.unsubscribe_push_updates()
-
-
-# ---------------------------------------------------------------------------
-# Duplicate code notification tests
-# ---------------------------------------------------------------------------
-
-
-async def test_duplicate_code_notification_marks_rejected(
-    hass: HomeAssistant,
-    zwave_integration: MockConfigEntry,
-    lock_entity: er.RegistryEntry,
-    lock_schlage_be469: Node,
-    mock_zwave_usercodes: tuple[MagicMock, MagicMock, dict[int, dict]],
-) -> None:
-    """Test that event 15 marks the slot rejected and clears in-progress."""
-    lcm_entry = await _setup_lcm_entry(
-        hass,
-        lock_entity.entity_id,
-        {"2": {CONF_NAME: "test", CONF_PIN: "1234", CONF_ENABLED: True}},
-        mock_zwave_usercodes,
-    )
-
-    # Find the ZWaveJSLock instance created by LCM setup
-    runtime_data: LockCodeManagerConfigEntryRuntimeData = lcm_entry.runtime_data
-    lock_instance = runtime_data.locks[lock_entity.entity_id]
-    lock_instance._set_in_progress_code_slot = 2
-
-    lock_schlage_be469.receive_event(
-        make_duplicate_code_event(lock_schlage_be469.node_id, user_id=2)
-    )
-    await hass.async_block_till_done()
-
-    # Slot should be marked as rejected for the sync manager to pick up
-    assert 2 in lock_instance._rejected_code_slots
-
-    # In-progress field should be cleared
-    assert lock_instance._set_in_progress_code_slot is None
-
-    await hass.config_entries.async_unload(lcm_entry.entry_id)
-
-
-async def test_duplicate_code_notification_no_user_id_marks_rejected(
-    hass: HomeAssistant,
-    zwave_integration: MockConfigEntry,
-    lock_entity: er.RegistryEntry,
-    lock_schlage_be469: Node,
-    mock_zwave_usercodes: tuple[MagicMock, MagicMock, dict[int, dict]],
-) -> None:
-    """Test event 15 with no userId in params still marks rejected using in-progress slot."""
-    lcm_entry = await _setup_lcm_entry(
-        hass,
-        lock_entity.entity_id,
-        {"3": {CONF_NAME: "test", CONF_PIN: "1234", CONF_ENABLED: True}},
-        mock_zwave_usercodes,
-    )
-
-    runtime_data: LockCodeManagerConfigEntryRuntimeData = lcm_entry.runtime_data
-    lock_instance = runtime_data.locks[lock_entity.entity_id]
-    lock_instance._set_in_progress_code_slot = 3
-
-    lock_schlage_be469.receive_event(
-        make_duplicate_code_event(lock_schlage_be469.node_id)
-    )
-    await hass.async_block_till_done()
-
-    assert 3 in lock_instance._rejected_code_slots
-    assert lock_instance._set_in_progress_code_slot is None
-
-    await hass.config_entries.async_unload(lcm_entry.entry_id)
-
-
-async def test_duplicate_code_notification_ignored_when_not_in_progress(
-    hass: HomeAssistant,
-    zwave_integration: MockConfigEntry,
-    lock_entity: er.RegistryEntry,
-    lock_schlage_be469: Node,
-    mock_zwave_usercodes: tuple[MagicMock, MagicMock, dict[int, dict]],
-) -> None:
-    """Test event 15 is ignored when _set_in_progress_code_slot is None."""
-    lcm_entry = await _setup_lcm_entry(
-        hass,
-        lock_entity.entity_id,
-        {"2": {CONF_NAME: "test", CONF_PIN: "1234", CONF_ENABLED: True}},
-        mock_zwave_usercodes,
-    )
-    switch_entity_id = get_enabled_switch_entity_id(hass, lcm_entry.entry_id, 2)
-    assert hass.states.get(switch_entity_id).state == STATE_ON
-
-    # Do NOT set _set_in_progress_code_slot (external trigger)
-    lock_schlage_be469.receive_event(
-        make_duplicate_code_event(lock_schlage_be469.node_id, user_id=2)
-    )
-    await hass.async_block_till_done()
-
-    # Switch should still be on
-    assert hass.states.get(switch_entity_id).state == STATE_ON
-
-    # No repair issue created for slot_disabled
-    issue_registry = async_get_issue_registry(hass)
-    matching_issues = [
-        issue
-        for issue in issue_registry.issues.values()
-        if issue.domain == DOMAIN and issue.issue_id.startswith("slot_disabled_")
-    ]
-    assert len(matching_issues) == 0
-
-    await hass.config_entries.async_unload(lcm_entry.entry_id)
-
-
-async def test_duplicate_code_notification_ignored_when_user_id_mismatches(
-    hass: HomeAssistant,
-    zwave_integration: MockConfigEntry,
-    lock_entity: er.RegistryEntry,
-    lock_schlage_be469: Node,
-    mock_zwave_usercodes: tuple[MagicMock, MagicMock, dict[int, dict]],
-) -> None:
-    """Test event 15 is ignored when userId doesn't match in-progress slot."""
-    lcm_entry = await _setup_lcm_entry(
-        hass,
-        lock_entity.entity_id,
-        {
-            "2": {CONF_NAME: "test2", CONF_PIN: "1234", CONF_ENABLED: True},
-            "3": {CONF_NAME: "test3", CONF_PIN: "5678", CONF_ENABLED: True},
-        },
-        mock_zwave_usercodes,
-    )
-    switch_2 = get_enabled_switch_entity_id(hass, lcm_entry.entry_id, 2)
-    switch_3 = get_enabled_switch_entity_id(hass, lcm_entry.entry_id, 3)
-
-    runtime_data: LockCodeManagerConfigEntryRuntimeData = lcm_entry.runtime_data
-    lock_instance = runtime_data.locks[lock_entity.entity_id]
-
-    # LCM is setting slot 2, but notification says slot 3
-    lock_instance._set_in_progress_code_slot = 2
-
-    lock_schlage_be469.receive_event(
-        make_duplicate_code_event(lock_schlage_be469.node_id, user_id=3)
-    )
-    await hass.async_block_till_done()
-
-    # Neither switch should be turned off
-    assert hass.states.get(switch_2).state == STATE_ON
-    assert hass.states.get(switch_3).state == STATE_ON
-
-    # In-progress should NOT be cleared (it wasn't our event)
-    assert lock_instance._set_in_progress_code_slot == 2
-
-    await hass.config_entries.async_unload(lcm_entry.entry_id)
-
-
-# ---------------------------------------------------------------------------
-# In-progress tracking tests
-# ---------------------------------------------------------------------------
-
-
-async def test_set_in_progress_cleared_on_value_update(
-    hass: HomeAssistant,
-    zwave_js_lock: ZWaveJSLock,
-    lock_schlage_be469: Node,
-) -> None:
-    """Test that a push value update for the in-progress slot clears the field."""
-    mock_coordinator = MagicMock()
-    mock_coordinator.data = {2: SlotCredential.empty()}
-    zwave_js_lock.coordinator = mock_coordinator
-
-    zwave_js_lock.subscribe_push_updates()
-
-    # Simulate LCM setting a code on slot 2
-    zwave_js_lock._set_in_progress_code_slot = 2
-
-    # Simulate a push value update for slot 2 (lock accepted the code)
-    event = ZwaveEvent(
-        type="value updated",
-        data={
-            "args": {
-                "commandClass": CommandClass.USER_CODE,
-                "property": LOCK_USERCODE_PROPERTY,
-                "propertyKey": 2,
-                "newValue": "1234",
-            },
-        },
-    )
-    lock_schlage_be469.emit("value updated", event.data)
-    await hass.async_block_till_done()
-
-    # In-progress should be cleared
-    assert zwave_js_lock._set_in_progress_code_slot is None
-
-    zwave_js_lock.unsubscribe_push_updates()
-
-
-async def test_internal_set_usercode_raises_duplicate_for_rejected_slot(
-    hass: HomeAssistant,
-    zwave_integration: MockConfigEntry,
-    lock_entity: er.RegistryEntry,
-    lock_schlage_be469: Node,
-    mock_zwave_usercodes: tuple[MagicMock, MagicMock, dict[int, dict]],
-) -> None:
-    """
-    Test async_internal_set_usercode raises DuplicateCodeError for rejected slots.
-
-    When a slot is in _rejected_code_slots (marked by event 15), the next call to
-    async_internal_set_usercode should raise DuplicateCodeError without calling the
-    provider's async_set_usercode, and clear the slot from the rejected set.
-    """
-    lcm_entry = await _setup_lcm_entry(
-        hass,
-        lock_entity.entity_id,
-        {"2": {CONF_NAME: "test", CONF_PIN: "1234", CONF_ENABLED: True}},
-        mock_zwave_usercodes,
-    )
-
-    runtime_data: LockCodeManagerConfigEntryRuntimeData = lcm_entry.runtime_data
-    lock_instance = runtime_data.locks[lock_entity.entity_id]
-
-    # Mark slot 2 as rejected (simulating event 15)
-    lock_instance.mark_code_rejected(2)
-    assert 2 in lock_instance._rejected_code_slots
-
-    # Attempt to set usercode should raise DuplicateCodeError
-    with pytest.raises(DuplicateCodeError) as exc_info:
-        await lock_instance.async_internal_set_usercode(2, "1234", source="sync")
-
-    assert exc_info.value.code_slot == 2
-    assert exc_info.value.conflicting_slot is None
-    assert "duplicate detected by lock firmware" in str(exc_info.value)
-
-    # Slot should be cleared from the rejected set
-    assert 2 not in lock_instance._rejected_code_slots
-
-    await hass.config_entries.async_unload(lcm_entry.entry_id)

--- a/tests/providers/zwave_js/test_events.py
+++ b/tests/providers/zwave_js/test_events.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 from zwave_js_server.const.command_class.access_control import UserCredentialType
 from zwave_js_server.event import Event as ZwaveEvent
@@ -22,6 +23,7 @@ from custom_components.lock_code_manager.const import (
     DOMAIN,
     EVENT_LOCK_STATE_CHANGED,
 )
+from custom_components.lock_code_manager.domain.exceptions import LockDisconnected
 from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers.zwave_js import ZWaveJSLock
 
@@ -118,6 +120,39 @@ async def test_subscribe_push_no_crash_on_node_error(
         zwave_js_lock.subscribe_push_updates()
 
     assert not zwave_js_lock._push_unsubs
+
+
+async def test_subscribe_push_cleans_up_partial_subscription_on_error(
+    hass: HomeAssistant,
+    zwave_js_lock: ZWaveJSLock,
+    zwave_integration: MockConfigEntry,
+    lock_schlage_be469: Node,
+) -> None:
+    """A failure partway through subscribing releases the unsubs already registered."""
+    lcm_entry = MockConfigEntry(domain=DOMAIN, data={CONF_LOCKS: [], CONF_SLOTS: {}})
+    lcm_entry.add_to_hass(hass)
+    await zwave_js_lock.async_setup_internal(lcm_entry)
+
+    zwave_js_lock.unsubscribe_push_updates()
+    assert not zwave_js_lock._push_unsubs
+
+    # First node.on succeeds (registers an unsub), the second raises -> the
+    # partial registration must be cleaned up, not leaked.
+    first_unsub = MagicMock()
+    with (
+        patch.object(
+            lock_schlage_be469,
+            "on",
+            side_effect=[first_unsub, ValueError("not ready")],
+        ),
+        pytest.raises(LockDisconnected),
+    ):
+        # Call the raw subscriber directly; the public wrapper swallows
+        # LockDisconnected, so it would hide the raise we want to assert.
+        zwave_js_lock.setup_push_subscription()
+
+    assert not zwave_js_lock._push_unsubs
+    first_unsub.assert_called_once()
 
     await zwave_js_lock.async_unload(False)
 

--- a/tests/providers/zwave_js/test_events.py
+++ b/tests/providers/zwave_js/test_events.py
@@ -304,6 +304,45 @@ async def test_notification_event_keypad_unlock_fires_lock_state_changed(
     await zwave_js_lock.async_unload(False)
 
 
+async def test_notification_event_non_access_control_ignored(
+    hass: HomeAssistant,
+    zwave_js_lock: ZWaveJSLock,
+    zwave_integration: MockConfigEntry,
+    lock_schlage_be469: Node,
+) -> None:
+    """A notification of a non Access Control type is ignored (no LCM event)."""
+    lcm_entry = MockConfigEntry(domain=DOMAIN, data={CONF_LOCKS: [], CONF_SLOTS: {}})
+    lcm_entry.add_to_hass(hass)
+    await zwave_js_lock.async_setup_internal(lcm_entry)
+
+    events = async_capture_events(hass, EVENT_LOCK_STATE_CHANGED)
+
+    # Type 8 = POWER_MANAGEMENT (not ACCESS_CONTROL) → handler returns early
+    event = ZwaveEvent(
+        type="notification",
+        data={
+            "source": "node",
+            "event": "notification",
+            "nodeId": lock_schlage_be469.node_id,
+            "endpointIndex": 0,
+            "ccId": 113,
+            "args": {
+                "type": 8,
+                "event": 1,
+                "label": "Power Management",
+                "eventLabel": "Power has been applied",
+                "parameters": {},
+            },
+        },
+    )
+    lock_schlage_be469.receive_event(event)
+    await hass.async_block_till_done()
+
+    assert events == []
+
+    await zwave_js_lock.async_unload(False)
+
+
 # ---------------------------------------------------------------------------
 # Credential node event push tests
 # ---------------------------------------------------------------------------

--- a/tests/providers/zwave_js/test_events.py
+++ b/tests/providers/zwave_js/test_events.py
@@ -425,12 +425,11 @@ async def test_credential_added_non_pin_ignored(
 
     zwave_js_lock.subscribe_push_updates()
 
-    # Use a non-PIN credential type (e.g. RFID = 2)
     lock_schlage_be469.receive_event(
         _make_credential_added_event(
             lock_schlage_be469.node_id,
             credential_slot=2,
-            credential_type=2,  # not PIN_CODE (1)
+            credential_type=UserCredentialType.PASSWORD,  # not PIN_CODE
         )
     )
     await hass.async_block_till_done()
@@ -456,7 +455,7 @@ async def test_credential_deleted_non_pin_ignored(
         _make_credential_deleted_event(
             lock_schlage_be469.node_id,
             credential_slot=4,
-            credential_type=2,  # not PIN_CODE (1)
+            credential_type=UserCredentialType.PASSWORD,  # not PIN_CODE
         )
     )
     await hass.async_block_till_done()

--- a/tests/providers/zwave_js/test_provider.py
+++ b/tests/providers/zwave_js/test_provider.py
@@ -192,14 +192,27 @@ async def test_hard_refresh_codes_calls_access_control(
     assert 2 in codes
 
 
-async def test_hard_refresh_codes_raises_lock_disconnected_on_error(
+async def test_hard_refresh_codes_maps_transport_error_to_lock_disconnected(
     zwave_js_lock: ZWaveJSLock,
     mock_access_control: MagicMock,
 ) -> None:
-    """Test that async_hard_refresh_codes wraps any exception as LockDisconnected."""
-    mock_access_control.get_users.side_effect = RuntimeError("node gone")
+    """Z-Wave transport failure during hard refresh surfaces as LockDisconnected."""
+    mock_access_control.get_users.side_effect = FailedZWaveCommand(
+        "cmd", 1, "node gone"
+    )
 
-    with pytest.raises(LockDisconnected):
+    with pytest.raises(LockDisconnected, match="hard refresh failed"):
+        await zwave_js_lock.async_hard_refresh_codes()
+
+
+async def test_hard_refresh_codes_maps_ha_error_to_operation_failed(
+    zwave_js_lock: ZWaveJSLock,
+    mock_access_control: MagicMock,
+) -> None:
+    """A reachable-but-rejected hard refresh surfaces as LockOperationFailed."""
+    mock_access_control.get_users.side_effect = HomeAssistantError("rejected")
+
+    with pytest.raises(LockOperationFailed, match="hard refresh failed"):
         await zwave_js_lock.async_hard_refresh_codes()
 
 
@@ -1004,11 +1017,13 @@ async def test_async_set_user_falls_back_when_capabilities_fetch_fails(
     mock_lock_helpers: dict,
 ) -> None:
     """
-    A capabilities read failure must not block the write.
+    A capabilities read failure must not block the write or poison the cache.
 
     When the lazy max-name-length lookup raises, async_set_user proceeds with a
-    max length of 0 (names unsupported) rather than propagating a read error
-    out of a write path.
+    max length of 0 (names omitted) for this call but leaves the cache unset so
+    the next call retries the lookup. Caching a 0 sentinel on failure would
+    silently strip all user names for the provider instance after a single
+    transient disconnect.
     """
     mock_lock_helpers[
         "async_get_credential_capabilities"
@@ -1019,14 +1034,50 @@ async def test_async_set_user_falls_back_when_capabilities_fetch_fails(
     result = await zwave_js_lock.async_set_user(user)
 
     assert result == SetUserResult(user_id=1, created=True)
-    assert zwave_js_lock._max_user_name_length == 0
-    # max length 0 → the name is omitted
+    # Cache stays None on failure so the next call retries; the failed read
+    # only suppresses the name guard for THIS call.
+    assert zwave_js_lock._max_user_name_length is None
+    # max length 0 → the name is omitted on this call
     mock_lock_helpers["async_set_user"].assert_called_once_with(
         zwave_js_lock.node,
         user_id=1,
         user_name=None,
         active=True,
     )
+
+
+async def test_async_set_user_retries_capabilities_after_failure(
+    zwave_js_lock: ZWaveJSLock,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
+) -> None:
+    """
+    After a transient capabilities-fetch failure, the next call retries.
+
+    Regression guard for the bug where caching a 0 sentinel on failure would
+    permanently disable user-name validation until the integration reloaded.
+    """
+    mock_lock_helpers["async_get_credential_capabilities"].side_effect = [
+        FailedZWaveCommand("cmd", 1, "caps unavailable"),
+        {
+            "max_user_name_length": 10,
+            "supports_user_management": True,
+            "max_users": 5,
+            "supported_credential_types": {},
+        },
+    ]
+    mock_access_control.get_user_cached.return_value = None
+
+    # First call: caps fetch fails, name dropped, cache stays unset.
+    await zwave_js_lock.async_set_user(User(user_id=1, name="alice", active=True))
+    assert zwave_js_lock._max_user_name_length is None
+
+    # Second call: caps fetch retries and succeeds, name is now written.
+    await zwave_js_lock.async_set_user(User(user_id=2, name="bob", active=True))
+    assert zwave_js_lock._max_user_name_length == 10
+    assert mock_lock_helpers["async_get_credential_capabilities"].call_count == 2
+    last_call = mock_lock_helpers["async_set_user"].call_args_list[-1]
+    assert last_call.kwargs["user_name"] == "bob"
 
 
 async def test_async_set_user_maps_failed_command_to_lock_disconnected(

--- a/tests/providers/zwave_js/test_provider.py
+++ b/tests/providers/zwave_js/test_provider.py
@@ -1026,7 +1026,7 @@ async def test_async_set_user_uses_cached_max_name_length(
     mock_access_control: MagicMock,
     mock_lock_helpers: dict,
 ) -> None:
-    """After async_get_capabilities, async_set_user reuses the cached max name length."""
+    """After the base caches caps, async_set_user reuses the cached limit."""
     pin_type_str = lock_helpers.CREDENTIAL_TYPE_MAP[UserCredentialType.PIN_CODE]
     mock_lock_helpers["async_get_credential_capabilities"].return_value = {
         "supports_user_management": True,
@@ -1043,13 +1043,14 @@ async def test_async_set_user_uses_cached_max_name_length(
             }
         },
     }
-    # First call: async_get_capabilities populates the cache
-    await zwave_js_lock.async_get_capabilities()
+    # Prime the base capability cache via the same chokepoint async_set_user
+    # uses (_truncate_user_name → _get_cached_capabilities).
+    await zwave_js_lock._get_cached_capabilities()
 
     mock_access_control.get_user_cached.return_value = None
     mock_lock_helpers["async_set_user"].return_value = {"user_id": 1}
 
-    # Name "alexandra" (10 chars) truncated to "alex" (5 chars, matching cache)
+    # Name "alexandra" (10 chars) truncated to 5 chars per the cached limit.
     user = User(user_id=1, name="alexandra", active=True)
     await zwave_js_lock.async_set_user(user)
 
@@ -1059,8 +1060,7 @@ async def test_async_set_user_uses_cached_max_name_length(
         user_name="alexa",
         active=True,
     )
-    # async_get_credential_capabilities should NOT have been called again
-    # (the cache was already populated by async_get_capabilities)
+    # Cache is warm; no second helper call.
     assert mock_lock_helpers["async_get_credential_capabilities"].call_count == 1
 
 
@@ -1110,13 +1110,12 @@ async def test_async_set_user_falls_back_when_capabilities_fetch_fails(
     mock_lock_helpers: dict,
 ) -> None:
     """
-    A capabilities read failure must not block the write or poison the cache.
+    Caps-read failure drops the name for this call without poisoning the cache.
 
-    When the lazy max-name-length lookup raises, async_set_user proceeds with a
-    max length of 0 (names omitted) for this call but leaves the cache unset so
-    the next call retries the lookup. Caching a 0 sentinel on failure would
-    silently strip all user names for the provider instance after a single
-    transient disconnect.
+    Failure surfaces as ``LockDisconnected``/``LockOperationFailed`` which the
+    base ``_truncate_user_name`` catches; the cache stays None so the next
+    call retries instead of pinning a 0 sentinel that would silently strip
+    all user names for the provider instance lifetime.
     """
     mock_lock_helpers[
         "async_get_credential_capabilities"
@@ -1127,10 +1126,7 @@ async def test_async_set_user_falls_back_when_capabilities_fetch_fails(
     result = await zwave_js_lock.async_set_user(user)
 
     assert result == SetUserResult(user_id=1, created=True)
-    # Cache stays None on failure so the next call retries; the failed read
-    # only suppresses the name guard for THIS call.
-    assert zwave_js_lock._max_user_name_length is None
-    # max length 0 → the name is omitted on this call
+    assert zwave_js_lock._capabilities_cache is None
     mock_lock_helpers["async_set_user"].assert_called_once_with(
         zwave_js_lock.node,
         user_id=1,
@@ -1144,12 +1140,7 @@ async def test_async_set_user_retries_capabilities_after_failure(
     mock_access_control: MagicMock,
     mock_lock_helpers: dict,
 ) -> None:
-    """
-    After a transient capabilities-fetch failure, the next call retries.
-
-    Regression guard for the bug where caching a 0 sentinel on failure would
-    permanently disable user-name validation until the integration reloaded.
-    """
+    """After a transient caps-fetch failure, the next call retries and the name lands."""
     mock_lock_helpers["async_get_credential_capabilities"].side_effect = [
         FailedZWaveCommand("cmd", 1, "caps unavailable"),
         {
@@ -1161,13 +1152,14 @@ async def test_async_set_user_retries_capabilities_after_failure(
     ]
     mock_access_control.get_user_cached.return_value = None
 
-    # First call: caps fetch fails, name dropped, cache stays unset.
+    # First call: caps fetch fails, name dropped, base cache stays unset.
     await zwave_js_lock.async_set_user(User(user_id=1, name="alice", active=True))
-    assert zwave_js_lock._max_user_name_length is None
+    assert zwave_js_lock._capabilities_cache is None
 
-    # Second call: caps fetch retries and succeeds, name is now written.
+    # Second call: caps fetch retries, cache warms, name is now written.
     await zwave_js_lock.async_set_user(User(user_id=2, name="bob", active=True))
-    assert zwave_js_lock._max_user_name_length == 10
+    assert zwave_js_lock._capabilities_cache is not None
+    assert zwave_js_lock._capabilities_cache.max_user_name_length == 10
     assert mock_lock_helpers["async_get_credential_capabilities"].call_count == 2
     last_call = mock_lock_helpers["async_set_user"].call_args_list[-1]
     assert last_call.kwargs["user_name"] == "bob"

--- a/tests/providers/zwave_js/test_provider.py
+++ b/tests/providers/zwave_js/test_provider.py
@@ -19,6 +19,7 @@ from homeassistant.components.zwave_js import lock_helpers
 from homeassistant.components.zwave_js.const import DOMAIN as ZWAVE_JS_DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 
 from custom_components.lock_code_manager.const import (
     CONF_LOCKS,
@@ -27,11 +28,18 @@ from custom_components.lock_code_manager.const import (
 )
 from custom_components.lock_code_manager.domain.credentials import (
     Credential,
+    CredentialRef,
     CredentialType,
     CredentialTypeCapability,
     LockCapabilities,
+    SetUserResult,
+    User,
 )
-from custom_components.lock_code_manager.domain.exceptions import LockDisconnected
+from custom_components.lock_code_manager.domain.exceptions import (
+    CodeRejectedError,
+    DuplicateCodeError,
+    LockDisconnected,
+)
 from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers.zwave_js import ZWaveJSLock
 
@@ -847,4 +855,186 @@ async def test_async_get_capabilities_maps_lock_helpers_response(
                 supports_learn=False,
             )
         },
+    )
+
+
+# Write primitive tests (Task 2)
+
+
+async def test_async_set_user_returns_created_when_user_absent(
+    zwave_js_lock: ZWaveJSLock,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
+) -> None:
+    """
+    Test async_set_user reports created=True when no existing user is found.
+
+    When get_user_cached returns None the user does not yet exist on the lock,
+    so SetUserResult.created must be True. The helper is called with the correct
+    node, user_id, user_name, and active values.
+    """
+    mock_access_control.get_user_cached.return_value = None
+    mock_lock_helpers["async_set_user"].return_value = {"user_id": 5}
+
+    user = User(user_id=5, name="alice", active=True)
+    result = await zwave_js_lock.async_set_user(user)
+
+    assert result == SetUserResult(user_id=5, created=True)
+    mock_lock_helpers["async_set_user"].assert_called_once_with(
+        zwave_js_lock.node,
+        user_id=5,
+        user_name="alice",
+        active=True,
+    )
+
+
+async def test_async_set_user_returns_not_created_when_user_exists(
+    zwave_js_lock: ZWaveJSLock,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
+) -> None:
+    """
+    Test async_set_user reports created=False when the user already exists.
+
+    When get_user_cached returns a UserData object the slot is being updated,
+    not created, so SetUserResult.created must be False.
+    """
+    mock_access_control.get_user_cached.return_value = UserData(
+        user_id=3,
+        active=True,
+        user_type=UserCredentialUserType.GENERAL,
+        user_name="bob",
+    )
+    mock_lock_helpers["async_set_user"].return_value = {"user_id": 3}
+
+    user = User(user_id=3, name="bob", active=True)
+    result = await zwave_js_lock.async_set_user(user)
+
+    assert result == SetUserResult(user_id=3, created=False)
+
+
+async def test_async_set_credential_returns_true_on_success(
+    zwave_js_lock: ZWaveJSLock,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
+) -> None:
+    """
+    Test async_set_credential returns True and calls the helper with the right args.
+
+    The helper is called with the node, user_id, PIN_CODE credential type, the
+    readable Personal Identification Number string, and the credential slot.
+    """
+    mock_lock_helpers["async_set_credential"].return_value = {
+        "credential_slot": 2,
+        "user_id": 1,
+    }
+
+    credential = Credential(
+        type=CredentialType.PIN, slot=2, state=SlotCredential.known("5678")
+    )
+    result = await zwave_js_lock.async_set_credential(
+        user_id=1, credential=credential, name="alice", source="sync"
+    )
+
+    assert result is True
+    mock_lock_helpers["async_set_credential"].assert_called_once_with(
+        zwave_js_lock.node,
+        1,
+        UserCredentialType.PIN_CODE,
+        "5678",
+        credential_slot=2,
+    )
+
+
+async def test_async_set_credential_raises_duplicate_code_error(
+    zwave_js_lock: ZWaveJSLock,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
+) -> None:
+    """
+    Test async_set_credential raises DuplicateCodeError on duplicate rejection.
+
+    When the lock_helpers helper raises HomeAssistantError with
+    translation_key="credential_rejected_duplicate", the provider must re-raise
+    as DuplicateCodeError so the seam's orchestration can handle it correctly.
+    """
+    err = HomeAssistantError(translation_key="credential_rejected_duplicate")
+    mock_lock_helpers["async_set_credential"].side_effect = err
+
+    credential = Credential(
+        type=CredentialType.PIN, slot=3, state=SlotCredential.known("1111")
+    )
+    with pytest.raises(DuplicateCodeError) as exc_info:
+        await zwave_js_lock.async_set_credential(
+            user_id=1, credential=credential, name=None, source="sync"
+        )
+
+    assert exc_info.value.code_slot == 3
+    assert exc_info.value.lock_entity_id == zwave_js_lock.lock.entity_id
+
+
+async def test_async_set_credential_raises_code_rejected_error_on_other_ha_error(
+    zwave_js_lock: ZWaveJSLock,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
+) -> None:
+    """
+    Test async_set_credential raises CodeRejectedError for non-duplicate rejections.
+
+    When the lock_helpers helper raises HomeAssistantError with any other
+    translation_key (for example "credential_rejected_unknown"), the provider
+    must re-raise as CodeRejectedError.
+    """
+    err = HomeAssistantError(translation_key="credential_rejected_unknown")
+    mock_lock_helpers["async_set_credential"].side_effect = err
+
+    credential = Credential(
+        type=CredentialType.PIN, slot=4, state=SlotCredential.known("2222")
+    )
+    with pytest.raises(CodeRejectedError) as exc_info:
+        await zwave_js_lock.async_set_credential(
+            user_id=1, credential=credential, name=None, source="sync"
+        )
+
+    assert exc_info.value.code_slot == 4
+    assert not isinstance(exc_info.value, DuplicateCodeError)
+
+
+async def test_async_delete_user_calls_helper(
+    zwave_js_lock: ZWaveJSLock,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
+) -> None:
+    """
+    Test async_delete_user calls lock_helpers.async_delete_user with correct args.
+
+    The method delegates directly to the helper with the node and user_id.
+    """
+    await zwave_js_lock.async_delete_user(7)
+
+    mock_lock_helpers["async_delete_user"].assert_called_once_with(
+        zwave_js_lock.node, 7
+    )
+
+
+async def test_async_delete_credential_calls_helper_and_returns_true(
+    zwave_js_lock: ZWaveJSLock,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
+) -> None:
+    """
+    Test async_delete_credential calls the helper and returns True on success.
+
+    The helper is called with the node, user_id, PIN_CODE credential type, and
+    the credential slot resolved from the CredentialRef.
+    """
+    ref = CredentialRef(user_id=2, type=CredentialType.PIN, slot=5)
+    result = await zwave_js_lock.async_delete_credential(ref)
+
+    assert result is True
+    mock_lock_helpers["async_delete_credential"].assert_called_once_with(
+        zwave_js_lock.node,
+        2,
+        UserCredentialType.PIN_CODE,
+        5,
     )

--- a/tests/providers/zwave_js/test_provider.py
+++ b/tests/providers/zwave_js/test_provider.py
@@ -993,3 +993,150 @@ async def test_async_delete_credential_rejects_non_pin_type(
     assert exc_info.value.code_slot == 1
     assert "unsupported credential type" in str(exc_info.value)
     mock_lock_helpers["async_delete_credential"].assert_not_called()
+
+
+# ── Exception wrapping for write primitives ─────────────────────────
+
+
+async def test_async_set_user_falls_back_when_capabilities_fetch_fails(
+    zwave_js_lock: ZWaveJSLock,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
+) -> None:
+    """
+    A capabilities read failure must not block the write.
+
+    When the lazy max-name-length lookup raises, async_set_user proceeds with a
+    max length of 0 (names unsupported) rather than propagating a read error
+    out of a write path.
+    """
+    mock_lock_helpers[
+        "async_get_credential_capabilities"
+    ].side_effect = FailedZWaveCommand("cmd", 1, "caps unavailable")
+    mock_access_control.get_user_cached.return_value = None
+
+    user = User(user_id=1, name="alice", active=True)
+    result = await zwave_js_lock.async_set_user(user)
+
+    assert result == SetUserResult(user_id=1, created=True)
+    assert zwave_js_lock._max_user_name_length == 0
+    # max length 0 → the name is omitted
+    mock_lock_helpers["async_set_user"].assert_called_once_with(
+        zwave_js_lock.node,
+        user_id=1,
+        user_name=None,
+        active=True,
+    )
+
+
+async def test_async_set_user_maps_failed_command_to_lock_disconnected(
+    zwave_js_lock: ZWaveJSLock,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
+) -> None:
+    """A transient Z-Wave failure during set surfaces as LockDisconnected (retry)."""
+    mock_access_control.get_user_cached.return_value = None
+    mock_lock_helpers["async_set_user"].side_effect = FailedZWaveCommand(
+        "cmd", 1, "lock asleep"
+    )
+    with pytest.raises(LockDisconnected):
+        await zwave_js_lock.async_set_user(User(user_id=1, name="alice", active=True))
+
+
+async def test_async_set_user_maps_ha_error_to_operation_failed(
+    zwave_js_lock: ZWaveJSLock,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
+) -> None:
+    """A reachable-lock HomeAssistantError during set surfaces as LockOperationFailed."""
+    mock_access_control.get_user_cached.return_value = None
+    mock_lock_helpers["async_set_user"].side_effect = HomeAssistantError("nope")
+    with pytest.raises(LockOperationFailed):
+        await zwave_js_lock.async_set_user(User(user_id=1, name="alice", active=True))
+
+
+async def test_async_delete_user_maps_failed_command_to_lock_disconnected(
+    zwave_js_lock: ZWaveJSLock,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
+) -> None:
+    """A transient Z-Wave failure during delete-user surfaces as LockDisconnected."""
+    mock_lock_helpers["async_delete_user"].side_effect = FailedZWaveCommand(
+        "cmd", 1, "lock asleep"
+    )
+    with pytest.raises(LockDisconnected):
+        await zwave_js_lock.async_delete_user(7)
+
+
+async def test_async_delete_user_maps_ha_error_to_operation_failed(
+    zwave_js_lock: ZWaveJSLock,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
+) -> None:
+    """A reachable-lock HomeAssistantError during delete-user surfaces as LockOperationFailed."""
+    mock_lock_helpers["async_delete_user"].side_effect = HomeAssistantError("nope")
+    with pytest.raises(LockOperationFailed):
+        await zwave_js_lock.async_delete_user(7)
+
+
+async def test_async_delete_credential_maps_ha_error_to_operation_failed(
+    zwave_js_lock: ZWaveJSLock,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
+) -> None:
+    """A reachable-lock HomeAssistantError during delete-credential surfaces as LockOperationFailed."""
+    mock_lock_helpers["async_delete_credential"].side_effect = HomeAssistantError(
+        "nope"
+    )
+    with pytest.raises(LockOperationFailed):
+        await zwave_js_lock.async_delete_credential(
+            CredentialRef(user_id=4, type=CredentialType.PIN, slot=4)
+        )
+
+
+# ── Client-readiness gating ─────────────────────────────────────────
+
+
+async def test_get_client_state_not_ready_when_client_missing(
+    zwave_js_lock: ZWaveJSLock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A loaded entry with no client reports not-ready."""
+    runtime_data = MagicMock()
+    runtime_data.client = None
+    monkeypatch.setattr(zwave_js_lock.lock_config_entry, "runtime_data", runtime_data)
+
+    ready, reason = zwave_js_lock._get_client_state()
+
+    assert ready is False
+    assert "not ready" in reason
+
+
+async def test_get_client_state_not_ready_when_disconnected(
+    zwave_js_lock: ZWaveJSLock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A client that is present but disconnected reports not-ready."""
+    runtime_data = MagicMock()
+    runtime_data.client = MagicMock(connected=False)
+    monkeypatch.setattr(zwave_js_lock.lock_config_entry, "runtime_data", runtime_data)
+
+    ready, reason = zwave_js_lock._get_client_state()
+
+    assert ready is False
+    assert "not connected" in reason
+
+
+async def test_get_client_state_not_ready_when_driver_missing(
+    zwave_js_lock: ZWaveJSLock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A connected client with no driver reports not-ready."""
+    runtime_data = MagicMock()
+    runtime_data.client = MagicMock(connected=True, driver=None)
+    monkeypatch.setattr(zwave_js_lock.lock_config_entry, "runtime_data", runtime_data)
+
+    ready, reason = zwave_js_lock._get_client_state()
+
+    assert ready is False
+    assert "driver not ready" in reason

--- a/tests/providers/zwave_js/test_provider.py
+++ b/tests/providers/zwave_js/test_provider.py
@@ -1000,6 +1000,24 @@ async def test_async_set_credential_raises_code_rejected_error_on_other_ha_error
     assert not isinstance(exc_info.value, DuplicateCodeError)
 
 
+async def test_async_set_credential_rejects_unreadable_credential(
+    zwave_js_lock: ZWaveJSLock,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
+) -> None:
+    """An unreadable credential (no Personal Identification Number) is rejected cleanly."""
+    credential = Credential(
+        type=CredentialType.PIN, slot=4, state=SlotCredential.unreadable()
+    )
+    with pytest.raises(CodeRejectedError) as exc_info:
+        await zwave_js_lock.async_set_credential(
+            user_id=1, credential=credential, name=None, source="sync"
+        )
+
+    assert exc_info.value.code_slot == 4
+    mock_lock_helpers["async_set_credential"].assert_not_called()
+
+
 async def test_async_delete_user_calls_helper(
     zwave_js_lock: ZWaveJSLock,
     mock_access_control: MagicMock,

--- a/tests/providers/zwave_js/test_provider.py
+++ b/tests/providers/zwave_js/test_provider.py
@@ -432,17 +432,20 @@ async def test_is_device_available_returns_false_on_exception(
 # Credential API tests (Option B: readable PINs via node.access_control)
 
 
-async def test_async_get_users_maps_users_and_pin_credentials(
+async def test_async_get_users_returns_all_mappable_credential_types(
     zwave_js_lock: ZWaveJSLock,
     mock_access_control: MagicMock,
     mock_lock_helpers: dict,
 ) -> None:
     """
-    Test async_get_users returns users with PIN credentials correctly projected.
+    async_get_users returns every credential type the domain represents.
 
-    Given two users and three credentials (two PINs, one non-PIN), the result
-    maps each user to its PIN credentials only. Readable data becomes
-    SlotCredential.known; absent data becomes SlotCredential.unreadable.
+    The base orchestration filters to Personal Identification Number at
+    the slot-projection layer via ``user.pin_credentials``, so the
+    provider stores RFID/NFC/etc. alongside PINs rather than dropping
+    them up front. Readable Personal Identification Number data becomes
+    SlotCredential.known; non-PIN data is opaque to the integration so
+    those credentials surface as SlotCredential.unreadable.
     """
     mock_access_control.get_users_cached.return_value = [
         UserData(
@@ -478,12 +481,21 @@ async def test_async_get_users_maps_users_and_pin_credentials(
             slot=2,
             data=None,
         ),
-        # Non-PIN credential — must be filtered out.
+        # Non-PIN credential — now retained alongside the PIN, surfaced
+        # as unreadable so direct callers see it without exposing an
+        # opaque tag identifier to the slot-projection layer.
         CredentialData(
             user_id=1,
             type=UserCredentialType.RFID_CODE,
             slot=1,
             data="AABB",
+        ),
+        # Z-Wave type with no domain equivalent — dropped.
+        CredentialData(
+            user_id=1,
+            type=UserCredentialType.BLE,
+            slot=2,
+            data="raw",
         ),
     ]
 
@@ -495,20 +507,81 @@ async def test_async_get_users_maps_users_and_pin_credentials(
 
     user1 = next(u for u in users if u.user_id == 1)
     assert user1.name == "alice"
-    assert len(user1.credentials) == 1
-    assert user1.credentials[0] == Credential(
-        type=CredentialType.PIN,
-        slot=1,
-        state=SlotCredential.known("1234"),
-    )
+    # PIN_CODE -> CredentialType.PIN (known), RFID_CODE -> CredentialType.RFID
+    # (unreadable, opaque tag), BLE dropped.
+    assert user1.credentials == [
+        Credential(
+            type=CredentialType.PIN,
+            slot=1,
+            state=SlotCredential.known("1234"),
+        ),
+        Credential(
+            type=CredentialType.RFID,
+            slot=1,
+            state=SlotCredential.unreadable(),
+        ),
+    ]
+    # And pin_credentials still surfaces only the PIN so the base
+    # orchestration's slot projection is unaffected.
+    assert user1.pin_credentials == [
+        Credential(
+            type=CredentialType.PIN,
+            slot=1,
+            state=SlotCredential.known("1234"),
+        ),
+    ]
 
     user2 = next(u for u in users if u.user_id == 2)
-    assert len(user2.credentials) == 1
-    assert user2.credentials[0] == Credential(
-        type=CredentialType.PIN,
-        slot=2,
-        state=SlotCredential.unreadable(),
-    )
+    assert user2.credentials == [
+        Credential(
+            type=CredentialType.PIN,
+            slot=2,
+            state=SlotCredential.unreadable(),
+        ),
+    ]
+
+
+async def test_async_get_users_drops_orphan_credentials(
+    zwave_js_lock: ZWaveJSLock,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
+) -> None:
+    """
+    A credential whose user_id is not in the users list is silently dropped.
+
+    This is the Z-Wave equivalent of a stale credential row that lost its
+    owner; surfacing it under a synthetic user would invent state, so the
+    safer projection is to ignore it and let the next hard refresh clean
+    things up.
+    """
+    mock_access_control.get_users_cached.return_value = [
+        UserData(
+            user_id=1,
+            active=True,
+            user_type=UserCredentialUserType.GENERAL,
+            user_name="alice",
+        ),
+    ]
+    mock_access_control.get_all_credentials_cached.return_value = [
+        CredentialData(
+            user_id=1,
+            type=UserCredentialType.PIN_CODE,
+            slot=1,
+            data="1234",
+        ),
+        # Orphan: no matching user record.
+        CredentialData(
+            user_id=99,
+            type=UserCredentialType.PIN_CODE,
+            slot=2,
+            data="9999",
+        ),
+    ]
+
+    users = await zwave_js_lock.async_get_users()
+    assert len(users) == 1
+    assert users[0].user_id == 1
+    assert len(users[0].credentials) == 1
 
 
 async def test_async_get_capabilities_maps_lock_helpers_response(

--- a/tests/providers/zwave_js/test_provider.py
+++ b/tests/providers/zwave_js/test_provider.py
@@ -74,6 +74,21 @@ async def test_node_property(
     assert node.node_id == lock_schlage_be469.node_id
 
 
+async def test_setup_is_idempotent(
+    hass: HomeAssistant,
+    zwave_js_lock: ZWaveJSLock,
+    lock_code_manager_config_entry: MockConfigEntry,
+) -> None:
+    """Test that async_setup clears old listeners before re-registering."""
+    await zwave_js_lock.async_setup(lock_code_manager_config_entry)
+    assert len(zwave_js_lock._listeners) >= 1
+    count_after_first = len(zwave_js_lock._listeners)
+
+    # Call again -- should not accumulate listeners.
+    await zwave_js_lock.async_setup(lock_code_manager_config_entry)
+    assert len(zwave_js_lock._listeners) == count_after_first
+
+
 # Connection tests
 
 

--- a/tests/providers/zwave_js/test_provider.py
+++ b/tests/providers/zwave_js/test_provider.py
@@ -1059,40 +1059,6 @@ async def test_async_set_usercode_truncates_name_to_lock_limit(
 # ── Credential type validation ──────────────────────────────────────
 
 
-async def test_async_set_credential_rejects_non_pin_type(
-    zwave_js_lock: ZWaveJSLock,
-    mock_access_control: MagicMock,
-    mock_lock_helpers: dict,
-) -> None:
-    """A non-PIN credential type is rejected before reaching the helper."""
-    credential = Credential(
-        type=CredentialType.RFID, slot=1, state=SlotCredential.known("AABB")
-    )
-    with pytest.raises(CodeRejectedError) as exc_info:
-        await zwave_js_lock.async_set_credential(
-            user_id=1, credential=credential, name=None, source="sync"
-        )
-
-    assert exc_info.value.code_slot == 1
-    assert "unsupported credential type" in str(exc_info.value)
-    mock_lock_helpers["async_set_credential"].assert_not_called()
-
-
-async def test_async_delete_credential_rejects_non_pin_type(
-    zwave_js_lock: ZWaveJSLock,
-    mock_access_control: MagicMock,
-    mock_lock_helpers: dict,
-) -> None:
-    """A non-PIN CredentialRef type is rejected before reaching the helper."""
-    ref = CredentialRef(user_id=1, type=CredentialType.RFID, slot=1)
-    with pytest.raises(CodeRejectedError) as exc_info:
-        await zwave_js_lock.async_delete_credential(ref)
-
-    assert exc_info.value.code_slot == 1
-    assert "unsupported credential type" in str(exc_info.value)
-    mock_lock_helpers["async_delete_credential"].assert_not_called()
-
-
 # ── Exception wrapping for write primitives ─────────────────────────
 
 

--- a/tests/providers/zwave_js/test_provider.py
+++ b/tests/providers/zwave_js/test_provider.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -11,6 +12,7 @@ from zwave_js_server.const.command_class.access_control import (
     UserCredentialType,
     UserCredentialUserType,
 )
+from zwave_js_server.exceptions import FailedZWaveCommand
 from zwave_js_server.model.access_control import CredentialData, UserData
 from zwave_js_server.model.node import Node
 
@@ -698,6 +700,50 @@ async def test_async_set_credential_rejects_unreadable_credential(
 
     assert exc_info.value.code_slot == 4
     mock_lock_helpers["async_set_credential"].assert_not_called()
+
+
+async def test_async_set_credential_maps_failed_command_to_lock_disconnected(
+    zwave_js_lock: ZWaveJSLock,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
+) -> None:
+    """
+    A transient Z-Wave command failure routes to the retry path, not a suspend.
+
+    FailedZWaveCommand is not a HomeAssistantError; if it escaped, the sync
+    manager would treat it as an unexpected bug and suspend the slot. It must
+    surface as LockDisconnected so the lock is retried instead.
+    """
+    mock_lock_helpers["async_set_credential"].side_effect = FailedZWaveCommand(
+        "cmd", 1, "lock asleep"
+    )
+    credential = Credential(
+        type=CredentialType.PIN, slot=4, state=SlotCredential.known("2222")
+    )
+    with pytest.raises(LockDisconnected):
+        await zwave_js_lock.async_set_credential(
+            user_id=1, credential=credential, name=None, source="sync"
+        )
+
+
+async def test_async_delete_credential_maps_failed_command_to_lock_disconnected(
+    zwave_js_lock: ZWaveJSLock,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
+) -> None:
+    """A transient delete failure also routes to the retry path."""
+    mock_lock_helpers["async_delete_credential"].side_effect = FailedZWaveCommand(
+        "cmd", 1, "lock asleep"
+    )
+    with pytest.raises(LockDisconnected):
+        await zwave_js_lock.async_delete_credential(
+            CredentialRef(user_id=4, type=CredentialType.PIN, slot=4)
+        )
+
+
+async def test_hard_refresh_interval_is_hourly(zwave_js_lock: ZWaveJSLock) -> None:
+    """The drift-recovery backstop is scheduled (not disabled)."""
+    assert zwave_js_lock.hard_refresh_interval == timedelta(hours=1)
 
 
 async def test_async_delete_user_calls_helper(

--- a/tests/providers/zwave_js/test_provider.py
+++ b/tests/providers/zwave_js/test_provider.py
@@ -983,50 +983,49 @@ async def test_set_usercode_user_code_cc_skips_set_user_and_writes_credential_on
     mock_lock_helpers["async_set_credential"].assert_called_once()
 
 
-async def test_async_set_user_truncates_name_when_too_long(
+async def test_async_set_user_writes_name_verbatim(
     zwave_js_lock: ZWaveJSLock,
     mock_access_control: MagicMock,
     mock_lock_helpers: dict,
 ) -> None:
-    """When user name exceeds max_user_name_length, it is truncated."""
-    pin_type_str = lock_helpers.CREDENTIAL_TYPE_MAP[UserCredentialType.PIN_CODE]
-    mock_lock_helpers["async_get_credential_capabilities"].return_value = {
-        "supports_user_management": True,
-        "max_users": 30,
-        "supported_user_types": [],
-        "max_user_name_length": 3,
-        "supported_credential_rules": [],
-        "supported_credential_types": {
-            pin_type_str: {
-                "num_slots": 30,
-                "min_length": 4,
-                "max_length": 8,
-                "supports_learn": False,
-            }
-        },
-    }
+    """
+    Provider primitive writes user.name as-is.
+
+    Truncation is the base orchestration's responsibility (applied in
+    ``_put_credential`` before the call); the provider receives a User
+    with the name already shaped to the lock's limit and writes it
+    verbatim. End-to-end truncation behavior is covered through
+    ``async_set_usercode`` below.
+    """
     mock_access_control.get_user_cached.return_value = None
-    mock_lock_helpers["async_set_user"].return_value = {"user_id": 5}
+    mock_lock_helpers["async_set_user"].return_value = {"user_id": 1}
 
-    # Name "alice" (5 chars) truncated to "ali" (3 chars)
-    user = User(user_id=5, name="alice", active=True)
-    result = await zwave_js_lock.async_set_user(user)
+    user = User(user_id=1, name="alice", active=True)
+    await zwave_js_lock.async_set_user(user)
 
-    assert result == SetUserResult(user_id=5, created=True)
     mock_lock_helpers["async_set_user"].assert_called_once_with(
         zwave_js_lock.node,
-        user_id=5,
-        user_name="ali",
+        user_id=1,
+        user_name="alice",
         active=True,
     )
 
 
-async def test_async_set_user_uses_cached_max_name_length(
+async def test_async_set_usercode_truncates_name_to_lock_limit(
+    hass: HomeAssistant,
     zwave_js_lock: ZWaveJSLock,
     mock_access_control: MagicMock,
     mock_lock_helpers: dict,
 ) -> None:
-    """After the base caches caps, async_set_user reuses the cached limit."""
+    """End-to-end: ``async_set_usercode`` truncates per the cached limit."""
+    lcm_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_LOCKS: [zwave_js_lock.lock.entity_id],
+            CONF_SLOTS: {"1": {}},
+        },
+    )
+    lcm_entry.add_to_hass(hass)
     pin_type_str = lock_helpers.CREDENTIAL_TYPE_MAP[UserCredentialType.PIN_CODE]
     mock_lock_helpers["async_get_credential_capabilities"].return_value = {
         "supports_user_management": True,
@@ -1043,16 +1042,11 @@ async def test_async_set_user_uses_cached_max_name_length(
             }
         },
     }
-    # Prime the base capability cache via the same chokepoint async_set_user
-    # uses (_truncate_user_name → _get_cached_capabilities).
-    await zwave_js_lock._get_cached_capabilities()
-
     mock_access_control.get_user_cached.return_value = None
     mock_lock_helpers["async_set_user"].return_value = {"user_id": 1}
 
-    # Name "alexandra" (10 chars) truncated to 5 chars per the cached limit.
-    user = User(user_id=1, name="alexandra", active=True)
-    await zwave_js_lock.async_set_user(user)
+    # "alexandra" (9 chars) → truncated to "alexa" (5 chars) by the base.
+    await zwave_js_lock.async_set_usercode(1, "1234", name="alexandra")
 
     mock_lock_helpers["async_set_user"].assert_called_once_with(
         zwave_js_lock.node,
@@ -1060,8 +1054,6 @@ async def test_async_set_user_uses_cached_max_name_length(
         user_name="alexa",
         active=True,
     )
-    # Cache is warm; no second helper call.
-    assert mock_lock_helpers["async_get_credential_capabilities"].call_count == 1
 
 
 # ── Credential type validation ──────────────────────────────────────
@@ -1102,67 +1094,6 @@ async def test_async_delete_credential_rejects_non_pin_type(
 
 
 # ── Exception wrapping for write primitives ─────────────────────────
-
-
-async def test_async_set_user_falls_back_when_capabilities_fetch_fails(
-    zwave_js_lock: ZWaveJSLock,
-    mock_access_control: MagicMock,
-    mock_lock_helpers: dict,
-) -> None:
-    """
-    Caps-read failure drops the name for this call without poisoning the cache.
-
-    Failure surfaces as ``LockDisconnected``/``LockOperationFailed`` which the
-    base ``_truncate_user_name`` catches; the cache stays None so the next
-    call retries instead of pinning a 0 sentinel that would silently strip
-    all user names for the provider instance lifetime.
-    """
-    mock_lock_helpers[
-        "async_get_credential_capabilities"
-    ].side_effect = FailedZWaveCommand("cmd", 1, "caps unavailable")
-    mock_access_control.get_user_cached.return_value = None
-
-    user = User(user_id=1, name="alice", active=True)
-    result = await zwave_js_lock.async_set_user(user)
-
-    assert result == SetUserResult(user_id=1, created=True)
-    assert zwave_js_lock._capabilities_cache is None
-    mock_lock_helpers["async_set_user"].assert_called_once_with(
-        zwave_js_lock.node,
-        user_id=1,
-        user_name=None,
-        active=True,
-    )
-
-
-async def test_async_set_user_retries_capabilities_after_failure(
-    zwave_js_lock: ZWaveJSLock,
-    mock_access_control: MagicMock,
-    mock_lock_helpers: dict,
-) -> None:
-    """After a transient caps-fetch failure, the next call retries and the name lands."""
-    mock_lock_helpers["async_get_credential_capabilities"].side_effect = [
-        FailedZWaveCommand("cmd", 1, "caps unavailable"),
-        {
-            "max_user_name_length": 10,
-            "supports_user_management": True,
-            "max_users": 5,
-            "supported_credential_types": {},
-        },
-    ]
-    mock_access_control.get_user_cached.return_value = None
-
-    # First call: caps fetch fails, name dropped, base cache stays unset.
-    await zwave_js_lock.async_set_user(User(user_id=1, name="alice", active=True))
-    assert zwave_js_lock._capabilities_cache is None
-
-    # Second call: caps fetch retries, cache warms, name is now written.
-    await zwave_js_lock.async_set_user(User(user_id=2, name="bob", active=True))
-    assert zwave_js_lock._capabilities_cache is not None
-    assert zwave_js_lock._capabilities_cache.max_user_name_length == 10
-    assert mock_lock_helpers["async_get_credential_capabilities"].call_count == 2
-    last_call = mock_lock_helpers["async_set_user"].call_args_list[-1]
-    assert last_call.kwargs["user_name"] == "bob"
 
 
 async def test_async_set_user_maps_failed_command_to_lock_disconnected(

--- a/tests/providers/zwave_js/test_provider.py
+++ b/tests/providers/zwave_js/test_provider.py
@@ -817,9 +817,9 @@ async def test_async_get_capabilities_raises_lock_disconnected_on_zwave_error(
     mock_lock_helpers: dict,
 ) -> None:
     """BaseZwaveJSServerError from lock_helpers surfaces as LockDisconnected."""
-    mock_lock_helpers["async_get_credential_capabilities"].side_effect = (
-        FailedZWaveCommand("cmd", 1, "server error")
-    )
+    mock_lock_helpers[
+        "async_get_credential_capabilities"
+    ].side_effect = FailedZWaveCommand("cmd", 1, "server error")
     with pytest.raises(LockDisconnected):
         await zwave_js_lock.async_get_capabilities()
 
@@ -829,9 +829,9 @@ async def test_async_get_capabilities_raises_lock_operation_failed_on_ha_error(
     mock_lock_helpers: dict,
 ) -> None:
     """HomeAssistantError from lock_helpers surfaces as LockOperationFailed."""
-    mock_lock_helpers["async_get_credential_capabilities"].side_effect = (
-        HomeAssistantError("boom")
-    )
+    mock_lock_helpers[
+        "async_get_credential_capabilities"
+    ].side_effect = HomeAssistantError("boom")
     with pytest.raises(LockOperationFailed):
         await zwave_js_lock.async_get_capabilities()
 
@@ -993,4 +993,3 @@ async def test_async_delete_credential_rejects_non_pin_type(
     assert exc_info.value.code_slot == 1
     assert "unsupported credential type" in str(exc_info.value)
     mock_lock_helpers["async_delete_credential"].assert_not_called()
-

--- a/tests/providers/zwave_js/test_provider.py
+++ b/tests/providers/zwave_js/test_provider.py
@@ -2,14 +2,20 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 from zwave_js_server.const import CommandClass, NodeStatus
+from zwave_js_server.const.command_class.access_control import (
+    UserCredentialType,
+    UserCredentialUserType,
+)
 from zwave_js_server.exceptions import FailedZWaveCommand
+from zwave_js_server.model.access_control import CredentialData, UserData
 from zwave_js_server.model.node import Node
 
+from homeassistant.components.zwave_js import lock_helpers
 from homeassistant.components.zwave_js.const import DOMAIN as ZWAVE_JS_DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
@@ -18,6 +24,12 @@ from custom_components.lock_code_manager.const import (
     CONF_LOCKS,
     CONF_SLOTS,
     DOMAIN,
+)
+from custom_components.lock_code_manager.domain.credentials import (
+    Credential,
+    CredentialType,
+    CredentialTypeCapability,
+    LockCapabilities,
 )
 from custom_components.lock_code_manager.domain.exceptions import LockDisconnected
 from custom_components.lock_code_manager.domain.models import SlotCredential
@@ -709,3 +721,121 @@ async def test_is_device_available_returns_false_on_exception(
         new_callable=lambda: property(raise_error),
     ):
         assert await zwave_js_lock.async_is_device_available() is False
+
+
+# Credential API tests (Option B: readable PINs via node.access_control)
+
+
+async def test_async_get_users_maps_users_and_pin_credentials(
+    zwave_js_lock: ZWaveJSLock,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
+) -> None:
+    """
+    Test async_get_users returns users with PIN credentials correctly projected.
+
+    Given two users and three credentials (two PINs, one non-PIN), the result
+    maps each user to its PIN credentials only. Readable data becomes
+    SlotCredential.known; absent data becomes SlotCredential.unreadable.
+    """
+    mock_access_control.get_users_cached.return_value = [
+        UserData(
+            user_id=1,
+            active=True,
+            user_type=UserCredentialUserType.GENERAL,
+            user_name="alice",
+        ),
+        UserData(
+            user_id=2,
+            active=True,
+            user_type=UserCredentialUserType.GENERAL,
+            user_name=None,
+        ),
+    ]
+    mock_access_control.get_all_credentials_cached.return_value = [
+        CredentialData(
+            user_id=1,
+            type=UserCredentialType.PIN_CODE,
+            slot=1,
+            data="1234",
+        ),
+        CredentialData(
+            user_id=2,
+            type=UserCredentialType.PIN_CODE,
+            slot=2,
+            data=None,
+        ),
+        # Non-PIN credential — must be filtered out.
+        CredentialData(
+            user_id=1,
+            type=UserCredentialType.RFID_CODE,
+            slot=1,
+            data="AABB",
+        ),
+    ]
+
+    users = await zwave_js_lock.async_get_users()
+
+    assert len(users) == 2
+
+    user1 = next(u for u in users if u.user_id == 1)
+    assert user1.name == "alice"
+    assert len(user1.credentials) == 1
+    assert user1.credentials[0] == Credential(
+        type=CredentialType.PIN,
+        slot=1,
+        state=SlotCredential.known("1234"),
+    )
+
+    user2 = next(u for u in users if u.user_id == 2)
+    assert len(user2.credentials) == 1
+    assert user2.credentials[0] == Credential(
+        type=CredentialType.PIN,
+        slot=2,
+        state=SlotCredential.unreadable(),
+    )
+
+
+async def test_async_get_capabilities_maps_lock_helpers_response(
+    zwave_js_lock: ZWaveJSLock,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
+) -> None:
+    """
+    Test async_get_capabilities maps the lock_helpers response to LockCapabilities.
+
+    The raw dict from async_get_credential_capabilities is projected to the
+    domain LockCapabilities type, pulling the Personal Identification Number
+    entry from supported_credential_types.
+    """
+    pin_type_str = lock_helpers.CREDENTIAL_TYPE_MAP[UserCredentialType.PIN_CODE]
+    mock_lock_helpers["async_get_credential_capabilities"].return_value = {
+        "supports_user_management": True,
+        "max_users": 30,
+        "supported_user_types": [],
+        "max_user_name_length": 10,
+        "supported_credential_rules": [],
+        "supported_credential_types": {
+            pin_type_str: {
+                "num_slots": 30,
+                "min_length": 4,
+                "max_length": 8,
+                "supports_learn": False,
+            }
+        },
+    }
+
+    caps = await zwave_js_lock.async_get_capabilities()
+
+    assert caps == LockCapabilities(
+        supports_user_management=True,
+        max_users=30,
+        credential_types={
+            CredentialType.PIN: CredentialTypeCapability(
+                num_slots=30,
+                min_length=4,
+                max_length=8,
+                supports_learn=False,
+            )
+        },
+    )

--- a/tests/providers/zwave_js/test_provider.py
+++ b/tests/providers/zwave_js/test_provider.py
@@ -81,6 +81,8 @@ async def test_setup_is_idempotent(
     hass: HomeAssistant,
     zwave_js_lock: ZWaveJSLock,
     lock_code_manager_config_entry: MockConfigEntry,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
 ) -> None:
     """Test that async_setup clears old listeners before re-registering."""
     await zwave_js_lock.async_setup(lock_code_manager_config_entry)
@@ -125,6 +127,8 @@ async def test_setup_registers_event_listener(
     hass: HomeAssistant,
     zwave_js_lock: ZWaveJSLock,
     zwave_integration: MockConfigEntry,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
 ) -> None:
     """Test that setup registers an event listener for Z-Wave JS events."""
     lcm_entry = MockConfigEntry(domain=DOMAIN, data={CONF_LOCKS: [], CONF_SLOTS: {}})
@@ -145,6 +149,8 @@ async def test_unload_cleans_up_push_subscription(
     hass: HomeAssistant,
     zwave_js_lock: ZWaveJSLock,
     zwave_integration: MockConfigEntry,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
 ) -> None:
     """Test that unload cleans up push subscriptions."""
     lcm_entry = MockConfigEntry(domain=DOMAIN, data={CONF_LOCKS: [], CONF_SLOTS: {}})
@@ -626,6 +632,7 @@ async def test_async_get_capabilities_maps_lock_helpers_response(
                 supports_learn=False,
             )
         },
+        max_user_name_length=10,
     )
 
 
@@ -925,12 +932,33 @@ async def test_async_get_capabilities_raises_lock_operation_failed_on_ha_error(
 # ── Name length validation in async_set_user ───────────────────────
 
 
-async def test_async_set_user_omits_name_when_max_name_length_is_zero(
+async def test_set_usercode_user_code_cc_skips_set_user_and_writes_credential_only(
+    hass: HomeAssistant,
     zwave_js_lock: ZWaveJSLock,
     mock_access_control: MagicMock,
     mock_lock_helpers: dict,
 ) -> None:
-    """When max_user_name_length is 0, user_name is passed as None."""
+    """
+    On a User Code CC lock, the seam orchestration skips set_user entirely.
+
+    The unified accessControl API's setUser cannot run before a credential
+    exists on a UC lock (the user IS the code), so the base orchestration
+    in _put_credential takes the no-user-write path when the capabilities
+    report ``max_user_name_length == 0``. async_set_credential creates
+    the user implicitly. End-to-end check via async_set_usercode covers
+    the gate, the cache, and the provider-level credential write.
+    """
+    lcm_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_LOCKS: [zwave_js_lock.lock.entity_id],
+            CONF_SLOTS: {"5": {}},
+        },
+    )
+    lcm_entry.add_to_hass(hass)
+    # UC-shaped capabilities: real user-record support is hardcoded to
+    # True by the driver, but max_user_name_length == 0 signals the user
+    # is implicit in the credential.
     pin_type_str = lock_helpers.CREDENTIAL_TYPE_MAP[UserCredentialType.PIN_CODE]
     mock_lock_helpers["async_get_credential_capabilities"].return_value = {
         "supports_user_management": True,
@@ -947,20 +975,12 @@ async def test_async_set_user_omits_name_when_max_name_length_is_zero(
             }
         },
     }
-    mock_access_control.get_user_cached.return_value = None
-    mock_lock_helpers["async_set_user"].return_value = {"user_id": 5}
 
-    # Name is provided, but the lock doesn't support names → pass None
-    user = User(user_id=5, name="alice", active=True)
-    result = await zwave_js_lock.async_set_user(user)
+    changed = await zwave_js_lock.async_set_usercode(5, "9999", name="alice")
 
-    assert result == SetUserResult(user_id=5, created=True)
-    mock_lock_helpers["async_set_user"].assert_called_once_with(
-        zwave_js_lock.node,
-        user_id=5,
-        user_name=None,
-        active=True,
-    )
+    assert changed is True
+    mock_lock_helpers["async_set_user"].assert_not_called()
+    mock_lock_helpers["async_set_credential"].assert_called_once()
 
 
 async def test_async_set_user_truncates_name_when_too_long(

--- a/tests/providers/zwave_js/test_provider.py
+++ b/tests/providers/zwave_js/test_provider.py
@@ -40,6 +40,7 @@ from custom_components.lock_code_manager.domain.exceptions import (
     CodeRejectedError,
     DuplicateCodeError,
     LockDisconnected,
+    LockOperationFailed,
 )
 from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers.zwave_js import ZWaveJSLock
@@ -784,3 +785,212 @@ async def test_async_delete_credential_calls_helper_and_returns_true(
         UserCredentialType.PIN_CODE,
         5,
     )
+
+
+# ── Exception wrapping for read primitives ──────────────────────────
+
+
+async def test_async_get_users_raises_lock_disconnected_on_zwave_error(
+    zwave_js_lock: ZWaveJSLock,
+    mock_access_control: MagicMock,
+) -> None:
+    """BaseZwaveJSServerError from access_control reads surfaces as LockDisconnected."""
+    mock_access_control.get_users_cached.side_effect = FailedZWaveCommand(
+        "cmd", 1, "server error"
+    )
+    with pytest.raises(LockDisconnected):
+        await zwave_js_lock.async_get_users()
+
+
+async def test_async_get_users_raises_lock_operation_failed_on_ha_error(
+    zwave_js_lock: ZWaveJSLock,
+    mock_access_control: MagicMock,
+) -> None:
+    """HomeAssistantError from access_control reads surfaces as LockOperationFailed."""
+    mock_access_control.get_users_cached.side_effect = HomeAssistantError("boom")
+    with pytest.raises(LockOperationFailed):
+        await zwave_js_lock.async_get_users()
+
+
+async def test_async_get_capabilities_raises_lock_disconnected_on_zwave_error(
+    zwave_js_lock: ZWaveJSLock,
+    mock_lock_helpers: dict,
+) -> None:
+    """BaseZwaveJSServerError from lock_helpers surfaces as LockDisconnected."""
+    mock_lock_helpers["async_get_credential_capabilities"].side_effect = (
+        FailedZWaveCommand("cmd", 1, "server error")
+    )
+    with pytest.raises(LockDisconnected):
+        await zwave_js_lock.async_get_capabilities()
+
+
+async def test_async_get_capabilities_raises_lock_operation_failed_on_ha_error(
+    zwave_js_lock: ZWaveJSLock,
+    mock_lock_helpers: dict,
+) -> None:
+    """HomeAssistantError from lock_helpers surfaces as LockOperationFailed."""
+    mock_lock_helpers["async_get_credential_capabilities"].side_effect = (
+        HomeAssistantError("boom")
+    )
+    with pytest.raises(LockOperationFailed):
+        await zwave_js_lock.async_get_capabilities()
+
+
+# ── Name length validation in async_set_user ───────────────────────
+
+
+async def test_async_set_user_omits_name_when_max_name_length_is_zero(
+    zwave_js_lock: ZWaveJSLock,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
+) -> None:
+    """When max_user_name_length is 0, user_name is passed as None."""
+    pin_type_str = lock_helpers.CREDENTIAL_TYPE_MAP[UserCredentialType.PIN_CODE]
+    mock_lock_helpers["async_get_credential_capabilities"].return_value = {
+        "supports_user_management": True,
+        "max_users": 30,
+        "supported_user_types": [],
+        "max_user_name_length": 0,
+        "supported_credential_rules": [],
+        "supported_credential_types": {
+            pin_type_str: {
+                "num_slots": 30,
+                "min_length": 4,
+                "max_length": 8,
+                "supports_learn": False,
+            }
+        },
+    }
+    mock_access_control.get_user_cached.return_value = None
+    mock_lock_helpers["async_set_user"].return_value = {"user_id": 5}
+
+    # Name is provided, but the lock doesn't support names → pass None
+    user = User(user_id=5, name="alice", active=True)
+    result = await zwave_js_lock.async_set_user(user)
+
+    assert result == SetUserResult(user_id=5, created=True)
+    mock_lock_helpers["async_set_user"].assert_called_once_with(
+        zwave_js_lock.node,
+        user_id=5,
+        user_name=None,
+        active=True,
+    )
+
+
+async def test_async_set_user_truncates_name_when_too_long(
+    zwave_js_lock: ZWaveJSLock,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
+) -> None:
+    """When user name exceeds max_user_name_length, it is truncated."""
+    pin_type_str = lock_helpers.CREDENTIAL_TYPE_MAP[UserCredentialType.PIN_CODE]
+    mock_lock_helpers["async_get_credential_capabilities"].return_value = {
+        "supports_user_management": True,
+        "max_users": 30,
+        "supported_user_types": [],
+        "max_user_name_length": 3,
+        "supported_credential_rules": [],
+        "supported_credential_types": {
+            pin_type_str: {
+                "num_slots": 30,
+                "min_length": 4,
+                "max_length": 8,
+                "supports_learn": False,
+            }
+        },
+    }
+    mock_access_control.get_user_cached.return_value = None
+    mock_lock_helpers["async_set_user"].return_value = {"user_id": 5}
+
+    # Name "alice" (5 chars) truncated to "ali" (3 chars)
+    user = User(user_id=5, name="alice", active=True)
+    result = await zwave_js_lock.async_set_user(user)
+
+    assert result == SetUserResult(user_id=5, created=True)
+    mock_lock_helpers["async_set_user"].assert_called_once_with(
+        zwave_js_lock.node,
+        user_id=5,
+        user_name="ali",
+        active=True,
+    )
+
+
+async def test_async_set_user_uses_cached_max_name_length(
+    zwave_js_lock: ZWaveJSLock,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
+) -> None:
+    """After async_get_capabilities, async_set_user reuses the cached max name length."""
+    pin_type_str = lock_helpers.CREDENTIAL_TYPE_MAP[UserCredentialType.PIN_CODE]
+    mock_lock_helpers["async_get_credential_capabilities"].return_value = {
+        "supports_user_management": True,
+        "max_users": 30,
+        "supported_user_types": [],
+        "max_user_name_length": 5,
+        "supported_credential_rules": [],
+        "supported_credential_types": {
+            pin_type_str: {
+                "num_slots": 30,
+                "min_length": 4,
+                "max_length": 8,
+                "supports_learn": False,
+            }
+        },
+    }
+    # First call: async_get_capabilities populates the cache
+    await zwave_js_lock.async_get_capabilities()
+
+    mock_access_control.get_user_cached.return_value = None
+    mock_lock_helpers["async_set_user"].return_value = {"user_id": 1}
+
+    # Name "alexandra" (10 chars) truncated to "alex" (5 chars, matching cache)
+    user = User(user_id=1, name="alexandra", active=True)
+    await zwave_js_lock.async_set_user(user)
+
+    mock_lock_helpers["async_set_user"].assert_called_once_with(
+        zwave_js_lock.node,
+        user_id=1,
+        user_name="alexa",
+        active=True,
+    )
+    # async_get_credential_capabilities should NOT have been called again
+    # (the cache was already populated by async_get_capabilities)
+    assert mock_lock_helpers["async_get_credential_capabilities"].call_count == 1
+
+
+# ── Credential type validation ──────────────────────────────────────
+
+
+async def test_async_set_credential_rejects_non_pin_type(
+    zwave_js_lock: ZWaveJSLock,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
+) -> None:
+    """A non-PIN credential type is rejected before reaching the helper."""
+    credential = Credential(
+        type=CredentialType.RFID, slot=1, state=SlotCredential.known("AABB")
+    )
+    with pytest.raises(CodeRejectedError) as exc_info:
+        await zwave_js_lock.async_set_credential(
+            user_id=1, credential=credential, name=None, source="sync"
+        )
+
+    assert exc_info.value.code_slot == 1
+    assert "unsupported credential type" in str(exc_info.value)
+    mock_lock_helpers["async_set_credential"].assert_not_called()
+
+
+async def test_async_delete_credential_rejects_non_pin_type(
+    zwave_js_lock: ZWaveJSLock,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
+) -> None:
+    """A non-PIN CredentialRef type is rejected before reaching the helper."""
+    ref = CredentialRef(user_id=1, type=CredentialType.RFID, slot=1)
+    with pytest.raises(CodeRejectedError) as exc_info:
+        await zwave_js_lock.async_delete_credential(ref)
+
+    assert exc_info.value.code_slot == 1
+    assert "unsupported credential type" in str(exc_info.value)
+    mock_lock_helpers["async_delete_credential"].assert_not_called()
+

--- a/tests/providers/zwave_js/test_provider.py
+++ b/tests/providers/zwave_js/test_provider.py
@@ -943,7 +943,7 @@ async def test_set_usercode_user_code_cc_skips_set_user_and_writes_credential_on
 
     The unified accessControl API's setUser cannot run before a credential
     exists on a UC lock (the user IS the code), so the base orchestration
-    in _put_credential takes the no-user-write path when the capabilities
+    in _set_credential takes the no-user-write path when the capabilities
     report ``max_user_name_length == 0``. async_set_credential creates
     the user implicitly. End-to-end check via async_set_usercode covers
     the gate, the cache, and the provider-level credential write.
@@ -992,7 +992,7 @@ async def test_async_set_user_writes_name_verbatim(
     Provider primitive writes user.name as-is.
 
     Truncation is the base orchestration's responsibility (applied in
-    ``_put_credential`` before the call); the provider receives a User
+    ``_set_credential`` before the call); the provider receives a User
     with the name already shaped to the lock's limit and writes it
     verbatim. End-to-end truncation behavior is covered through
     ``async_set_usercode`` below.

--- a/tests/providers/zwave_js/test_provider.py
+++ b/tests/providers/zwave_js/test_provider.py
@@ -2,16 +2,15 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
-from zwave_js_server.const import CommandClass, NodeStatus
+from zwave_js_server.const import NodeStatus
 from zwave_js_server.const.command_class.access_control import (
     UserCredentialType,
     UserCredentialUserType,
 )
-from zwave_js_server.exceptions import FailedZWaveCommand
 from zwave_js_server.model.access_control import CredentialData, UserData
 from zwave_js_server.model.node import Node
 
@@ -43,8 +42,6 @@ from custom_components.lock_code_manager.domain.exceptions import (
 from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers.zwave_js import ZWaveJSLock
 
-from .helpers import _PROVIDER_MODULE
-
 # Properties tests
 
 
@@ -63,54 +60,9 @@ async def test_connection_check_interval_is_none(zwave_js_lock: ZWaveJSLock) -> 
     assert zwave_js_lock.connection_check_interval is None
 
 
-async def test_setup_is_idempotent(
-    hass: HomeAssistant,
-    zwave_js_lock: ZWaveJSLock,
-    lock_code_manager_config_entry: MockConfigEntry,
-) -> None:
-    """Test that async_setup clears old listeners before re-registering."""
-    await zwave_js_lock.async_setup(lock_code_manager_config_entry)
-    assert len(zwave_js_lock._listeners) >= 1
-    count_after_first = len(zwave_js_lock._listeners)
-
-    # Call again — should not accumulate listeners
-    await zwave_js_lock.async_setup(lock_code_manager_config_entry)
-    assert len(zwave_js_lock._listeners) == count_after_first
-
-
-# CC version detection tests
-
-
-async def test_usercode_cc_version_v1(zwave_js_lock: ZWaveJSLock) -> None:
-    """Test that V1 lock reports correct CC version."""
-    assert zwave_js_lock._usercode_cc_version == 1
-
-
-async def test_usercode_cc_version_v2(zwave_js_lock_v2: ZWaveJSLock) -> None:
-    """Test that V2 lock reports correct CC version."""
-    assert zwave_js_lock_v2._usercode_cc_version == 2
-
-
-async def test_usercode_cc_version_missing(
-    zwave_js_lock: ZWaveJSLock,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Test warning when User Code CC is not found on node."""
-    # Remove User Code CC from the node's command classes
-    node = zwave_js_lock.node
-    endpoint = node.endpoints[0]
-    original_ccs = endpoint.data["commandClasses"]
-    endpoint.data["commandClasses"] = [
-        cc for cc in original_ccs if cc["id"] != CommandClass.USER_CODE.value
-    ]
-    # zwave-js-server-python 0.70+ added @cached_property on endpoint.command_classes
-    # so direct endpoint.data mutation needs cache invalidation here too.
-    endpoint.__dict__.pop("command_classes", None)
-    # Clear cached property so it re-evaluates
-    zwave_js_lock.__dict__.pop("_usercode_cc_version", None)
-
-    assert zwave_js_lock._usercode_cc_version == 1
-    assert "User Code CC not found" in caplog.text
+async def test_supports_native_users(zwave_js_lock: ZWaveJSLock) -> None:
+    """Test that Z-Wave JS lock reports supports_native_users=True."""
+    assert zwave_js_lock.supports_native_users is True
 
 
 async def test_node_property(
@@ -146,335 +98,6 @@ async def test_is_integration_not_connected_when_not_loaded(
 
     assert zwave_integration.state != ConfigEntryState.LOADED
     assert await zwave_js_lock.async_is_integration_connected() is False
-
-
-# Usercode tests
-
-
-async def test_set_usercode_skips_when_unchanged(
-    zwave_js_lock: ZWaveJSLock,
-) -> None:
-    """Test that set_usercode returns False when code is already set."""
-    # Slot 2 already has "1234" in the fixture
-    result = await zwave_js_lock.async_set_usercode(2, "1234", "Test User")
-
-    assert result is False
-
-
-async def test_set_usercode_skips_when_code_matches(
-    zwave_js_lock: ZWaveJSLock,
-) -> None:
-    """Test that set_usercode returns False when cached code matches the target PIN."""
-    # Mock the cache to return the same code we're trying to set
-    matching_slot = {"code_slot": 2, "usercode": "5678", "in_use": True}
-
-    with patch(
-        f"{_PROVIDER_MODULE}.get_usercode",
-        return_value=matching_slot,
-    ):
-        result = await zwave_js_lock.async_set_usercode(2, "5678", "Test User")
-
-        # Should skip the set operation since code already matches
-        assert result is False
-
-
-async def test_set_usercode_proceeds_when_masked(
-    zwave_js_lock: ZWaveJSLock,
-) -> None:
-    """
-    Test that set_usercode proceeds when code is masked (all asterisks).
-
-    Some locks (like Yale) return masked PINs (****) instead of actual codes.
-    Since we cannot compare masked codes, the set operation should always proceed.
-    """
-    # Mock the cache to return a masked code
-    masked_slot = {"code_slot": 2, "usercode": "****", "in_use": True}
-
-    with patch(
-        f"{_PROVIDER_MODULE}.get_usercode",
-        return_value=masked_slot,
-    ):
-        result = await zwave_js_lock.async_set_usercode(2, "5678", "Test User")
-
-        # Should proceed since masked codes cannot be compared
-        assert result is True
-
-
-async def test_set_usercode_proceeds_on_cache_failure(
-    zwave_js_lock: ZWaveJSLock,
-) -> None:
-    """
-    Test that set_usercode proceeds when the cache lookup raises.
-
-    A stale or missing cache entry must not block the set operation —
-    the bare-except in the cache short-circuit guards against this.
-    """
-    with patch(
-        f"{_PROVIDER_MODULE}.get_usercode",
-        side_effect=ValueError("cache miss"),
-    ):
-        result = await zwave_js_lock.async_set_usercode(4, "5678", "Test User")
-
-        assert result is True
-
-
-async def test_clear_usercode_skips_when_already_cleared(
-    zwave_js_lock: ZWaveJSLock,
-) -> None:
-    """Test that clear_usercode returns False when slot is already empty."""
-    # Slot 3 is already empty in the fixture
-    result = await zwave_js_lock.async_clear_usercode(3)
-
-    assert result is False
-
-
-async def test_clear_usercode_proceeds_on_cache_failure(
-    zwave_js_lock: ZWaveJSLock,
-) -> None:
-    """
-    Test that clear_usercode proceeds when the cache lookup raises.
-
-    Mirrors test_set_usercode_proceeds_on_cache_failure for the clear path.
-    """
-    with patch(
-        f"{_PROVIDER_MODULE}.get_usercode",
-        side_effect=ValueError("cache miss"),
-    ):
-        result = await zwave_js_lock.async_clear_usercode(2)
-
-        assert result is True
-
-
-async def test_set_usercode_optimistic_update(
-    zwave_js_lock: ZWaveJSLock,
-    mock_coordinator,
-) -> None:
-    """
-    Test that set_usercode performs optimistic coordinator update.
-
-    When a set operation succeeds, the coordinator should be updated immediately
-    with the new value. This prevents sync loops where the binary sensor reads
-    stale cached data and triggers repeated sync attempts.
-
-    The Z-Wave command is acknowledged by the lock (via Supervision CC), but
-    the JS value cache updates asynchronously via push notifications. Without
-    the optimistic update, there's a race condition where coordinator refresh
-    reads stale cache data.
-    """
-    # Set up a mock coordinator with stale data (simulating the race condition)
-    zwave_js_lock.coordinator = mock_coordinator(
-        {4: SlotCredential.empty()}
-    )  # Slot appears empty in stale cache
-
-    result = await zwave_js_lock.async_set_usercode(4, "5678", "Test User")
-
-    assert result is True
-    # Verify optimistic update was called with new PIN
-    zwave_js_lock.coordinator.push_update.assert_called_once_with(
-        {4: SlotCredential.known("5678")}
-    )
-
-
-async def test_set_usercode_optimistic_update_prevents_stale_read(
-    zwave_js_lock: ZWaveJSLock,
-    mock_coordinator,
-) -> None:
-    """Test that optimistic update prevents sync loops from stale cache reads."""
-    # Simulate stale cache: coordinator thinks slot is empty
-    zwave_js_lock.coordinator = mock_coordinator({4: SlotCredential.empty()})
-
-    await zwave_js_lock.async_set_usercode(4, "9999")
-
-    # The optimistic update should have been called
-    zwave_js_lock.coordinator.push_update.assert_called_once_with(
-        {4: SlotCredential.known("9999")}
-    )
-
-    # Simulate what push_update does - update coordinator data
-    zwave_js_lock.coordinator.data[4] = SlotCredential.known("9999")
-    assert zwave_js_lock.coordinator.data[4] == SlotCredential.known("9999")
-
-
-async def test_clear_usercode_optimistic_update(
-    zwave_js_lock: ZWaveJSLock,
-    mock_coordinator,
-) -> None:
-    """
-    Test that clear_usercode performs optimistic coordinator update.
-
-    When a clear operation succeeds, the coordinator should be updated immediately
-    with SlotCredential.empty(). This prevents sync loops where the binary sensor reads
-    stale cached data showing the old PIN and triggers repeated clear attempts.
-    """
-    # Set up a mock coordinator with stale data (still shows old PIN)
-    zwave_js_lock.coordinator = mock_coordinator(
-        {2: SlotCredential.known("1234")}
-    )  # Stale: slot still shows PIN
-
-    result = await zwave_js_lock.async_clear_usercode(2)
-
-    assert result is True
-    # Verify optimistic update was called with SlotCredential.empty()
-    zwave_js_lock.coordinator.push_update.assert_called_once_with(
-        {2: SlotCredential.empty()}
-    )
-
-
-# V1 cache poll tests
-
-
-async def test_v1_set_usercode_polls_slot(
-    zwave_js_lock: ZWaveJSLock,
-    lock_schlage_be469: Node,
-    mock_get_usercode_from_node,
-    mock_coordinator,
-) -> None:
-    """
-    Test that V1 set_usercode polls the slot from the device after set.
-
-    V1 locks don't reliably update the Z-Wave JS value cache after a set
-    operation. Polling the slot forces the cache to update before the
-    coordinator reads it, preventing sync loops.
-    """
-    zwave_js_lock.coordinator = mock_coordinator({4: SlotCredential.empty()})
-
-    await zwave_js_lock.async_set_usercode(4, "5678", "Test User")
-
-    mock_get_usercode_from_node.assert_called_once_with(lock_schlage_be469, 4)
-
-
-async def test_v1_clear_usercode_polls_slot(
-    zwave_js_lock: ZWaveJSLock,
-    lock_schlage_be469: Node,
-    mock_get_usercode_from_node,
-    mock_coordinator,
-) -> None:
-    """Test that V1 clear_usercode polls the slot from the device after clear."""
-    zwave_js_lock.coordinator = mock_coordinator({2: SlotCredential.known("1234")})
-
-    await zwave_js_lock.async_clear_usercode(2)
-
-    mock_get_usercode_from_node.assert_called_once_with(lock_schlage_be469, 2)
-
-
-async def test_v2_set_usercode_does_not_poll_slot(
-    zwave_js_lock_v2: ZWaveJSLock,
-    mock_get_usercode_from_node,
-    mock_coordinator,
-) -> None:
-    """Test that V2 set_usercode does NOT poll the slot (cache updates reliably)."""
-    zwave_js_lock_v2.coordinator = mock_coordinator({4: SlotCredential.empty()})
-
-    await zwave_js_lock_v2.async_set_usercode(4, "5678", "Test User")
-
-    mock_get_usercode_from_node.assert_not_called()
-
-
-async def test_v1_set_usercode_poll_failure_raises_lock_disconnected(
-    zwave_js_lock: ZWaveJSLock,
-    mock_get_usercode_from_node,
-    mock_coordinator,
-) -> None:
-    """
-    Test that a V1 set poll failure raises LockDisconnected.
-
-    When get_usercode_from_node raises after a V1 set operation, the error
-    should be wrapped as LockDisconnected so it routes into the retry path
-    instead of the generic exception handler that would suspend the lock.
-    """
-    zwave_js_lock.coordinator = mock_coordinator({4: SlotCredential.empty()})
-
-    mock_get_usercode_from_node.side_effect = FailedZWaveCommand(
-        "msg_id", 202, "Node presumed dead"
-    )
-
-    with pytest.raises(LockDisconnected, match="Post-set verification poll failed"):
-        await zwave_js_lock.async_set_usercode(4, "5678", "Test User")
-
-
-async def test_v1_clear_usercode_poll_failure_raises_lock_disconnected(
-    zwave_js_lock: ZWaveJSLock,
-    mock_get_usercode_from_node,
-    mock_coordinator,
-) -> None:
-    """
-    Test that a V1 clear poll failure raises LockDisconnected.
-
-    When get_usercode_from_node raises after a V1 clear operation, the error
-    should be wrapped as LockDisconnected so it routes into the retry path
-    instead of the generic exception handler that would suspend the lock.
-    """
-    zwave_js_lock.coordinator = mock_coordinator({2: SlotCredential.known("1234")})
-
-    mock_get_usercode_from_node.side_effect = FailedZWaveCommand(
-        "msg_id", 202, "Node presumed dead"
-    )
-
-    with pytest.raises(LockDisconnected, match="Post-clear verification poll failed"):
-        await zwave_js_lock.async_clear_usercode(2)
-
-
-async def test_v1_set_usercode_poll_non_zwave_error_propagates(
-    zwave_js_lock: ZWaveJSLock,
-    mock_get_usercode_from_node,
-    mock_coordinator,
-) -> None:
-    """
-    Non-Z-Wave errors from V1 post-set poll propagate uncaught.
-
-    Only FailedZWaveCommand is wrapped as LockDisconnected. Other
-    exceptions (programming errors) should propagate so the sync
-    manager's generic handler can suspend the lock and surface the bug.
-    """
-    zwave_js_lock.coordinator = mock_coordinator({4: SlotCredential.empty()})
-
-    mock_get_usercode_from_node.side_effect = RuntimeError("unexpected bug")
-
-    with pytest.raises(RuntimeError, match="unexpected bug"):
-        await zwave_js_lock.async_set_usercode(4, "5678", "Test User")
-
-
-async def test_v1_clear_usercode_poll_non_zwave_error_propagates(
-    zwave_js_lock: ZWaveJSLock,
-    mock_get_usercode_from_node,
-    mock_coordinator,
-) -> None:
-    """Non-Z-Wave errors from V1 post-clear poll propagate uncaught."""
-    zwave_js_lock.coordinator = mock_coordinator({2: SlotCredential.known("1234")})
-
-    mock_get_usercode_from_node.side_effect = RuntimeError("unexpected bug")
-
-    with pytest.raises(RuntimeError, match="unexpected bug"):
-        await zwave_js_lock.async_clear_usercode(2)
-
-
-async def test_set_usercode_no_coordinator(
-    zwave_js_lock: ZWaveJSLock,
-) -> None:
-    """
-    Test that set_usercode handles missing coordinator gracefully.
-
-    The coordinator check is defensive - in normal operation it always exists
-    after setup. This test verifies the guard clause works.
-    """
-    # Remove coordinator to test defensive check (explicit for clarity)
-    zwave_js_lock.coordinator = None
-
-    # Should not raise even without coordinator
-    result = await zwave_js_lock.async_set_usercode(4, "5678")
-    assert result is True
-
-
-async def test_clear_usercode_no_coordinator(
-    zwave_js_lock: ZWaveJSLock,
-) -> None:
-    """Test that clear_usercode handles missing coordinator gracefully."""
-    # Remove coordinator to test defensive check (explicit for clarity)
-    zwave_js_lock.coordinator = None
-
-    # Should not raise even without coordinator
-    result = await zwave_js_lock.async_clear_usercode(2)
-    assert result is True
 
 
 # Setup/unload tests
@@ -520,12 +143,18 @@ async def test_unload_cleans_up_push_subscription(
 # Hard refresh tests
 
 
-async def test_hard_refresh_calls_refresh_cc_values(
+async def test_hard_refresh_codes_calls_access_control(
     hass: HomeAssistant,
     zwave_js_lock: ZWaveJSLock,
-    lock_schlage_be469: Node,
+    mock_access_control: MagicMock,
 ) -> None:
-    """Test that hard refresh calls the node's refresh method."""
+    """
+    Test that async_hard_refresh_codes refreshes both users and credentials from the lock.
+
+    The non-cached methods (get_users and get_all_credentials) are called to force a
+    fresh read from the device, bypassing any cached state. The result is then projected
+    through the base class async_get_usercodes which calls the cached reads.
+    """
     lcm_entry = MockConfigEntry(
         domain=DOMAIN,
         data={
@@ -535,155 +164,193 @@ async def test_hard_refresh_calls_refresh_cc_values(
     )
     lcm_entry.add_to_hass(hass)
 
-    with patch.object(
-        lock_schlage_be469,
-        "async_refresh_cc_values",
-        new_callable=AsyncMock,
-    ) as mock_refresh:
-        codes = await zwave_js_lock.async_hard_refresh_codes()
+    codes = await zwave_js_lock.async_hard_refresh_codes()
 
-        mock_refresh.assert_called_once_with(CommandClass.USER_CODE)
-        assert isinstance(codes, dict)
-
-
-# Masked usercode tests
+    mock_access_control.get_users.assert_called_once()
+    mock_access_control.get_all_credentials.assert_called_once()
+    assert isinstance(codes, dict)
+    # Managed slots 1 and 2 are present (empty since mock returns no users)
+    assert 1 in codes
+    assert 2 in codes
 
 
-async def test_get_usercodes_masked_pin_unmanaged_slot_returns_masked_value(
+async def test_hard_refresh_codes_raises_lock_disconnected_on_error(
+    zwave_js_lock: ZWaveJSLock,
+    mock_access_control: MagicMock,
+) -> None:
+    """Test that async_hard_refresh_codes wraps any exception as LockDisconnected."""
+    mock_access_control.get_users.side_effect = RuntimeError("node gone")
+
+    with pytest.raises(LockDisconnected):
+        await zwave_js_lock.async_hard_refresh_codes()
+
+
+# Base orchestration integration tests
+
+
+async def test_async_get_usercodes_returns_projection_with_managed_slots(
     hass: HomeAssistant,
     zwave_js_lock: ZWaveJSLock,
+    mock_access_control: MagicMock,
 ) -> None:
     """
-    Test mixed slots: managed with real code vs unmanaged with masked code.
+    Test that async_get_usercodes projects lock users to slot-keyed credentials.
 
-    This test verifies behavior when the lock cache contains:
-    - Slot 1: Managed by LCM, has real code "9999" -> should be returned
-    - Slot 5: NOT managed by LCM, has masked code "****" -> returns UNREADABLE_CODE
-
-    Unmanaged slots with masked PINs return SlotCredential.unreadable() so sync
-    logic knows a PIN exists on the lock, even if we can't read the actual value.
+    The base implementation ensures every managed slot is present in the result
+    (starting from empty), and overlays any Personal Identification Number
+    credentials returned by async_get_users. With no users on the lock, all
+    managed slots are present and empty.
     """
-    # Configure LCM to only manage slot 1 (not slot 5)
     lcm_entry = MockConfigEntry(
         domain=DOMAIN,
         data={
             CONF_LOCKS: [zwave_js_lock.lock.entity_id],
-            CONF_SLOTS: {"1": {}},  # Only slot 1 is managed
+            CONF_SLOTS: {"1": {}, "2": {}},
         },
     )
     lcm_entry.add_to_hass(hass)
+    # No users on the lock
+    mock_access_control.get_users_cached.return_value = []
+    mock_access_control.get_all_credentials_cached.return_value = []
 
-    # Mock the cache to include a slot with a masked PIN that isn't managed by LCM
-    masked_slots = [
-        {"code_slot": 1, "usercode": "9999", "in_use": True},  # Managed by LCM
-        {"code_slot": 5, "usercode": "****", "in_use": True},  # NOT managed, masked
-    ]
+    codes = await zwave_js_lock.async_get_usercodes()
 
-    with (
-        patch.object(
-            zwave_js_lock, "_get_usercodes_from_cache", return_value=masked_slots
+    assert codes[1] == SlotCredential.empty()
+    assert codes[2] == SlotCredential.empty()
+
+
+async def test_async_get_usercodes_overlays_pin_credentials(
+    hass: HomeAssistant,
+    zwave_js_lock: ZWaveJSLock,
+    mock_access_control: MagicMock,
+) -> None:
+    """
+    Test that async_get_usercodes projects Personal Identification Number credentials onto slot keys.
+
+    When the lock has a user with a PIN credential at slot 1, the result maps slot 1
+    to the readable credential value.
+    """
+    lcm_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_LOCKS: [zwave_js_lock.lock.entity_id],
+            CONF_SLOTS: {"1": {}, "2": {}},
+        },
+    )
+    lcm_entry.add_to_hass(hass)
+    mock_access_control.get_users_cached.return_value = [
+        UserData(
+            user_id=1,
+            active=True,
+            user_type=UserCredentialUserType.GENERAL,
+            user_name="alice",
         ),
-        # Slot 5 not in Z-Wave node data, so code_slot_in_use returns None
-        patch.object(
-            zwave_js_lock,
-            "code_slot_in_use",
-            side_effect=lambda s: True if s == 1 else None,
+    ]
+    mock_access_control.get_all_credentials_cached.return_value = [
+        CredentialData(
+            user_id=1,
+            type=UserCredentialType.PIN_CODE,
+            slot=1,
+            data="9999",
         ),
-    ):
-        codes = await zwave_js_lock.async_get_usercodes()
+    ]
 
-        # Slot 1 should have its code
-        assert codes[1] == SlotCredential.known("9999")
-        # Slot 5 returns an unreadable credential (masked code, so sync logic knows a PIN exists)
-        assert codes[5] is SlotCredential.unreadable()
+    codes = await zwave_js_lock.async_get_usercodes()
+
+    assert codes[1] == SlotCredential.known("9999")
+    assert codes[2] == SlotCredential.empty()
 
 
-async def test_get_usercodes_masked_pin_returns_unknown(
+async def test_async_internal_set_usercode_calls_primitives(
     hass: HomeAssistant,
     zwave_js_lock: ZWaveJSLock,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
+    zwave_integration: MockConfigEntry,
 ) -> None:
     """
-    Test that masked PINs return SlotCredential.unreadable().
+    Test that async_internal_set_usercode drives the base User->Credential orchestration.
 
-    When the lock returns masked codes (all asterisks), the provider returns
-    SlotCredential.unreadable() so consumers know a code exists but the value is hidden.
+    With supports_native_users=True and the connection up, the base class runs
+    async_set_user (to create or update the user) then async_set_credential (to write
+    the Personal Identification Number), both delegating to lock_helpers.
     """
     lcm_entry = MockConfigEntry(
         domain=DOMAIN,
         data={
             CONF_LOCKS: [zwave_js_lock.lock.entity_id],
-            CONF_SLOTS: {"2": {}},
+            CONF_SLOTS: {"1": {}},
         },
     )
     lcm_entry.add_to_hass(hass)
 
-    # Mock the cache to have a masked PIN on a managed slot
-    masked_slots = [
-        {"code_slot": 2, "usercode": "****", "in_use": True},
-    ]
+    # Disable the operation delay so the test does not wait
+    zwave_js_lock._min_operation_delay = 0.0
+    mock_access_control.get_user_cached.return_value = None
 
-    with patch.object(
-        zwave_js_lock, "_get_usercodes_from_cache", return_value=masked_slots
-    ):
-        codes = await zwave_js_lock.async_get_usercodes()
+    await zwave_js_lock.async_internal_set_usercode(
+        1, "5678", name="alice", source="sync"
+    )
 
-        # Masked PIN should be returned as SlotCredential.unreadable()
-        assert codes[2] is SlotCredential.unreadable()
+    mock_lock_helpers["async_set_user"].assert_called_once()
+    mock_lock_helpers["async_set_credential"].assert_called_once()
+    # Verify the credential call carries the right Personal Identification Number and slot
+    call_args = mock_lock_helpers["async_set_credential"].call_args
+    assert call_args.args[1] == 1  # user_id from set_user result
+    assert call_args.args[2] == UserCredentialType.PIN_CODE
+    assert call_args.args[3] == "5678"
+    assert call_args.kwargs["credential_slot"] == 1
 
 
-async def test_get_usercodes_empty_usercode_in_use_skipped(
+async def test_async_internal_clear_usercode_calls_delete_primitives(
     hass: HomeAssistant,
     zwave_js_lock: ZWaveJSLock,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
+    zwave_integration: MockConfigEntry,
 ) -> None:
-    """Test that in_use=True with empty usercode is skipped (partially populated cache)."""
+    """
+    Test that async_internal_clear_usercode drives the base drop-credential lifecycle.
+
+    With supports_native_users=True, the base class resolves the credential owner
+    from async_get_users, then calls async_delete_credential and (when the user has no
+    remaining credentials) async_delete_user.
+    """
     lcm_entry = MockConfigEntry(
         domain=DOMAIN,
         data={
             CONF_LOCKS: [zwave_js_lock.lock.entity_id],
-            CONF_SLOTS: {"2": {}, "3": {}},
+            CONF_SLOTS: {"1": {}},
         },
     )
     lcm_entry.add_to_hass(hass)
 
-    # Slot 2: in_use=True but empty usercode (cache not populated yet)
-    # Slot 3: normal code
-    slots = [
-        {"code_slot": 2, "usercode": "", "in_use": True},
-        {"code_slot": 3, "usercode": "5678", "in_use": True},
+    zwave_js_lock._min_operation_delay = 0.0
+    # Seed the lock with one user owning one PIN at slot 1
+    mock_access_control.get_users_cached.return_value = [
+        UserData(
+            user_id=1,
+            active=True,
+            user_type=UserCredentialUserType.GENERAL,
+            user_name="alice",
+        ),
+    ]
+    mock_access_control.get_all_credentials_cached.return_value = [
+        CredentialData(
+            user_id=1,
+            type=UserCredentialType.PIN_CODE,
+            slot=1,
+            data="5678",
+        ),
     ]
 
-    with patch.object(zwave_js_lock, "_get_usercodes_from_cache", return_value=slots):
-        codes = await zwave_js_lock.async_get_usercodes()
+    await zwave_js_lock.async_internal_clear_usercode(1, source="sync")
 
-        # Slot 2 should be skipped (not in result)
-        assert 2 not in codes
-        # Slot 3 should have its code
-        assert codes[3] == SlotCredential.known("5678")
-
-
-# code_slot_in_use tests
-
-
-@pytest.mark.parametrize(
-    ("mock_config", "expected"),
-    [
-        ({"return_value": {"in_use": True, "usercode": "1234"}}, True),
-        ({"return_value": {"in_use": False, "usercode": ""}}, False),
-        ({"side_effect": KeyError("slot not found")}, None),
-        ({"side_effect": ValueError("invalid slot")}, None),
-    ],
-)
-async def test_code_slot_in_use(
-    zwave_js_lock: ZWaveJSLock,
-    mock_config: dict,
-    expected: bool | None,
-) -> None:
-    """Test code_slot_in_use for various return values and exceptions."""
-    with patch(
-        f"{_PROVIDER_MODULE}.get_usercode",
-        **mock_config,
-    ):
-        assert zwave_js_lock.code_slot_in_use(1) is expected
+    mock_lock_helpers["async_delete_credential"].assert_called_once()
+    # The user had exactly one credential so it should be deleted too
+    mock_lock_helpers["async_delete_user"].assert_called_once_with(
+        zwave_js_lock.node, 1
+    )
 
 
 # Device availability tests

--- a/tests/providers/zwave_js/test_provider.py
+++ b/tests/providers/zwave_js/test_provider.py
@@ -751,6 +751,13 @@ async def test_async_get_users_maps_users_and_pin_credentials(
             user_type=UserCredentialUserType.GENERAL,
             user_name=None,
         ),
+        # User with no credentials at all -> projects to an empty list.
+        UserData(
+            user_id=3,
+            active=True,
+            user_type=UserCredentialUserType.GENERAL,
+            user_name="carol",
+        ),
     ]
     mock_access_control.get_all_credentials_cached.return_value = [
         CredentialData(
@@ -776,7 +783,9 @@ async def test_async_get_users_maps_users_and_pin_credentials(
 
     users = await zwave_js_lock.async_get_users()
 
-    assert len(users) == 2
+    assert len(users) == 3
+    user3 = next(u for u in users if u.user_id == 3)
+    assert user3.credentials == []
 
     user1 = next(u for u in users if u.user_id == 1)
     assert user1.name == "alice"

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -174,6 +174,34 @@ class TestUser:
         user = User(user_id=3, credentials=[pin, rfid])
         assert user.pin_credentials == [pin]
 
+    def test_credentials_of_type_filters_generically(self) -> None:
+        pin = Credential(
+            type=CredentialType.PIN, slot=1, state=SlotCredential.known("1234")
+        )
+        password = Credential(
+            type=CredentialType.PASSWORD, slot=2, state=SlotCredential.known("hunter2")
+        )
+        rfid = Credential(
+            type=CredentialType.RFID, slot=3, state=SlotCredential.unreadable()
+        )
+        user = User(user_id=3, credentials=[pin, password, rfid])
+        assert user.credentials_of_type(CredentialType.PIN) == [pin]
+        assert user.credentials_of_type(CredentialType.PASSWORD) == [password]
+        assert user.credentials_of_type(CredentialType.RFID) == [rfid]
+        # An unrepresented credential type returns an empty list, not None.
+        assert user.credentials_of_type(CredentialType.NFC) == []
+
+    def test_pin_credentials_delegates_to_credentials_of_type(self) -> None:
+        """pin_credentials is the Personal Identification Number flavor of the generic accessor."""
+        pin = Credential(
+            type=CredentialType.PIN, slot=3, state=SlotCredential.known("1234")
+        )
+        password = Credential(
+            type=CredentialType.PASSWORD, slot=4, state=SlotCredential.known("pwd")
+        )
+        user = User(user_id=3, credentials=[pin, password])
+        assert user.pin_credentials == user.credentials_of_type(CredentialType.PIN)
+
     def test_credential_for_returns_first_match_or_none(self) -> None:
         empty_pin = Credential(
             type=CredentialType.PIN, slot=3, state=SlotCredential.empty()


### PR DESCRIPTION
## Proposed change

Migrates the Z-Wave JS lock provider off the legacy User Code Command Class path onto Home Assistant's unified credential API (`node.access_control` + `homeassistant.components.zwave_js.lock_helpers`), implementing the `BaseLock` credential primitives introduced in #1225, and **hoists all capability-derived decisions into BaseLock** so future providers and credential types are additive. This is PR 4 of the credential-management refactor (PR 3 = #1225, the seam).

The Z-Wave provider now:
- Sets `supports_native_users = True` and implements `async_set_user` / `async_delete_user` / `async_set_credential` / `async_delete_credential` / `async_get_users` / `async_get_capabilities`, and **drops its `async_set_usercode` / `async_clear_usercode` / `async_get_usercodes` overrides** — the base orchestration from #1225 now drives set/clear/get.
- **Reads PIN values directly from `node.access_control`** (`get_users_cached()` + `get_all_credentials_cached()`), so codes read back as `known(pin)` when the lock returns them. This gives the sync loop a fixed point (`actual == desired` → no-op) so it no longer re-writes every managed slot on each restart. Writes and capability queries go through `lock_helpers`.
- **Transparently supports both User Credential CC AND User Code CC** — node-zwave-js v15.23.4+ exposes the `accessControl` API for both, dispatching CC differences inside the driver. The base orchestration gates the user-record write on `capabilities.supports_user_management AND max_user_name_length > 0`: User Credential CC locks (700/800-series) take the set-user-first lifecycle, User Code CC locks (500-series) skip the user write since the user IS the code. **No regression for 500-series users.**
- **Stores every credential type the domain represents** (PIN, RFID, NFC, password, face, fingerprint) from a single `async_get_users` read; the base class's `_project_users_to_slots(credential_type)` filters per type at the seam. Sets up multi-type expansion (password) as additive without provider changes.
- **Duplicate detection** uses the lock's typed `credential_rejected_duplicate` result (mapped to `DuplicateCodeError`), replacing the brittle `NEW_USER_CODE_NOT_ADDED_DUE_TO_DUPLICATE_CODE` notification-sniffing.
- **Push** moves from User Code CC value events to the access-control credential node events (`credential added` / `modified` / `deleted`); lock/unlock **operation** notifications still drive the code-slot events. A 1-hour `hard_refresh_interval` backstops missed events.
- **Provider primitives become pure writes** — `async_set_user` writes `user.name` verbatim (truncation in base), `async_set_credential` / `async_delete_credential` no longer assert credential type (asserted in base). Net negative LOC in the provider.

`hacs.json` already requires HA 2026.6.0 (#1221), where `lock_helpers` shipped — no version bump needed. The unified `accessControl` API requires zwave-js 15.23.4+, satisfied by HA 2026.6.0.

## Base orchestration additions (the hoists)

This PR adds the following to `BaseLock` / domain so providers stop repeating themselves and password expansion is additive:

- `LockCapabilities.max_user_name_length: int = 0` — backward-compatible new field.
- `BaseLock._capabilities_cache` + `_get_cached_capabilities()` — single source of truth for capability reads, per-provider-instance.
- `BaseLock._supports_user_records()` — capability-derived gate `supports_user_management AND max_user_name_length > 0`. Used by `_put_credential` to decide whether to call `async_set_user`.
- `BaseLock._truncate_user_name(name)` — capability-aware name truncation. Called by `_put_credential` BEFORE `async_set_user`, so providers receive pre-shaped names and write verbatim.
- `BaseLock._assert_credential_type_supported(credential)` / `_assert_credential_ref_supported(ref)` — capability-driven type guards. Called by `_put_credential` / `_drop_credential` before any provider primitive, so providers don't repeat the check and adoption of new credential types (PASSWORD, etc.) is additive.
- `BaseLock._project_users_to_slots(credential_type)` — type-parametric projection; `async_get_usercodes` is now a thin PIN-shaped wrapper.
- `User.credentials_of_type(type)` — generic per-type accessor; `pin_credentials` delegates to it.
- `BaseLock.async_setup_internal` — validates `supports_user_management` + PIN credential support for native-user providers before delegating to the provider's `async_setup`. Unmanageable locks fail setup with a typed `LockCodeManagerProviderError`.
- `BaseLock.async_get_capabilities` default raises `ProviderNotImplementedError`; native-user providers must override.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- Net `−511` lines in the provider plus net negative LOC from the hoists themselves; the legacy User Code CC code, V1 post-write verification, duplicate-notification sniffing, the provider-side `_max_user_name_length` field, the inline PIN-type guards, and the provider-side setup probe are all removed.
- Z-Wave PIN reads are now `known` (readable) again via the direct access-control read path — an explicit design choice (vs the helper, which withholds data) so the sync loop has a fixed point and avoids re-writing slots on restart.
- Default `LockCapabilities.max_user_name_length=0` keeps existing constructors backward-compatible.
- TODO.md additions cover the follow-up work the base class is now ready for: sync-state expansion to include user name + every managed credential type, LCD capability aggregation across multiple locks in a config entry, and the password-credential expansion + Option B entity/slot-mapping decision.
- Test suite rewritten onto the unified API (mocked `lock_helpers` + `node.access_control`); covers readable/unreadable projection, capability mapping, created-vs-updated user derivation, typed duplicate → `DuplicateCodeError`, transient failure → `LockDisconnected`, credential-event push (incl. value-carrying events), partial-subscription cleanup, capability-cache retry-after-failure, transparent User Code CC routing through the base gate, parametric per-type projection, the base assertion / truncation / setup-validation helpers across their accept/reject matrices, end-to-end name truncation through the seam, and a full LCM e2e lifecycle. Full suite: 1042 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)