### PR TITLE
refactor(providers): hoist PIN-readability guard to base seam

### DIFF
--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -866,13 +866,15 @@ class BaseLock:
         """
         state = SlotCredential.known(usercode)
         credential = credential_from_slot(code_slot, state)
+        pin = self._require_readable_pin(credential)
         if not self.supports_native_users:
             return await self.async_set_credential(
-                code_slot, credential, name=name, source=source
+                code_slot, credential, pin, name=name, source=source
             )
         return await self._set_credential(
             user_from_slot(code_slot, state, name),
             credential,
+            pin,
             name=name,
             source=source,
         )
@@ -1106,11 +1108,33 @@ class BaseLock:
                 reason=f"unsupported credential type: {ref.type}",
             )
 
+    def _require_readable_pin(self, credential: Credential) -> str:
+        """
+        Return the credential's readable PIN, or raise ``CodeRejectedError``.
+
+        The seam (``async_set_usercode``) builds credentials from a string
+        usercode so ``readable_pin`` is always set by construction along
+        that path. Providers call this helper at the top of their
+        ``async_set_credential`` override so the contract is expressed
+        once and the per-provider write path can use the returned ``str``
+        directly without an ``or ""`` coercion (which would silently send
+        a blank PIN to the device).
+        """
+        pin = credential.readable_pin
+        if pin is None:
+            raise CodeRejectedError(
+                code_slot=credential.slot,
+                lock_entity_id=self.lock.entity_id,
+                reason="cannot write an unreadable credential",
+            )
+        return pin
+
     @final
     async def _set_credential(
         self,
         user: User,
         credential: Credential,
+        pin: str,
         *,
         name: str | None,
         source: Literal["sync", "direct"],
@@ -1126,6 +1150,11 @@ class BaseLock:
         newly-created user when the credential write fails so the lock
         isn't left with a credential-less user the slot-keyed coordinator
         can't reconcile. Returns True if the value changed.
+
+        ``pin`` is the resolved readable PIN that the caller (the seam in
+        ``async_set_usercode``) has already validated via
+        ``_require_readable_pin``; threading it through avoids a second
+        validation pass in the provider.
         """
         await self._assert_credential_type_supported(credential)
         if await self._supports_user_records():
@@ -1141,7 +1170,7 @@ class BaseLock:
             rollback_user_id = None
         try:
             return await self.async_set_credential(
-                credential_user_id, credential, name=name, source=source
+                credential_user_id, credential, pin, name=name, source=source
             )
         except Exception:
             if rollback_user_id is not None:
@@ -1235,6 +1264,7 @@ class BaseLock:
         self,
         user_id: int,
         credential: Credential,
+        pin: str,
         *,
         name: str | None,
         source: Literal["sync", "direct"],
@@ -1244,12 +1274,16 @@ class BaseLock:
 
         Every migrated provider implements this. ``user_id`` identifies the
         owning user for native-user providers; slot-only providers ignore it
-        and address the credential by ``credential.slot``. Providers raise
-        ``DuplicateCodeError`` when the lock rejects the value as a duplicate.
-        Native-user providers carry the user's name on the user record, so they
-        may treat ``name`` here as advisory; slot-only providers use it (for
-        example as a tagged code name). A ``name`` of ``None`` means leave any
-        existing name unchanged, never clear it.
+        and address the credential by ``credential.slot``. ``pin`` is the
+        resolved readable PIN string; the base seam validates that
+        ``credential.readable_pin`` is non-None and passes it through so
+        providers receive a guaranteed string and don't need their own
+        defensive checks. Providers raise ``DuplicateCodeError`` when the
+        lock rejects the value as a duplicate. Native-user providers carry
+        the user's name on the user record, so they may treat ``name`` here
+        as advisory; slot-only providers use it (for example as a tagged
+        code name). A ``name`` of ``None`` means leave any existing name
+        unchanged, never clear it.
 
         Return True if the value changed, False if it was already set to this
         value. When the provider cannot determine whether a change occurred

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -1112,13 +1112,19 @@ class BaseLock:
         """
         Return the credential's readable PIN, or raise ``CodeRejectedError``.
 
-        The seam (``async_set_usercode``) builds credentials from a string
-        usercode so ``readable_pin`` is always set by construction along
-        that path. Providers call this helper at the top of their
-        ``async_set_credential`` override so the contract is expressed
-        once and the per-provider write path can use the returned ``str``
-        directly without an ``or ""`` coercion (which would silently send
-        a blank PIN to the device).
+        Called by the seam (``async_set_usercode`` and ``_set_credential``)
+        before dispatching to the provider's ``async_set_credential``
+        override; the resolved ``pin: str`` is threaded through as a
+        positional argument so the provider receives a guaranteed string
+        and does not need its own defensive check.
+
+        The seam already builds credentials from a string usercode so
+        ``readable_pin`` is non-None by construction along that path -- the
+        guard catches future regressions (a credential constructed outside
+        the seam, a refactor that loses the invariant) and never the
+        normal flow. Providers MUST NOT re-add their own readable-pin
+        check; doing so duplicates the contract and re-introduces the
+        ``or ""`` silent coercion pattern this helper exists to eliminate.
         """
         pin = credential.readable_pin
         if pin is None:

--- a/custom_components/lock_code_manager/providers/akuvox.py
+++ b/custom_components/lock_code_manager/providers/akuvox.py
@@ -330,6 +330,7 @@ class AkuvoxLock(BaseLock):
         self,
         user_id: int,
         credential: Credential,
+        pin: str,
         *,
         name: str | None,
         source: Literal["sync", "direct"],
@@ -349,7 +350,6 @@ class AkuvoxLock(BaseLock):
         credential by slot.
         """
         code_slot = credential.slot
-        usercode = credential.readable_pin or ""
         async with self._serialize_sequence():
             users = await self._async_list_users()
 
@@ -370,10 +370,10 @@ class AkuvoxLock(BaseLock):
 
             if existing_device_id:
                 await self._async_modify_user(
-                    existing_device_id, name=tagged_name, pin=usercode
+                    existing_device_id, name=tagged_name, pin=pin
                 )
             else:
-                await self._async_add_user(tagged_name, usercode)
+                await self._async_add_user(tagged_name, pin)
 
         LOGGER.debug(
             "Lock %s: set Personal Identification Number credential on slot %s",

--- a/custom_components/lock_code_manager/providers/matter.py
+++ b/custom_components/lock_code_manager/providers/matter.py
@@ -410,6 +410,7 @@ class MatterLock(BaseLock):
         self,
         user_id: int,
         credential: Credential,
+        pin: str,
         *,
         name: str | None,
         source: Literal["sync", "direct"],
@@ -417,24 +418,15 @@ class MatterLock(BaseLock):
         """
         Write a Personal Identification Number credential to the lock.
 
-        Raises CodeRejectedError when the credential has no readable value
-        (for example when projecting an already-unreadable slot — the lock
-        requires a concrete PIN string). Handles the duplicate-slot restart
-        case for sync sources by clearing and retrying once.
+        ``pin`` is the resolved PIN string the seam already validated as
+        non-None; surgical write path only. Handles the duplicate-slot
+        restart case for sync sources by clearing and retrying once.
 
         The base orchestration skips coordinator refresh for push providers.
         Matter does not emit LockUserChange for LCM-initiated writes, so an
         optimistic push is required to keep the coordinator current.
         """
-        if credential.readable_pin is None:
-            raise CodeRejectedError(
-                code_slot=credential.slot,
-                lock_entity_id=self.lock.entity_id,
-                reason="credential has no readable Personal Identification Number value",
-            )
-
         client, node = self._require_client_and_node()
-        pin = credential.readable_pin
         slot = credential.slot
 
         try:

--- a/custom_components/lock_code_manager/providers/schlage.py
+++ b/custom_components/lock_code_manager/providers/schlage.py
@@ -352,6 +352,7 @@ class SchlageLock(BaseLock):
         self,
         user_id: int,
         credential: Credential,
+        pin: str,
         *,
         name: str | None,
         source: Literal["sync", "direct"],
@@ -368,7 +369,6 @@ class SchlageLock(BaseLock):
         address the credential by slot.
         """
         code_slot = credential.slot
-        usercode = credential.readable_pin or ""
         async with self._serialize_sequence():
             codes = await self._async_get_codes()
 
@@ -396,7 +396,7 @@ class SchlageLock(BaseLock):
                     await self._async_delete_code(code_name)
 
             try:
-                await self._async_add_code(tagged_name, usercode)
+                await self._async_add_code(tagged_name, pin)
             except (LockDisconnected, LockOperationFailed) as err:
                 # Schlage's cloud API has eventual consistency: a delete may not
                 # propagate before the add, causing "already exists".  Since Personal

--- a/custom_components/lock_code_manager/providers/virtual.py
+++ b/custom_components/lock_code_manager/providers/virtual.py
@@ -69,6 +69,7 @@ class VirtualLock(BaseLock):
         self,
         user_id: int,
         credential: Credential,
+        pin: str,
         *,
         name: str | None,
         source: Literal["sync", "direct"],
@@ -80,7 +81,7 @@ class VirtualLock(BaseLock):
         Ignores ``user_id``; slot-only providers address the credential by slot.
         """
         slot_key = str(credential.slot)
-        new_data = CodeSlotData(code=credential.readable_pin or "", name=name)
+        new_data = CodeSlotData(code=pin, name=name)
         if slot_key in self._data and self._data[slot_key] == new_data:
             return False
         self._data[slot_key] = new_data

--- a/custom_components/lock_code_manager/providers/zha.py
+++ b/custom_components/lock_code_manager/providers/zha.py
@@ -224,6 +224,7 @@ class ZHALock(BaseLock):
         self,
         user_id: int,
         credential: Credential,
+        pin: str,
         *,
         name: str | None,
         source: Literal["sync", "direct"],
@@ -243,14 +244,13 @@ class ZHALock(BaseLock):
         by ``credential.slot``.
         """
         code_slot = credential.slot
-        usercode = credential.readable_pin or ""
         cluster = await self._get_connected_cluster()
         try:
             result = await cluster.set_pin_code(
                 code_slot,
                 DoorLock.UserStatus.Enabled,
                 DoorLock.UserType.Unrestricted,
-                str(usercode),
+                pin,
             )
         except Exception as err:
             raise LockDisconnected(f"Failed to set PIN: {err}") from err
@@ -266,7 +266,7 @@ class ZHALock(BaseLock):
                 lock_entity_id=self.lock.entity_id,
                 reason=f"set_pin_code rejected: status {result.status}",
             )
-        self._push_credential_update(code_slot, SlotCredential.known(usercode))
+        self._push_credential_update(code_slot, SlotCredential.known(pin))
         return True
 
     async def async_delete_credential(self, ref: CredentialRef) -> bool:

--- a/custom_components/lock_code_manager/providers/zigbee2mqtt.py
+++ b/custom_components/lock_code_manager/providers/zigbee2mqtt.py
@@ -407,6 +407,7 @@ class Zigbee2MQTTLock(BaseLock):
         self,
         user_id: int,
         credential: Credential,
+        pin: str,
         *,
         name: str | None,
         source: Literal["sync", "direct"],
@@ -420,7 +421,6 @@ class Zigbee2MQTTLock(BaseLock):
         slot-only providers address the credential by ``credential.slot``.
         """
         code_slot = credential.slot
-        usercode = credential.readable_pin or ""
 
         if not mqtt_config_entry_enabled(self.hass):
             raise LockDisconnected("MQTT component not available")
@@ -439,7 +439,7 @@ class Zigbee2MQTTLock(BaseLock):
                 "pin_code": {
                     "user": code_slot,
                     "user_type": "unrestricted",
-                    "pin_code": str(usercode),
+                    "pin_code": pin,
                     "user_enabled": True,
                 }
             }
@@ -473,7 +473,7 @@ class Zigbee2MQTTLock(BaseLock):
             code_slot,
         )
         # Optimistic coordinator update after publish (MQTT QoS 0); hard_refresh mitigates drift.
-        self._push_credential_update(code_slot, SlotCredential.known(str(usercode)))
+        self._push_credential_update(code_slot, SlotCredential.known(pin))
         return True
 
     async def async_delete_credential(self, ref: CredentialRef) -> bool:

--- a/custom_components/lock_code_manager/providers/zwave_js.py
+++ b/custom_components/lock_code_manager/providers/zwave_js.py
@@ -271,21 +271,12 @@ class ZWaveJSLock(BaseLock):
         self,
         user_id: int,
         credential: Credential,
+        pin: str,
         *,
         name: str | None,
         source: Literal["sync", "direct"],
     ) -> bool:
         """Write the Personal Identification Number credential under user_id; map device rejections."""
-        pin = credential.readable_pin
-        if pin is None:
-            # The set path only ever carries a readable Personal Identification
-            # Number; guard so an unreadable credential fails cleanly rather
-            # than passing None into the helper's str-only signature.
-            raise CodeRejectedError(
-                code_slot=credential.slot,
-                lock_entity_id=self.lock.entity_id,
-                reason="cannot write an unreadable credential",
-            )
         try:
             await lock_helpers.async_set_credential(
                 self.node,

--- a/tests/providers/akuvox/test_e2e.py
+++ b/tests/providers/akuvox/test_e2e.py
@@ -61,6 +61,7 @@ class TestSetAndClearCredentials:
         result = await e2e_akuvox_lock.async_set_credential(
             1,
             credential_from_slot(1, SlotCredential.known("9999")),
+            (credential_from_slot(1, SlotCredential.known("9999"))).readable_pin or "",
             name="E2E Guest",
             source="direct",
         )
@@ -94,6 +95,7 @@ class TestSetAndClearCredentials:
         result = await e2e_akuvox_lock.async_set_credential(
             1,
             credential_from_slot(1, SlotCredential.known("5678")),
+            (credential_from_slot(1, SlotCredential.known("5678"))).readable_pin or "",
             name="Updated",
             source="direct",
         )

--- a/tests/providers/akuvox/test_e2e.py
+++ b/tests/providers/akuvox/test_e2e.py
@@ -61,7 +61,7 @@ class TestSetAndClearCredentials:
         result = await e2e_akuvox_lock.async_set_credential(
             1,
             credential_from_slot(1, SlotCredential.known("9999")),
-            (credential_from_slot(1, SlotCredential.known("9999"))).readable_pin or "",
+            "9999",
             name="E2E Guest",
             source="direct",
         )
@@ -95,7 +95,7 @@ class TestSetAndClearCredentials:
         result = await e2e_akuvox_lock.async_set_credential(
             1,
             credential_from_slot(1, SlotCredential.known("5678")),
-            (credential_from_slot(1, SlotCredential.known("5678"))).readable_pin or "",
+            "5678",
             name="Updated",
             source="direct",
         )

--- a/tests/providers/akuvox/test_provider.py
+++ b/tests/providers/akuvox/test_provider.py
@@ -371,7 +371,7 @@ class TestSetCredential:
         result = await akuvox_lock.async_set_credential(
             1,
             _pin_cred(1, "9999"),
-            (_pin_cred(1, "9999")).readable_pin or "",
+            "9999",
             name=None,
             source="direct",
         )
@@ -398,7 +398,7 @@ class TestSetCredential:
             await akuvox_lock.async_set_credential(
                 1,
                 _pin_cred(1, "1234"),
-                (_pin_cred(1, "1234")).readable_pin or "",
+                "1234",
                 name=None,
                 source="direct",
             )
@@ -691,14 +691,14 @@ class TestAutoTagging:
             akuvox_lock.async_set_credential(
                 1,
                 _pin_cred(1, "1111"),
-                (_pin_cred(1, "1111")).readable_pin or "",
+                "1111",
                 name=None,
                 source="direct",
             ),
             akuvox_lock.async_set_credential(
                 2,
                 _pin_cred(2, "2222"),
-                (_pin_cred(2, "2222")).readable_pin or "",
+                "2222",
                 name=None,
                 source="direct",
             ),
@@ -769,7 +769,7 @@ class TestBaseOrchestration:
         await akuvox_lock.async_set_credential(
             1,
             _pin_cred(1, "7777"),
-            (_pin_cred(1, "7777")).readable_pin or "",
+            "7777",
             name="base_test",
             source="direct",
         )

--- a/tests/providers/akuvox/test_provider.py
+++ b/tests/providers/akuvox/test_provider.py
@@ -369,7 +369,11 @@ class TestSetCredential:
         )
 
         result = await akuvox_lock.async_set_credential(
-            1, _pin_cred(1, "9999"), name=None, source="direct"
+            1,
+            _pin_cred(1, "9999"),
+            (_pin_cred(1, "9999")).readable_pin or "",
+            name=None,
+            source="direct",
         )
 
         assert result is True
@@ -392,7 +396,11 @@ class TestSetCredential:
 
         with pytest.raises(LockOperationFailed, match="device offline"):
             await akuvox_lock.async_set_credential(
-                1, _pin_cred(1, "1234"), name=None, source="direct"
+                1,
+                _pin_cred(1, "1234"),
+                (_pin_cred(1, "1234")).readable_pin or "",
+                name=None,
+                source="direct",
             )
 
 
@@ -681,10 +689,18 @@ class TestAutoTagging:
 
         await asyncio.gather(
             akuvox_lock.async_set_credential(
-                1, _pin_cred(1, "1111"), name=None, source="direct"
+                1,
+                _pin_cred(1, "1111"),
+                (_pin_cred(1, "1111")).readable_pin or "",
+                name=None,
+                source="direct",
             ),
             akuvox_lock.async_set_credential(
-                2, _pin_cred(2, "2222"), name=None, source="direct"
+                2,
+                _pin_cred(2, "2222"),
+                (_pin_cred(2, "2222")).readable_pin or "",
+                name=None,
+                source="direct",
             ),
         )
 
@@ -751,7 +767,11 @@ class TestBaseOrchestration:
         )
 
         await akuvox_lock.async_set_credential(
-            1, _pin_cred(1, "7777"), name="base_test", source="direct"
+            1,
+            _pin_cred(1, "7777"),
+            (_pin_cred(1, "7777")).readable_pin or "",
+            name="base_test",
+            source="direct",
         )
 
         # After setting, the mock now returns the tagged user with the PIN

--- a/tests/providers/matter/test_provider.py
+++ b/tests/providers/matter/test_provider.py
@@ -1622,7 +1622,7 @@ class TestSetCredential:
             result = await matter_lock_simple.async_set_credential(
                 1,
                 credential,
-                credential.readable_pin or "",
+                "1234",
                 name="Alice",
                 source="direct",
             )
@@ -1648,7 +1648,7 @@ class TestSetCredential:
             patch(f"{_PROVIDER_MODULE}.set_lock_credential", mock_set_credential),
         ):
             await matter_lock_simple.async_set_credential(
-                2, credential, credential.readable_pin or "", name=None, source="direct"
+                2, credential, "5678", name=None, source="direct"
             )
 
         mock_coordinator.push_update.assert_called_once_with(
@@ -1674,7 +1674,7 @@ class TestSetCredential:
             pytest.raises(DuplicateCodeError),
         ):
             await matter_lock_simple.async_set_credential(
-                1, credential, credential.readable_pin or "", name=None, source="direct"
+                1, credential, "1234", name=None, source="direct"
             )
 
     async def test_set_credential_duplicate_sync_retries_and_succeeds(
@@ -1700,7 +1700,7 @@ class TestSetCredential:
             patch(f"{_PROVIDER_MODULE}.clear_lock_credential", mock_clear),
         ):
             result = await matter_lock_simple.async_set_credential(
-                1, credential, credential.readable_pin or "", name=None, source="sync"
+                1, credential, "1234", name=None, source="sync"
             )
 
         assert result is True
@@ -1728,7 +1728,7 @@ class TestSetCredential:
             pytest.raises(DuplicateCodeError),
         ):
             await matter_lock_simple.async_set_credential(
-                1, credential, credential.readable_pin or "", name=None, source="sync"
+                1, credential, "1234", name=None, source="sync"
             )
 
         assert mock_set_credential.call_count == 2
@@ -1755,7 +1755,7 @@ class TestSetCredential:
             pytest.raises(LockDisconnected, match="sync-duplicate retry"),
         ):
             await matter_lock_simple.async_set_credential(
-                1, credential, credential.readable_pin or "", name=None, source="sync"
+                1, credential, "1234", name=None, source="sync"
             )
         # First set raised duplicate; clear failed; no retry attempt is made.
         assert mock_set_credential.call_count == 1
@@ -1781,7 +1781,7 @@ class TestSetCredential:
             pytest.raises(LockOperationFailed, match="sync-duplicate retry"),
         ):
             await matter_lock_simple.async_set_credential(
-                1, credential, credential.readable_pin or "", name=None, source="sync"
+                1, credential, "1234", name=None, source="sync"
             )
         assert mock_set_credential.call_count == 1
 
@@ -1804,7 +1804,7 @@ class TestSetCredential:
             pytest.raises(CodeRejectedError),
         ):
             await matter_lock_simple.async_set_credential(
-                1, credential, credential.readable_pin or "", name=None, source="direct"
+                1, credential, "1234", name=None, source="direct"
             )
 
     async def test_set_credential_ha_error_raises_code_rejected(
@@ -1826,7 +1826,7 @@ class TestSetCredential:
             pytest.raises(CodeRejectedError),
         ):
             await matter_lock_simple.async_set_credential(
-                1, credential, credential.readable_pin or "", name=None, source="direct"
+                1, credential, "1", name=None, source="direct"
             )
 
     async def test_set_credential_transport_error_raises_lock_disconnected(
@@ -1846,7 +1846,7 @@ class TestSetCredential:
             pytest.raises(LockDisconnected),
         ):
             await matter_lock_simple.async_set_credential(
-                1, credential, credential.readable_pin or "", name=None, source="direct"
+                1, credential, "1234", name=None, source="direct"
             )
 
     async def test_set_credential_passes_correct_args(
@@ -1869,7 +1869,7 @@ class TestSetCredential:
             await matter_lock_simple.async_set_credential(
                 3,
                 credential,
-                credential.readable_pin or "",
+                "9999",
                 name="Carol",
                 source="direct",
             )

--- a/tests/providers/matter/test_provider.py
+++ b/tests/providers/matter/test_provider.py
@@ -1620,7 +1620,11 @@ class TestSetCredential:
             patch(f"{_PROVIDER_MODULE}.set_lock_credential", mock_set_credential),
         ):
             result = await matter_lock_simple.async_set_credential(
-                1, credential, name="Alice", source="direct"
+                1,
+                credential,
+                credential.readable_pin or "",
+                name="Alice",
+                source="direct",
             )
         assert result is True
 
@@ -1644,26 +1648,12 @@ class TestSetCredential:
             patch(f"{_PROVIDER_MODULE}.set_lock_credential", mock_set_credential),
         ):
             await matter_lock_simple.async_set_credential(
-                2, credential, name=None, source="direct"
+                2, credential, credential.readable_pin or "", name=None, source="direct"
             )
 
         mock_coordinator.push_update.assert_called_once_with(
             {2: SlotCredential.unreadable()}
         )
-
-    async def test_set_credential_unreadable_pin_raises_code_rejected(
-        self, hass: HomeAssistant, matter_lock_simple: MatterLock
-    ) -> None:
-        """A credential with no readable_pin raises CodeRejectedError immediately."""
-        credential = Credential(
-            type=CredentialType.PIN,
-            slot=1,
-            state=SlotCredential.unreadable(),
-        )
-        with pytest.raises(CodeRejectedError):
-            await matter_lock_simple.async_set_credential(
-                1, credential, name=None, source="direct"
-            )
 
     async def test_set_credential_duplicate_direct_raises(
         self, hass: HomeAssistant, matter_lock_simple: MatterLock
@@ -1684,7 +1674,7 @@ class TestSetCredential:
             pytest.raises(DuplicateCodeError),
         ):
             await matter_lock_simple.async_set_credential(
-                1, credential, name=None, source="direct"
+                1, credential, credential.readable_pin or "", name=None, source="direct"
             )
 
     async def test_set_credential_duplicate_sync_retries_and_succeeds(
@@ -1710,7 +1700,7 @@ class TestSetCredential:
             patch(f"{_PROVIDER_MODULE}.clear_lock_credential", mock_clear),
         ):
             result = await matter_lock_simple.async_set_credential(
-                1, credential, name=None, source="sync"
+                1, credential, credential.readable_pin or "", name=None, source="sync"
             )
 
         assert result is True
@@ -1738,7 +1728,7 @@ class TestSetCredential:
             pytest.raises(DuplicateCodeError),
         ):
             await matter_lock_simple.async_set_credential(
-                1, credential, name=None, source="sync"
+                1, credential, credential.readable_pin or "", name=None, source="sync"
             )
 
         assert mock_set_credential.call_count == 2
@@ -1765,7 +1755,7 @@ class TestSetCredential:
             pytest.raises(LockDisconnected, match="sync-duplicate retry"),
         ):
             await matter_lock_simple.async_set_credential(
-                1, credential, name=None, source="sync"
+                1, credential, credential.readable_pin or "", name=None, source="sync"
             )
         # First set raised duplicate; clear failed; no retry attempt is made.
         assert mock_set_credential.call_count == 1
@@ -1791,7 +1781,7 @@ class TestSetCredential:
             pytest.raises(LockOperationFailed, match="sync-duplicate retry"),
         ):
             await matter_lock_simple.async_set_credential(
-                1, credential, name=None, source="sync"
+                1, credential, credential.readable_pin or "", name=None, source="sync"
             )
         assert mock_set_credential.call_count == 1
 
@@ -1814,7 +1804,7 @@ class TestSetCredential:
             pytest.raises(CodeRejectedError),
         ):
             await matter_lock_simple.async_set_credential(
-                1, credential, name=None, source="direct"
+                1, credential, credential.readable_pin or "", name=None, source="direct"
             )
 
     async def test_set_credential_ha_error_raises_code_rejected(
@@ -1836,7 +1826,7 @@ class TestSetCredential:
             pytest.raises(CodeRejectedError),
         ):
             await matter_lock_simple.async_set_credential(
-                1, credential, name=None, source="direct"
+                1, credential, credential.readable_pin or "", name=None, source="direct"
             )
 
     async def test_set_credential_transport_error_raises_lock_disconnected(
@@ -1856,7 +1846,7 @@ class TestSetCredential:
             pytest.raises(LockDisconnected),
         ):
             await matter_lock_simple.async_set_credential(
-                1, credential, name=None, source="direct"
+                1, credential, credential.readable_pin or "", name=None, source="direct"
             )
 
     async def test_set_credential_passes_correct_args(
@@ -1877,7 +1867,11 @@ class TestSetCredential:
             patch(f"{_PROVIDER_MODULE}.set_lock_credential", mock_set_credential),
         ):
             await matter_lock_simple.async_set_credential(
-                3, credential, name="Carol", source="direct"
+                3,
+                credential,
+                credential.readable_pin or "",
+                name="Carol",
+                source="direct",
             )
 
         call_kwargs = mock_set_credential.call_args.kwargs

--- a/tests/providers/schlage/test_e2e.py
+++ b/tests/providers/schlage/test_e2e.py
@@ -59,7 +59,7 @@ class TestSetAndClearCredentials:
         result = await e2e_schlage_lock.async_set_credential(
             1,
             credential_from_slot(1, SlotCredential.known("9999")),
-            (credential_from_slot(1, SlotCredential.known("9999"))).readable_pin or "",
+            "9999",
             name="Test User",
             source="direct",
         )

--- a/tests/providers/schlage/test_e2e.py
+++ b/tests/providers/schlage/test_e2e.py
@@ -59,6 +59,7 @@ class TestSetAndClearCredentials:
         result = await e2e_schlage_lock.async_set_credential(
             1,
             credential_from_slot(1, SlotCredential.known("9999")),
+            (credential_from_slot(1, SlotCredential.known("9999"))).readable_pin or "",
             name="Test User",
             source="direct",
         )

--- a/tests/providers/schlage/test_provider.py
+++ b/tests/providers/schlage/test_provider.py
@@ -485,13 +485,25 @@ async def test_concurrent_set_credential_serialized_under_sequence_lock(
 
     await asyncio.gather(
         schlage_lock.async_set_credential(
-            1, _pin_cred(1, "1111"), name=None, source="direct"
+            1,
+            _pin_cred(1, "1111"),
+            (_pin_cred(1, "1111")).readable_pin or "",
+            name=None,
+            source="direct",
         ),
         schlage_lock.async_set_credential(
-            2, _pin_cred(2, "2222"), name=None, source="direct"
+            2,
+            _pin_cred(2, "2222"),
+            (_pin_cred(2, "2222")).readable_pin or "",
+            name=None,
+            source="direct",
         ),
         schlage_lock.async_set_credential(
-            3, _pin_cred(3, "3333"), name=None, source="direct"
+            3,
+            _pin_cred(3, "3333"),
+            (_pin_cred(3, "3333")).readable_pin or "",
+            name=None,
+            source="direct",
         ),
     )
 
@@ -520,7 +532,11 @@ async def test_set_credential_replaces_existing(
     register_mock_service(hass, SCHLAGE_DOMAIN, "delete_code", delete_handler)
 
     result = await schlage_lock.async_set_credential(
-        1, _pin_cred(1, "5678"), name="New Name", source="direct"
+        1,
+        _pin_cred(1, "5678"),
+        (_pin_cred(1, "5678")).readable_pin or "",
+        name="New Name",
+        source="direct",
     )
 
     assert result is True
@@ -561,7 +577,11 @@ async def test_set_credential_preserves_existing_name(
     delete_handler.side_effect = lambda _: call_order.append("delete")
 
     result = await schlage_lock.async_set_credential(
-        1, _pin_cred(1, "9999"), name=None, source="direct"
+        1,
+        _pin_cred(1, "9999"),
+        (_pin_cred(1, "9999")).readable_pin or "",
+        name=None,
+        source="direct",
     )
 
     assert result is True
@@ -599,7 +619,11 @@ async def test_set_credential_already_exists_treated_as_success(
     register_mock_service(hass, SCHLAGE_DOMAIN, "delete_code", delete_handler)
 
     result = await schlage_lock.async_set_credential(
-        1, _pin_cred(1, "1234"), name="Guest", source="direct"
+        1,
+        _pin_cred(1, "1234"),
+        (_pin_cred(1, "1234")).readable_pin or "",
+        name="Guest",
+        source="direct",
     )
 
     assert result is True
@@ -619,7 +643,11 @@ async def test_set_credential_non_exists_error_still_raises(
 
     with pytest.raises(LockOperationFailed, match="connection lost"):
         await schlage_lock.async_set_credential(
-            1, _pin_cred(1, "1234"), name=None, source="direct"
+            1,
+            _pin_cred(1, "1234"),
+            (_pin_cred(1, "1234")).readable_pin or "",
+            name=None,
+            source="direct",
         )
 
 
@@ -635,7 +663,11 @@ async def test_set_credential_service_failure(
 
     with pytest.raises(LockOperationFailed, match="connection lost"):
         await schlage_lock.async_set_credential(
-            1, _pin_cred(1, "1234"), name=None, source="direct"
+            1,
+            _pin_cred(1, "1234"),
+            (_pin_cred(1, "1234")).readable_pin or "",
+            name=None,
+            source="direct",
         )
 
 
@@ -770,7 +802,11 @@ async def test_base_orchestration_set_and_get(
     )
 
     await schlage_lock.async_set_credential(
-        1, _pin_cred(1, "9999"), name="test", source="direct"
+        1,
+        _pin_cred(1, "9999"),
+        (_pin_cred(1, "9999")).readable_pin or "",
+        name="test",
+        source="direct",
     )
 
     # After setting, the lock reports the slot as unreadable (write-only Personal Identification Number)

--- a/tests/providers/schlage/test_provider.py
+++ b/tests/providers/schlage/test_provider.py
@@ -487,21 +487,21 @@ async def test_concurrent_set_credential_serialized_under_sequence_lock(
         schlage_lock.async_set_credential(
             1,
             _pin_cred(1, "1111"),
-            (_pin_cred(1, "1111")).readable_pin or "",
+            "1111",
             name=None,
             source="direct",
         ),
         schlage_lock.async_set_credential(
             2,
             _pin_cred(2, "2222"),
-            (_pin_cred(2, "2222")).readable_pin or "",
+            "2222",
             name=None,
             source="direct",
         ),
         schlage_lock.async_set_credential(
             3,
             _pin_cred(3, "3333"),
-            (_pin_cred(3, "3333")).readable_pin or "",
+            "3333",
             name=None,
             source="direct",
         ),
@@ -534,7 +534,7 @@ async def test_set_credential_replaces_existing(
     result = await schlage_lock.async_set_credential(
         1,
         _pin_cred(1, "5678"),
-        (_pin_cred(1, "5678")).readable_pin or "",
+        "5678",
         name="New Name",
         source="direct",
     )
@@ -579,7 +579,7 @@ async def test_set_credential_preserves_existing_name(
     result = await schlage_lock.async_set_credential(
         1,
         _pin_cred(1, "9999"),
-        (_pin_cred(1, "9999")).readable_pin or "",
+        "9999",
         name=None,
         source="direct",
     )
@@ -621,7 +621,7 @@ async def test_set_credential_already_exists_treated_as_success(
     result = await schlage_lock.async_set_credential(
         1,
         _pin_cred(1, "1234"),
-        (_pin_cred(1, "1234")).readable_pin or "",
+        "1234",
         name="Guest",
         source="direct",
     )
@@ -645,7 +645,7 @@ async def test_set_credential_non_exists_error_still_raises(
         await schlage_lock.async_set_credential(
             1,
             _pin_cred(1, "1234"),
-            (_pin_cred(1, "1234")).readable_pin or "",
+            "1234",
             name=None,
             source="direct",
         )
@@ -665,7 +665,7 @@ async def test_set_credential_service_failure(
         await schlage_lock.async_set_credential(
             1,
             _pin_cred(1, "1234"),
-            (_pin_cred(1, "1234")).readable_pin or "",
+            "1234",
             name=None,
             source="direct",
         )
@@ -804,7 +804,7 @@ async def test_base_orchestration_set_and_get(
     await schlage_lock.async_set_credential(
         1,
         _pin_cred(1, "9999"),
-        (_pin_cred(1, "9999")).readable_pin or "",
+        "9999",
         name="test",
         source="direct",
     )

--- a/tests/providers/test_seam.py
+++ b/tests/providers/test_seam.py
@@ -78,6 +78,7 @@ class _NativeStubLock(BaseLock):
         self,
         user_id: int,
         credential: Credential,
+        pin: str,
         *,
         name: str | None,
         source: Literal["sync", "direct"],
@@ -86,6 +87,7 @@ class _NativeStubLock(BaseLock):
         self.last_set_credential = {
             "user_id": user_id,
             "slot": credential.slot,
+            "pin": pin,
             "name": name,
             "source": source,
         }
@@ -137,6 +139,7 @@ class _DegenerateStubLock(BaseLock):
         self,
         user_id: int,
         credential: Credential,
+        pin: str,
         *,
         name: str | None,
         source: Literal["sync", "direct"],
@@ -170,6 +173,7 @@ async def test_primitive_defaults_raise(hass: HomeAssistant) -> None:
         await lock.async_set_credential(
             1,
             credential_from_slot(1, SlotCredential.known("1")),
+            "1",
             name=None,
             source="direct",
         )
@@ -542,7 +546,9 @@ async def test_set_credential_rejects_unsupported_credential_type(
     )
     user = User(user_id=2, credentials=[rfid_credential])
     with pytest.raises(CodeRejectedError):
-        await lock._set_credential(user, rfid_credential, name=None, source="direct")
+        await lock._set_credential(
+            user, rfid_credential, "AABB", name=None, source="direct"
+        )
     # No primitive was reached because the assertion fired first.
     assert lock.calls == []
 
@@ -557,6 +563,25 @@ async def test_delete_credential_rejects_unsupported_credential_type(
     with pytest.raises(CodeRejectedError):
         await lock._delete_credential(owner, ref)
     assert lock.calls == []
+
+
+async def test_require_readable_pin_rejects_unreadable_credential(
+    hass: HomeAssistant,
+) -> None:
+    """The base contract helper raises before any provider primitive is reached.
+
+    The seam (``async_set_usercode``) constructs Known credentials so this
+    branch is unreachable in production; the helper exists to express the
+    invariant once and give providers a guaranteed-string ``pin`` argument.
+    A direct call here pins that contract.
+    """
+    lock = _make_lock(hass, _NativeStubLock, "seam_require_pin")
+    unreadable = Credential(
+        type=CredentialType.PIN, slot=4, state=SlotCredential.unreadable()
+    )
+    with pytest.raises(CodeRejectedError) as exc_info:
+        lock._require_readable_pin(unreadable)
+    assert exc_info.value.code_slot == 4
 
 
 async def test_set_usercode_native_user_first_and_threads_id(
@@ -757,6 +782,7 @@ async def test_set_usercode_threads_name_and_source(hass: HomeAssistant) -> None
     assert lock.last_set_credential == {
         "user_id": 2,
         "slot": 2,
+        "pin": "2468",
         "name": None,
         "source": "sync",
     }
@@ -769,6 +795,7 @@ class _CredentialWriteFailsLock(_NativeStubLock):
         self,
         user_id: int,
         credential: Credential,
+        pin: str,
         *,
         name: str | None,
         source: Literal["sync", "direct"],

--- a/tests/providers/virtual/test_e2e.py
+++ b/tests/providers/virtual/test_e2e.py
@@ -49,6 +49,7 @@ class TestSetAndGetUsercodes:
         await e2e_virtual_lock.async_set_credential(
             1,
             credential_from_slot(1, SlotCredential.known("1111")),
+            (credential_from_slot(1, SlotCredential.known("1111"))).readable_pin or "",
             name="test_user",
             source="direct",
         )
@@ -65,6 +66,7 @@ class TestSetAndGetUsercodes:
         await e2e_virtual_lock.async_set_credential(
             1,
             credential_from_slot(1, SlotCredential.known("1111")),
+            (credential_from_slot(1, SlotCredential.known("1111"))).readable_pin or "",
             name="test_user",
             source="direct",
         )
@@ -107,12 +109,14 @@ class TestSetAndGetUsercodes:
         await e2e_virtual_lock.async_set_credential(
             1,
             credential_from_slot(1, SlotCredential.known("1111")),
+            (credential_from_slot(1, SlotCredential.known("1111"))).readable_pin or "",
             name="user1",
             source="direct",
         )
         await e2e_virtual_lock.async_set_credential(
             2,
             credential_from_slot(2, SlotCredential.known("2222")),
+            (credential_from_slot(2, SlotCredential.known("2222"))).readable_pin or "",
             name="user2",
             source="direct",
         )
@@ -137,6 +141,7 @@ class TestSetAndGetUsercodes:
         await e2e_virtual_lock.async_set_credential(
             1,
             credential_from_slot(1, SlotCredential.known("1111")),
+            (credential_from_slot(1, SlotCredential.known("1111"))).readable_pin or "",
             name="user1",
             source="direct",
         )
@@ -155,6 +160,7 @@ class TestSetAndGetUsercodes:
         await e2e_virtual_lock.async_set_credential(
             1,
             credential_from_slot(1, SlotCredential.known("5555")),
+            (credential_from_slot(1, SlotCredential.known("5555"))).readable_pin or "",
             name="slot_user",
             source="direct",
         )

--- a/tests/providers/virtual/test_e2e.py
+++ b/tests/providers/virtual/test_e2e.py
@@ -49,7 +49,7 @@ class TestSetAndGetUsercodes:
         await e2e_virtual_lock.async_set_credential(
             1,
             credential_from_slot(1, SlotCredential.known("1111")),
-            (credential_from_slot(1, SlotCredential.known("1111"))).readable_pin or "",
+            "1111",
             name="test_user",
             source="direct",
         )
@@ -66,7 +66,7 @@ class TestSetAndGetUsercodes:
         await e2e_virtual_lock.async_set_credential(
             1,
             credential_from_slot(1, SlotCredential.known("1111")),
-            (credential_from_slot(1, SlotCredential.known("1111"))).readable_pin or "",
+            "1111",
             name="test_user",
             source="direct",
         )
@@ -109,14 +109,14 @@ class TestSetAndGetUsercodes:
         await e2e_virtual_lock.async_set_credential(
             1,
             credential_from_slot(1, SlotCredential.known("1111")),
-            (credential_from_slot(1, SlotCredential.known("1111"))).readable_pin or "",
+            "1111",
             name="user1",
             source="direct",
         )
         await e2e_virtual_lock.async_set_credential(
             2,
             credential_from_slot(2, SlotCredential.known("2222")),
-            (credential_from_slot(2, SlotCredential.known("2222"))).readable_pin or "",
+            "2222",
             name="user2",
             source="direct",
         )
@@ -141,7 +141,7 @@ class TestSetAndGetUsercodes:
         await e2e_virtual_lock.async_set_credential(
             1,
             credential_from_slot(1, SlotCredential.known("1111")),
-            (credential_from_slot(1, SlotCredential.known("1111"))).readable_pin or "",
+            "1111",
             name="user1",
             source="direct",
         )
@@ -160,7 +160,7 @@ class TestSetAndGetUsercodes:
         await e2e_virtual_lock.async_set_credential(
             1,
             credential_from_slot(1, SlotCredential.known("5555")),
-            (credential_from_slot(1, SlotCredential.known("5555"))).readable_pin or "",
+            "5555",
             name="slot_user",
             source="direct",
         )

--- a/tests/providers/virtual/test_provider.py
+++ b/tests/providers/virtual/test_provider.py
@@ -21,27 +21,43 @@ async def test_set_credential_returns_changed_status(virtual_lock: VirtualLock):
 
     # First set should return True (value changed from empty)
     changed = await lock.async_set_credential(
-        1, _make_credential(1, "1234"), name="test", source="direct"
+        1,
+        _make_credential(1, "1234"),
+        (_make_credential(1, "1234")).readable_pin or "",
+        name="test",
+        source="direct",
     )
     assert changed is True
     assert lock._data["1"] == {"code": "1234", "name": "test"}
 
     # Setting the same value should return False (no change)
     changed = await lock.async_set_credential(
-        1, _make_credential(1, "1234"), name="test", source="direct"
+        1,
+        _make_credential(1, "1234"),
+        (_make_credential(1, "1234")).readable_pin or "",
+        name="test",
+        source="direct",
     )
     assert changed is False
 
     # Changing the code should return True
     changed = await lock.async_set_credential(
-        1, _make_credential(1, "5678"), name="test", source="direct"
+        1,
+        _make_credential(1, "5678"),
+        (_make_credential(1, "5678")).readable_pin or "",
+        name="test",
+        source="direct",
     )
     assert changed is True
     assert lock._data["1"] == {"code": "5678", "name": "test"}
 
     # Changing the name should return True
     changed = await lock.async_set_credential(
-        1, _make_credential(1, "5678"), name="new_name", source="direct"
+        1,
+        _make_credential(1, "5678"),
+        (_make_credential(1, "5678")).readable_pin or "",
+        name="new_name",
+        source="direct",
     )
     assert changed is True
     assert lock._data["1"] == {"code": "5678", "name": "new_name"}
@@ -62,6 +78,7 @@ async def test_delete_credential_returns_changed_status(virtual_lock: VirtualLoc
     await lock.async_set_credential(
         1,
         credential_from_slot(1, SlotCredential.known("1234")),
+        (credential_from_slot(1, SlotCredential.known("1234"))).readable_pin or "",
         name="test",
         source="direct",
     )
@@ -94,6 +111,7 @@ async def test_get_users_returns_empty_for_cleared_slots(
     await lock.async_set_credential(
         1,
         credential_from_slot(1, SlotCredential.known("1234")),
+        (credential_from_slot(1, SlotCredential.known("1234"))).readable_pin or "",
         name="slot1",
         source="direct",
     )
@@ -128,6 +146,7 @@ async def test_get_users_includes_unmanaged_occupied_slots(
     await lock.async_set_credential(
         1,
         credential_from_slot(1, SlotCredential.known("1234")),
+        (credential_from_slot(1, SlotCredential.known("1234"))).readable_pin or "",
         name="slot1",
         source="direct",
     )
@@ -177,6 +196,7 @@ async def test_base_orchestration_set_clear_get(virtual_lock_with_slots: Virtual
     await lock.async_set_credential(
         1,
         credential_from_slot(1, SlotCredential.known("4321")),
+        (credential_from_slot(1, SlotCredential.known("4321"))).readable_pin or "",
         name="orchestration_test",
         source="direct",
     )
@@ -200,6 +220,7 @@ async def test_get_users_returns_user_objects(virtual_lock_with_slots: VirtualLo
     await lock.async_set_credential(
         1,
         credential_from_slot(1, SlotCredential.known("7777")),
+        (credential_from_slot(1, SlotCredential.known("7777"))).readable_pin or "",
         name=None,
         source="direct",
     )

--- a/tests/providers/virtual/test_provider.py
+++ b/tests/providers/virtual/test_provider.py
@@ -23,7 +23,7 @@ async def test_set_credential_returns_changed_status(virtual_lock: VirtualLock):
     changed = await lock.async_set_credential(
         1,
         _make_credential(1, "1234"),
-        (_make_credential(1, "1234")).readable_pin or "",
+        "1234",
         name="test",
         source="direct",
     )
@@ -34,7 +34,7 @@ async def test_set_credential_returns_changed_status(virtual_lock: VirtualLock):
     changed = await lock.async_set_credential(
         1,
         _make_credential(1, "1234"),
-        (_make_credential(1, "1234")).readable_pin or "",
+        "1234",
         name="test",
         source="direct",
     )
@@ -44,7 +44,7 @@ async def test_set_credential_returns_changed_status(virtual_lock: VirtualLock):
     changed = await lock.async_set_credential(
         1,
         _make_credential(1, "5678"),
-        (_make_credential(1, "5678")).readable_pin or "",
+        "5678",
         name="test",
         source="direct",
     )
@@ -55,7 +55,7 @@ async def test_set_credential_returns_changed_status(virtual_lock: VirtualLock):
     changed = await lock.async_set_credential(
         1,
         _make_credential(1, "5678"),
-        (_make_credential(1, "5678")).readable_pin or "",
+        "5678",
         name="new_name",
         source="direct",
     )
@@ -78,7 +78,7 @@ async def test_delete_credential_returns_changed_status(virtual_lock: VirtualLoc
     await lock.async_set_credential(
         1,
         credential_from_slot(1, SlotCredential.known("1234")),
-        (credential_from_slot(1, SlotCredential.known("1234"))).readable_pin or "",
+        "1234",
         name="test",
         source="direct",
     )
@@ -111,7 +111,7 @@ async def test_get_users_returns_empty_for_cleared_slots(
     await lock.async_set_credential(
         1,
         credential_from_slot(1, SlotCredential.known("1234")),
-        (credential_from_slot(1, SlotCredential.known("1234"))).readable_pin or "",
+        "1234",
         name="slot1",
         source="direct",
     )
@@ -146,7 +146,7 @@ async def test_get_users_includes_unmanaged_occupied_slots(
     await lock.async_set_credential(
         1,
         credential_from_slot(1, SlotCredential.known("1234")),
-        (credential_from_slot(1, SlotCredential.known("1234"))).readable_pin or "",
+        "1234",
         name="slot1",
         source="direct",
     )
@@ -196,7 +196,7 @@ async def test_base_orchestration_set_clear_get(virtual_lock_with_slots: Virtual
     await lock.async_set_credential(
         1,
         credential_from_slot(1, SlotCredential.known("4321")),
-        (credential_from_slot(1, SlotCredential.known("4321"))).readable_pin or "",
+        "4321",
         name="orchestration_test",
         source="direct",
     )
@@ -220,7 +220,7 @@ async def test_get_users_returns_user_objects(virtual_lock_with_slots: VirtualLo
     await lock.async_set_credential(
         1,
         credential_from_slot(1, SlotCredential.known("7777")),
-        (credential_from_slot(1, SlotCredential.known("7777"))).readable_pin or "",
+        "7777",
         name=None,
         source="direct",
     )

--- a/tests/providers/zha/test_provider.py
+++ b/tests/providers/zha/test_provider.py
@@ -168,7 +168,7 @@ async def test_set_credential(
 
     credential = credential_from_slot(3, SlotCredential.known("5678"))
     result = await zha_lock.async_set_credential(
-        3, credential, credential.readable_pin or "", name="Test User", source="direct"
+        3, credential, "5678", name="Test User", source="direct"
     )
 
     assert result is True
@@ -196,7 +196,7 @@ async def test_set_credential_failure(
     credential = credential_from_slot(3, SlotCredential.known("5678"))
     with pytest.raises(CodeRejectedError, match="set_pin_code rejected"):
         await zha_lock.async_set_credential(
-            3, credential, credential.readable_pin or "", name=None, source="direct"
+            3, credential, "5678", name=None, source="direct"
         )
 
 
@@ -661,7 +661,7 @@ async def test_set_credential_generic_exception(
     credential = credential_from_slot(1, SlotCredential.known("1234"))
     with pytest.raises(LockDisconnected, match="Failed to set PIN"):
         await zha_lock.async_set_credential(
-            1, credential, credential.readable_pin or "", name=None, source="direct"
+            1, credential, "1234", name=None, source="direct"
         )
 
 

--- a/tests/providers/zha/test_provider.py
+++ b/tests/providers/zha/test_provider.py
@@ -168,7 +168,7 @@ async def test_set_credential(
 
     credential = credential_from_slot(3, SlotCredential.known("5678"))
     result = await zha_lock.async_set_credential(
-        3, credential, name="Test User", source="direct"
+        3, credential, credential.readable_pin or "", name="Test User", source="direct"
     )
 
     assert result is True
@@ -195,7 +195,9 @@ async def test_set_credential_failure(
 
     credential = credential_from_slot(3, SlotCredential.known("5678"))
     with pytest.raises(CodeRejectedError, match="set_pin_code rejected"):
-        await zha_lock.async_set_credential(3, credential, name=None, source="direct")
+        await zha_lock.async_set_credential(
+            3, credential, credential.readable_pin or "", name=None, source="direct"
+        )
 
 
 async def test_delete_credential(
@@ -658,7 +660,9 @@ async def test_set_credential_generic_exception(
 
     credential = credential_from_slot(1, SlotCredential.known("1234"))
     with pytest.raises(LockDisconnected, match="Failed to set PIN"):
-        await zha_lock.async_set_credential(1, credential, name=None, source="direct")
+        await zha_lock.async_set_credential(
+            1, credential, credential.readable_pin or "", name=None, source="direct"
+        )
 
 
 async def test_delete_credential_generic_exception(

--- a/tests/providers/zigbee2mqtt/test_provider.py
+++ b/tests/providers/zigbee2mqtt/test_provider.py
@@ -440,7 +440,7 @@ class TestAsyncSetClearHardRefresh:
             pytest.raises(LockDisconnected, match="MQTT component not available"),
         ):
             await lock.async_set_credential(
-                1, credential, credential.readable_pin or "", name=None, source="direct"
+                1, credential, "1234", name=None, source="direct"
             )
 
     async def test_async_delete_credential_raises_when_mqtt_disabled(
@@ -481,7 +481,7 @@ class TestAsyncSetClearHardRefresh:
             pytest.raises(LockDisconnected, match="Lock not connected"),
         ):
             await lock.async_set_credential(
-                3, credential, credential.readable_pin or "", name=None, source="direct"
+                3, credential, "9999", name=None, source="direct"
             )
 
     async def test_async_delete_credential_raises_when_not_connected(
@@ -524,7 +524,7 @@ class TestAsyncSetClearHardRefresh:
             pytest.raises(LockDisconnected, match="not a Zigbee2MQTT lock"),
         ):
             await lock.async_set_credential(
-                1, credential, credential.readable_pin or "", name=None, source="direct"
+                1, credential, "1234", name=None, source="direct"
             )
 
     async def test_async_set_credential_raises_when_topic_unavailable(
@@ -550,7 +550,7 @@ class TestAsyncSetClearHardRefresh:
             pytest.raises(LockDisconnected, match="Could not determine MQTT topic"),
         ):
             await lock.async_set_credential(
-                2, credential, credential.readable_pin or "", name=None, source="direct"
+                2, credential, "8888", name=None, source="direct"
             )
 
     async def test_async_delete_credential_raises_when_topic_unavailable(
@@ -602,7 +602,7 @@ class TestAsyncSetClearHardRefresh:
                 await lock.async_set_credential(
                     2,
                     credential,
-                    credential.readable_pin or "",
+                    "9999",
                     name=None,
                     source="direct",
                 )
@@ -637,7 +637,7 @@ class TestAsyncSetClearHardRefresh:
             pytest.raises(LockDisconnected, match="Failed to set PIN"),
         ):
             await lock.async_set_credential(
-                1, credential, credential.readable_pin or "", name=None, source="direct"
+                1, credential, "1111", name=None, source="direct"
             )
 
     async def test_async_set_credential_publish_ha_error_raises_operation_failed(
@@ -663,7 +663,7 @@ class TestAsyncSetClearHardRefresh:
             pytest.raises(LockOperationFailed, match="Failed to set PIN"),
         ):
             await lock.async_set_credential(
-                1, credential, credential.readable_pin or "", name=None, source="direct"
+                1, credential, "1111", name=None, source="direct"
             )
 
     async def test_async_delete_credential_publish_failure_raises(

--- a/tests/providers/zigbee2mqtt/test_provider.py
+++ b/tests/providers/zigbee2mqtt/test_provider.py
@@ -439,7 +439,9 @@ class TestAsyncSetClearHardRefresh:
             ),
             pytest.raises(LockDisconnected, match="MQTT component not available"),
         ):
-            await lock.async_set_credential(1, credential, name=None, source="direct")
+            await lock.async_set_credential(
+                1, credential, credential.readable_pin or "", name=None, source="direct"
+            )
 
     async def test_async_delete_credential_raises_when_mqtt_disabled(
         self,
@@ -478,7 +480,9 @@ class TestAsyncSetClearHardRefresh:
             ),
             pytest.raises(LockDisconnected, match="Lock not connected"),
         ):
-            await lock.async_set_credential(3, credential, name=None, source="direct")
+            await lock.async_set_credential(
+                3, credential, credential.readable_pin or "", name=None, source="direct"
+            )
 
     async def test_async_delete_credential_raises_when_not_connected(
         self,
@@ -519,7 +523,9 @@ class TestAsyncSetClearHardRefresh:
             ),
             pytest.raises(LockDisconnected, match="not a Zigbee2MQTT lock"),
         ):
-            await lock.async_set_credential(1, credential, name=None, source="direct")
+            await lock.async_set_credential(
+                1, credential, credential.readable_pin or "", name=None, source="direct"
+            )
 
     async def test_async_set_credential_raises_when_topic_unavailable(
         self,
@@ -543,7 +549,9 @@ class TestAsyncSetClearHardRefresh:
             patch.object(lock, "_get_topic", return_value=None),
             pytest.raises(LockDisconnected, match="Could not determine MQTT topic"),
         ):
-            await lock.async_set_credential(2, credential, name=None, source="direct")
+            await lock.async_set_credential(
+                2, credential, credential.readable_pin or "", name=None, source="direct"
+            )
 
     async def test_async_delete_credential_raises_when_topic_unavailable(
         self,
@@ -592,7 +600,11 @@ class TestAsyncSetClearHardRefresh:
         ):
             assert (
                 await lock.async_set_credential(
-                    2, credential, name=None, source="direct"
+                    2,
+                    credential,
+                    credential.readable_pin or "",
+                    name=None,
+                    source="direct",
                 )
                 is True
             )
@@ -624,7 +636,9 @@ class TestAsyncSetClearHardRefresh:
             ),
             pytest.raises(LockDisconnected, match="Failed to set PIN"),
         ):
-            await lock.async_set_credential(1, credential, name=None, source="direct")
+            await lock.async_set_credential(
+                1, credential, credential.readable_pin or "", name=None, source="direct"
+            )
 
     async def test_async_set_credential_publish_ha_error_raises_operation_failed(
         self,
@@ -648,7 +662,9 @@ class TestAsyncSetClearHardRefresh:
             ),
             pytest.raises(LockOperationFailed, match="Failed to set PIN"),
         ):
-            await lock.async_set_credential(1, credential, name=None, source="direct")
+            await lock.async_set_credential(
+                1, credential, credential.readable_pin or "", name=None, source="direct"
+            )
 
     async def test_async_delete_credential_publish_failure_raises(
         self,

--- a/tests/providers/zwave_js/test_provider.py
+++ b/tests/providers/zwave_js/test_provider.py
@@ -713,7 +713,7 @@ async def test_async_set_credential_returns_true_on_success(
     result = await zwave_js_lock.async_set_credential(
         user_id=1,
         credential=credential,
-        pin=credential.readable_pin or "",
+        pin="5678",
         name="alice",
         source="sync",
     )
@@ -750,7 +750,7 @@ async def test_async_set_credential_raises_duplicate_code_error(
         await zwave_js_lock.async_set_credential(
             user_id=1,
             credential=credential,
-            pin=credential.readable_pin or "",
+            pin="1111",
             name=None,
             source="sync",
         )
@@ -781,7 +781,7 @@ async def test_async_set_credential_raises_code_rejected_error_on_other_ha_error
         await zwave_js_lock.async_set_credential(
             user_id=1,
             credential=credential,
-            pin=credential.readable_pin or "",
+            pin="2222",
             name=None,
             source="sync",
         )
@@ -812,7 +812,7 @@ async def test_async_set_credential_maps_failed_command_to_lock_disconnected(
         await zwave_js_lock.async_set_credential(
             user_id=1,
             credential=credential,
-            pin=credential.readable_pin or "",
+            pin="2222",
             name=None,
             source="sync",
         )

--- a/tests/providers/zwave_js/test_provider.py
+++ b/tests/providers/zwave_js/test_provider.py
@@ -711,7 +711,11 @@ async def test_async_set_credential_returns_true_on_success(
         type=CredentialType.PIN, slot=2, state=SlotCredential.known("5678")
     )
     result = await zwave_js_lock.async_set_credential(
-        user_id=1, credential=credential, name="alice", source="sync"
+        user_id=1,
+        credential=credential,
+        pin=credential.readable_pin or "",
+        name="alice",
+        source="sync",
     )
 
     assert result is True
@@ -744,7 +748,11 @@ async def test_async_set_credential_raises_duplicate_code_error(
     )
     with pytest.raises(DuplicateCodeError) as exc_info:
         await zwave_js_lock.async_set_credential(
-            user_id=1, credential=credential, name=None, source="sync"
+            user_id=1,
+            credential=credential,
+            pin=credential.readable_pin or "",
+            name=None,
+            source="sync",
         )
 
     assert exc_info.value.code_slot == 3
@@ -771,29 +779,15 @@ async def test_async_set_credential_raises_code_rejected_error_on_other_ha_error
     )
     with pytest.raises(CodeRejectedError) as exc_info:
         await zwave_js_lock.async_set_credential(
-            user_id=1, credential=credential, name=None, source="sync"
+            user_id=1,
+            credential=credential,
+            pin=credential.readable_pin or "",
+            name=None,
+            source="sync",
         )
 
     assert exc_info.value.code_slot == 4
     assert not isinstance(exc_info.value, DuplicateCodeError)
-
-
-async def test_async_set_credential_rejects_unreadable_credential(
-    zwave_js_lock: ZWaveJSLock,
-    mock_access_control: MagicMock,
-    mock_lock_helpers: dict,
-) -> None:
-    """An unreadable credential (no Personal Identification Number) is rejected cleanly."""
-    credential = Credential(
-        type=CredentialType.PIN, slot=4, state=SlotCredential.unreadable()
-    )
-    with pytest.raises(CodeRejectedError) as exc_info:
-        await zwave_js_lock.async_set_credential(
-            user_id=1, credential=credential, name=None, source="sync"
-        )
-
-    assert exc_info.value.code_slot == 4
-    mock_lock_helpers["async_set_credential"].assert_not_called()
 
 
 async def test_async_set_credential_maps_failed_command_to_lock_disconnected(
@@ -816,7 +810,11 @@ async def test_async_set_credential_maps_failed_command_to_lock_disconnected(
     )
     with pytest.raises(LockDisconnected):
         await zwave_js_lock.async_set_credential(
-            user_id=1, credential=credential, name=None, source="sync"
+            user_id=1,
+            credential=credential,
+            pin=credential.readable_pin or "",
+            name=None,
+            source="sync",
         )
 
 


### PR DESCRIPTION
## Proposed change

Address PR #1229 review feedback (Copilot flagged silent empty-PIN fallback in slot-only providers) by **hoisting** the PIN-readability guard from per-provider to the base seam, rather than duplicating it across every provider.

### Before
- \`zwave_js\` and \`matter\` each had an inline \`if credential.readable_pin is None: raise CodeRejectedError(...)\` guard at the top of \`async_set_credential\`.
- Slot-only providers (virtual, zha, akuvox, schlage, zigbee2mqtt) used \`credential.readable_pin or \"\"\` — coercing to empty string and silently writing a blank PIN if the credential was unreadable.

### After
- New \`BaseLock._require_readable_pin(credential)\` helper expresses the contract once.
- The seam (\`async_set_usercode\`) validates and threads the resolved \`pin: str\` through \`_set_credential\` → \`async_set_credential\`.
- Every provider's \`async_set_credential\` now takes \`pin: str\` as a guaranteed non-None argument. No per-provider guard. No \`or \"\"\` coercion.
- This mirrors the established \`async_setup_internal\` / \`async_setup\` pattern in BaseLock: cross-cutting concerns belong in the base seam; provider methods are surgical leaves that don't \`super()\` and don't re-validate.

### Net effect per provider

| File | Net lines |
|---|---|
| \`zwave_js.py\` | -9 |
| \`matter.py\` | -8 |
| \`virtual.py\` | +1 |
| \`zha.py\` | -2 |
| \`akuvox.py\` | -1 |
| \`schlage.py\` | -1 |
| \`zigbee2mqtt.py\` | -1 |
| \`_base.py\` | +30 (helper + signature thread + docstring) |

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- Follow-up to PR #1229 review feedback. The third Copilot concern (stale \`set usercode\` / \`cleared usercode\` log wording in akuvox/schlage) was already addressed in #1229 commit \`6adfe3a1\`, so this PR doesn't touch it.
- All 1077 tests pass after the refactor. The two provider-level tests that asserted the per-provider PIN guard (\`test_async_set_credential_rejects_unreadable_credential\` in zwave_js, \`test_set_credential_unreadable_pin_raises_code_rejected\` in matter) were obsoleted by the move; replaced with a single base-level test (\`test_require_readable_pin_rejects_unreadable_credential\` in \`test_seam.py\`) that pins the contract once.

- This PR is related to issue: PR #1229 review comments