### PR TITLE
refactor(providers): migrate slot-only providers onto credential primitives

### DIFF
--- a/custom_components/lock_code_manager/providers/akuvox.py
+++ b/custom_components/lock_code_manager/providers/akuvox.py
@@ -20,6 +20,7 @@ from typing import Any, Literal
 
 from homeassistant.config_entries import ConfigEntry
 
+from ..domain.credentials import Credential, CredentialRef, User, user_from_slot
 from ..domain.exceptions import (
     LockCodeManagerProviderError,
     LockDisconnected,
@@ -284,25 +285,24 @@ class AkuvoxLock(BaseLock):
                 "will be retried on reconnect"
             ) from first_disconnect
 
-    async def async_get_usercodes(self) -> dict[int, SlotCredential]:
+    async def async_get_users(self) -> list[User]:
         """
-        Get dictionary of code slots and usercodes.
+        Return users by reading tagged local users from the Akuvox device.
 
-        Users already bearing a ``[LCM:<slot>]`` tag in their name are
-        mapped to the embedded slot number. Only reads and classifies;
-        auto-tagging of unmanaged users is handled separately by
-        ``_async_tag_unmanaged_users()``.
-
-        Only codes whose slot numbers fall within the managed set are returned.
+        Users bearing a ``[LCM:<slot>]`` tag in their name are mapped to the
+        embedded slot number. Only reads and classifies; auto-tagging of
+        unmanaged users is handled separately by ``_async_tag_unmanaged_users()``.
+        Only users whose slot numbers fall within the managed set are returned.
+        Personal Identification Numbers are readable on Akuvox, so occupied
+        slots report the actual value.
         """
         managed_slots = self.managed_slots
         if not managed_slots:
-            return {}
+            return []
 
         users = await self._async_list_users()
 
-        # Start with all managed slots empty
-        result: dict[int, SlotCredential] = dict.fromkeys(
+        slot_states: dict[int, SlotCredential] = dict.fromkeys(
             managed_slots, SlotCredential.empty()
         )
 
@@ -314,7 +314,7 @@ class AkuvoxLock(BaseLock):
             slot_num, _ = _parse_tag(name)
 
             if slot_num is not None and slot_num in managed_slots:
-                result[slot_num] = (
+                slot_states[slot_num] = (
                     SlotCredential.known(pin) if pin else SlotCredential.empty()
                 )
 
@@ -322,30 +322,34 @@ class AkuvoxLock(BaseLock):
             "Lock %s: %s managed slots, %s occupied",
             self.lock.entity_id,
             len(managed_slots),
-            sum(1 for v in result.values() if v.is_present),
+            sum(1 for v in slot_states.values() if v.is_present),
         )
-        return result
+        return [user_from_slot(slot, state) for slot, state in slot_states.items()]
 
-    async def async_set_usercode(
+    async def async_set_credential(
         self,
-        code_slot: int,
-        usercode: str,
-        name: str | None = None,
-        source: Literal["sync", "direct"] = "direct",
+        user_id: int,
+        credential: Credential,
+        *,
+        name: str | None,
+        source: Literal["sync", "direct"],
     ) -> bool:
         """
-        Set user code on a virtual slot.
+        Set a Personal Identification Number credential on a slot.
 
-        If a user already exists for the given slot, the PIN (and
-        optionally the name) is updated via ``modify_user``. Otherwise
-        a new user is created via ``add_user``.
+        If a user already exists for the given slot, the Personal
+        Identification Number (and optionally the name) is updated via
+        ``modify_user``. Otherwise a new user is created via ``add_user``.
 
         Returns True unconditionally because the Akuvox API does not
         indicate whether the value actually changed. The list/modify
         (or list/add) sequence runs under the sequence lock so concurrent
         callers cannot interleave their own multi-step writes against the
-        same slot.
+        same slot. Ignores ``user_id``; slot-only providers address the
+        credential by slot.
         """
+        code_slot = credential.slot
+        usercode = credential.readable_pin or ""
         async with self._serialize_sequence():
             users = await self._async_list_users()
 
@@ -378,14 +382,15 @@ class AkuvoxLock(BaseLock):
         )
         return True
 
-    async def async_clear_usercode(self, code_slot: int) -> bool:
+    async def async_delete_credential(self, ref: CredentialRef) -> bool:
         """
-        Clear user code from a virtual slot by deleting the user.
+        Delete the credential addressed by ``ref``; return whether it changed.
 
         Returns True if a user was deleted, False if the slot was already
         empty. The list/delete sequence runs under the sequence lock for
-        the same reason ``async_set_usercode`` does.
+        the same reason ``async_set_credential`` does.
         """
+        code_slot = ref.slot
         async with self._serialize_sequence():
             users = await self._async_list_users()
             target_device_id: str | None = None

--- a/custom_components/lock_code_manager/providers/akuvox.py
+++ b/custom_components/lock_code_manager/providers/akuvox.py
@@ -376,7 +376,7 @@ class AkuvoxLock(BaseLock):
                 await self._async_add_user(tagged_name, usercode)
 
         LOGGER.debug(
-            "Lock %s: set usercode on slot %s",
+            "Lock %s: set Personal Identification Number credential on slot %s",
             self.lock.entity_id,
             code_slot,
         )
@@ -407,7 +407,7 @@ class AkuvoxLock(BaseLock):
 
             await self._async_delete_user(target_device_id)
         LOGGER.debug(
-            "Lock %s: cleared usercode from slot %s",
+            "Lock %s: deleted Personal Identification Number credential on slot %s",
             self.lock.entity_id,
             code_slot,
         )

--- a/custom_components/lock_code_manager/providers/schlage.py
+++ b/custom_components/lock_code_manager/providers/schlage.py
@@ -26,6 +26,7 @@ from typing import Literal
 
 from homeassistant.config_entries import ConfigEntry
 
+from ..domain.credentials import Credential, CredentialRef, User, user_from_slot
 from ..domain.exceptions import (
     LockCodeManagerProviderError,
     LockDisconnected,
@@ -287,20 +288,20 @@ class SchlageLock(BaseLock):
                 "will be retried on reconnect"
             ) from first_disconnect
 
-    async def async_get_usercodes(self) -> dict[int, SlotCredential]:
+    async def async_get_users(self) -> list[User]:
         """
-        Get dictionary of code slots and usercodes.
+        Return users by reading all tagged codes from the Schlage lock.
 
-        Schlage PINs are write-only (returned as masked values), so occupied
-        slots return ``SlotCredential.unreadable()`` and cleared slots return
-        ``SlotCredential.empty()``.
-
-        This method only reads and classifies codes; auto-tagging of unmanaged
-        codes is handled by ``_async_tag_unmanaged_codes()``.
+        Schlage Personal Identification Numbers are write-only (returned as
+        masked values by ``get_codes``), so occupied slots surface as
+        ``SlotCredential.unreadable()`` users and empty managed slots surface
+        as ``SlotCredential.empty()`` users. Only codes whose slot numbers
+        fall within the managed set are returned. Auto-tagging of unmanaged
+        codes is handled separately by ``_async_tag_unmanaged_codes()``.
         """
         managed_slots = self.managed_slots
         if not managed_slots:
-            return {}
+            return []
 
         codes = await self._async_get_codes()
 
@@ -337,7 +338,7 @@ class SchlageLock(BaseLock):
             seen_slots.add(slot_num)
             occupied_slots.add(slot_num)
 
-        return {
+        slot_states = {
             slot: (
                 SlotCredential.unreadable()
                 if slot in occupied_slots
@@ -345,24 +346,29 @@ class SchlageLock(BaseLock):
             )
             for slot in managed_slots
         }
+        return [user_from_slot(slot, state) for slot, state in slot_states.items()]
 
-    async def async_set_usercode(
+    async def async_set_credential(
         self,
-        code_slot: int,
-        usercode: str,
-        name: str | None = None,
-        source: Literal["sync", "direct"] = "direct",
+        user_id: int,
+        credential: Credential,
+        *,
+        name: str | None,
+        source: Literal["sync", "direct"],
     ) -> bool:
         """
-        Set user code on a virtual slot.
+        Set a Personal Identification Number credential on a slot.
 
         If a code already exists for the given slot it is replaced.
-        Returns True unconditionally because Schlage PINs are write-only
-        and we cannot determine whether the value actually changed. The
-        get/delete/add sequence runs under the sequence lock so concurrent
-        sync ticks cannot interleave their own multi-step writes against
-        the same slot.
+        Returns True unconditionally because Schlage Personal Identification
+        Numbers are write-only and we cannot determine whether the value
+        actually changed. The get/delete/add sequence runs under the sequence
+        lock so concurrent sync ticks cannot interleave their own multi-step
+        writes against the same slot. Ignores ``user_id``; slot-only providers
+        address the credential by slot.
         """
+        code_slot = credential.slot
+        usercode = credential.readable_pin or ""
         async with self._serialize_sequence():
             codes = await self._async_get_codes()
 
@@ -393,10 +399,10 @@ class SchlageLock(BaseLock):
                 await self._async_add_code(tagged_name, usercode)
             except (LockDisconnected, LockOperationFailed) as err:
                 # Schlage's cloud API has eventual consistency: a delete may not
-                # propagate before the add, causing "already exists".  Since PINs
-                # are write-only we can't verify the value, but the code IS on the
-                # lock — treat it as success so _last_set_pin gets recorded and the
-                # sync manager doesn't loop.
+                # propagate before the add, causing "already exists".  Since Personal
+                # Identification Numbers are write-only we can't verify the value,
+                # but the code IS on the lock — treat it as success so the sync
+                # manager doesn't loop.
                 if "already exists" not in str(err).lower():
                     raise
 
@@ -414,14 +420,16 @@ class SchlageLock(BaseLock):
         )
         return True
 
-    async def async_clear_usercode(self, code_slot: int) -> bool:
+    async def async_delete_credential(self, ref: CredentialRef) -> bool:
         """
-        Clear user code from a virtual slot.
+        Delete the credential addressed by ``ref``; return whether it changed.
 
         Returns True if a code was deleted, False if the slot was already
-        empty. The get/delete sequence runs under the sequence lock for
-        the same reason ``async_set_usercode`` does.
+        empty. The get/delete sequence runs under the sequence lock so
+        concurrent callers cannot interleave their own multi-step reads
+        against the same slot.
         """
+        code_slot = ref.slot
         async with self._serialize_sequence():
             codes = await self._async_get_codes()
             target_name: str | None = None

--- a/custom_components/lock_code_manager/providers/schlage.py
+++ b/custom_components/lock_code_manager/providers/schlage.py
@@ -414,7 +414,7 @@ class SchlageLock(BaseLock):
                 )
 
         LOGGER.debug(
-            "Lock %s: set usercode on slot %s",
+            "Lock %s: set Personal Identification Number credential on slot %s",
             self.lock.entity_id,
             code_slot,
         )
@@ -450,7 +450,7 @@ class SchlageLock(BaseLock):
             await self._async_delete_code(target_name)
 
         LOGGER.debug(
-            "Lock %s: cleared usercode from slot %s",
+            "Lock %s: deleted Personal Identification Number credential on slot %s",
             self.lock.entity_id,
             code_slot,
         )

--- a/custom_components/lock_code_manager/providers/virtual.py
+++ b/custom_components/lock_code_manager/providers/virtual.py
@@ -10,6 +10,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.storage import Store
 
 from ..const import DOMAIN
+from ..domain.credentials import Credential, CredentialRef, User, user_from_slot
 from ..domain.models import SlotCredential
 from ._base import BaseLock
 from ._util import parse_slot_num
@@ -64,44 +65,48 @@ class VirtualLock(BaseLock):
         self._data = data if (data := await self._store.async_load()) else {}
         return await self.async_get_usercodes()
 
-    async def async_set_usercode(
+    async def async_set_credential(
         self,
-        code_slot: int,
-        usercode: str,
-        name: str | None = None,
-        source: Literal["sync", "direct"] = "direct",
+        user_id: int,
+        credential: Credential,
+        *,
+        name: str | None,
+        source: Literal["sync", "direct"],
     ) -> bool:
         """
-        Set a usercode on a code slot.
+        Set a Personal Identification Number credential on a code slot.
 
         Returns True if the value was changed, False if already set to this value.
+        Ignores ``user_id``; slot-only providers address the credential by slot.
         """
-        slot_key = str(code_slot)
-        new_data = CodeSlotData(code=usercode, name=name)
+        slot_key = str(credential.slot)
+        new_data = CodeSlotData(code=credential.readable_pin or "", name=name)
         if slot_key in self._data and self._data[slot_key] == new_data:
             return False
         self._data[slot_key] = new_data
         return True
 
-    async def async_clear_usercode(self, code_slot: int) -> bool:
+    async def async_delete_credential(self, ref: CredentialRef) -> bool:
         """
-        Clear a usercode on a code slot.
+        Delete the credential addressed by ``ref``; return whether it changed.
 
-        Returns True if the value was changed, False if already cleared.
+        Returns True if a code was removed, False if the slot was already empty.
         """
-        slot_key = str(code_slot)
+        slot_key = str(ref.slot)
         if slot_key not in self._data:
             return False
         self._data.pop(slot_key)
         return True
 
-    async def async_get_usercodes(self) -> dict[int, SlotCredential]:
+    async def async_get_users(self) -> list[User]:
         """
-        Get dictionary of code slots and usercodes.
+        Return users by reading all stored and managed slots.
 
-        Returns all slots with data plus managed empty slots. Unmanaged
-        occupied slots are included so callers like the lock reset config
-        flow step can detect codes not managed by Lock Code Manager.
+        Returns occupied slots as known-Personal-Identification-Number users
+        and managed empty slots as empty users so the base projection can
+        surface them. Unmanaged occupied slots are also included so callers
+        like the lock-reset config flow step can detect codes not managed
+        by Lock Code Manager.
         """
         managed_slots = self.managed_slots
         stored_slots = set()
@@ -116,11 +121,13 @@ class VirtualLock(BaseLock):
                 continue
             stored_slots.add(slot_num)
         all_slots = managed_slots | stored_slots
-        data: dict[int, SlotCredential] = {}
+        slot_states: dict[int, SlotCredential] = {}
         for slot_num in all_slots:
             slot_key = str(slot_num)
             if slot_key in self._data:
-                data[slot_num] = SlotCredential.known(str(self._data[slot_key]["code"]))
+                slot_states[slot_num] = SlotCredential.known(
+                    str(self._data[slot_key]["code"])
+                )
             else:
-                data[slot_num] = SlotCredential.empty()
-        return data
+                slot_states[slot_num] = SlotCredential.empty()
+        return [user_from_slot(slot, state) for slot, state in slot_states.items()]

--- a/custom_components/lock_code_manager/providers/zha.py
+++ b/custom_components/lock_code_manager/providers/zha.py
@@ -24,6 +24,7 @@ from homeassistant.components.zha.helpers import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import callback
 
+from ..domain.credentials import Credential, CredentialRef, User, user_from_slot
 from ..domain.exceptions import CodeRejectedError, LockDisconnected
 from ..domain.models import SlotCredential
 from ._base import BaseLock
@@ -217,51 +218,18 @@ class ZHALock(BaseLock):
             return False
         return device_proxy.device.available
 
-    # -- Usercode operations -------------------------------------------------
+    # -- Credential primitives -----------------------------------------------
 
-    async def async_get_usercodes(self) -> dict[int, SlotCredential]:
-        """Read PIN codes from all managed slots."""
-        cluster = await self._get_connected_cluster()
-        managed = self.managed_slots
-        if not managed:
-            return {}
-
-        data: dict[int, SlotCredential] = {}
-        for slot_num in managed:
-            try:
-                result = await cluster.get_pin_code(slot_num)
-                _LOGGER.debug(
-                    "Lock %s slot %s get_pin_code: %s",
-                    self.lock.entity_id,
-                    slot_num,
-                    result,
-                )
-                user_status, pin_code = self._parse_pin_response(result)
-                if user_status == DoorLock.UserStatus.Enabled and pin_code:
-                    data[slot_num] = SlotCredential.known(pin_code)
-                else:
-                    data[slot_num] = SlotCredential.empty()
-            except LockDisconnected:
-                raise
-            except Exception:
-                _LOGGER.debug(
-                    "Lock %s: failed to read slot %s, marking unreadable",
-                    self.lock.entity_id,
-                    slot_num,
-                    exc_info=True,
-                )
-                data[slot_num] = SlotCredential.unreadable()
-        return data
-
-    async def async_set_usercode(
+    async def async_set_credential(
         self,
-        code_slot: int,
-        usercode: str,
-        name: str | None = None,
-        source: Literal["sync", "direct"] = "direct",
+        user_id: int,
+        credential: Credential,
+        *,
+        name: str | None,
+        source: Literal["sync", "direct"],
     ) -> bool:
         """
-        Set a PIN code on a slot.
+        Set a Personal Identification Number credential on a slot.
 
         Bypasses ``async_call_service`` because ZHA exposes its cluster
         operations as zigpy method calls rather than Home Assistant
@@ -270,7 +238,12 @@ class ZHALock(BaseLock):
         failure — these are routed to ``LockDisconnected`` so retries
         and reconnect handling apply, mirroring the OSError branch of
         the service-call wrapper.
+
+        ``user_id`` is ignored; slot-only providers address the credential
+        by ``credential.slot``.
         """
+        code_slot = credential.slot
+        usercode = credential.readable_pin or ""
         cluster = await self._get_connected_cluster()
         try:
             result = await cluster.set_pin_code(
@@ -296,13 +269,14 @@ class ZHALock(BaseLock):
         self._push_credential_update(code_slot, SlotCredential.known(usercode))
         return True
 
-    async def async_clear_usercode(self, code_slot: int) -> bool:
+    async def async_delete_credential(self, ref: CredentialRef) -> bool:
         """
-        Clear a PIN code from a slot.
+        Clear a Personal Identification Number from a slot.
 
-        See ``async_set_usercode`` for why bare zigpy failures route to
+        See ``async_set_credential`` for why bare zigpy failures route to
         ``LockDisconnected`` instead of ``LockOperationFailed``.
         """
+        code_slot = ref.slot
         cluster = await self._get_connected_cluster()
         try:
             result = await cluster.clear_pin_code(code_slot)
@@ -322,6 +296,47 @@ class ZHALock(BaseLock):
             )
         self._push_credential_update(code_slot, SlotCredential.empty())
         return True
+
+    async def async_get_users(self) -> list[User]:
+        """
+        Read Personal Identification Number codes from all managed slots.
+
+        Returns a user per slot via the one-slot-one-user projection.
+        Known codes surface as occupied users; failed reads produce
+        unreadable credentials so the coordinator does not treat a
+        transient cluster error as a confirmed-empty slot.
+        """
+        cluster = await self._get_connected_cluster()
+        managed = self.managed_slots
+        if not managed:
+            return []
+
+        slot_states: dict[int, SlotCredential] = {}
+        for slot_num in managed:
+            try:
+                result = await cluster.get_pin_code(slot_num)
+                _LOGGER.debug(
+                    "Lock %s slot %s get_pin_code: %s",
+                    self.lock.entity_id,
+                    slot_num,
+                    result,
+                )
+                user_status, pin_code = self._parse_pin_response(result)
+                if user_status == DoorLock.UserStatus.Enabled and pin_code:
+                    slot_states[slot_num] = SlotCredential.known(pin_code)
+                else:
+                    slot_states[slot_num] = SlotCredential.empty()
+            except LockDisconnected:
+                raise
+            except Exception:
+                _LOGGER.debug(
+                    "Lock %s: failed to read slot %s, marking unreadable",
+                    self.lock.entity_id,
+                    slot_num,
+                    exc_info=True,
+                )
+                slot_states[slot_num] = SlotCredential.unreadable()
+        return [user_from_slot(slot, state) for slot, state in slot_states.items()]
 
     async def async_hard_refresh_codes(self) -> dict[int, SlotCredential]:
         """Re-read all codes from the lock (no cache to invalidate)."""

--- a/custom_components/lock_code_manager/providers/zigbee2mqtt.py
+++ b/custom_components/lock_code_manager/providers/zigbee2mqtt.py
@@ -19,6 +19,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
 
+from ..domain.credentials import Credential, CredentialRef, User, user_from_slot
 from ..domain.exceptions import LockDisconnected, LockOperationFailed
 from ..domain.models import SlotCredential
 from ._base import BaseLock
@@ -402,93 +403,25 @@ class Zigbee2MQTTLock(BaseLock):
                 future.cancel()
         self._pending_codes.clear()
 
-    async def async_get_usercodes(self) -> dict[int, SlotCredential]:
-        """Get dictionary of code slots and usercodes."""
-        if not mqtt_config_entry_enabled(self.hass):
-            raise LockDisconnected("MQTT component not available")
-
-        if not await self.async_is_integration_connected():
-            self._maybe_raise_wrong_bridge_disconnect()
-            raise LockDisconnected("Lock not connected")
-
-        if not await self.async_is_device_available():
-            raise LockDisconnected("Device not available")
-
-        get_topic = self._get_topic("get")
-        if not get_topic:
-            raise LockDisconnected("Could not determine MQTT topic")
-
-        # Get configured code slots for this lock (any LCM entry that includes this lock).
-        code_slots = self.managed_slots
-
-        if not code_slots:
-            return {}
-
-        loop = asyncio.get_running_loop()
-        data: dict[int, SlotCredential] = {}
-
-        # Query one slot at a time so Zigbee2MQTT / firmware can answer each GET before
-        # the next. Parallel gathers plus per-slot timeouts used to raise and fail the
-        # entire refresh, leaving coordinator.data empty — sync then skips every slot
-        # (see SlotSyncManager._resolve_slot_state).
-        # Transient publish/timeout/read failures use the unreadable credential so sync
-        # does not treat the slot as confirmed-empty and storm reprogramming after MQTT
-        # recovery.
-        for slot_num in sorted(code_slots):
-            future = loop.create_future()
-            self._pending_codes[slot_num] = future
-            payload = json.dumps({"pin_code": {"user": slot_num}})
-            try:
-                await async_publish(self.hass, get_topic, payload)
-            except (HomeAssistantError, OSError) as err:
-                LOGGER.debug(
-                    "MQTT publish failed for PIN get %s slot %s: %s",
-                    self.lock.entity_id,
-                    slot_num,
-                    err,
-                )
-                data[slot_num] = SlotCredential.unreadable()
-                self._pending_codes.pop(slot_num, None)
-                continue
-
-            try:
-                result = await asyncio.wait_for(future, timeout=10.0)
-            except TimeoutError:
-                LOGGER.debug(
-                    "Timeout waiting for PIN code response for %s slot %s",
-                    self.lock.entity_id,
-                    slot_num,
-                )
-                data[slot_num] = SlotCredential.unreadable()
-            except Exception as err:
-                # Broad catch is intentional: the future is resolved by the MQTT
-                # callback, and any exception from resolution (InvalidStateError,
-                # data processing errors) should not crash the entire refresh.
-                # CancelledError is BaseException in Python 3.11+ and propagates.
-                LOGGER.warning(
-                    "Unexpected error getting PIN for %s slot %s: %s",
-                    self.lock.entity_id,
-                    slot_num,
-                    err,
-                )
-                data[slot_num] = SlotCredential.unreadable()
-            else:
-                data[slot_num] = (
-                    SlotCredential.known(result) if result else SlotCredential.empty()
-                )
-            finally:
-                self._pending_codes.pop(slot_num, None)
-
-        return data
-
-    async def async_set_usercode(
+    async def async_set_credential(
         self,
-        code_slot: int,
-        usercode: str,
-        name: str | None = None,
-        source: Literal["sync", "direct"] = "direct",
+        user_id: int,
+        credential: Credential,
+        *,
+        name: str | None,
+        source: Literal["sync", "direct"],
     ) -> bool:
-        """Set a usercode on a code slot."""
+        """
+        Set a Personal Identification Number credential on a code slot.
+
+        Publishes a Zigbee2MQTT ``set`` payload and immediately pushes an
+        optimistic coordinator update (MQTT QoS 0 gives no delivery
+        guarantee; hard-refresh mitigates drift). ``user_id`` is ignored;
+        slot-only providers address the credential by ``credential.slot``.
+        """
+        code_slot = credential.slot
+        usercode = credential.readable_pin or ""
+
         if not mqtt_config_entry_enabled(self.hass):
             raise LockDisconnected("MQTT component not available")
 
@@ -543,8 +476,18 @@ class Zigbee2MQTTLock(BaseLock):
         self._push_credential_update(code_slot, SlotCredential.known(str(usercode)))
         return True
 
-    async def async_clear_usercode(self, code_slot: int) -> bool:
-        """Clear a usercode on a code slot."""
+    async def async_delete_credential(self, ref: CredentialRef) -> bool:
+        """
+        Clear a Personal Identification Number from a code slot.
+
+        Publishes a Zigbee2MQTT ``set`` payload with ``user_enabled=false``
+        and ``pin_code=null`` (many locks require both to fully clear the
+        slot) and immediately pushes an optimistic coordinator update.
+        See ``async_set_credential`` for the OSError-versus-HomeAssistantError
+        routing rationale.
+        """
+        code_slot = ref.slot
+
         if not mqtt_config_entry_enabled(self.hass):
             raise LockDisconnected("MQTT component not available")
 
@@ -572,7 +515,7 @@ class Zigbee2MQTTLock(BaseLock):
         try:
             await async_publish(self.hass, set_topic, payload)
         except OSError as err:
-            # See ``async_set_usercode`` for the OSError split rationale.
+            # See ``async_set_credential`` for the OSError split rationale.
             LOGGER.error(
                 "Failed to clear PIN for %s slot %s: %s",
                 self.lock.entity_id,
@@ -594,9 +537,96 @@ class Zigbee2MQTTLock(BaseLock):
             self.lock.entity_id,
             code_slot,
         )
-        # Same optimistic push as ``async_set_usercode``.
+        # Same optimistic push as ``async_set_credential``.
         self._push_credential_update(code_slot, SlotCredential.empty())
         return True
+
+    async def async_get_users(self) -> list[User]:
+        """
+        Read Personal Identification Number codes from all managed slots.
+
+        Queries Zigbee2MQTT one slot at a time over MQTT so the bridge can
+        respond to each GET before the next. Transient publish/timeout/read
+        failures produce an unreadable credential so the coordinator does
+        not treat a transient MQTT error as a confirmed-empty slot and storm
+        reprogramming after recovery.
+        """
+        if not mqtt_config_entry_enabled(self.hass):
+            raise LockDisconnected("MQTT component not available")
+
+        if not await self.async_is_integration_connected():
+            self._maybe_raise_wrong_bridge_disconnect()
+            raise LockDisconnected("Lock not connected")
+
+        if not await self.async_is_device_available():
+            raise LockDisconnected("Device not available")
+
+        get_topic = self._get_topic("get")
+        if not get_topic:
+            raise LockDisconnected("Could not determine MQTT topic")
+
+        # Get configured code slots for this lock (any LCM entry that includes this lock).
+        code_slots = self.managed_slots
+
+        if not code_slots:
+            return []
+
+        loop = asyncio.get_running_loop()
+        slot_states: dict[int, SlotCredential] = {}
+
+        # Query one slot at a time so Zigbee2MQTT / firmware can answer each GET before
+        # the next. Parallel gathers plus per-slot timeouts used to raise and fail the
+        # entire refresh, leaving coordinator.data empty — sync then skips every slot
+        # (see SlotSyncManager._resolve_slot_state).
+        # Transient publish/timeout/read failures use the unreadable credential so sync
+        # does not treat the slot as confirmed-empty and storm reprogramming after MQTT
+        # recovery.
+        for slot_num in sorted(code_slots):
+            future = loop.create_future()
+            self._pending_codes[slot_num] = future
+            payload = json.dumps({"pin_code": {"user": slot_num}})
+            try:
+                await async_publish(self.hass, get_topic, payload)
+            except (HomeAssistantError, OSError) as err:
+                LOGGER.debug(
+                    "MQTT publish failed for PIN get %s slot %s: %s",
+                    self.lock.entity_id,
+                    slot_num,
+                    err,
+                )
+                slot_states[slot_num] = SlotCredential.unreadable()
+                self._pending_codes.pop(slot_num, None)
+                continue
+
+            try:
+                result = await asyncio.wait_for(future, timeout=10.0)
+            except TimeoutError:
+                LOGGER.debug(
+                    "Timeout waiting for PIN code response for %s slot %s",
+                    self.lock.entity_id,
+                    slot_num,
+                )
+                slot_states[slot_num] = SlotCredential.unreadable()
+            except Exception as err:
+                # Broad catch is intentional: the future is resolved by the MQTT
+                # callback, and any exception from resolution (InvalidStateError,
+                # data processing errors) should not crash the entire refresh.
+                # CancelledError is BaseException in Python 3.11+ and propagates.
+                LOGGER.warning(
+                    "Unexpected error getting PIN for %s slot %s: %s",
+                    self.lock.entity_id,
+                    slot_num,
+                    err,
+                )
+                slot_states[slot_num] = SlotCredential.unreadable()
+            else:
+                slot_states[slot_num] = (
+                    SlotCredential.known(result) if result else SlotCredential.empty()
+                )
+            finally:
+                self._pending_codes.pop(slot_num, None)
+
+        return [user_from_slot(slot, state) for slot, state in slot_states.items()]
 
     async def async_hard_refresh_codes(self) -> dict[int, SlotCredential]:
         """Perform hard refresh and return all codes."""

--- a/tests/providers/akuvox/test_e2e.py
+++ b/tests/providers/akuvox/test_e2e.py
@@ -9,6 +9,11 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
+from custom_components.lock_code_manager.domain.credentials import (
+    CredentialRef,
+    CredentialType,
+    credential_from_slot,
+)
 from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers.akuvox import (
     AKUVOX_DOMAIN,
@@ -42,30 +47,35 @@ class TestFullSetupLifecycle:
         assert e2e_akuvox_lock.coordinator is not None
 
 
-class TestSetAndClearUsercodes:
+class TestSetAndClearCredentials:
     """Verify set/clear operations call the correct Akuvox services."""
 
-    async def test_set_usercode_new(
+    async def test_set_credential_new(
         self,
         hass: HomeAssistant,
         e2e_akuvox_lock: AkuvoxLock,
         akuvox_mock_services: dict[str, AsyncMock],
     ) -> None:
-        """Set a code on an empty slot and verify add_user service was called."""
+        """Set a credential on an empty slot and verify add_user service was called."""
         akuvox_mock_services["add_user"].reset_mock()
-        result = await e2e_akuvox_lock.async_set_usercode(1, "9999", "E2E Guest")
+        result = await e2e_akuvox_lock.async_set_credential(
+            1,
+            credential_from_slot(1, SlotCredential.known("9999")),
+            name="E2E Guest",
+            source="direct",
+        )
 
         assert result is True
         assert akuvox_mock_services["add_user"].call_count >= 1
 
-    async def test_set_usercode_existing(
+    async def test_set_credential_existing(
         self,
         hass: HomeAssistant,
         e2e_akuvox_lock: AkuvoxLock,
         akuvox_lock_entity: er.RegistryEntry,
         akuvox_mock_services: dict[str, AsyncMock],
     ) -> None:
-        """Set a code on an occupied slot and verify modify_user service was called."""
+        """Set a credential on an occupied slot and verify modify_user service was called."""
         entity_id = akuvox_lock_entity.entity_id
 
         # Override list_users to report an existing tagged user
@@ -81,19 +91,24 @@ class TestSetAndClearUsercodes:
         )
 
         akuvox_mock_services["modify_user"].reset_mock()
-        result = await e2e_akuvox_lock.async_set_usercode(1, "5678", "Updated")
+        result = await e2e_akuvox_lock.async_set_credential(
+            1,
+            credential_from_slot(1, SlotCredential.known("5678")),
+            name="Updated",
+            source="direct",
+        )
 
         assert result is True
         assert akuvox_mock_services["modify_user"].call_count >= 1
 
-    async def test_clear_usercode(
+    async def test_delete_credential(
         self,
         hass: HomeAssistant,
         e2e_akuvox_lock: AkuvoxLock,
         akuvox_lock_entity: er.RegistryEntry,
         akuvox_mock_services: dict[str, AsyncMock],
     ) -> None:
-        """Clear a code and verify delete_user service was called."""
+        """Delete a credential and verify delete_user service was called."""
         entity_id = akuvox_lock_entity.entity_id
 
         # Override list_users to report a tagged user to delete
@@ -109,16 +124,57 @@ class TestSetAndClearUsercodes:
         )
 
         akuvox_mock_services["delete_user"].reset_mock()
-        result = await e2e_akuvox_lock.async_clear_usercode(1)
+        result = await e2e_akuvox_lock.async_delete_credential(
+            CredentialRef(user_id=1, type=CredentialType.PIN, slot=1)
+        )
 
         assert result is True
         assert akuvox_mock_services["delete_user"].call_count >= 1
 
+    async def test_base_orchestration_set_credential(
+        self,
+        hass: HomeAssistant,
+        e2e_akuvox_lock: AkuvoxLock,
+        akuvox_mock_services: dict[str, AsyncMock],
+    ) -> None:
+        """Set via async_internal_set_usercode routes through base → async_set_credential."""
+        akuvox_mock_services["add_user"].reset_mock()
+        await e2e_akuvox_lock.async_internal_set_usercode(1, "9999", "E2E Guest")
 
-class TestGetUsercodes:
-    """Verify reading usercodes from the Akuvox lock."""
+        assert akuvox_mock_services["add_user"].call_count >= 1
 
-    async def test_get_usercodes_returns_codes(
+    async def test_base_orchestration_clear_credential(
+        self,
+        hass: HomeAssistant,
+        e2e_akuvox_lock: AkuvoxLock,
+        akuvox_lock_entity: er.RegistryEntry,
+        akuvox_mock_services: dict[str, AsyncMock],
+    ) -> None:
+        """Clear via async_internal_clear_usercode routes through base → async_delete_credential."""
+        entity_id = akuvox_lock_entity.entity_id
+
+        # Override list_users to report a tagged user to delete
+        akuvox_mock_services["list_users"] = AsyncMock(
+            return_value={
+                entity_id: {
+                    "users": [make_user("100", "[LCM:1] Guest", "1234")],
+                },
+            }
+        )
+        register_mock_service(
+            hass, AKUVOX_DOMAIN, "list_users", akuvox_mock_services["list_users"]
+        )
+
+        akuvox_mock_services["delete_user"].reset_mock()
+        await e2e_akuvox_lock.async_internal_clear_usercode(1)
+
+        assert akuvox_mock_services["delete_user"].call_count >= 1
+
+
+class TestGetUsers:
+    """Verify reading users (usercodes) from the Akuvox lock."""
+
+    async def test_get_users_returns_codes(
         self,
         hass: HomeAssistant,
         e2e_akuvox_lock: AkuvoxLock,
@@ -126,15 +182,42 @@ class TestGetUsercodes:
         akuvox_mock_services: dict[str, AsyncMock],
     ) -> None:
         """
-        Get usercodes returns mapped slot data from Akuvox.
+        async_get_users returns mapped slot data from Akuvox.
 
         After initial setup with empty users, both managed slots should
-        be EMPTY. When the mock reports a tagged user with a PIN on
-        slot 1, that slot should report the PIN value.
+        be EMPTY. When the mock reports a tagged user with a Personal
+        Identification Number on slot 1, that slot should report the PIN value.
         """
         entity_id = akuvox_lock_entity.entity_id
 
         # Override list_users to report a tagged user on slot 1
+        akuvox_mock_services["list_users"] = AsyncMock(
+            return_value={
+                entity_id: {
+                    "users": [make_user("100", "[LCM:1] Guest", "4321")],
+                },
+            }
+        )
+        register_mock_service(
+            hass, AKUVOX_DOMAIN, "list_users", akuvox_mock_services["list_users"]
+        )
+
+        users = await e2e_akuvox_lock.async_get_users()
+        user_map = {u.user_id: u for u in users}
+
+        assert user_map[1].pin_credentials[0].state == SlotCredential.known("4321")
+        assert user_map[2].pin_credentials[0].state is SlotCredential.empty()
+
+    async def test_get_usercodes_projection(
+        self,
+        hass: HomeAssistant,
+        e2e_akuvox_lock: AkuvoxLock,
+        akuvox_lock_entity: er.RegistryEntry,
+        akuvox_mock_services: dict[str, AsyncMock],
+    ) -> None:
+        """The base async_get_usercodes projection produces the same slot->SlotCredential dict."""
+        entity_id = akuvox_lock_entity.entity_id
+
         akuvox_mock_services["list_users"] = AsyncMock(
             return_value={
                 entity_id: {

--- a/tests/providers/akuvox/test_provider.py
+++ b/tests/providers/akuvox/test_provider.py
@@ -13,6 +13,12 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 
+from custom_components.lock_code_manager.domain.credentials import (
+    Credential,
+    CredentialRef,
+    CredentialType,
+    credential_from_slot,
+)
 from custom_components.lock_code_manager.domain.exceptions import (
     LockCodeManagerError,
     LockDisconnected,
@@ -32,6 +38,17 @@ from tests.providers.helpers import (
 )
 
 from .conftest import LOCK_ENTITY_ID, make_user
+
+
+def _pin_cred(slot: int, pin: str) -> Credential:
+    """Build a known-Personal-Identification-Number credential for a slot."""
+    return credential_from_slot(slot, SlotCredential.known(pin))
+
+
+def _cred_ref(slot: int) -> CredentialRef:
+    """Build a CredentialRef for a slot."""
+    return CredentialRef(user_id=slot, type=CredentialType.PIN, slot=slot)
+
 
 # ---------------------------------------------------------------------------
 # Helper function tests
@@ -143,20 +160,46 @@ class TestConnection(ServiceProviderConnectionTests):
 
 
 # ---------------------------------------------------------------------------
-# Get usercodes
+# async_get_users
 # ---------------------------------------------------------------------------
 
 
-class TestGetUsercodes:
-    """Tests for async_get_usercodes."""
+class TestGetUsers:
+    """Tests for async_get_users."""
 
-    async def test_get_usercodes_no_users(
+    async def test_get_users_no_users(
         self,
         hass: HomeAssistant,
         akuvox_lock: AkuvoxLock,
         lcm_config_entry: MockConfigEntry,
     ) -> None:
-        """Test get_usercodes when no users exist on the lock."""
+        """Test async_get_users when no users exist on the lock returns empty users for managed slots."""
+        mock_response = {LOCK_ENTITY_ID: {"users": []}}
+        handler = AsyncMock(return_value=mock_response)
+        register_mock_service(hass, AKUVOX_DOMAIN, "list_users", handler)
+
+        users = await akuvox_lock.async_get_users()
+        user_map = {u.user_id: u for u in users}
+
+        assert user_map[1].pin_credentials[0].state is SlotCredential.empty()
+        assert user_map[2].pin_credentials[0].state is SlotCredential.empty()
+
+    async def test_get_users_no_configured_slots(
+        self,
+        hass: HomeAssistant,
+        akuvox_lock: AkuvoxLock,
+    ) -> None:
+        """Test async_get_users returns empty list when no slots are configured."""
+        users = await akuvox_lock.async_get_users()
+        assert users == []
+
+    async def test_get_usercodes_base_projection_no_users(
+        self,
+        hass: HomeAssistant,
+        akuvox_lock: AkuvoxLock,
+        lcm_config_entry: MockConfigEntry,
+    ) -> None:
+        """Test async_get_usercodes base projection returns empty for managed slots with no users."""
         mock_response = {LOCK_ENTITY_ID: {"users": []}}
         handler = AsyncMock(return_value=mock_response)
         register_mock_service(hass, AKUVOX_DOMAIN, "list_users", handler)
@@ -171,17 +214,17 @@ class TestGetUsercodes:
         hass: HomeAssistant,
         akuvox_lock: AkuvoxLock,
     ) -> None:
-        """Test get_usercodes returns empty dict when no slots are configured."""
+        """Test async_get_usercodes returns empty dict when no slots are configured."""
         codes = await akuvox_lock.async_get_usercodes()
         assert codes == {}
 
-    async def test_get_usercodes_does_not_auto_tag(
+    async def test_get_users_does_not_auto_tag(
         self,
         hass: HomeAssistant,
         akuvox_lock: AkuvoxLock,
         lcm_config_entry: MockConfigEntry,
     ) -> None:
-        """Test that async_get_usercodes does not auto-tag untagged users."""
+        """Test that async_get_users does not auto-tag untagged users."""
         mock_response = {
             LOCK_ENTITY_ID: {
                 "users": [
@@ -192,13 +235,14 @@ class TestGetUsercodes:
         list_handler = AsyncMock(return_value=mock_response)
         register_mock_service(hass, AKUVOX_DOMAIN, "list_users", list_handler)
 
-        codes = await akuvox_lock.async_get_usercodes()
+        users = await akuvox_lock.async_get_users()
+        user_map = {u.user_id: u for u in users}
 
         # Untagged user should NOT appear in results (no auto-tagging)
-        assert codes[1] is SlotCredential.empty()
-        assert codes[2] is SlotCredential.empty()
+        assert user_map[1].pin_credentials[0].state is SlotCredential.empty()
+        assert user_map[2].pin_credentials[0].state is SlotCredential.empty()
 
-    async def test_get_usercodes_skips_cloud_users(
+    async def test_get_users_skips_cloud_users(
         self,
         hass: HomeAssistant,
         akuvox_lock: AkuvoxLock,
@@ -215,18 +259,19 @@ class TestGetUsercodes:
         handler = AsyncMock(return_value=mock_response)
         register_mock_service(hass, AKUVOX_DOMAIN, "list_users", handler)
 
-        codes = await akuvox_lock.async_get_usercodes()
+        users = await akuvox_lock.async_get_users()
+        user_map = {u.user_id: u for u in users}
 
-        assert codes[1] is SlotCredential.empty()
-        assert codes[2] is SlotCredential.empty()
+        assert user_map[1].pin_credentials[0].state is SlotCredential.empty()
+        assert user_map[2].pin_credentials[0].state is SlotCredential.empty()
 
-    async def test_get_usercodes_tagged_user_no_pin(
+    async def test_get_users_tagged_user_no_pin(
         self,
         hass: HomeAssistant,
         akuvox_lock: AkuvoxLock,
         lcm_config_entry: MockConfigEntry,
     ) -> None:
-        """Test that a tagged user with no PIN is reported as EMPTY."""
+        """Test that a tagged user with no Personal Identification Number is reported as EMPTY."""
         mock_response = {
             LOCK_ENTITY_ID: {
                 "users": [
@@ -237,11 +282,12 @@ class TestGetUsercodes:
         handler = AsyncMock(return_value=mock_response)
         register_mock_service(hass, AKUVOX_DOMAIN, "list_users", handler)
 
-        codes = await akuvox_lock.async_get_usercodes()
+        users = await akuvox_lock.async_get_users()
+        user_map = {u.user_id: u for u in users}
 
-        assert codes[1] is SlotCredential.empty()
+        assert user_map[1].pin_credentials[0].state is SlotCredential.empty()
 
-    async def test_get_usercodes_tagged_outside_managed_range(
+    async def test_get_users_tagged_outside_managed_range(
         self,
         hass: HomeAssistant,
         akuvox_lock: AkuvoxLock,
@@ -258,25 +304,50 @@ class TestGetUsercodes:
         handler = AsyncMock(return_value=mock_response)
         register_mock_service(hass, AKUVOX_DOMAIN, "list_users", handler)
 
-        codes = await akuvox_lock.async_get_usercodes()
+        users = await akuvox_lock.async_get_users()
+        user_ids = {u.user_id for u in users}
 
-        assert 99 not in codes
-        assert codes[1] is SlotCredential.empty()
-        assert codes[2] is SlotCredential.empty()
+        assert 99 not in user_ids
+        user_map = {u.user_id: u for u in users}
+        assert user_map[1].pin_credentials[0].state is SlotCredential.empty()
+        assert user_map[2].pin_credentials[0].state is SlotCredential.empty()
+
+    async def test_get_users_known_pin(
+        self,
+        hass: HomeAssistant,
+        akuvox_lock: AkuvoxLock,
+        lcm_config_entry: MockConfigEntry,
+    ) -> None:
+        """Test that a tagged user with a readable Personal Identification Number surfaces correctly."""
+        mock_response = {
+            LOCK_ENTITY_ID: {
+                "users": [
+                    make_user("100", "[LCM:1] Guest", "4321"),
+                ],
+            },
+        }
+        handler = AsyncMock(return_value=mock_response)
+        register_mock_service(hass, AKUVOX_DOMAIN, "list_users", handler)
+
+        users = await akuvox_lock.async_get_users()
+        user_map = {u.user_id: u for u in users}
+
+        assert user_map[1].pin_credentials[0].state == SlotCredential.known("4321")
+        assert user_map[2].pin_credentials[0].state is SlotCredential.empty()
 
 
 # ---------------------------------------------------------------------------
-# Set usercode
+# async_set_credential
 # ---------------------------------------------------------------------------
 
 
-class TestSetUsercode:
-    """Tests for async_set_usercode."""
+class TestSetCredential:
+    """Tests for async_set_credential."""
 
-    async def test_set_usercode_no_name_keeps_existing(
+    async def test_set_credential_no_name_keeps_existing(
         self, hass: HomeAssistant, akuvox_lock: AkuvoxLock
     ) -> None:
-        """Test setting a usercode without a name preserves the existing name."""
+        """Test setting a credential without a name preserves the existing name."""
         list_response = {
             LOCK_ENTITY_ID: {
                 "users": [
@@ -297,12 +368,14 @@ class TestSetUsercode:
             hass, AKUVOX_DOMAIN, "modify_user", AsyncMock(side_effect=_capture_modify)
         )
 
-        result = await akuvox_lock.async_set_usercode(1, "9999")
+        result = await akuvox_lock.async_set_credential(
+            1, _pin_cred(1, "9999"), name=None, source="direct"
+        )
 
         assert result is True
         assert modify_calls[0]["name"] == "[LCM:1] Guest"
 
-    async def test_set_usercode_service_failure(
+    async def test_set_credential_service_failure(
         self, hass: HomeAssistant, akuvox_lock: AkuvoxLock
     ) -> None:
         """Test that service failures raise LockOperationFailed."""
@@ -318,30 +391,32 @@ class TestSetUsercode:
         )
 
         with pytest.raises(LockOperationFailed, match="device offline"):
-            await akuvox_lock.async_set_usercode(1, "1234")
+            await akuvox_lock.async_set_credential(
+                1, _pin_cred(1, "1234"), name=None, source="direct"
+            )
 
 
 # ---------------------------------------------------------------------------
-# Clear usercode
+# async_delete_credential
 # ---------------------------------------------------------------------------
 
 
-class TestClearUsercode:
-    """Tests for async_clear_usercode."""
+class TestDeleteCredential:
+    """Tests for async_delete_credential."""
 
-    async def test_clear_usercode_already_empty(
+    async def test_delete_credential_already_empty(
         self, hass: HomeAssistant, akuvox_lock: AkuvoxLock
     ) -> None:
-        """Test clearing returns False when the slot has no user."""
+        """Test deleting returns False when the slot has no user."""
         list_response = {LOCK_ENTITY_ID: {"users": []}}
         register_mock_service(
             hass, AKUVOX_DOMAIN, "list_users", AsyncMock(return_value=list_response)
         )
 
-        result = await akuvox_lock.async_clear_usercode(1)
+        result = await akuvox_lock.async_delete_credential(_cred_ref(1))
         assert result is False
 
-    async def test_clear_usercode_service_failure(
+    async def test_delete_credential_service_failure(
         self, hass: HomeAssistant, akuvox_lock: AkuvoxLock
     ) -> None:
         """Test that service failures raise LockOperationFailed."""
@@ -363,7 +438,7 @@ class TestClearUsercode:
         )
 
         with pytest.raises(LockOperationFailed, match="device offline"):
-            await akuvox_lock.async_clear_usercode(1)
+            await akuvox_lock.async_delete_credential(_cred_ref(1))
 
 
 # ---------------------------------------------------------------------------
@@ -389,7 +464,7 @@ class TestListUsersErrors:
         )
 
         with pytest.raises(LockOperationFailed, match="connection lost"):
-            await akuvox_lock.async_get_usercodes()
+            await akuvox_lock.async_get_users()
 
     async def test_list_users_invalid_response(
         self,
@@ -413,7 +488,7 @@ class TestListUsersErrors:
         with pytest.raises(
             LockOperationFailed, match="Service call local_akuvox.list_users failed"
         ):
-            await akuvox_lock.async_get_usercodes()
+            await akuvox_lock.async_get_users()
 
     async def test_list_users_malformed_entity_response(
         self,
@@ -433,7 +508,7 @@ class TestListUsersErrors:
         with pytest.raises(
             LockCodeManagerError, match="Malformed list_users entity response"
         ):
-            await akuvox_lock.async_get_usercodes()
+            await akuvox_lock.async_get_users()
 
 
 # ---------------------------------------------------------------------------
@@ -450,7 +525,7 @@ class TestAutoTagging:
         akuvox_lock: AkuvoxLock,
         lcm_config_entry: MockConfigEntry,
     ) -> None:
-        """Test that untagged local users with PINs are auto-tagged."""
+        """Test that untagged local users with Personal Identification Numbers are auto-tagged."""
         mock_response = {
             LOCK_ENTITY_ID: {
                 "users": [
@@ -582,13 +657,13 @@ class TestAutoTagging:
         await akuvox_lock.async_setup(lcm_config_entry)
         assert akuvox_lock._tagged_once is True
 
-    async def test_concurrent_set_usercode_serialized_under_sequence_lock(
+    async def test_concurrent_set_credential_serialized_under_sequence_lock(
         self,
         hass: HomeAssistant,
         akuvox_lock: AkuvoxLock,
         lcm_config_entry: MockConfigEntry,
     ) -> None:
-        """Concurrent set_usercode calls must not interleave their read-modify-write."""
+        """Concurrent async_set_credential calls must not interleave their read-modify-write."""
         in_section = [0]
         max_overlap = [0]
 
@@ -605,8 +680,12 @@ class TestAutoTagging:
         )
 
         await asyncio.gather(
-            akuvox_lock.async_set_usercode(1, "1111"),
-            akuvox_lock.async_set_usercode(2, "2222"),
+            akuvox_lock.async_set_credential(
+                1, _pin_cred(1, "1111"), name=None, source="direct"
+            ),
+            akuvox_lock.async_set_credential(
+                2, _pin_cred(2, "2222"), name=None, source="direct"
+            ),
         )
 
         assert max_overlap[0] == 1
@@ -626,7 +705,7 @@ class TestHardRefresh:
         akuvox_lock: AkuvoxLock,
         lcm_config_entry: MockConfigEntry,
     ) -> None:
-        """Test that hard refresh auto-tags first, then reads codes."""
+        """Test that hard refresh auto-tags first, then reads codes via base projection."""
         # First call returns untagged user, second call returns tagged user
         untagged_response = {
             LOCK_ENTITY_ID: {
@@ -645,4 +724,75 @@ class TestHardRefresh:
         codes = await akuvox_lock.async_hard_refresh_codes()
 
         assert codes[1] == SlotCredential.known("9999")
+        assert codes[2] is SlotCredential.empty()
+
+
+# ---------------------------------------------------------------------------
+# Base orchestration end-to-end
+# ---------------------------------------------------------------------------
+
+
+class TestBaseOrchestration:
+    """Test the base set/clear/get flow through the primitives."""
+
+    async def test_set_and_get(
+        self,
+        hass: HomeAssistant,
+        akuvox_lock: AkuvoxLock,
+        lcm_config_entry: MockConfigEntry,
+    ) -> None:
+        """async_set_credential + async_get_usercodes base projection shows known Personal Identification Number."""
+        empty_response = {LOCK_ENTITY_ID: {"users": []}}
+        register_mock_service(
+            hass, AKUVOX_DOMAIN, "list_users", AsyncMock(return_value=empty_response)
+        )
+        register_mock_service(
+            hass, AKUVOX_DOMAIN, "add_user", AsyncMock(return_value=None)
+        )
+
+        await akuvox_lock.async_set_credential(
+            1, _pin_cred(1, "7777"), name="base_test", source="direct"
+        )
+
+        # After setting, the mock now returns the tagged user with the PIN
+        after_response = {
+            LOCK_ENTITY_ID: {
+                "users": [make_user("100", "[LCM:1] base_test", "7777")],
+            },
+        }
+        register_mock_service(
+            hass, AKUVOX_DOMAIN, "list_users", AsyncMock(return_value=after_response)
+        )
+
+        codes = await akuvox_lock.async_get_usercodes()
+        assert codes[1] == SlotCredential.known("7777")
+        assert codes[2] is SlotCredential.empty()
+
+    async def test_clear(
+        self,
+        hass: HomeAssistant,
+        akuvox_lock: AkuvoxLock,
+        lcm_config_entry: MockConfigEntry,
+    ) -> None:
+        """async_delete_credential + async_get_usercodes base projection shows empty."""
+        with_user = {
+            LOCK_ENTITY_ID: {
+                "users": [make_user("100", "[LCM:1] Guest", "1234")],
+            },
+        }
+        register_mock_service(
+            hass, AKUVOX_DOMAIN, "list_users", AsyncMock(return_value=with_user)
+        )
+        register_mock_service(
+            hass, AKUVOX_DOMAIN, "delete_user", AsyncMock(return_value=None)
+        )
+
+        await akuvox_lock.async_delete_credential(_cred_ref(1))
+
+        empty_response = {LOCK_ENTITY_ID: {"users": []}}
+        register_mock_service(
+            hass, AKUVOX_DOMAIN, "list_users", AsyncMock(return_value=empty_response)
+        )
+        codes = await akuvox_lock.async_get_usercodes()
+        assert codes[1] is SlotCredential.empty()
         assert codes[2] is SlotCredential.empty()

--- a/tests/providers/schlage/test_e2e.py
+++ b/tests/providers/schlage/test_e2e.py
@@ -9,6 +9,11 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
+from custom_components.lock_code_manager.domain.credentials import (
+    CredentialRef,
+    CredentialType,
+    credential_from_slot,
+)
 from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers.schlage import (
     SCHLAGE_DOMAIN,
@@ -40,18 +45,23 @@ class TestFullSetupLifecycle:
         assert e2e_schlage_lock.coordinator is not None
 
 
-class TestSetAndClearUsercodes:
+class TestSetAndClearCredentials:
     """Verify set/clear operations call the correct Schlage services."""
 
-    async def test_set_usercode(
+    async def test_set_credential(
         self,
         hass: HomeAssistant,
         e2e_schlage_lock: SchlageLock,
         schlage_mock_services: dict[str, AsyncMock],
     ) -> None:
-        """Set a code via the provider and verify the add_code service was called."""
+        """Set a credential via the provider and verify the add_code service was called."""
         schlage_mock_services["add_code"].reset_mock()
-        result = await e2e_schlage_lock.async_set_usercode(1, "9999", "Test User")
+        result = await e2e_schlage_lock.async_set_credential(
+            1,
+            credential_from_slot(1, SlotCredential.known("9999")),
+            name="Test User",
+            source="direct",
+        )
 
         assert result is True
         assert schlage_mock_services["add_code"].call_count >= 1
@@ -59,17 +69,17 @@ class TestSetAndClearUsercodes:
         assert add_call.data["name"] == "[LCM:1] Test User"
         assert add_call.data["code"] == "9999"
 
-    async def test_clear_usercode(
+    async def test_delete_credential(
         self,
         hass: HomeAssistant,
         e2e_schlage_lock: SchlageLock,
         schlage_lock_entity: er.RegistryEntry,
         schlage_mock_services: dict[str, AsyncMock],
     ) -> None:
-        """Clear a code via the provider and verify the delete_code service was called."""
+        """Clear a credential via the provider and verify the delete_code service was called."""
         entity_id = schlage_lock_entity.entity_id
 
-        # First set a code so there is something to clear
+        # Set up a code to delete
         schlage_mock_services["get_codes"] = AsyncMock(
             return_value={
                 entity_id: {
@@ -82,12 +92,30 @@ class TestSetAndClearUsercodes:
         )
         schlage_mock_services["delete_code"].reset_mock()
 
-        result = await e2e_schlage_lock.async_clear_usercode(1)
+        result = await e2e_schlage_lock.async_delete_credential(
+            CredentialRef(user_id=1, type=CredentialType.PIN, slot=1)
+        )
 
         assert result is True
         assert schlage_mock_services["delete_code"].call_count >= 1
 
-    async def test_coordinator_reflects_set_usercode(
+    async def test_base_orchestration_set_credential(
+        self,
+        hass: HomeAssistant,
+        e2e_schlage_lock: SchlageLock,
+        schlage_mock_services: dict[str, AsyncMock],
+    ) -> None:
+        """Set via async_internal_set_usercode routes through base → async_set_credential."""
+        schlage_mock_services["add_code"].reset_mock()
+        await e2e_schlage_lock.async_internal_set_usercode(1, "9999", "Test User")
+
+        # internal returns None (fires coordinator refresh) — check service call
+        assert schlage_mock_services["add_code"].call_count >= 1
+        add_call = schlage_mock_services["add_code"].call_args[0][0]
+        assert add_call.data["name"] == "[LCM:1] Test User"
+        assert add_call.data["code"] == "9999"
+
+    async def test_coordinator_reflects_set_credential(
         self,
         hass: HomeAssistant,
         e2e_schlage_lock: SchlageLock,
@@ -119,7 +147,7 @@ class TestSetAndClearUsercodes:
         assert e2e_schlage_lock.coordinator.data.get(1) is SlotCredential.unreadable()
         assert e2e_schlage_lock.coordinator.data.get(2) is SlotCredential.empty()
 
-    async def test_coordinator_reflects_clear_usercode(
+    async def test_coordinator_reflects_clear_credential(
         self,
         hass: HomeAssistant,
         e2e_schlage_lock: SchlageLock,
@@ -141,10 +169,10 @@ class TestSetAndClearUsercodes:
         assert e2e_schlage_lock.coordinator.data.get(2) is SlotCredential.empty()
 
 
-class TestGetUsercodes:
-    """Verify reading usercodes from the Schlage lock."""
+class TestGetUsers:
+    """Verify reading users (usercodes) from the Schlage lock."""
 
-    async def test_get_usercodes_returns_codes(
+    async def test_get_users_returns_codes(
         self,
         hass: HomeAssistant,
         e2e_schlage_lock: SchlageLock,
@@ -152,7 +180,7 @@ class TestGetUsercodes:
         schlage_mock_services: dict[str, AsyncMock],
     ) -> None:
         """
-        Get usercodes returns slot occupancy from Schlage.
+        async_get_users returns slot occupancy from Schlage.
 
         After initial setup with empty codes, both managed slots should
         be EMPTY. When the mock reports a tagged code on slot 1, that
@@ -161,6 +189,38 @@ class TestGetUsercodes:
         entity_id = schlage_lock_entity.entity_id
 
         # Override the get_codes mock to report an occupied slot
+        schlage_mock_services["get_codes"] = AsyncMock(
+            return_value={
+                entity_id: {
+                    "code1": {"name": "[LCM:1] Guest", "code": "****"},
+                },
+            }
+        )
+        register_mock_service(
+            hass,
+            SCHLAGE_DOMAIN,
+            "get_codes",
+            schlage_mock_services["get_codes"],
+        )
+
+        users = await e2e_schlage_lock.async_get_users()
+        user_map = {u.user_id: u for u in users}
+
+        assert user_map[1].pin_credentials[0].state is SlotCredential.unreadable()
+        assert user_map[2].pin_credentials[0].state is SlotCredential.empty()
+
+    async def test_get_usercodes_projection(
+        self,
+        hass: HomeAssistant,
+        e2e_schlage_lock: SchlageLock,
+        schlage_lock_entity: er.RegistryEntry,
+        schlage_mock_services: dict[str, AsyncMock],
+    ) -> None:
+        """
+        The base async_get_usercodes projection produces the same slot->SlotCredential dict.
+        """
+        entity_id = schlage_lock_entity.entity_id
+
         schlage_mock_services["get_codes"] = AsyncMock(
             return_value={
                 entity_id: {

--- a/tests/providers/schlage/test_provider.py
+++ b/tests/providers/schlage/test_provider.py
@@ -12,6 +12,12 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 
+from custom_components.lock_code_manager.domain.credentials import (
+    Credential,
+    CredentialRef,
+    CredentialType,
+    credential_from_slot,
+)
 from custom_components.lock_code_manager.domain.exceptions import (
     LockCodeManagerError,
     LockDisconnected,
@@ -31,6 +37,17 @@ from tests.providers.helpers import (
 )
 
 from .conftest import LOCK_ENTITY_ID
+
+
+def _pin_cred(slot: int, pin: str) -> Credential:
+    """Build a known-Personal-Identification-Number credential for a slot."""
+    return credential_from_slot(slot, SlotCredential.known(pin))
+
+
+def _cred_ref(slot: int) -> CredentialRef:
+    """Build a CredentialRef for a slot."""
+    return CredentialRef(user_id=slot, type=CredentialType.PIN, slot=slot)
+
 
 # ---------------------------------------------------------------------------
 # Helper function tests
@@ -106,16 +123,42 @@ class TestDeviceAvailability(ServiceProviderDeviceAvailabilityTests):
 
 
 # ---------------------------------------------------------------------------
-# get_usercodes tests
+# async_get_users / async_get_usercodes tests
 # ---------------------------------------------------------------------------
 
 
-async def test_get_usercodes_no_codes(
+async def test_get_users_no_codes(
     hass: HomeAssistant,
     schlage_lock: SchlageLock,
     simple_lcm_config_entry: MockConfigEntry,
 ) -> None:
-    """Test get_usercodes when no codes exist on the lock."""
+    """Test async_get_users when no codes exist on the lock returns empty users for managed slots."""
+    mock_response = {LOCK_ENTITY_ID: {}}
+    handler = AsyncMock(return_value=mock_response)
+    register_mock_service(hass, SCHLAGE_DOMAIN, "get_codes", handler)
+
+    users = await schlage_lock.async_get_users()
+    user_map = {u.user_id: u for u in users}
+
+    assert user_map[1].pin_credentials[0].state is SlotCredential.empty()
+    assert user_map[2].pin_credentials[0].state is SlotCredential.empty()
+
+
+async def test_get_users_no_configured_slots(
+    hass: HomeAssistant,
+    schlage_lock: SchlageLock,
+) -> None:
+    """Test async_get_users returns empty list when no slots are configured."""
+    users = await schlage_lock.async_get_users()
+    assert users == []
+
+
+async def test_get_usercodes_base_projection_no_codes(
+    hass: HomeAssistant,
+    schlage_lock: SchlageLock,
+    simple_lcm_config_entry: MockConfigEntry,
+) -> None:
+    """Test async_get_usercodes base projection returns empty for managed slots with no codes."""
     mock_response = {LOCK_ENTITY_ID: {}}
     handler = AsyncMock(return_value=mock_response)
     register_mock_service(hass, SCHLAGE_DOMAIN, "get_codes", handler)
@@ -130,17 +173,17 @@ async def test_get_usercodes_no_configured_slots(
     hass: HomeAssistant,
     schlage_lock: SchlageLock,
 ) -> None:
-    """Test get_usercodes returns empty dict when no slots are configured."""
+    """Test async_get_usercodes returns empty dict when no slots are configured."""
     codes = await schlage_lock.async_get_usercodes()
     assert codes == {}
 
 
-async def test_get_usercodes_does_not_auto_tag(
+async def test_get_users_does_not_auto_tag(
     hass: HomeAssistant,
     schlage_lock: SchlageLock,
     simple_lcm_config_entry: MockConfigEntry,
 ) -> None:
-    """Test that get_usercodes does not auto-tag untagged codes."""
+    """Test that async_get_users does not auto-tag untagged codes."""
     get_response = {
         LOCK_ENTITY_ID: {
             "code1": {"name": "Guest", "code": "1234"},
@@ -151,17 +194,18 @@ async def test_get_usercodes_does_not_auto_tag(
     register_mock_service(hass, SCHLAGE_DOMAIN, "get_codes", get_handler)
     register_mock_service(hass, SCHLAGE_DOMAIN, "add_code", add_handler)
 
-    codes = await schlage_lock.async_get_usercodes()
+    users = await schlage_lock.async_get_users()
+    user_map = {u.user_id: u for u in users}
 
     # Untagged codes are not counted as occupied
-    assert codes[1] is SlotCredential.empty()
-    assert codes[2] is SlotCredential.empty()
+    assert user_map[1].pin_credentials[0].state is SlotCredential.empty()
+    assert user_map[2].pin_credentials[0].state is SlotCredential.empty()
 
     # No add_code call should have been made
     assert add_handler.call_count == 0
 
 
-async def test_get_usercodes_duplicate_tag_uses_first(
+async def test_get_users_duplicate_tag_uses_first(
     hass: HomeAssistant,
     schlage_lock: SchlageLock,
     simple_lcm_config_entry: MockConfigEntry,
@@ -176,13 +220,14 @@ async def test_get_usercodes_duplicate_tag_uses_first(
     handler = AsyncMock(return_value=mock_response)
     register_mock_service(hass, SCHLAGE_DOMAIN, "get_codes", handler)
 
-    codes = await schlage_lock.async_get_usercodes()
+    users = await schlage_lock.async_get_users()
+    user_map = {u.user_id: u for u in users}
 
-    assert codes[1] is SlotCredential.unreadable()
-    assert codes[2] is SlotCredential.empty()
+    assert user_map[1].pin_credentials[0].state is SlotCredential.unreadable()
+    assert user_map[2].pin_credentials[0].state is SlotCredential.empty()
 
 
-async def test_get_usercodes_ignores_tags_outside_managed_range(
+async def test_get_users_ignores_tags_outside_managed_range(
     hass: HomeAssistant,
     schlage_lock: SchlageLock,
     simple_lcm_config_entry: MockConfigEntry,
@@ -196,10 +241,11 @@ async def test_get_usercodes_ignores_tags_outside_managed_range(
     handler = AsyncMock(return_value=mock_response)
     register_mock_service(hass, SCHLAGE_DOMAIN, "get_codes", handler)
 
-    codes = await schlage_lock.async_get_usercodes()
+    users = await schlage_lock.async_get_users()
+    user_map = {u.user_id: u for u in users}
 
-    assert codes[1] is SlotCredential.empty()
-    assert codes[2] is SlotCredential.empty()
+    assert user_map[1].pin_credentials[0].state is SlotCredential.empty()
+    assert user_map[2].pin_credentials[0].state is SlotCredential.empty()
 
 
 # ---------------------------------------------------------------------------
@@ -412,12 +458,12 @@ async def test_async_setup_retries_after_disconnect_on_delete_step(
     assert schlage_lock._tagged_once is False
 
 
-async def test_concurrent_set_usercode_serialized_under_sequence_lock(
+async def test_concurrent_set_credential_serialized_under_sequence_lock(
     hass: HomeAssistant,
     schlage_lock: SchlageLock,
     simple_lcm_config_entry: MockConfigEntry,
 ) -> None:
-    """Concurrent set_usercode calls must not interleave their read-modify-write."""
+    """Concurrent async_set_credential calls must not interleave their read-modify-write."""
     in_section = [0]
     max_overlap = [0]
 
@@ -438,23 +484,29 @@ async def test_concurrent_set_usercode_serialized_under_sequence_lock(
     )
 
     await asyncio.gather(
-        schlage_lock.async_set_usercode(1, "1111"),
-        schlage_lock.async_set_usercode(2, "2222"),
-        schlage_lock.async_set_usercode(3, "3333"),
+        schlage_lock.async_set_credential(
+            1, _pin_cred(1, "1111"), name=None, source="direct"
+        ),
+        schlage_lock.async_set_credential(
+            2, _pin_cred(2, "2222"), name=None, source="direct"
+        ),
+        schlage_lock.async_set_credential(
+            3, _pin_cred(3, "3333"), name=None, source="direct"
+        ),
     )
 
     assert max_overlap[0] == 1
 
 
 # ---------------------------------------------------------------------------
-# set_usercode tests
+# async_set_credential tests
 # ---------------------------------------------------------------------------
 
 
-async def test_set_usercode_replaces_existing(
+async def test_set_credential_replaces_existing(
     hass: HomeAssistant, schlage_lock: SchlageLock
 ) -> None:
-    """Test set_usercode replaces an existing code on the same slot."""
+    """Test async_set_credential replaces an existing code on the same slot."""
     get_response = {
         LOCK_ENTITY_ID: {
             "code1": {"name": "[LCM:1] Old Name", "code": "****"},
@@ -467,7 +519,9 @@ async def test_set_usercode_replaces_existing(
     register_mock_service(hass, SCHLAGE_DOMAIN, "add_code", add_handler)
     register_mock_service(hass, SCHLAGE_DOMAIN, "delete_code", delete_handler)
 
-    result = await schlage_lock.async_set_usercode(1, "5678", "New Name")
+    result = await schlage_lock.async_set_credential(
+        1, _pin_cred(1, "5678"), name="New Name", source="direct"
+    )
 
     assert result is True
     # add_code called with new tagged name
@@ -480,14 +534,14 @@ async def test_set_usercode_replaces_existing(
     assert deleted_names == {"[LCM:1] Old Name", "[LCM:1] New Name"}
 
 
-async def test_set_usercode_preserves_existing_name(
+async def test_set_credential_preserves_existing_name(
     hass: HomeAssistant, schlage_lock: SchlageLock
 ) -> None:
     """
-    Test set_usercode preserves the existing friendly name when no name is provided.
+    Test async_set_credential preserves the existing friendly name when no name is provided.
 
-    When the name does not change (PIN-only update), the old code must be deleted
-    first because Schlage rejects add_code with a duplicate name.
+    When the name does not change (Personal Identification Number-only update), the old
+    code must be deleted first because Schlage rejects add_code with a duplicate name.
     """
     get_response = {
         LOCK_ENTITY_ID: {
@@ -506,7 +560,9 @@ async def test_set_usercode_preserves_existing_name(
     add_handler.side_effect = lambda _: call_order.append("add")
     delete_handler.side_effect = lambda _: call_order.append("delete")
 
-    result = await schlage_lock.async_set_usercode(1, "9999")
+    result = await schlage_lock.async_set_credential(
+        1, _pin_cred(1, "9999"), name=None, source="direct"
+    )
 
     assert result is True
     # Name unchanged so existing_full_name == tagged_name, deduplicated to 1 delete
@@ -520,15 +576,15 @@ async def test_set_usercode_preserves_existing_name(
     assert call_order == ["delete", "add"]
 
 
-async def test_set_usercode_already_exists_treated_as_success(
+async def test_set_credential_already_exists_treated_as_success(
     hass: HomeAssistant, schlage_lock: SchlageLock
 ) -> None:
     """
     Test that 'already exists' on add_code is treated as success.
 
     Schlage's cloud API has eventual consistency: a delete may not propagate
-    before the add, causing 'already exists'.  Since PINs are write-only,
-    we can't verify the value but the code IS on the lock.
+    before the add, causing 'already exists'.  Since Personal Identification
+    Numbers are write-only, we can't verify the value but the code IS on the lock.
     """
     get_response = {LOCK_ENTITY_ID: {}}
     get_handler = AsyncMock(return_value=get_response)
@@ -542,12 +598,14 @@ async def test_set_usercode_already_exists_treated_as_success(
     register_mock_service(hass, SCHLAGE_DOMAIN, "add_code", add_handler)
     register_mock_service(hass, SCHLAGE_DOMAIN, "delete_code", delete_handler)
 
-    result = await schlage_lock.async_set_usercode(1, "1234", "Guest")
+    result = await schlage_lock.async_set_credential(
+        1, _pin_cred(1, "1234"), name="Guest", source="direct"
+    )
 
     assert result is True
 
 
-async def test_set_usercode_non_exists_error_still_raises(
+async def test_set_credential_non_exists_error_still_raises(
     hass: HomeAssistant, schlage_lock: SchlageLock
 ) -> None:
     """Test that add_code errors other than 'already exists' still raise."""
@@ -560,13 +618,15 @@ async def test_set_usercode_non_exists_error_still_raises(
     register_mock_service(hass, SCHLAGE_DOMAIN, "delete_code", delete_handler)
 
     with pytest.raises(LockOperationFailed, match="connection lost"):
-        await schlage_lock.async_set_usercode(1, "1234")
+        await schlage_lock.async_set_credential(
+            1, _pin_cred(1, "1234"), name=None, source="direct"
+        )
 
 
-async def test_set_usercode_service_failure(
+async def test_set_credential_service_failure(
     hass: HomeAssistant, schlage_lock: SchlageLock
 ) -> None:
-    """Test that set_usercode raises LockOperationFailed on service failure."""
+    """Test that async_set_credential raises LockOperationFailed on service failure."""
     get_response = {LOCK_ENTITY_ID: {}}
     get_handler = AsyncMock(return_value=get_response)
     add_handler = AsyncMock(side_effect=HomeAssistantError("connection lost"))
@@ -574,31 +634,33 @@ async def test_set_usercode_service_failure(
     register_mock_service(hass, SCHLAGE_DOMAIN, "add_code", add_handler)
 
     with pytest.raises(LockOperationFailed, match="connection lost"):
-        await schlage_lock.async_set_usercode(1, "1234")
+        await schlage_lock.async_set_credential(
+            1, _pin_cred(1, "1234"), name=None, source="direct"
+        )
 
 
 # ---------------------------------------------------------------------------
-# clear_usercode tests
+# async_delete_credential tests
 # ---------------------------------------------------------------------------
 
 
-async def test_clear_usercode_already_empty(
+async def test_delete_credential_already_empty(
     hass: HomeAssistant, schlage_lock: SchlageLock
 ) -> None:
-    """Test clear_usercode returns False when no code exists for the slot."""
+    """Test async_delete_credential returns False when no code exists for the slot."""
     get_response = {LOCK_ENTITY_ID: {}}
     get_handler = AsyncMock(return_value=get_response)
     register_mock_service(hass, SCHLAGE_DOMAIN, "get_codes", get_handler)
 
-    result = await schlage_lock.async_clear_usercode(1)
+    result = await schlage_lock.async_delete_credential(_cred_ref(1))
 
     assert result is False
 
 
-async def test_clear_usercode_service_failure(
+async def test_delete_credential_service_failure(
     hass: HomeAssistant, schlage_lock: SchlageLock
 ) -> None:
-    """Test that clear_usercode raises LockOperationFailed on service failure."""
+    """Test that async_delete_credential raises LockOperationFailed on service failure."""
     get_response = {
         LOCK_ENTITY_ID: {
             "code1": {"name": "[LCM:1] Guest", "code": "****"},
@@ -610,7 +672,7 @@ async def test_clear_usercode_service_failure(
     register_mock_service(hass, SCHLAGE_DOMAIN, "delete_code", delete_handler)
 
     with pytest.raises(LockOperationFailed, match="connection lost"):
-        await schlage_lock.async_clear_usercode(1)
+        await schlage_lock.async_delete_credential(_cred_ref(1))
 
 
 # ---------------------------------------------------------------------------
@@ -623,7 +685,7 @@ async def test_hard_refresh_codes(
     schlage_lock: SchlageLock,
     simple_lcm_config_entry: MockConfigEntry,
 ) -> None:
-    """Test hard_refresh_codes calls tagging then returns usercodes."""
+    """Test hard_refresh_codes calls tagging then returns usercodes via base projection."""
     mock_response = {
         LOCK_ENTITY_ID: {
             "code1": {"name": "[LCM:2] Family", "code": "****"},
@@ -650,12 +712,12 @@ async def test_get_codes_service_failure(
     schlage_lock: SchlageLock,
     simple_lcm_config_entry: MockConfigEntry,
 ) -> None:
-    """Test that get_usercodes raises LockOperationFailed on service failure."""
+    """Test that async_get_users raises LockOperationFailed on service failure."""
     handler = AsyncMock(side_effect=HomeAssistantError("connection lost"))
     register_mock_service(hass, SCHLAGE_DOMAIN, "get_codes", handler)
 
     with pytest.raises(LockOperationFailed, match="connection lost"):
-        await schlage_lock.async_get_usercodes()
+        await schlage_lock.async_get_users()
 
 
 async def test_get_codes_service_validation_error(
@@ -663,12 +725,12 @@ async def test_get_codes_service_validation_error(
     schlage_lock: SchlageLock,
     simple_lcm_config_entry: MockConfigEntry,
 ) -> None:
-    """Test that get_usercodes raises LockOperationFailed on ServiceValidationError."""
+    """Test that async_get_users raises LockOperationFailed on ServiceValidationError."""
     handler = AsyncMock(side_effect=ServiceValidationError("invalid entity"))
     register_mock_service(hass, SCHLAGE_DOMAIN, "get_codes", handler)
 
     with pytest.raises(LockOperationFailed, match="invalid entity"):
-        await schlage_lock.async_get_usercodes()
+        await schlage_lock.async_get_users()
 
 
 async def test_get_codes_malformed_entity_response(
@@ -682,4 +744,67 @@ async def test_get_codes_malformed_entity_response(
     register_mock_service(hass, SCHLAGE_DOMAIN, "get_codes", handler)
 
     with pytest.raises(LockCodeManagerError, match="malformed entity response"):
-        await schlage_lock.async_get_usercodes()
+        await schlage_lock.async_get_users()
+
+
+# ---------------------------------------------------------------------------
+# Base orchestration end-to-end (primitive layer, no connection guard)
+# ---------------------------------------------------------------------------
+
+
+async def test_base_orchestration_set_and_get(
+    hass: HomeAssistant,
+    schlage_lock: SchlageLock,
+    simple_lcm_config_entry: MockConfigEntry,
+) -> None:
+    """async_set_credential + async_get_usercodes (base projection) shows unreadable after set."""
+    get_response = {LOCK_ENTITY_ID: {}}
+    register_mock_service(
+        hass, SCHLAGE_DOMAIN, "get_codes", AsyncMock(return_value=get_response)
+    )
+    register_mock_service(
+        hass, SCHLAGE_DOMAIN, "add_code", AsyncMock(return_value=None)
+    )
+    register_mock_service(
+        hass, SCHLAGE_DOMAIN, "delete_code", AsyncMock(return_value=None)
+    )
+
+    await schlage_lock.async_set_credential(
+        1, _pin_cred(1, "9999"), name="test", source="direct"
+    )
+
+    # After setting, the lock reports the slot as unreadable (write-only Personal Identification Number)
+    mock_after = {LOCK_ENTITY_ID: {"c1": {"name": "[LCM:1] test", "code": "****"}}}
+    register_mock_service(
+        hass, SCHLAGE_DOMAIN, "get_codes", AsyncMock(return_value=mock_after)
+    )
+
+    codes = await schlage_lock.async_get_usercodes()
+    assert codes[1] is SlotCredential.unreadable()
+    assert codes[2] is SlotCredential.empty()
+
+
+async def test_base_orchestration_clear(
+    hass: HomeAssistant,
+    schlage_lock: SchlageLock,
+    simple_lcm_config_entry: MockConfigEntry,
+) -> None:
+    """async_delete_credential + async_get_usercodes (base projection) shows empty after clear."""
+    get_response = {LOCK_ENTITY_ID: {"c1": {"name": "[LCM:1] Guest", "code": "****"}}}
+    register_mock_service(
+        hass, SCHLAGE_DOMAIN, "get_codes", AsyncMock(return_value=get_response)
+    )
+    register_mock_service(
+        hass, SCHLAGE_DOMAIN, "delete_code", AsyncMock(return_value=None)
+    )
+
+    await schlage_lock.async_delete_credential(_cred_ref(1))
+
+    # After clearing, the lock reports empty
+    empty_response = {LOCK_ENTITY_ID: {}}
+    register_mock_service(
+        hass, SCHLAGE_DOMAIN, "get_codes", AsyncMock(return_value=empty_response)
+    )
+    codes = await schlage_lock.async_get_usercodes()
+    assert codes[1] is SlotCredential.empty()
+    assert codes[2] is SlotCredential.empty()

--- a/tests/providers/virtual/test_e2e.py
+++ b/tests/providers/virtual/test_e2e.py
@@ -4,6 +4,11 @@ from __future__ import annotations
 
 from homeassistant.core import HomeAssistant
 
+from custom_components.lock_code_manager.domain.credentials import (
+    CredentialRef,
+    CredentialType,
+    credential_from_slot,
+)
 from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers.virtual import VirtualLock
 
@@ -40,8 +45,13 @@ class TestSetAndGetUsercodes:
         hass: HomeAssistant,
         e2e_virtual_lock: VirtualLock,
     ) -> None:
-        """Set a code, then get_usercodes and verify it is present."""
-        await e2e_virtual_lock.async_set_usercode(1, "1111", "test_user")
+        """Set a credential, then get_usercodes via base projection and verify it is present."""
+        await e2e_virtual_lock.async_set_credential(
+            1,
+            credential_from_slot(1, SlotCredential.known("1111")),
+            name="test_user",
+            source="direct",
+        )
 
         codes = await e2e_virtual_lock.async_get_usercodes()
         assert codes[1] == SlotCredential.known("1111")
@@ -51,9 +61,39 @@ class TestSetAndGetUsercodes:
         hass: HomeAssistant,
         e2e_virtual_lock: VirtualLock,
     ) -> None:
-        """Set a code, clear it, and verify it is gone."""
-        await e2e_virtual_lock.async_set_usercode(1, "1111", "test_user")
-        await e2e_virtual_lock.async_clear_usercode(1)
+        """Set a credential, clear it, and verify it is gone."""
+        await e2e_virtual_lock.async_set_credential(
+            1,
+            credential_from_slot(1, SlotCredential.known("1111")),
+            name="test_user",
+            source="direct",
+        )
+        await e2e_virtual_lock.async_delete_credential(
+            CredentialRef(user_id=1, type=CredentialType.PIN, slot=1)
+        )
+
+        codes = await e2e_virtual_lock.async_get_usercodes()
+        assert codes[1] is SlotCredential.empty()
+
+    async def test_base_orchestration_set_and_get(
+        self,
+        hass: HomeAssistant,
+        e2e_virtual_lock: VirtualLock,
+    ) -> None:
+        """Set via async_internal_set_usercode (base orchestration → primitive) and verify via projection."""
+        await e2e_virtual_lock.async_internal_set_usercode(1, "2222", "orchestrated")
+
+        codes = await e2e_virtual_lock.async_get_usercodes()
+        assert codes[1] == SlotCredential.known("2222")
+
+    async def test_base_orchestration_clear(
+        self,
+        hass: HomeAssistant,
+        e2e_virtual_lock: VirtualLock,
+    ) -> None:
+        """Set then clear via base orchestration; verify projection shows empty."""
+        await e2e_virtual_lock.async_internal_set_usercode(1, "3333", "user")
+        await e2e_virtual_lock.async_internal_clear_usercode(1)
 
         codes = await e2e_virtual_lock.async_get_usercodes()
         assert codes[1] is SlotCredential.empty()
@@ -64,8 +104,18 @@ class TestSetAndGetUsercodes:
         e2e_virtual_lock: VirtualLock,
     ) -> None:
         """Set codes, unload (persists to store), reload, verify codes survive."""
-        await e2e_virtual_lock.async_set_usercode(1, "1111", "user1")
-        await e2e_virtual_lock.async_set_usercode(2, "2222", "user2")
+        await e2e_virtual_lock.async_set_credential(
+            1,
+            credential_from_slot(1, SlotCredential.known("1111")),
+            name="user1",
+            source="direct",
+        )
+        await e2e_virtual_lock.async_set_credential(
+            2,
+            credential_from_slot(2, SlotCredential.known("2222")),
+            name="user2",
+            source="direct",
+        )
 
         # Unload without removing permanently saves data to the store
         config_entry = e2e_virtual_lock._lcm_config_entry
@@ -84,9 +134,36 @@ class TestSetAndGetUsercodes:
         e2e_virtual_lock: VirtualLock,
     ) -> None:
         """Hard refresh reloads from the store, so unsaved codes are lost."""
-        await e2e_virtual_lock.async_set_usercode(1, "1111", "user1")
+        await e2e_virtual_lock.async_set_credential(
+            1,
+            credential_from_slot(1, SlotCredential.known("1111")),
+            name="user1",
+            source="direct",
+        )
 
         # Hard refresh reloads from the store (which has not been saved to)
         codes = await e2e_virtual_lock.async_hard_refresh_codes()
 
         assert codes[1] is SlotCredential.empty()
+
+    async def test_get_users_returns_correct_structure(
+        self,
+        hass: HomeAssistant,
+        e2e_virtual_lock: VirtualLock,
+    ) -> None:
+        """async_get_users returns User objects wrapping the slot credentials."""
+        await e2e_virtual_lock.async_set_credential(
+            1,
+            credential_from_slot(1, SlotCredential.known("5555")),
+            name="slot_user",
+            source="direct",
+        )
+
+        users = await e2e_virtual_lock.async_get_users()
+        user_map = {u.user_id: u for u in users}
+
+        assert 1 in user_map
+        assert user_map[1].active is True
+        assert user_map[1].pin_credentials[0].state == SlotCredential.known("5555")
+        assert 2 in user_map
+        assert user_map[2].active is False

--- a/tests/providers/virtual/test_provider.py
+++ b/tests/providers/virtual/test_provider.py
@@ -1,52 +1,79 @@
 """Test the Virtual lock platform."""
 
+from custom_components.lock_code_manager.domain.credentials import (
+    Credential,
+    CredentialRef,
+    CredentialType,
+    User,
+    credential_from_slot,
+    user_from_slot,
+)
 from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers.virtual import VirtualLock
 
 
-async def test_set_usercode_returns_changed_status(virtual_lock: VirtualLock):
-    """Test that set_usercode returns True when value changes, False when unchanged."""
+async def test_set_credential_returns_changed_status(virtual_lock: VirtualLock):
+    """Test that async_set_credential returns True when value changes, False when unchanged."""
     lock = virtual_lock
 
+    def _make_credential(slot: int, pin: str) -> Credential:
+        return credential_from_slot(slot, SlotCredential.known(pin))
+
     # First set should return True (value changed from empty)
-    changed = await lock.async_set_usercode(1, "1234", "test")
+    changed = await lock.async_set_credential(
+        1, _make_credential(1, "1234"), name="test", source="direct"
+    )
     assert changed is True
     assert lock._data["1"] == {"code": "1234", "name": "test"}
 
     # Setting the same value should return False (no change)
-    changed = await lock.async_set_usercode(1, "1234", "test")
+    changed = await lock.async_set_credential(
+        1, _make_credential(1, "1234"), name="test", source="direct"
+    )
     assert changed is False
 
     # Changing the code should return True
-    changed = await lock.async_set_usercode(1, "5678", "test")
+    changed = await lock.async_set_credential(
+        1, _make_credential(1, "5678"), name="test", source="direct"
+    )
     assert changed is True
     assert lock._data["1"] == {"code": "5678", "name": "test"}
 
     # Changing the name should return True
-    changed = await lock.async_set_usercode(1, "5678", "new_name")
+    changed = await lock.async_set_credential(
+        1, _make_credential(1, "5678"), name="new_name", source="direct"
+    )
     assert changed is True
     assert lock._data["1"] == {"code": "5678", "name": "new_name"}
 
 
-async def test_clear_usercode_returns_changed_status(virtual_lock: VirtualLock):
-    """Test that clear_usercode returns True when value changes, False when already cleared."""
+async def test_delete_credential_returns_changed_status(virtual_lock: VirtualLock):
+    """Test that async_delete_credential returns True when value changes, False when already cleared."""
     lock = virtual_lock
 
+    def _make_ref(slot: int) -> CredentialRef:
+        return CredentialRef(user_id=slot, type=CredentialType.PIN, slot=slot)
+
     # Clearing non-existent slot should return False
-    changed = await lock.async_clear_usercode(1)
+    changed = await lock.async_delete_credential(_make_ref(1))
     assert changed is False
 
-    # Set a usercode first
-    await lock.async_set_usercode(1, "1234", "test")
+    # Set a credential first via the primitive
+    await lock.async_set_credential(
+        1,
+        credential_from_slot(1, SlotCredential.known("1234")),
+        name="test",
+        source="direct",
+    )
     assert "1" in lock._data
 
     # Clearing existing slot should return True
-    changed = await lock.async_clear_usercode(1)
+    changed = await lock.async_delete_credential(_make_ref(1))
     assert changed is True
     assert "1" not in lock._data
 
     # Clearing again should return False (already cleared)
-    changed = await lock.async_clear_usercode(1)
+    changed = await lock.async_delete_credential(_make_ref(1))
     assert changed is False
 
 
@@ -57,44 +84,70 @@ async def test_virtual_lock_does_not_support_code_slot_events(
     assert virtual_lock.supports_code_slot_events is False
 
 
-async def test_get_usercodes_returns_empty_for_cleared_slots(
+async def test_get_users_returns_empty_for_cleared_slots(
     virtual_lock_with_slots: VirtualLock,
 ):
-    """Test that async_get_usercodes returns SlotCredential.empty() for cleared slots."""
+    """Test that async_get_users returns SlotCredential.empty() users for cleared slots."""
     lock = virtual_lock_with_slots
 
     # Set code on slot 1 only
-    await lock.async_set_usercode(1, "1234", "slot1")
+    await lock.async_set_credential(
+        1,
+        credential_from_slot(1, SlotCredential.known("1234")),
+        name="slot1",
+        source="direct",
+    )
 
-    # Get usercodes: slot 1 should have code, slot 2 should be EMPTY
+    # async_get_users: slot 1 should have a known credential, slot 2 should be empty
+    users = await lock.async_get_users()
+    user_map = {u.user_id: u for u in users}
+    assert user_map[1].pin_credentials[0].state == SlotCredential.known("1234")
+    assert user_map[2].pin_credentials[0].state is SlotCredential.empty()
+
+    # Verify get_usercodes projection (base default projection)
     codes = await lock.async_get_usercodes()
     assert codes[1] == SlotCredential.known("1234")
     assert codes[2] is SlotCredential.empty()
 
     # Clear slot 1 and verify it becomes EMPTY
-    await lock.async_clear_usercode(1)
+    await lock.async_delete_credential(
+        CredentialRef(user_id=1, type=CredentialType.PIN, slot=1)
+    )
     codes = await lock.async_get_usercodes()
     assert codes[1] is SlotCredential.empty()
     assert codes[2] is SlotCredential.empty()
 
 
-async def test_get_usercodes_includes_unmanaged_slots(
+async def test_get_users_includes_unmanaged_occupied_slots(
     virtual_lock_with_slots: VirtualLock,
 ):
-    """Test that async_get_usercodes returns unmanaged occupied slots."""
+    """Test that async_get_users returns unmanaged occupied slots as users."""
     lock = virtual_lock_with_slots
 
-    # Set code on managed slot 1 and unmanaged slot 99
-    await lock.async_set_usercode(1, "1234", "slot1")
+    # Set code on managed slot 1 and inject an unmanaged slot 99 directly
+    await lock.async_set_credential(
+        1,
+        credential_from_slot(1, SlotCredential.known("1234")),
+        name="slot1",
+        source="direct",
+    )
     lock._data["99"] = {"code": "9999", "name": "unmanaged"}
 
+    users = await lock.async_get_users()
+    user_map = {u.user_id: u for u in users}
+
+    assert user_map[1].pin_credentials[0].state == SlotCredential.known("1234")
+    assert user_map[2].pin_credentials[0].state is SlotCredential.empty()
+    assert user_map[99].pin_credentials[0].state == SlotCredential.known("9999")
+
+    # Also verify via the base projection
     codes = await lock.async_get_usercodes()
     assert codes[1] == SlotCredential.known("1234")
     assert codes[2] is SlotCredential.empty()
     assert codes[99] == SlotCredential.known("9999")
 
 
-async def test_get_usercodes_invalid_stored_key_skipped(
+async def test_get_users_invalid_stored_key_skipped(
     virtual_lock_with_slots: VirtualLock,
 ):
     """Test that invalid stored slot keys are skipped with a warning."""
@@ -103,7 +156,69 @@ async def test_get_usercodes_invalid_stored_key_skipped(
     lock._data["bad_key"] = {"code": "1111", "name": "corrupt"}
     lock._data["3"] = {"code": "3333", "name": "valid_unmanaged"}
 
-    codes = await lock.async_get_usercodes()
+    users = await lock.async_get_users()
+    user_map = {u.user_id: u for u in users}
+
     # "bad_key" should be skipped; slot 3 should appear
+    assert 3 in user_map
+    assert user_map[3].pin_credentials[0].state == SlotCredential.known("3333")
+
+    # Also verify via the base projection
+    codes = await lock.async_get_usercodes()
     assert 3 in codes
     assert codes[3] == SlotCredential.known("3333")
+
+
+async def test_base_orchestration_set_clear_get(virtual_lock_with_slots: VirtualLock):
+    """Test set/clear/get flow through the base primitives + projection."""
+    lock = virtual_lock_with_slots
+
+    # async_set_credential routes through the primitive and stores the code
+    await lock.async_set_credential(
+        1,
+        credential_from_slot(1, SlotCredential.known("4321")),
+        name="orchestration_test",
+        source="direct",
+    )
+    # async_get_usercodes uses the base projection over async_get_users
+    codes = await lock.async_get_usercodes()
+    assert codes[1] == SlotCredential.known("4321")
+    assert codes[2] is SlotCredential.empty()
+
+    # async_delete_credential removes the code
+    await lock.async_delete_credential(
+        CredentialRef(user_id=1, type=CredentialType.PIN, slot=1)
+    )
+    codes = await lock.async_get_usercodes()
+    assert codes[1] is SlotCredential.empty()
+
+
+async def test_get_users_returns_user_objects(virtual_lock_with_slots: VirtualLock):
+    """Test that async_get_users returns properly constructed User objects."""
+    lock = virtual_lock_with_slots
+
+    await lock.async_set_credential(
+        1,
+        credential_from_slot(1, SlotCredential.known("7777")),
+        name=None,
+        source="direct",
+    )
+
+    users = await lock.async_get_users()
+    assert all(isinstance(u, User) for u in users)
+
+    user_1 = next(u for u in users if u.user_id == 1)
+    assert user_1.active is True
+    assert len(user_1.pin_credentials) == 1
+    assert user_1.pin_credentials[0].slot == 1
+    assert user_1.pin_credentials[0].state == SlotCredential.known("7777")
+
+    user_2 = next(u for u in users if u.user_id == 2)
+    assert user_2.active is False
+    assert user_2.pin_credentials[0].state is SlotCredential.empty()
+
+    # user_from_slot helper produces the same structure
+    expected = user_from_slot(1, SlotCredential.known("7777"))
+    assert user_1.user_id == expected.user_id
+    assert user_1.active == expected.active
+    assert user_1.pin_credentials[0].state == expected.pin_credentials[0].state

--- a/tests/providers/zha/test_provider.py
+++ b/tests/providers/zha/test_provider.py
@@ -12,6 +12,11 @@ from zigpy.zcl.clusters.closures import DoorLock
 from homeassistant.components.zha.const import DOMAIN as ZHA_DOMAIN
 from homeassistant.core import HomeAssistant
 
+from custom_components.lock_code_manager.domain.credentials import (
+    CredentialRef,
+    CredentialType,
+    credential_from_slot,
+)
 from custom_components.lock_code_manager.domain.exceptions import (
     CodeRejectedError,
     LockDisconnected,
@@ -85,16 +90,47 @@ async def test_get_door_lock_cluster_caches_result(
 
 
 # ---------------------------------------------------------------------------
-# Usercode tests
+# Credential primitive tests
 # ---------------------------------------------------------------------------
 
 
-async def test_get_usercodes(
+async def test_get_users(
     hass: HomeAssistant,
     zha_lock: ZHALock,
     simple_lcm_config_entry: MockConfigEntry,
 ) -> None:
-    """Test reading usercodes from the lock."""
+    """Test async_get_users reads from the cluster and returns a user per slot."""
+    cluster = zha_lock._get_door_lock_cluster()
+    assert cluster is not None
+
+    async def mock_get_pin_code(slot_num):
+        if slot_num == 1:
+            return type(
+                "Response",
+                (),
+                {"user_status": DoorLock.UserStatus.Enabled, "code": "1234"},
+            )()
+        return type(
+            "Response",
+            (),
+            {"user_status": DoorLock.UserStatus.Available, "code": ""},
+        )()
+
+    cluster.get_pin_code = AsyncMock(side_effect=mock_get_pin_code)
+
+    users = await zha_lock.async_get_users()
+
+    by_slot = {u.user_id: u for u in users}
+    assert by_slot[1].pin_credentials[0].state == SlotCredential.known("1234")
+    assert by_slot[2].pin_credentials[0].state is SlotCredential.empty()
+
+
+async def test_get_usercodes_via_base_projection(
+    hass: HomeAssistant,
+    zha_lock: ZHALock,
+    simple_lcm_config_entry: MockConfigEntry,
+) -> None:
+    """Base async_get_usercodes projection surfaces all managed slots."""
     cluster = zha_lock._get_door_lock_cluster()
     assert cluster is not None
 
@@ -119,18 +155,21 @@ async def test_get_usercodes(
     assert codes[2] is SlotCredential.empty()
 
 
-async def test_set_usercode(
+async def test_set_credential(
     hass: HomeAssistant,
     zha_lock: ZHALock,
     simple_lcm_config_entry: MockConfigEntry,
 ) -> None:
-    """Test set_usercode calls the cluster and pushes optimistic update."""
+    """Test async_set_credential calls the cluster and pushes optimistic update."""
     cluster = zha_lock._get_door_lock_cluster()
     assert cluster is not None
     cluster.set_pin_code = AsyncMock(return_value=type("Response", (), {"status": 0})())
     zha_lock.coordinator = MagicMock()
 
-    result = await zha_lock.async_set_usercode(3, "5678", "Test User")
+    credential = credential_from_slot(3, SlotCredential.known("5678"))
+    result = await zha_lock.async_set_credential(
+        3, credential, name="Test User", source="direct"
+    )
 
     assert result is True
     cluster.set_pin_code.assert_called_once_with(
@@ -144,26 +183,27 @@ async def test_set_usercode(
     )
 
 
-async def test_set_usercode_failure(
+async def test_set_credential_failure(
     hass: HomeAssistant,
     zha_lock: ZHALock,
     simple_lcm_config_entry: MockConfigEntry,
 ) -> None:
-    """Test set_usercode raises CodeRejectedError on non-zero status."""
+    """Test async_set_credential raises CodeRejectedError on non-zero status."""
     cluster = zha_lock._get_door_lock_cluster()
     assert cluster is not None
     cluster.set_pin_code = AsyncMock(return_value=type("Response", (), {"status": 1})())
 
+    credential = credential_from_slot(3, SlotCredential.known("5678"))
     with pytest.raises(CodeRejectedError, match="set_pin_code rejected"):
-        await zha_lock.async_set_usercode(3, "5678")
+        await zha_lock.async_set_credential(3, credential, name=None, source="direct")
 
 
-async def test_clear_usercode(
+async def test_delete_credential(
     hass: HomeAssistant,
     zha_lock: ZHALock,
     simple_lcm_config_entry: MockConfigEntry,
 ) -> None:
-    """Test clear_usercode calls the cluster and pushes optimistic update."""
+    """Test async_delete_credential calls the cluster and pushes optimistic update."""
     cluster = zha_lock._get_door_lock_cluster()
     assert cluster is not None
     cluster.clear_pin_code = AsyncMock(
@@ -171,7 +211,8 @@ async def test_clear_usercode(
     )
     zha_lock.coordinator = MagicMock()
 
-    result = await zha_lock.async_clear_usercode(3)
+    ref = CredentialRef(user_id=3, type=CredentialType.PIN, slot=3)
+    result = await zha_lock.async_delete_credential(ref)
 
     assert result is True
     cluster.clear_pin_code.assert_called_once_with(3)
@@ -180,20 +221,21 @@ async def test_clear_usercode(
     )
 
 
-async def test_clear_usercode_failure(
+async def test_delete_credential_failure(
     hass: HomeAssistant,
     zha_lock: ZHALock,
     simple_lcm_config_entry: MockConfigEntry,
 ) -> None:
-    """Test clear_usercode raises CodeRejectedError on non-zero status."""
+    """Test async_delete_credential raises CodeRejectedError on non-zero status."""
     cluster = zha_lock._get_door_lock_cluster()
     assert cluster is not None
     cluster.clear_pin_code = AsyncMock(
         return_value=type("Response", (), {"status": 1})()
     )
 
+    ref = CredentialRef(user_id=3, type=CredentialType.PIN, slot=3)
     with pytest.raises(CodeRejectedError, match="clear_pin_code rejected"):
-        await zha_lock.async_clear_usercode(3)
+        await zha_lock.async_delete_credential(ref)
 
 
 # ---------------------------------------------------------------------------
@@ -576,57 +618,59 @@ async def test_check_programming_support_read_failure(
 
 
 # ---------------------------------------------------------------------------
-# get_usercodes error handling
+# Primitive error handling
 # ---------------------------------------------------------------------------
 
 
-async def test_get_usercodes_slot_read_failure(
+async def test_get_users_slot_read_failure(
     hass: HomeAssistant,
     zha_lock: ZHALock,
     simple_lcm_config_entry: MockConfigEntry,
 ) -> None:
-    """Test get_usercodes returns UNREADABLE_CODE for slots that fail to read."""
+    """Test async_get_users marks unreadable for slots that fail to read."""
     cluster = zha_lock._get_door_lock_cluster()
     assert cluster is not None
     cluster.get_pin_code = AsyncMock(side_effect=RuntimeError("zigpy timeout"))
 
-    codes = await zha_lock.async_get_usercodes()
+    users = await zha_lock.async_get_users()
+    by_slot = {u.user_id: u for u in users}
+    assert by_slot[1].pin_credentials[0].state is SlotCredential.unreadable()
+    assert by_slot[2].pin_credentials[0].state is SlotCredential.unreadable()
 
-    assert codes[1] is SlotCredential.unreadable()
-    assert codes[2] is SlotCredential.unreadable()
 
-
-async def test_get_usercodes_no_managed_slots(
+async def test_get_users_no_managed_slots(
     hass: HomeAssistant, zha_lock: ZHALock
 ) -> None:
-    """Test get_usercodes returns empty dict with no managed slots."""
-    codes = await zha_lock.async_get_usercodes()
-    assert codes == {}
+    """Test async_get_users returns empty list with no managed slots."""
+    users = await zha_lock.async_get_users()
+    assert users == []
 
 
-async def test_set_usercode_generic_exception(
+async def test_set_credential_generic_exception(
     hass: HomeAssistant,
     zha_lock: ZHALock,
     simple_lcm_config_entry: MockConfigEntry,
 ) -> None:
-    """Test set_usercode wraps zigpy comms failures as LockDisconnected."""
+    """Test async_set_credential wraps zigpy comms failures as LockDisconnected."""
     cluster = zha_lock._get_door_lock_cluster()
     assert cluster is not None
     cluster.set_pin_code = AsyncMock(side_effect=RuntimeError("zigpy error"))
 
+    credential = credential_from_slot(1, SlotCredential.known("1234"))
     with pytest.raises(LockDisconnected, match="Failed to set PIN"):
-        await zha_lock.async_set_usercode(1, "1234")
+        await zha_lock.async_set_credential(1, credential, name=None, source="direct")
 
 
-async def test_clear_usercode_generic_exception(
+async def test_delete_credential_generic_exception(
     hass: HomeAssistant,
     zha_lock: ZHALock,
     simple_lcm_config_entry: MockConfigEntry,
 ) -> None:
-    """Test clear_usercode wraps zigpy comms failures as LockDisconnected."""
+    """Test async_delete_credential wraps zigpy comms failures as LockDisconnected."""
     cluster = zha_lock._get_door_lock_cluster()
     assert cluster is not None
     cluster.clear_pin_code = AsyncMock(side_effect=RuntimeError("zigpy error"))
 
+    ref = CredentialRef(user_id=1, type=CredentialType.PIN, slot=1)
     with pytest.raises(LockDisconnected, match="Failed to clear PIN"):
-        await zha_lock.async_clear_usercode(1)
+        await zha_lock.async_delete_credential(ref)

--- a/tests/providers/zigbee2mqtt/test_provider.py
+++ b/tests/providers/zigbee2mqtt/test_provider.py
@@ -13,6 +13,11 @@ from homeassistant.components.mqtt import DOMAIN as MQTT_DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 
+from custom_components.lock_code_manager.domain.credentials import (
+    CredentialRef,
+    CredentialType,
+    credential_from_slot,
+)
 from custom_components.lock_code_manager.domain.exceptions import (
     LockDisconnected,
     LockOperationFailed,
@@ -187,8 +192,8 @@ class TestPushSubscription:
         assert fut.cancelled()
 
 
-class TestAsyncGetUsercodes:
-    """Request/response path for async_get_usercodes via MQTT get + pin_code futures."""
+class TestAsyncGetUsers:
+    """Request/response path for async_get_users via MQTT get + pin_code futures."""
 
     async def test_wait_for_timeout_maps_slot_to_unreadable(
         self,
@@ -225,9 +230,10 @@ class TestAsyncGetUsercodes:
                 side_effect=fast_pin_timeout,
             ),
         ):
-            result = await lock.async_get_usercodes()
+            users = await lock.async_get_users()
 
-        assert result == {11: SlotCredential.unreadable()}
+        by_slot = {u.user_id: u for u in users}
+        assert by_slot[11].pin_credentials[0].state is SlotCredential.unreadable()
 
     async def test_publish_failure_maps_slot_to_unreadable(
         self,
@@ -255,16 +261,17 @@ class TestAsyncGetUsercodes:
                 side_effect=boom,
             ),
         ):
-            result = await lock.async_get_usercodes()
+            users = await lock.async_get_users()
 
-        assert result == {7: SlotCredential.unreadable()}
+        by_slot = {u.user_id: u for u in users}
+        assert by_slot[7].pin_credentials[0].state is SlotCredential.unreadable()
 
-    async def test_async_get_usercodes_raises_when_lock_not_connected(
+    async def test_async_get_users_raises_when_lock_not_connected(
         self,
         hass: HomeAssistant,
         zigbee2mqtt_lock_with_device: Zigbee2MQTTLock,
     ) -> None:
-        """When the lock is not considered connected, get usercodes does not run."""
+        """When the lock is not considered connected, get users does not run."""
         lock = zigbee2mqtt_lock_with_device
         hass.states.async_set(lock.lock.entity_id, "locked")
         with (
@@ -279,9 +286,9 @@ class TestAsyncGetUsercodes:
             ),
             pytest.raises(LockDisconnected, match="Lock not connected"),
         ):
-            await lock.async_get_usercodes()
+            await lock.async_get_users()
 
-    async def test_async_get_usercodes_raises_when_not_zigbee2mqtt_bridge(
+    async def test_async_get_users_raises_when_not_zigbee2mqtt_bridge(
         self,
         hass: HomeAssistant,
         zigbee2mqtt_lock_wrong_identifier: Zigbee2MQTTLock,
@@ -300,9 +307,9 @@ class TestAsyncGetUsercodes:
             ),
             pytest.raises(LockDisconnected, match="not a Zigbee2MQTT lock"),
         ):
-            await lock.async_get_usercodes()
+            await lock.async_get_users()
 
-    async def test_async_get_usercodes_raises_when_get_topic_unavailable(
+    async def test_async_get_users_raises_when_get_topic_unavailable(
         self,
         hass: HomeAssistant,
         zigbee2mqtt_lock_with_device: Zigbee2MQTTLock,
@@ -318,9 +325,9 @@ class TestAsyncGetUsercodes:
             patch.object(lock, "_get_topic", return_value=None),
             pytest.raises(LockDisconnected, match="Could not determine MQTT topic"),
         ):
-            await lock.async_get_usercodes()
+            await lock.async_get_users()
 
-    async def test_async_get_usercodes_raises_when_device_unavailable(
+    async def test_async_get_users_raises_when_device_unavailable(
         self,
         hass: HomeAssistant,
         zigbee2mqtt_lock_with_device: Zigbee2MQTTLock,
@@ -335,7 +342,7 @@ class TestAsyncGetUsercodes:
             ),
             pytest.raises(LockDisconnected, match="Device not available"),
         ):
-            await lock.async_get_usercodes()
+            await lock.async_get_users()
 
     async def test_wait_pin_non_timeout_exception_maps_slot_to_unreadable(
         self,
@@ -367,20 +374,21 @@ class TestAsyncGetUsercodes:
                 side_effect=boom,
             ),
         ):
-            result = await lock.async_get_usercodes()
+            users = await lock.async_get_users()
 
-        assert result == {21: SlotCredential.unreadable()}
+        by_slot = {u.user_id: u for u in users}
+        assert by_slot[21].pin_credentials[0].state is SlotCredential.unreadable()
 
 
 class TestAsyncSetClearHardRefresh:
-    """Cover async_set_usercode, async_clear_usercode, mqtt errors, and teardown."""
+    """Cover async_set_credential, async_delete_credential, mqtt errors, and teardown."""
 
-    async def test_async_get_usercodes_empty_managed_returns_empty_dict(
+    async def test_async_get_users_empty_managed_returns_empty_list(
         self,
         hass: HomeAssistant,
         zigbee2mqtt_lock_with_device: Zigbee2MQTTLock,
     ) -> None:
-        """No managed slots yields an empty mapping without publishing."""
+        """No managed slots yields an empty list without publishing."""
         lock = zigbee2mqtt_lock_with_device
         hass.states.async_set(lock.lock.entity_id, "locked")
         with (
@@ -397,12 +405,12 @@ class TestAsyncSetClearHardRefresh:
                 new_callable=AsyncMock,
             ) as mock_pub,
         ):
-            result = await lock.async_get_usercodes()
+            result = await lock.async_get_users()
 
-        assert result == {}
+        assert result == []
         mock_pub.assert_not_called()
 
-    async def test_async_get_usercodes_mqtt_disabled_raises(
+    async def test_async_get_users_mqtt_disabled_raises(
         self,
         zigbee2mqtt_lock_with_device: Zigbee2MQTTLock,
     ) -> None:
@@ -415,14 +423,15 @@ class TestAsyncSetClearHardRefresh:
             ),
             pytest.raises(LockDisconnected),
         ):
-            await lock.async_get_usercodes()
+            await lock.async_get_users()
 
-    async def test_async_set_usercode_raises_when_mqtt_disabled(
+    async def test_async_set_credential_raises_when_mqtt_disabled(
         self,
         zigbee2mqtt_lock_with_device: Zigbee2MQTTLock,
     ) -> None:
         """MQTT integration disabled rejects set before connectivity checks."""
         lock = zigbee2mqtt_lock_with_device
+        credential = credential_from_slot(1, SlotCredential.known("1234"))
         with (
             patch(
                 "custom_components.lock_code_manager.providers.zigbee2mqtt.mqtt_config_entry_enabled",
@@ -430,14 +439,15 @@ class TestAsyncSetClearHardRefresh:
             ),
             pytest.raises(LockDisconnected, match="MQTT component not available"),
         ):
-            await lock.async_set_usercode(1, "1234")
+            await lock.async_set_credential(1, credential, name=None, source="direct")
 
-    async def test_async_clear_usercode_raises_when_mqtt_disabled(
+    async def test_async_delete_credential_raises_when_mqtt_disabled(
         self,
         zigbee2mqtt_lock_with_device: Zigbee2MQTTLock,
     ) -> None:
         """MQTT integration disabled rejects clear before connectivity checks."""
         lock = zigbee2mqtt_lock_with_device
+        ref = CredentialRef(user_id=5, type=CredentialType.PIN, slot=5)
         with (
             patch(
                 "custom_components.lock_code_manager.providers.zigbee2mqtt.mqtt_config_entry_enabled",
@@ -445,9 +455,9 @@ class TestAsyncSetClearHardRefresh:
             ),
             pytest.raises(LockDisconnected, match="MQTT component not available"),
         ):
-            await lock.async_clear_usercode(5)
+            await lock.async_delete_credential(ref)
 
-    async def test_async_set_usercode_raises_when_not_connected(
+    async def test_async_set_credential_raises_when_not_connected(
         self,
         hass: HomeAssistant,
         zigbee2mqtt_lock_with_device: Zigbee2MQTTLock,
@@ -455,6 +465,7 @@ class TestAsyncSetClearHardRefresh:
         """Disconnected lock raises before publishing a set PIN payload."""
         lock = zigbee2mqtt_lock_with_device
         hass.states.async_set(lock.lock.entity_id, "locked")
+        credential = credential_from_slot(3, SlotCredential.known("9999"))
         with (
             patch(
                 "custom_components.lock_code_manager.providers.zigbee2mqtt.mqtt_config_entry_enabled",
@@ -467,9 +478,9 @@ class TestAsyncSetClearHardRefresh:
             ),
             pytest.raises(LockDisconnected, match="Lock not connected"),
         ):
-            await lock.async_set_usercode(3, "9999")
+            await lock.async_set_credential(3, credential, name=None, source="direct")
 
-    async def test_async_clear_usercode_raises_when_not_connected(
+    async def test_async_delete_credential_raises_when_not_connected(
         self,
         hass: HomeAssistant,
         zigbee2mqtt_lock_with_device: Zigbee2MQTTLock,
@@ -477,6 +488,7 @@ class TestAsyncSetClearHardRefresh:
         """Disconnected lock raises before publishing a clear PIN payload."""
         lock = zigbee2mqtt_lock_with_device
         hass.states.async_set(lock.lock.entity_id, "locked")
+        ref = CredentialRef(user_id=9, type=CredentialType.PIN, slot=9)
         with (
             patch(
                 "custom_components.lock_code_manager.providers.zigbee2mqtt.mqtt_config_entry_enabled",
@@ -489,9 +501,9 @@ class TestAsyncSetClearHardRefresh:
             ),
             pytest.raises(LockDisconnected, match="Lock not connected"),
         ):
-            await lock.async_clear_usercode(9)
+            await lock.async_delete_credential(ref)
 
-    async def test_async_set_usercode_raises_when_not_zigbee2mqtt_bridge(
+    async def test_async_set_credential_raises_when_not_zigbee2mqtt_bridge(
         self,
         hass: HomeAssistant,
         zigbee2mqtt_lock_wrong_identifier: Zigbee2MQTTLock,
@@ -499,6 +511,7 @@ class TestAsyncSetClearHardRefresh:
         """MQTT lock without zigbee2mqtt_* id fails set with the same hint as reads."""
         lock = zigbee2mqtt_lock_wrong_identifier
         hass.states.async_set(lock.lock.entity_id, "locked")
+        credential = credential_from_slot(1, SlotCredential.known("1234"))
         with (
             patch(
                 "custom_components.lock_code_manager.providers.zigbee2mqtt.mqtt_config_entry_enabled",
@@ -506,9 +519,9 @@ class TestAsyncSetClearHardRefresh:
             ),
             pytest.raises(LockDisconnected, match="not a Zigbee2MQTT lock"),
         ):
-            await lock.async_set_usercode(1, "1234")
+            await lock.async_set_credential(1, credential, name=None, source="direct")
 
-    async def test_async_set_usercode_raises_when_topic_unavailable(
+    async def test_async_set_credential_raises_when_topic_unavailable(
         self,
         hass: HomeAssistant,
         zigbee2mqtt_lock_with_device: Zigbee2MQTTLock,
@@ -516,6 +529,7 @@ class TestAsyncSetClearHardRefresh:
         """If the MQTT topic cannot be resolved, set PIN fails early."""
         lock = zigbee2mqtt_lock_with_device
         hass.states.async_set(lock.lock.entity_id, "locked")
+        credential = credential_from_slot(2, SlotCredential.known("8888"))
         with (
             patch(
                 "custom_components.lock_code_manager.providers.zigbee2mqtt.mqtt_config_entry_enabled",
@@ -529,9 +543,9 @@ class TestAsyncSetClearHardRefresh:
             patch.object(lock, "_get_topic", return_value=None),
             pytest.raises(LockDisconnected, match="Could not determine MQTT topic"),
         ):
-            await lock.async_set_usercode(2, "8888")
+            await lock.async_set_credential(2, credential, name=None, source="direct")
 
-    async def test_async_clear_usercode_raises_when_topic_unavailable(
+    async def test_async_delete_credential_raises_when_topic_unavailable(
         self,
         hass: HomeAssistant,
         zigbee2mqtt_lock_with_device: Zigbee2MQTTLock,
@@ -539,6 +553,7 @@ class TestAsyncSetClearHardRefresh:
         """If the MQTT topic cannot be resolved, clear PIN fails early."""
         lock = zigbee2mqtt_lock_with_device
         hass.states.async_set(lock.lock.entity_id, "locked")
+        ref = CredentialRef(user_id=6, type=CredentialType.PIN, slot=6)
         with (
             patch(
                 "custom_components.lock_code_manager.providers.zigbee2mqtt.mqtt_config_entry_enabled",
@@ -552,9 +567,9 @@ class TestAsyncSetClearHardRefresh:
             patch.object(lock, "_get_topic", return_value=None),
             pytest.raises(LockDisconnected, match="Could not determine MQTT topic"),
         ):
-            await lock.async_clear_usercode(6)
+            await lock.async_delete_credential(ref)
 
-    async def test_async_set_usercode_without_coordinator_still_true(
+    async def test_async_set_credential_without_coordinator_still_true(
         self,
         hass: HomeAssistant,
         zigbee2mqtt_lock_with_device: Zigbee2MQTTLock,
@@ -563,6 +578,7 @@ class TestAsyncSetClearHardRefresh:
         lock = zigbee2mqtt_lock_with_device
         hass.states.async_set(lock.lock.entity_id, "locked")
         lock.coordinator = None
+        credential = credential_from_slot(2, SlotCredential.known("9999"))
         mock_pub = AsyncMock()
         with (
             patch(
@@ -574,9 +590,14 @@ class TestAsyncSetClearHardRefresh:
                 mock_pub,
             ),
         ):
-            assert await lock.async_set_usercode(2, "9999") is True
+            assert (
+                await lock.async_set_credential(
+                    2, credential, name=None, source="direct"
+                )
+                is True
+            )
 
-    async def test_async_set_usercode_publish_oserror_raises_lock_disconnected(
+    async def test_async_set_credential_publish_oserror_raises_lock_disconnected(
         self,
         hass: HomeAssistant,
         zigbee2mqtt_lock_with_device: Zigbee2MQTTLock,
@@ -589,6 +610,7 @@ class TestAsyncSetClearHardRefresh:
         """
         lock = zigbee2mqtt_lock_with_device
         hass.states.async_set(lock.lock.entity_id, "locked")
+        credential = credential_from_slot(1, SlotCredential.known("1111"))
         mock_pub = AsyncMock(side_effect=OSError("broker"))
 
         with (
@@ -602,9 +624,9 @@ class TestAsyncSetClearHardRefresh:
             ),
             pytest.raises(LockDisconnected, match="Failed to set PIN"),
         ):
-            await lock.async_set_usercode(1, "1111")
+            await lock.async_set_credential(1, credential, name=None, source="direct")
 
-    async def test_async_set_usercode_publish_ha_error_raises_operation_failed(
+    async def test_async_set_credential_publish_ha_error_raises_operation_failed(
         self,
         hass: HomeAssistant,
         zigbee2mqtt_lock_with_device: Zigbee2MQTTLock,
@@ -612,6 +634,7 @@ class TestAsyncSetClearHardRefresh:
         """HomeAssistantError from publish surfaces as LockOperationFailed."""
         lock = zigbee2mqtt_lock_with_device
         hass.states.async_set(lock.lock.entity_id, "locked")
+        credential = credential_from_slot(1, SlotCredential.known("1111"))
         mock_pub = AsyncMock(side_effect=HomeAssistantError("payload rejected"))
 
         with (
@@ -625,9 +648,9 @@ class TestAsyncSetClearHardRefresh:
             ),
             pytest.raises(LockOperationFailed, match="Failed to set PIN"),
         ):
-            await lock.async_set_usercode(1, "1111")
+            await lock.async_set_credential(1, credential, name=None, source="direct")
 
-    async def test_async_clear_usercode_publish_failure_raises(
+    async def test_async_delete_credential_publish_failure_raises(
         self,
         hass: HomeAssistant,
         zigbee2mqtt_lock_with_device: Zigbee2MQTTLock,
@@ -635,6 +658,7 @@ class TestAsyncSetClearHardRefresh:
         """Non-MQTT publish failures propagate for visibility (not masked as disconnected)."""
         lock = zigbee2mqtt_lock_with_device
         hass.states.async_set(lock.lock.entity_id, "locked")
+        ref = CredentialRef(user_id=4, type=CredentialType.PIN, slot=4)
         mock_pub = AsyncMock(side_effect=RuntimeError("fail"))
 
         with (
@@ -648,9 +672,9 @@ class TestAsyncSetClearHardRefresh:
             ),
             pytest.raises(RuntimeError, match="fail"),
         ):
-            await lock.async_clear_usercode(4)
+            await lock.async_delete_credential(ref)
 
-    async def test_async_clear_usercode_publish_oserror_raises_lock_disconnected(
+    async def test_async_delete_credential_publish_oserror_raises_lock_disconnected(
         self,
         hass: HomeAssistant,
         zigbee2mqtt_lock_with_device: Zigbee2MQTTLock,
@@ -658,6 +682,7 @@ class TestAsyncSetClearHardRefresh:
         """Clear path maps MQTT OSError publish failures to LockDisconnected."""
         lock = zigbee2mqtt_lock_with_device
         hass.states.async_set(lock.lock.entity_id, "locked")
+        ref = CredentialRef(user_id=4, type=CredentialType.PIN, slot=4)
         mock_pub = AsyncMock(side_effect=OSError("broker"))
 
         with (
@@ -671,9 +696,9 @@ class TestAsyncSetClearHardRefresh:
             ),
             pytest.raises(LockDisconnected, match="Failed to clear PIN"),
         ):
-            await lock.async_clear_usercode(4)
+            await lock.async_delete_credential(ref)
 
-    async def test_async_clear_usercode_publish_ha_error_raises_operation_failed(
+    async def test_async_delete_credential_publish_ha_error_raises_operation_failed(
         self,
         hass: HomeAssistant,
         zigbee2mqtt_lock_with_device: Zigbee2MQTTLock,
@@ -681,6 +706,7 @@ class TestAsyncSetClearHardRefresh:
         """HomeAssistantError from publish surfaces as LockOperationFailed."""
         lock = zigbee2mqtt_lock_with_device
         hass.states.async_set(lock.lock.entity_id, "locked")
+        ref = CredentialRef(user_id=4, type=CredentialType.PIN, slot=4)
         mock_pub = AsyncMock(side_effect=HomeAssistantError("payload rejected"))
 
         with (
@@ -694,7 +720,7 @@ class TestAsyncSetClearHardRefresh:
             ),
             pytest.raises(LockOperationFailed, match="Failed to clear PIN"),
         ):
-            await lock.async_clear_usercode(4)
+            await lock.async_delete_credential(ref)
 
     async def test_async_hard_refresh_delegates_to_get_usercodes(
         self,


### PR DESCRIPTION
## Proposed change

Migrates the five slot-only lock providers — `virtual`, `zha`, `zigbee2mqtt`, `schlage`, `akuvox` — onto the `BaseLock` credential-primitive interface from #1225. This is PR 6 of the credential-management refactor (the "degenerate fixed point"), completing the provider layer alongside zwave_js (#1227) and matter (#1228).

These providers have **no native user concept**, so they keep `supports_native_users = False` (the default). The base orchestration then routes `async_set_usercode → async_set_credential(user_id=slot, …)` and `async_clear_usercode → async_delete_credential(ref)`, ignoring the user layer entirely. Each provider:
- implements `async_set_credential` (the old `async_set_usercode` body, using `credential.readable_pin`/`credential.slot`), `async_delete_credential` (old clear body, using `ref.slot`), and `async_get_users` (old `async_get_usercodes` dict wrapped via `user_from_slot`);
- drops the `async_set_usercode` / `async_clear_usercode` / `async_get_usercodes` overrides — the base orchestration + get-projection (which seeds empty managed slots) take over;
- preserves everything else: `zha`/`zigbee2mqtt` keep their optimistic `_push_credential_update` and push subscriptions; `schlage`/`akuvox` keep their `[LCM:<slot>]` tagging + setup; all keep `async_hard_refresh_codes`, connection/availability, and `supports_push`.

**Behavior is unchanged** — this is a pure refactor onto one interface. The `get → async_get_users → base projection` round-trip is lossless (`user_from_slot` then flatten is identity on the slot→state map), and empty-managed-slot / unmanaged-occupied handling is preserved.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- Depends on #1225 (merged). Independent of #1227 (zwave_js) and #1228 (matter).
- Debug log wording in `akuvox` and `schlage` `async_set_credential` / `async_delete_credential` aligned with credential-primitive terminology ("set/deleted Personal Identification Number credential" rather than the legacy "set/cleared usercode") so grep tracing stays consistent across the new interface.
- Pre-commit ruff hook bumped to v0.15.16 to match main (PR predates the autoupdate #1226).
- Tests rewritten to drive the primitives + base orchestration end-to-end while keeping every legacy behavioral assertion (same device/store calls, same optimistic push, same known/empty/unreadable projection), plus new seam/projection coverage. Full suite: 1044 passing; ruff + providers mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)