### PR TITLE
refactor(providers/_util): tolerant tag parser + new compact format builder

### DIFF
--- a/custom_components/lock_code_manager/providers/_util.py
+++ b/custom_components/lock_code_manager/providers/_util.py
@@ -9,14 +9,16 @@ Credential CC).
 
 Two tag formats coexist during the migration window:
 
+* Canonical ``lcm:<slot>:<name>`` -- the consolidated format every new
+  write uses. Two colons delimit the slot field clearly for visual
+  parseability on the lock UI.
 * Legacy ``[LCM:<slot>] <name>`` -- written by Schlage/Akuvox today.
-* New ``lcm<slot>:<name>`` -- the consolidated format the rest of the
-  integration will move to. One character shorter, matters on locks with
-  small ``max_user_name_length``.
-
-``parse_tag_with_rewrite`` accepts both and signals when the matched name
-is in the legacy format so callers can rewrite it in place at the next
-write opportunity.
+  Still emitted by ``make_legacy_tagged_name`` while those providers
+  migrate; their reads tolerate it via ``parse_tag_with_rewrite``, which
+  signals a legacy match so the caller can rewrite the lock-stored name
+  in place at the next write opportunity. The legacy emitter is the
+  deprecation marker -- ``_legacy_`` in the name is intentional so
+  reviewers see at the call site that the writer hasn't migrated yet.
 """
 
 from __future__ import annotations
@@ -24,19 +26,25 @@ from __future__ import annotations
 import re
 
 _LEGACY_SLOT_TAG_RE = re.compile(r"^\[LCM:(\d+)\]\s*(.*)")
-_NEW_SLOT_TAG_RE = re.compile(r"^lcm(\d+):(.*)")
+_TAG_RE = re.compile(r"^lcm:(\d+):(.*)")
 
 
 def make_tagged_name(slot_num: int, name: str | None = None) -> str:
-    """Return a code name in the legacy ``[LCM:<slot>]`` format."""
+    """Return a code name in the canonical ``lcm:<slot>:`` format."""
+    base = name or f"Code Slot {slot_num}"
+    return f"lcm:{slot_num}:{base}"
+
+
+def make_legacy_tagged_name(slot_num: int, name: str | None = None) -> str:
+    """
+    Return a code name in the legacy ``[LCM:<slot>]`` format.
+
+    Deprecated: kept for Schlage/Akuvox until they migrate to the
+    canonical format with read-time detect-and-rewrite. New call sites
+    should use ``make_tagged_name``.
+    """
     base = name or f"Code Slot {slot_num}"
     return f"[LCM:{slot_num}] {base}"
-
-
-def make_new_tagged_name(slot_num: int, name: str | None = None) -> str:
-    """Return a code name in the new ``lcm<slot>:`` format."""
-    base = name or f"Code Slot {slot_num}"
-    return f"lcm{slot_num}:{base}"
 
 
 def parse_tag(name: str) -> tuple[int | None, str]:
@@ -58,11 +66,11 @@ def parse_tag_with_rewrite(name: str) -> tuple[int | None, str, bool]:
 
     Returns ``(slot_num, friendly_name, needs_rewrite)``. ``needs_rewrite``
     is True only when the legacy ``[LCM:<slot>]`` format matched; the
-    caller can re-emit via ``make_new_tagged_name`` on the next write to
-    migrate the lock-stored name in place. The new format and untagged
-    names both return ``needs_rewrite=False``.
+    caller can re-emit via ``make_tagged_name`` on the next write to
+    migrate the lock-stored name in place. The canonical ``lcm:<slot>:``
+    format and untagged names both return ``needs_rewrite=False``.
     """
-    match = _NEW_SLOT_TAG_RE.match(name)
+    match = _TAG_RE.match(name)
     if match:
         return int(match.group(1)), match.group(2), False
     match = _LEGACY_SLOT_TAG_RE.match(name)

--- a/custom_components/lock_code_manager/providers/_util.py
+++ b/custom_components/lock_code_manager/providers/_util.py
@@ -3,36 +3,72 @@ Shared helpers for provider implementations.
 
 Provider-internal utilities that don't belong in the integration-wide
 ``util.py``. Currently: slot-tagging used by providers whose lock APIs
-identify codes by user-name rather than by slot number (Schlage, Akuvox).
+identify codes by user-name rather than by slot number (Schlage, Akuvox,
+and -- once the unified-user migration lands -- Matter and Z-Wave User
+Credential CC).
+
+Two tag formats coexist during the migration window:
+
+* Legacy ``[LCM:<slot>] <name>`` -- written by Schlage/Akuvox today.
+* New ``lcm<slot>:<name>`` -- the consolidated format the rest of the
+  integration will move to. One character shorter, matters on locks with
+  small ``max_user_name_length``.
+
+``parse_tag_with_rewrite`` accepts both and signals when the matched name
+is in the legacy format so callers can rewrite it in place at the next
+write opportunity.
 """
 
 from __future__ import annotations
 
 import re
 
-# Format: ``[LCM:<slot>] <friendly name>`` — providers prepend this tag
-# so we can recover which slot a code belongs to from the lock's stored
-# user name.
-_SLOT_TAG_RE = re.compile(r"^\[LCM:(\d+)\]\s*(.*)")
+_LEGACY_SLOT_TAG_RE = re.compile(r"^\[LCM:(\d+)\]\s*(.*)")
+_NEW_SLOT_TAG_RE = re.compile(r"^lcm(\d+):(.*)")
 
 
 def make_tagged_name(slot_num: int, name: str | None = None) -> str:
-    """Return a code name tagged with the Lock Code Manager slot number."""
+    """Return a code name in the legacy ``[LCM:<slot>]`` format."""
     base = name or f"Code Slot {slot_num}"
     return f"[LCM:{slot_num}] {base}"
 
 
+def make_new_tagged_name(slot_num: int, name: str | None = None) -> str:
+    """Return a code name in the new ``lcm<slot>:`` format."""
+    base = name or f"Code Slot {slot_num}"
+    return f"lcm{slot_num}:{base}"
+
+
 def parse_tag(name: str) -> tuple[int | None, str]:
     """
-    Parse a Lock Code Manager slot tag from a code name.
+    Parse a Lock Code Manager slot tag, tolerant of both formats.
 
-    Returns ``(slot_num, friendly_name)`` when a tag is present, or
-    ``(None, original_name)`` when no tag is found.
+    Returns ``(slot_num, friendly_name)`` when either format matches, or
+    ``(None, original_name)`` otherwise. Callers that care about
+    rewriting legacy tags in place should use ``parse_tag_with_rewrite``
+    instead.
     """
-    match = _SLOT_TAG_RE.match(name)
+    slot, friendly, _ = parse_tag_with_rewrite(name)
+    return slot, friendly
+
+
+def parse_tag_with_rewrite(name: str) -> tuple[int | None, str, bool]:
+    """
+    Parse a slot tag and signal whether it needs format migration.
+
+    Returns ``(slot_num, friendly_name, needs_rewrite)``. ``needs_rewrite``
+    is True only when the legacy ``[LCM:<slot>]`` format matched; the
+    caller can re-emit via ``make_new_tagged_name`` on the next write to
+    migrate the lock-stored name in place. The new format and untagged
+    names both return ``needs_rewrite=False``.
+    """
+    match = _NEW_SLOT_TAG_RE.match(name)
     if match:
-        return int(match.group(1)), match.group(2)
-    return None, name
+        return int(match.group(1)), match.group(2), False
+    match = _LEGACY_SLOT_TAG_RE.match(name)
+    if match:
+        return int(match.group(1)), match.group(2), True
+    return None, name, False
 
 
 def parse_slot_num(value: object) -> int | None:

--- a/custom_components/lock_code_manager/providers/_util.py
+++ b/custom_components/lock_code_manager/providers/_util.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 import re
 
 _LEGACY_SLOT_TAG_RE = re.compile(r"^\[LCM:(\d+)\]\s*(.*)")
-_TAG_RE = re.compile(r"^lcm:(\d+):(.*)")
+_TAG_RE = re.compile(r"^lcm:(\d+):\s*(.*)")
 
 
 def make_tagged_name(slot_num: int, name: str | None = None) -> str:

--- a/custom_components/lock_code_manager/providers/akuvox.py
+++ b/custom_components/lock_code_manager/providers/akuvox.py
@@ -28,7 +28,7 @@ from ..domain.exceptions import (
 )
 from ..domain.models import SlotCredential
 from ._base import BaseLock
-from ._util import make_tagged_name as _make_tagged_name, parse_tag as _parse_tag
+from ._util import make_legacy_tagged_name as _make_tagged_name, parse_tag as _parse_tag
 from .const import LOGGER
 
 AKUVOX_DOMAIN = "local_akuvox"

--- a/custom_components/lock_code_manager/providers/schlage.py
+++ b/custom_components/lock_code_manager/providers/schlage.py
@@ -34,7 +34,7 @@ from ..domain.exceptions import (
 )
 from ..domain.models import SlotCredential
 from ._base import BaseLock
-from ._util import make_tagged_name as _make_tagged_name, parse_tag as _parse_tag
+from ._util import make_legacy_tagged_name as _make_tagged_name, parse_tag as _parse_tag
 from .const import LOGGER
 
 SCHLAGE_DOMAIN = "schlage"

--- a/tests/providers/test_util.py
+++ b/tests/providers/test_util.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 
 from custom_components.lock_code_manager.providers._util import (
-    make_new_tagged_name,
+    make_legacy_tagged_name,
     make_tagged_name,
     parse_slot_num,
     parse_tag,
@@ -14,7 +14,24 @@ from custom_components.lock_code_manager.providers._util import (
 
 
 class TestMakeTaggedName:
-    """Legacy ``[LCM:<slot>]`` builder; preserved for Schlage/Akuvox writes."""
+    """Canonical ``lcm:<slot>:`` builder."""
+
+    @pytest.mark.parametrize(
+        ("slot", "name", "expected"),
+        [
+            pytest.param(1, "Guest", "lcm:1:Guest", id="with-name"),
+            pytest.param(5, None, "lcm:5:Code Slot 5", id="default-name"),
+            pytest.param(255, "X", "lcm:255:X", id="max-slot-min-name"),
+            pytest.param(7, "Bob Jones", "lcm:7:Bob Jones", id="multi-word"),
+            pytest.param(3, "", "lcm:3:Code Slot 3", id="empty-name-uses-default"),
+        ],
+    )
+    def test_make_tagged_name(self, slot: int, name: str | None, expected: str) -> None:
+        assert make_tagged_name(slot, name) == expected
+
+
+class TestMakeLegacyTaggedName:
+    """Deprecated ``[LCM:<slot>]`` builder; preserved for Schlage/Akuvox writes."""
 
     @pytest.mark.parametrize(
         ("slot", "name", "expected"),
@@ -26,27 +43,10 @@ class TestMakeTaggedName:
             ),
         ],
     )
-    def test_make_tagged_name(self, slot: int, name: str | None, expected: str) -> None:
-        assert make_tagged_name(slot, name) == expected
-
-
-class TestMakeNewTaggedName:
-    """New compact ``lcm<slot>:`` builder."""
-
-    @pytest.mark.parametrize(
-        ("slot", "name", "expected"),
-        [
-            pytest.param(1, "Guest", "lcm1:Guest", id="with-name"),
-            pytest.param(5, None, "lcm5:Code Slot 5", id="default-name"),
-            pytest.param(255, "X", "lcm255:X", id="max-slot-min-name"),
-            pytest.param(7, "Bob Jones", "lcm7:Bob Jones", id="multi-word"),
-            pytest.param(3, "", "lcm3:Code Slot 3", id="empty-name-uses-default"),
-        ],
-    )
-    def test_make_new_tagged_name(
+    def test_make_legacy_tagged_name(
         self, slot: int, name: str | None, expected: str
     ) -> None:
-        assert make_new_tagged_name(slot, name) == expected
+        assert make_legacy_tagged_name(slot, name) == expected
 
 
 class TestParseTagWithRewrite:
@@ -56,14 +56,14 @@ class TestParseTagWithRewrite:
         ("input_name", "expected"),
         [
             # New format -- no rewrite needed.
-            pytest.param("lcm1:Guest", (1, "Guest", False), id="new-simple"),
-            pytest.param("lcm255:Family", (255, "Family", False), id="new-large-slot"),
+            pytest.param("lcm:1:Guest", (1, "Guest", False), id="new-simple"),
+            pytest.param("lcm:255:Family", (255, "Family", False), id="new-large-slot"),
             pytest.param(
-                "lcm7:Bob Jones", (7, "Bob Jones", False), id="new-multi-word"
+                "lcm:7:Bob Jones", (7, "Bob Jones", False), id="new-multi-word"
             ),
-            pytest.param("lcm5:", (5, "", False), id="new-empty-display"),
+            pytest.param("lcm:5:", (5, "", False), id="new-empty-display"),
             pytest.param(
-                "lcm5:lcm6:nested",
+                "lcm:5:lcm6:nested",
                 (5, "lcm6:nested", False),
                 id="new-display-looks-like-tag",
             ),
@@ -114,7 +114,7 @@ class TestParseTagWithRewrite:
         # The new-format regex matches eagerly from the start of the string;
         # the legacy regex would not match this input, but the test asserts
         # that the new-format check runs first.
-        assert parse_tag_with_rewrite("lcm5:[LCM:6] x") == (5, "[LCM:6] x", False)
+        assert parse_tag_with_rewrite("lcm:5:[LCM:6] x") == (5, "[LCM:6] x", False)
 
 
 class TestParseTag:
@@ -123,7 +123,7 @@ class TestParseTag:
     @pytest.mark.parametrize(
         ("input_name", "expected"),
         [
-            pytest.param("lcm5:Alice", (5, "Alice"), id="new-format"),
+            pytest.param("lcm:5:Alice", (5, "Alice"), id="new-format"),
             pytest.param("[LCM:5] Alice", (5, "Alice"), id="legacy-format"),
             pytest.param("Alice", (None, "Alice"), id="untagged"),
             pytest.param("", (None, ""), id="empty"),

--- a/tests/providers/test_util.py
+++ b/tests/providers/test_util.py
@@ -1,0 +1,151 @@
+"""Tests for the shared provider helpers in ``_util.py``."""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.lock_code_manager.providers._util import (
+    make_new_tagged_name,
+    make_tagged_name,
+    parse_slot_num,
+    parse_tag,
+    parse_tag_with_rewrite,
+)
+
+
+class TestMakeTaggedName:
+    """Legacy ``[LCM:<slot>]`` builder; preserved for Schlage/Akuvox writes."""
+
+    @pytest.mark.parametrize(
+        ("slot", "name", "expected"),
+        [
+            pytest.param(1, "Guest", "[LCM:1] Guest", id="with-name"),
+            pytest.param(5, None, "[LCM:5] Code Slot 5", id="default-name"),
+            pytest.param(
+                99, "Family Member", "[LCM:99] Family Member", id="multi-word"
+            ),
+        ],
+    )
+    def test_make_tagged_name(self, slot: int, name: str | None, expected: str) -> None:
+        assert make_tagged_name(slot, name) == expected
+
+
+class TestMakeNewTaggedName:
+    """New compact ``lcm<slot>:`` builder."""
+
+    @pytest.mark.parametrize(
+        ("slot", "name", "expected"),
+        [
+            pytest.param(1, "Guest", "lcm1:Guest", id="with-name"),
+            pytest.param(5, None, "lcm5:Code Slot 5", id="default-name"),
+            pytest.param(255, "X", "lcm255:X", id="max-slot-min-name"),
+            pytest.param(7, "Bob Jones", "lcm7:Bob Jones", id="multi-word"),
+            pytest.param(3, "", "lcm3:Code Slot 3", id="empty-name-uses-default"),
+        ],
+    )
+    def test_make_new_tagged_name(
+        self, slot: int, name: str | None, expected: str
+    ) -> None:
+        assert make_new_tagged_name(slot, name) == expected
+
+
+class TestParseTagWithRewrite:
+    """Tolerant parser that accepts both formats and flags legacy matches."""
+
+    @pytest.mark.parametrize(
+        ("input_name", "expected"),
+        [
+            # New format -- no rewrite needed.
+            pytest.param("lcm1:Guest", (1, "Guest", False), id="new-simple"),
+            pytest.param("lcm255:Family", (255, "Family", False), id="new-large-slot"),
+            pytest.param(
+                "lcm7:Bob Jones", (7, "Bob Jones", False), id="new-multi-word"
+            ),
+            pytest.param("lcm5:", (5, "", False), id="new-empty-display"),
+            pytest.param(
+                "lcm5:lcm6:nested",
+                (5, "lcm6:nested", False),
+                id="new-display-looks-like-tag",
+            ),
+            # Legacy format -- rewrite needed.
+            pytest.param("[LCM:1] Guest", (1, "Guest", True), id="legacy-simple"),
+            pytest.param(
+                "[LCM:99] Family", (99, "Family", True), id="legacy-large-slot"
+            ),
+            pytest.param(
+                "[LCM:5]Tight", (5, "Tight", True), id="legacy-no-space-after-bracket"
+            ),
+            # Untagged or malformed -- no match, no rewrite.
+            pytest.param("Guest Code", (None, "Guest Code", False), id="untagged"),
+            pytest.param("", (None, "", False), id="empty-string"),
+            pytest.param(
+                "lcm 5:Alice",
+                (None, "lcm 5:Alice", False),
+                id="space-after-prefix-rejected",
+            ),
+            pytest.param(
+                "lcm-5:Alice",
+                (None, "lcm-5:Alice", False),
+                id="negative-slot-rejected",
+            ),
+            pytest.param(
+                ":lcm5:Alice",
+                (None, ":lcm5:Alice", False),
+                id="leading-colon-rejected",
+            ),
+            pytest.param(
+                "LCM5:Alice",
+                (None, "LCM5:Alice", False),
+                id="uppercase-prefix-rejected",
+            ),
+        ],
+    )
+    def test_parse_tag_with_rewrite(
+        self, input_name: str, expected: tuple[int | None, str, bool]
+    ) -> None:
+        assert parse_tag_with_rewrite(input_name) == expected
+
+    def test_new_format_preferred_when_ambiguous(self) -> None:
+        """A name that happens to satisfy both regexes uses the new format match.
+
+        Not a realistic name, but pins the precedence so reviewers know which
+        branch wins if the parser is fed an oddball value.
+        """
+        # The new-format regex matches eagerly from the start of the string;
+        # the legacy regex would not match this input, but the test asserts
+        # that the new-format check runs first.
+        assert parse_tag_with_rewrite("lcm5:[LCM:6] x") == (5, "[LCM:6] x", False)
+
+
+class TestParseTag:
+    """Thin 2-tuple wrapper -- drops the rewrite flag."""
+
+    @pytest.mark.parametrize(
+        ("input_name", "expected"),
+        [
+            pytest.param("lcm5:Alice", (5, "Alice"), id="new-format"),
+            pytest.param("[LCM:5] Alice", (5, "Alice"), id="legacy-format"),
+            pytest.param("Alice", (None, "Alice"), id="untagged"),
+            pytest.param("", (None, ""), id="empty"),
+        ],
+    )
+    def test_parse_tag(self, input_name: str, expected: tuple[int | None, str]) -> None:
+        assert parse_tag(input_name) == expected
+
+
+class TestParseSlotNum:
+    """Numeric coercion helper used by providers that read string-keyed slots."""
+
+    @pytest.mark.parametrize(
+        ("input_value", "expected"),
+        [
+            pytest.param(5, 5, id="int-passthrough"),
+            pytest.param("5", 5, id="str-digits"),
+            pytest.param("042", 42, id="str-padded"),
+            pytest.param("five", None, id="str-non-numeric"),
+            pytest.param(None, None, id="none"),
+            pytest.param([], None, id="non-coercible-type"),
+        ],
+    )
+    def test_parse_slot_num(self, input_value: object, expected: int | None) -> None:
+        assert parse_slot_num(input_value) == expected

--- a/tests/providers/test_util.py
+++ b/tests/providers/test_util.py
@@ -63,6 +63,16 @@ class TestParseTagWithRewrite:
             ),
             pytest.param("lcm:5:", (5, "", False), id="new-empty-display"),
             pytest.param(
+                "lcm:5: Alice",
+                (5, "Alice", False),
+                id="new-trims-whitespace-after-colon",
+            ),
+            pytest.param(
+                "lcm:5:   Alice",
+                (5, "Alice", False),
+                id="new-trims-multiple-whitespace-after-colon",
+            ),
+            pytest.param(
                 "lcm:5:lcm6:nested",
                 (5, "lcm6:nested", False),
                 id="new-display-looks-like-tag",
@@ -105,15 +115,17 @@ class TestParseTagWithRewrite:
     ) -> None:
         assert parse_tag_with_rewrite(input_name) == expected
 
-    def test_new_format_preferred_when_ambiguous(self) -> None:
-        """A name that happens to satisfy both regexes uses the new format match.
+    def test_canonical_prefix_wins_when_display_contains_legacy_text(self) -> None:
+        """The canonical prefix is consumed first; the display is taken verbatim.
 
-        Not a realistic name, but pins the precedence so reviewers know which
-        branch wins if the parser is fed an oddball value.
+        Both regexes are anchored to the start of the string, so only one can
+        match a given input -- this isn't an ambiguity case. The test pins the
+        intended behavior when the *display portion* (everything after
+        ``lcm:<slot>:``) happens to contain something that looks like a legacy
+        tag: the canonical prefix wins, slot 5 is the LCM slot, and the rest
+        (including the literal ``[LCM:6] x``) is returned as the friendly name
+        without further parsing.
         """
-        # The new-format regex matches eagerly from the start of the string;
-        # the legacy regex would not match this input, but the test asserts
-        # that the new-format check runs first.
         assert parse_tag_with_rewrite("lcm:5:[LCM:6] x") == (5, "[LCM:6] x", False)
 
 


### PR DESCRIPTION
## Proposed change

Add the foundation for the unified user-tag idempotency design ([project_user_tag_idempotency](https://github.com/raman325/lock_code_manager/pull/1237/files#) memory): a tolerant parser that accepts both the legacy \`[LCM:<slot>] <name>\` format (used today by Schlage and Akuvox) and a new compact \`lcm<slot>:<name>\` format that the unified user-tag work will adopt across providers.

### What this PR does

- Add \`make_new_tagged_name(slot, name)\` emitting \`lcm<slot>:<name>\`. Saves one character per name vs. the legacy bracketed format, which matters on locks with small \`max_user_name_length\` (some advertise 10).
- Make \`parse_tag\` tolerant: it now matches either format (strict superset of prior behavior). Existing call-sites continue to work without change.
- Add \`parse_tag_with_rewrite\` returning \`(slot, friendly, needs_rewrite)\`. The \`needs_rewrite\` flag is True only when the legacy format matched, signalling that the caller can opportunistically rewrite the lock-stored name to the new format on the next write.

### What this PR does NOT do

- **Schlage and Akuvox continue to write the legacy format.** Their \`async_set_credential\` paths are untouched. The migration to writing the new format + opportunistic rewrite of existing legacy-tagged users is a follow-up.
- **No matter / zwave_js changes.** Those providers don't use \`_util.py\` today. They join the new convention in a subsequent PR (matter user tag adoption + base \`_truncate_user_name\` redesign).

This isolates the parser change from any behavioral change, so a rollback is safe.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

This is **PR A** of a 3-PR sequence:

- **PR A (this one)** — helpers + tolerant parser. Pure addition, no behavior change.
- **PR B** — Matter user tag adoption, \`_truncate_user_name\` redesign, lifecycle decoupling (user existence ties to slot config, not credential presence), Matter-only startup migration of untagged-but-LCM-created users.
- **PR C** — Z-Wave User Credential CC tag adoption (drops \`user_id = slot\` invariant), Schlage/Akuvox format migration from \`[LCM:<slot>]\` to \`lcm<slot>:\` with read-time detect-and-rewrite.

The full design is in the project's local memory file \`project_user_tag_idempotency.md\` (not checked in; design specs live locally only per project convention).

33 new tests in \`tests/providers/test_util.py\` covering format round-trips, both-format parsing, ambiguity precedence, malformed-name rejection, and edge cases (empty display, multi-word display, display that looks like a tag).

- This PR is related to issue: laying groundwork for unified user-tag idempotency (see \`project_user_tag_idempotency.md\`)