### PR TITLE
feat(matter): adopt user-tag identity, decouple user lifecycle from credentials

### DIFF
--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -81,6 +81,7 @@ from .const import (
     Platform,
 )
 from .domain.config import EntryConfig
+from .domain.exceptions import LockDisconnected, LockOperationFailed
 from .domain.locks import async_create_lock_instance, get_locks_from_targets
 from .domain.models import (
     LockCodeManagerConfigEntry,
@@ -976,6 +977,31 @@ async def async_update_listener(
                     entry_title,
                     slot_num,
                 )
+
+    # Release lock-side state LCM owns for any (lock, slot) pair that no
+    # longer exists in config. Native-user providers (Matter, Z-Wave User
+    # Credential CC under the user-tag idempotency design) override
+    # ``async_release_managed_slot`` to delete the LCM-tagged user that
+    # anchored the slot; slot-only providers leave the default no-op in
+    # place. This runs before ``locks_to_remove`` processing so providers
+    # in ``runtime_data.locks`` are still usable.
+    for lock_entity_id, slot_num in diff.pairs_removed:
+        release_lock = runtime_data.locks.get(lock_entity_id)
+        if release_lock is None:
+            continue
+        try:
+            await release_lock.async_release_managed_slot(slot_num)
+        except (LockDisconnected, LockOperationFailed) as err:
+            # The slot is gone from LCM config either way; lock-side cleanup
+            # is best-effort and must not block the teardown.
+            _LOGGER.warning(
+                "%s (%s): could not release slot %s on lock %s: %s",
+                entry_id,
+                entry_title,
+                slot_num,
+                lock_entity_id,
+                err,
+            )
 
     # Remove old lock entities
     if locks_to_remove:

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -1092,9 +1092,17 @@ class BaseLock:
         :func:`._util.make_tagged_name`) and truncates the display portion
         so the overall length fits ``max_user_name_length``. The tag prefix
         is sacred -- it's how :func:`._util.parse_tag` recovers the slot
-        binding on subsequent reads -- so truncation shortens only the
-        user-supplied display when the full prefix fits; if the lock's limit
-        is smaller than the prefix itself, the prefix is truncated to the limit.
+        binding on subsequent reads -- so when the full prefix fits,
+        truncation only ever shortens the user-supplied display.
+
+        When the lock's limit can't even fit the canonical prefix
+        (``len("lcm:{slot}:") > max_user_name_length``), the helper
+        falls back to writing just the slot number as the user name
+        (``str(slot)``). :func:`._util.parse_tag` recognizes
+        digit-only names as a length-constrained encoding of the slot
+        binding. Truncating the canonical prefix would lose the slot
+        recoverably, which is worse than the slot-only fallback's
+        ambiguity with external users whose names happen to be digits.
 
         Returns ``None`` when the lock has no concept of named users
         (``max_user_name_length == 0`` or ``supports_user_management`` is
@@ -1105,11 +1113,11 @@ class BaseLock:
         blocking the write -- the cache stays unset so the next call
         retries.
 
-        Worst-case prefix overhead is 8 characters (``lcm:255:``); on a
-        10-character-limit lock that leaves 2 characters of display, which
-        is degenerate but functional. Locks that advertise a length too
-        small to fit even the prefix (extremely uncommon) return the
-        prefix truncated to the advertised maximum.
+        Worst-case canonical prefix overhead is 8 characters
+        (``lcm:255:``); on a 10-character-limit lock that leaves 2
+        characters of display, which is degenerate but functional.
+        Locks advertising a length below that (rare) hit the slot-only
+        fallback.
         """
         try:
             caps = await self._get_cached_capabilities()
@@ -1118,6 +1126,13 @@ class BaseLock:
         if caps.max_user_name_length <= 0:
             return None
         tagged = make_tagged_name(slot, display)
+        if len(tagged) <= caps.max_user_name_length:
+            return tagged
+        if len(f"lcm:{slot}:") > caps.max_user_name_length:
+            # Canonical prefix doesn't fit. Fall back to the slot-only
+            # encoding so the slot binding survives the read.
+            return str(slot)[: caps.max_user_name_length]
+        # Canonical prefix fits; truncate only the display portion.
         return tagged[: caps.max_user_name_length]
 
     async def _assert_credential_type_supported(self, credential: Credential) -> None:

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -1246,6 +1246,16 @@ class BaseLock:
         await self._assert_credential_type_supported(credential)
         if await self._supports_user_records():
             tagged = await self._build_tagged_user_name(credential.slot, user.name)
+            if tagged is None:
+                # No stable slot tag fits the lock's max_user_name_length --
+                # writing a user without one (or with name=None) would break
+                # the find-or-create-by-tag lookup the next operation needs.
+                # Fail loudly rather than create an unrecoverable user.
+                raise LockOperationFailed(
+                    f"Lock {self.lock.entity_id} cannot encode a stable slot "
+                    f"tag for slot {credential.slot}; refusing to write a "
+                    "credential whose owning user could not be re-identified"
+                )
             user_for_write = user if tagged == user.name else replace(user, name=tagged)
             result = await self.async_set_user(user_for_write)
             credential_user_id = result.user_id

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -62,6 +62,7 @@ from ..domain.exceptions import (
 from ..domain.models import SlotCredential
 from ..domain.queries import find_entry_for_lock_slot, get_managed_slots
 from ..domain.util import mask_pin
+from ._util import make_tagged_name
 from .const import LOGGER
 
 _LOGGER = logging.getLogger(__name__)
@@ -931,13 +932,17 @@ class BaseLock:
         Slot-only providers address the credential by slot and delete it
         directly. Native-user providers must target the credential's actual
         owning user, which is not assumed to equal the slot index: a
-        credential may have been created on the lock by another controller, or
-        the integration may have allocated a user identifier that differs from
-        the slot. The owner is resolved from the lock's current users and the
-        delete-on-last user lifecycle runs via ``_delete_credential``. Returns
-        True if the value changed, False if it was already cleared -- and True
-        when the provider cannot determine whether a change occurred, so the
-        coordinator refreshes and verifies the actual state.
+        credential may have been created on the lock by another controller,
+        or the integration may have allocated a user identifier that differs
+        from the slot. The owning ``user_id`` is resolved from the lock's
+        current users and threaded through the ``CredentialRef`` so the
+        provider's delete primitive can address the credential precisely.
+        The lock-side user stays put; it is torn down only when the slot
+        is removed from LCM config (see ``async_release_managed_slot``).
+        Returns True if the value changed, False if it was already cleared
+        -- and True when the provider cannot determine whether a change
+        occurred, so the coordinator refreshes and verifies the actual
+        state.
         """
         if not self.supports_native_users:
             ref = CredentialRef(
@@ -945,23 +950,23 @@ class BaseLock:
             )
             return await self.async_delete_credential(ref)
 
-        owner = next(
+        owner_user_id = next(
             (
-                user
+                user.user_id
                 for user in await self.async_get_users()
                 for credential in user.pin_credentials
                 if credential.slot == code_slot
             ),
             None,
         )
-        if owner is None:
+        if owner_user_id is None:
             # No user owns this slot's credential -- nothing to clear.
             return False
 
         ref = CredentialRef(
-            user_id=owner.user_id, type=CredentialType.PIN, slot=code_slot
+            user_id=owner_user_id, type=CredentialType.PIN, slot=code_slot
         )
-        return await self._delete_credential(owner, ref)
+        return await self._delete_credential(ref)
 
     @final
     async def async_internal_clear_usercode(
@@ -1058,24 +1063,42 @@ class BaseLock:
         caps = await self._get_cached_capabilities()
         return caps.supports_user_management and caps.max_user_name_length > 0
 
-    async def _truncate_user_name(self, name: str | None) -> str | None:
+    async def _build_tagged_user_name(
+        self, slot: int, display: str | None
+    ) -> str | None:
         """
-        Truncate ``name`` to the lock's advertised user-name length.
+        Build the LCM-tagged user name for a slot, fitting the lock's length.
+
+        Emits ``lcm:{slot}:{display}`` (canonical format from
+        :func:`._util.make_tagged_name`) and truncates the display portion
+        so the overall length fits ``max_user_name_length``. The tag prefix
+        is sacred -- it's how :func:`._util.parse_tag` recovers the slot
+        binding on subsequent reads -- so truncation only ever shortens
+        the user-supplied display, never the prefix.
 
         Returns ``None`` when the lock has no concept of named users
-        (``max_user_name_length == 0``). A best-effort capabilities-fetch
-        failure also returns ``None`` rather than blocking the write --
-        the cache stays unset so the next call retries.
+        (``max_user_name_length == 0`` or ``supports_user_management`` is
+        False); the seam's ``_supports_user_records`` gate already short-
+        circuits the user-write path on such locks, so a ``None`` return
+        here means "do not write a user name." A best-effort
+        capabilities-fetch failure also returns ``None`` rather than
+        blocking the write -- the cache stays unset so the next call
+        retries.
+
+        Worst-case prefix overhead is 8 characters (``lcm:255:``); on a
+        10-character-limit lock that leaves 2 characters of display, which
+        is degenerate but functional. Locks that advertise a length too
+        small to fit even the prefix (extremely uncommon) return the
+        prefix truncated to the advertised maximum.
         """
-        if name is None:
-            return None
         try:
             caps = await self._get_cached_capabilities()
         except LockDisconnected, LockOperationFailed:
             return None
         if caps.max_user_name_length <= 0:
             return None
-        return name[: caps.max_user_name_length]
+        tagged = make_tagged_name(slot, display)
+        return tagged[: caps.max_user_name_length]
 
     async def _assert_credential_type_supported(self, credential: Credential) -> None:
         """
@@ -1164,10 +1187,8 @@ class BaseLock:
         """
         await self._assert_credential_type_supported(credential)
         if await self._supports_user_records():
-            truncated = await self._truncate_user_name(user.name)
-            user_for_write = (
-                user if truncated == user.name else replace(user, name=truncated)
-            )
+            tagged = await self._build_tagged_user_name(credential.slot, user.name)
+            user_for_write = user if tagged == user.name else replace(user, name=tagged)
             result = await self.async_set_user(user_for_write)
             credential_user_id = result.user_id
             rollback_user_id = result.user_id if result.created else None
@@ -1193,42 +1214,41 @@ class BaseLock:
             raise
 
     @final
-    async def _delete_credential(self, owner: User, ref: CredentialRef) -> bool:
+    async def _delete_credential(self, ref: CredentialRef) -> bool:
         """
-        Run the delete-on-last user lifecycle around a credential delete.
+        Delete a credential without touching its owning user.
 
         Native-user only. Asserts the lock advertises ``ref.type``, then
-        deletes the credential. On locks with separate user records
-        (mirroring ``_set_credential``'s gate), deletes ``owner`` when
-        that was its last credential -- the invariant being that a user
-        exists if and only if it owns at least one credential. On
-        implicit-user locks (e.g. Z-Wave User Code CC) the credential
-        delete already removed the user, so the cleanup call is skipped.
-        The count is read from ``owner``, a pre-deletion snapshot, so
-        the decision does not depend on whether the provider mutates the
-        user during the delete. Returns True if changed.
-
-        The credential delete is the operation that clears the slot, so a
-        failure of the follow-up user delete is logged rather than raised: the
-        slot is already cleared, and raising would only churn retries that
-        re-resolve to no owner. The leftover empty user is surfaced in the log.
+        deletes the credential. The lock-side user is now an LCM-managed
+        slot anchor (see the user-tag idempotency design) -- created on
+        first slot-configured write and removed only on slot removal
+        from LCM config via ``async_release_managed_slot``. Clear and
+        rewrite cycles preserve the slot's lock-side user, so this
+        helper is now a thin guard around ``async_delete_credential``.
+        Returns True if changed.
         """
         await self._assert_credential_ref_supported(ref)
-        was_only_credential = len(owner.credentials) <= 1
-        changed = await self.async_delete_credential(ref)
-        if changed and was_only_credential and await self._supports_user_records():
-            try:
-                await self.async_delete_user(owner.user_id)
-            except Exception as err:
-                LOGGER.warning(
-                    "Lock %s: cleared the credential at slot %s but failed to "
-                    "remove the now-empty user %s: %s",
-                    self.lock.entity_id,
-                    ref.slot,
-                    owner.user_id,
-                    err,
-                )
-        return changed
+        return await self.async_delete_credential(ref)
+
+    async def async_release_managed_slot(self, slot: int) -> None:
+        """
+        Release any lock-side state LCM owns for ``slot``.
+
+        Called by ``__init__.py``'s teardown path once a slot is removed
+        from LCM config (per the user-tag idempotency design's lifecycle
+        decoupling: a lock-side user is the slot's persistent anchor and
+        survives PIN clear/rewrite cycles, so it can only be torn down
+        when the slot itself is removed from LCM management).
+
+        Default is a no-op: slot-only providers have no user record to
+        tear down, and native-user providers that have not yet migrated
+        to the tag scheme don't carry a recoverable slot binding either.
+        Providers that DO carry the binding (Matter, eventually Z-Wave
+        User Credential CC) override this to find the user tagged for
+        ``slot`` and delete it -- the cascade defined by the lock's
+        protocol then removes the user's credentials.
+        """
+        return
 
     async def async_set_user(self, user: User) -> SetUserResult:
         """

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -960,12 +960,20 @@ class BaseLock:
         # user for slot A whose credential lands at index B would be
         # mis-matched when clearing slot B.
         users = await self.async_get_users()
+        # Both lookups require the user to actually own a PIN credential
+        # at the slot we're clearing. Under the persistent-user-anchor
+        # lifecycle a tagged user can exist without a PIN (between
+        # writes); resolving such a user as the owner would drive a
+        # spurious ``async_delete_credential`` call whose provider-
+        # specific return value can incorrectly report changed=True.
         owner_user_id: int | None
         try:
             owner_user_id = next(
                 user.user_id
                 for user in users
                 if user.name and parse_tag(user.name)[0] == code_slot
+                for credential in user.pin_credentials
+                if credential.slot == code_slot
             )
         except StopIteration:
             owner_user_id = next(
@@ -1100,38 +1108,50 @@ class BaseLock:
         falls back to writing just the slot number as the user name
         (``str(slot)``). :func:`._util.parse_tag` recognizes
         digit-only names as a length-constrained encoding of the slot
-        binding. Truncating the canonical prefix would lose the slot
-        recoverably, which is worse than the slot-only fallback's
-        ambiguity with external users whose names happen to be digits.
+        binding. If even the slot digits don't fit
+        (``len(str(slot)) > max_user_name_length``, e.g. slot 255 on a
+        2-char-limit lock), the helper returns ``None`` rather than
+        truncating the slot to a different number and silently
+        mis-binding the user. The seam treats ``None`` as "leave name
+        alone," which means LCM cannot identify its own user on such a
+        lock -- those locks are effectively unmanaged at the user-name
+        level.
 
         Returns ``None`` when the lock has no concept of named users
-        (``max_user_name_length == 0`` or ``supports_user_management`` is
-        False); the seam's ``_supports_user_records`` gate already short-
-        circuits the user-write path on such locks, so a ``None`` return
-        here means "do not write a user name." A best-effort
-        capabilities-fetch failure also returns ``None`` rather than
-        blocking the write -- the cache stays unset so the next call
-        retries.
+        (``supports_user_management`` is False or
+        ``max_user_name_length <= 0``); the seam's
+        ``_supports_user_records`` gate already short-circuits the
+        user-write path on such locks, but the guard here is
+        defensive in case the helper is called outside that gate. A
+        best-effort capabilities-fetch failure also returns ``None``
+        rather than blocking the write -- the cache stays unset so the
+        next call retries.
 
         Worst-case canonical prefix overhead is 8 characters
         (``lcm:255:``); on a 10-character-limit lock that leaves 2
         characters of display, which is degenerate but functional.
         Locks advertising a length below that (rare) hit the slot-only
-        fallback.
+        fallback or the ``None`` return.
         """
         try:
             caps = await self._get_cached_capabilities()
         except LockDisconnected, LockOperationFailed:
             return None
-        if caps.max_user_name_length <= 0:
+        if not caps.supports_user_management or caps.max_user_name_length <= 0:
             return None
         tagged = make_tagged_name(slot, display)
         if len(tagged) <= caps.max_user_name_length:
             return tagged
         if len(f"lcm:{slot}:") > caps.max_user_name_length:
-            # Canonical prefix doesn't fit. Fall back to the slot-only
-            # encoding so the slot binding survives the read.
-            return str(slot)[: caps.max_user_name_length]
+            # Canonical prefix doesn't fit. Try the slot-only fallback so
+            # the slot binding survives the read; if the slot digits
+            # themselves can't fit either, return ``None`` rather than
+            # truncate the slot number to a different one and mis-bind
+            # the user.
+            slot_str = str(slot)
+            if len(slot_str) > caps.max_user_name_length:
+                return None
+            return slot_str
         # Canonical prefix fits; truncate only the display portion.
         return tagged[: caps.max_user_name_length]
 

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -62,7 +62,7 @@ from ..domain.exceptions import (
 from ..domain.models import SlotCredential
 from ..domain.queries import find_entry_for_lock_slot, get_managed_slots
 from ..domain.util import mask_pin
-from ._util import make_tagged_name
+from ._util import make_tagged_name, parse_tag
 from .const import LOGGER
 
 _LOGGER = logging.getLogger(__name__)
@@ -950,15 +950,34 @@ class BaseLock:
             )
             return await self.async_delete_credential(ref)
 
-        owner_user_id = next(
-            (
+        # Owner resolution is two-pass to match the same identity rule the
+        # set path uses (see Matter's _find_user_index_for_slot). The
+        # canonical pass matches by the ``lcm:<slot>:`` tag in user.name;
+        # the legacy fallback handles pre-PR-B installs where
+        # ``credential.slot`` was pinned to the LCM slot. Matching by
+        # ``credential.slot == code_slot`` alone is unsafe once providers
+        # let the lock auto-allocate the credential index -- a tagged
+        # user for slot A whose credential lands at index B would be
+        # mis-matched when clearing slot B.
+        users = await self.async_get_users()
+        owner_user_id: int | None
+        try:
+            owner_user_id = next(
                 user.user_id
-                for user in await self.async_get_users()
-                for credential in user.pin_credentials
-                if credential.slot == code_slot
-            ),
-            None,
-        )
+                for user in users
+                if user.name and parse_tag(user.name)[0] == code_slot
+            )
+        except StopIteration:
+            owner_user_id = next(
+                (
+                    user.user_id
+                    for user in users
+                    if parse_tag(user.name or "")[0] is None
+                    for credential in user.pin_credentials
+                    if credential.slot == code_slot
+                ),
+                None,
+            )
         if owner_user_id is None:
             # No user owns this slot's credential -- nothing to clear.
             return False
@@ -1173,11 +1192,14 @@ class BaseLock:
 
         Native-user only (the slot adapters call the credential primitive
         directly). Asserts the lock advertises ``credential.type`` and
-        truncates ``user.name`` to the lock's advertised limit before
+        replaces ``user.name`` with the LCM-tagged name built via
+        ``_build_tagged_user_name(credential.slot, user.name)`` before
         handing the user to the provider, so each provider's
-        ``async_set_user`` can write the name verbatim. Rolls back a
-        newly-created user when the credential write fails so the lock
-        isn't left with a credential-less user the slot-keyed coordinator
+        ``async_set_user`` can write the tagged name verbatim. The tag
+        carries the slot binding the find-or-create-by-tag lookup
+        recovers on subsequent operations. Rolls back a newly-created
+        user when the credential write fails so the lock isn't left
+        with a credential-less user the slot-keyed coordinator
         can't reconcile. Returns True if the value changed.
 
         ``pin`` is the resolved readable PIN that the caller (the seam in
@@ -1277,9 +1299,13 @@ class BaseLock:
         """
         Delete a lock user (and, per the Z-Wave/Matter spec, its credentials).
 
-        Native-user providers only. The base calls this once a user's last
-        credential has been removed -- the lifecycle invariant is that a user
-        exists if and only if it owns at least one credential.
+        Native-user providers only. Under the user-tag idempotency design
+        the lock-side user is an LCM-managed slot anchor: it persists
+        through PIN clear / rewrite cycles and is removed only when the
+        slot is dropped from LCM config (the base calls this from a
+        provider's ``async_release_managed_slot`` override). Also called
+        as a rollback path when a credential write fails for a freshly
+        created user.
         """
         self._raise_not_implemented(
             "async_delete_user",

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -1092,8 +1092,9 @@ class BaseLock:
         :func:`._util.make_tagged_name`) and truncates the display portion
         so the overall length fits ``max_user_name_length``. The tag prefix
         is sacred -- it's how :func:`._util.parse_tag` recovers the slot
-        binding on subsequent reads -- so truncation only ever shortens
-        the user-supplied display, never the prefix.
+        binding on subsequent reads -- so truncation shortens only the
+        user-supplied display when the full prefix fits; if the lock's limit
+        is smaller than the prefix itself, the prefix is truncated to the limit.
 
         Returns ``None`` when the lock has no concept of named users
         (``max_user_name_length == 0`` or ``supports_user_management`` is

--- a/custom_components/lock_code_manager/providers/_util.py
+++ b/custom_components/lock_code_manager/providers/_util.py
@@ -7,11 +7,17 @@ identify codes by user-name rather than by slot number (Schlage, Akuvox,
 and -- once the unified-user migration lands -- Matter and Z-Wave User
 Credential CC).
 
-Two tag formats coexist during the migration window:
+Three tag formats coexist during the migration window:
 
 * Canonical ``lcm:<slot>:<name>`` -- the consolidated format every new
-  write uses. Two colons delimit the slot field clearly for visual
-  parseability on the lock UI.
+  write uses when the lock's ``max_user_name_length`` can fit the full
+  ``lcm:<slot>:`` prefix. Two colons delimit the slot field clearly for
+  visual parseability on the lock UI.
+* Slot-only ``<digits>`` -- the length-constrained fallback, used when
+  the lock's name field is too small to fit even the canonical prefix.
+  Just the slot number, written as ``str(slot)``. Ambiguous with any
+  external user named with only digits, but only encountered on locks
+  with absurdly small name limits, so the tradeoff is accepted.
 * Legacy ``[LCM:<slot>] <name>`` -- written by Schlage/Akuvox today.
   Still emitted by ``make_legacy_tagged_name`` while those providers
   migrate; their reads tolerate it via ``parse_tag_with_rewrite``, which
@@ -27,6 +33,7 @@ import re
 
 _LEGACY_SLOT_TAG_RE = re.compile(r"^\[LCM:(\d+)\]\s*(.*)")
 _TAG_RE = re.compile(r"^lcm:(\d+):\s*(.*)")
+_SLOT_ONLY_RE = re.compile(r"^(\d+)$")
 
 
 def make_tagged_name(slot_num: int, name: str | None = None) -> str:
@@ -67,8 +74,18 @@ def parse_tag_with_rewrite(name: str) -> tuple[int | None, str, bool]:
     Returns ``(slot_num, friendly_name, needs_rewrite)``. ``needs_rewrite``
     is True only when the legacy ``[LCM:<slot>]`` format matched; the
     caller can re-emit via ``make_tagged_name`` on the next write to
-    migrate the lock-stored name in place. The canonical ``lcm:<slot>:``
-    format and untagged names both return ``needs_rewrite=False``.
+    migrate the lock-stored name in place. The canonical
+    ``lcm:<slot>:`` format, the slot-only fallback, and untagged names
+    all return ``needs_rewrite=False``.
+
+    Match priority: canonical, then legacy, then slot-only digits. The
+    slot-only branch is the length-constrained encoding emitted by
+    :func:`._base.BaseLock._build_tagged_user_name` when the lock's
+    ``max_user_name_length`` cannot fit the canonical prefix; the
+    display portion is empty. Bare digits being treated as a slot tag
+    is intentional but ambiguous with external users whose names
+    happen to be digit-only -- the ambiguity is the cost of preserving
+    the slot binding on length-constrained locks.
     """
     match = _TAG_RE.match(name)
     if match:
@@ -76,6 +93,9 @@ def parse_tag_with_rewrite(name: str) -> tuple[int | None, str, bool]:
     match = _LEGACY_SLOT_TAG_RE.match(name)
     if match:
         return int(match.group(1)), match.group(2), True
+    match = _SLOT_ONLY_RE.match(name)
+    if match:
+        return int(match.group(1)), "", False
     return None, name, False
 
 

--- a/custom_components/lock_code_manager/providers/matter.py
+++ b/custom_components/lock_code_manager/providers/matter.py
@@ -24,7 +24,6 @@ from homeassistant.components.matter.lock_helpers import (
     SetCredentialFailedError,
     clear_lock_credential,
     clear_lock_user,
-    get_lock_credential_status,
     get_lock_info,
     get_lock_users,
     set_lock_credential,
@@ -52,7 +51,7 @@ from ..domain.exceptions import (
 )
 from ..domain.models import SlotCredential
 from ._base import BaseLock
-from ._util import parse_slot_num
+from ._util import parse_slot_num, parse_tag
 from .const import LOGGER
 
 # DoorLock cluster ID (0x0101 = 257)
@@ -254,63 +253,40 @@ class MatterLock(BaseLock):
 
     async def async_set_user(self, user: User) -> SetUserResult:
         """
-        Create or update a lock user, returning whether it was newly created.
+        Find-or-create the lock user for the LCM slot encoded in ``user.name``.
 
-        The user.user_id here is the slot (credential_index). Matter allocates
-        user_index independently: you cannot create a user at a chosen index —
-        set_lock_user raises UserSlotEmptyError when user_index is given for an
-        empty slot. So the flow is:
+        The base seam passes a tagged ``user.name`` (``lcm:<slot>:<display>``)
+        whose slot is the LCM-side identity for this credential. The Matter
+        lock's own ``user_index`` is whatever Matter happens to allocate;
+        LCM does NOT pin it to the slot. Discovery on every call walks the
+        lock's user list and matches by tag:
 
-        1. Check the credential slot's current owner via get_lock_credential_status.
-        2. If the slot is occupied (UPDATE): call set_lock_user with the existing
-           user_index from the status response.
-        3. If the slot is empty (CREATE): call set_lock_user with user_index=None
-           so Matter auto-allocates a free user slot and returns the new index.
+        1. Scan ``async_get_users()`` for a user whose name parses to the
+           same LCM slot as ``user`` carries.
+        2. If found (UPDATE): rename via ``set_lock_user`` with the
+           existing ``user_index``, return that index.
+        3. If not found (CREATE): allocate a fresh ``user_index`` via
+           ``set_lock_user(user_index=None)`` and return the new index.
 
-        The returned SetUserResult carries the real Matter user_index, which the
-        base orchestration passes into async_set_credential as the user_id.
+        ``user.user_id`` -- set by the seam from the LCM slot in
+        ``user_from_slot`` -- is used as the slot identity when ``user.name``
+        is untagged (defensive fallback; the seam should always pass a
+        tagged name on this code path).
         """
+        slot = self._slot_from_seam_user(user)
         client, node = self._require_client_and_node()
-        try:
-            status = await get_lock_credential_status(
-                client,
-                node,
-                credential_type="pin",
-                credential_index=user.user_id,
-            )
-        except ServiceValidationError as err:
-            raise LockOperationFailed(
-                f"Matter get_lock_credential_status rejected input for "
-                f"{self.lock.entity_id}: {err}"
-            ) from err
-        except HomeAssistantError as err:
-            raise LockDisconnected(
-                f"Matter get_lock_credential_status failed for "
-                f"{self.lock.entity_id}: {err}"
-            ) from err
 
-        credential_exists = status.get("credential_exists", False)
-        existing_user_index = status.get("user_index")
+        existing_user_index = await self._find_user_index_for_slot(slot)
 
-        if credential_exists and existing_user_index is None:
-            # The credential is reportedly occupied but the lock did not
-            # surface its owner. Falling through to CREATE would orphan
-            # the original user (it would still exist with zero credentials)
-            # and break the user-per-credential invariant, so refuse the
-            # write and let the caller decide how to recover.
-            raise LockOperationFailed(
-                f"Matter lock {self.lock.entity_id} slot {user.user_id} reports "
-                "credential_exists=True but no user_index"
-            )
-
-        if credential_exists and existing_user_index is not None:
-            # UPDATE: the slot is occupied — modify the existing user record.
-            # set_lock_user here is a metadata-only name update. The historical
-            # Matter contract (PR #1077) tolerated name-set failures so a
-            # transient 500 or a name the lock rejects does not block the
-            # subsequent credential write; the user still exists at the
-            # known index, the only thing lost is the name update. Log a
-            # warning and fall through.
+        if existing_user_index is not None:
+            # UPDATE: rename via set_lock_user.
+            #
+            # set_lock_user here is a metadata-only name update. The
+            # historical Matter contract (PR #1077) tolerated name-set
+            # failures so a transient 500 or a name the lock rejects does
+            # not block the subsequent credential write; the user still
+            # exists at the known index, the only thing lost is the name
+            # update. Log a warning and fall through.
             try:
                 await set_lock_user(
                     client,
@@ -323,13 +299,14 @@ class MatterLock(BaseLock):
                     "Lock %s: failed to update user name on slot %s "
                     "(user_index=%s); continuing without name update: %s",
                     self.lock.entity_id,
-                    user.user_id,
+                    slot,
                     existing_user_index,
                     err,
                 )
             return SetUserResult(user_id=existing_user_index, created=False)
 
-        # CREATE: the slot is empty — let Matter auto-allocate a user_index.
+        # CREATE: no LCM-tagged user exists for this slot yet — let Matter
+        # auto-allocate a free user_index.
         try:
             result = await set_lock_user(
                 client,
@@ -346,6 +323,55 @@ class MatterLock(BaseLock):
                 f"Matter set_lock_user failed for {self.lock.entity_id}: {err}"
             ) from err
         return SetUserResult(user_id=result["user_index"], created=True)
+
+    def _slot_from_seam_user(self, user: User) -> int:
+        """
+        Return the LCM slot encoded in ``user.name`` or fall back to ``user_id``.
+
+        The base seam always passes a tagged name; this helper centralizes
+        the fallback so the rest of the provider can treat the resolved
+        slot as a single value.
+        """
+        if user.name:
+            slot, _ = parse_tag(user.name)
+            if slot is not None:
+                return slot
+        return user.user_id
+
+    async def _find_user_index_for_slot(self, slot: int) -> int | None:
+        """
+        Return the ``user_index`` of the user LCM owns for ``slot``, if any.
+
+        Two lookups, in priority order:
+
+        1. **Canonical** -- a user whose name carries the
+           ``lcm:<slot>:`` tag. This is the post-PR-B identity rule.
+        2. **Legacy adoption** -- a user owning a PIN credential at
+           ``credential_index == slot``. Pre-PR-B Matter LCM pinned
+           ``credential_index`` to the LCM slot, so an untagged user
+           owning a PIN at that index is almost certainly the LCM 2.0
+           user for this slot. Adopting it (the subsequent
+           ``set_lock_user`` rewrites the name to the tagged form, and
+           ``set_lock_credential`` MODIFY'es the existing credential
+           index in place) preserves a single, identifiable user per
+           slot across the upgrade. Without this fallback the new model
+           would CREATE a second user every time, silently leaving the
+           pre-upgrade PIN active on the lock.
+
+        Returns ``None`` when neither lookup matches.
+        """
+        users = await self.async_get_users()
+        for existing in users:
+            if existing.name is None:
+                continue
+            parsed_slot, _ = parse_tag(existing.name)
+            if parsed_slot == slot:
+                return existing.user_id
+        for existing in users:
+            for cred in existing.pin_credentials:
+                if cred.slot == slot:
+                    return existing.user_id
+        return None
 
     async def async_delete_user(self, user_id: int) -> None:
         """
@@ -366,6 +392,32 @@ class MatterLock(BaseLock):
                 f"Matter clear_lock_user failed for {self.lock.entity_id}: {err}"
             ) from err
 
+    async def async_release_managed_slot(self, slot: int) -> None:
+        """
+        Tear down the LCM-owned user that anchors ``slot``.
+
+        Called by the base teardown path when the slot is removed from
+        LCM config (see ``__init__.py``'s ``pairs_removed`` loop). Looks
+        up the lock-side user via the same find-or-adopt logic the set
+        path uses, then deletes it. Matter's ClearUser cascade then
+        removes the user's PIN credential automatically.
+
+        Tolerates "no user found": the slot may have never had an LCM
+        user on this lock (e.g. the user was already removed out-of-band,
+        or the slot was configured but never written). Lock-side
+        transport failures bubble up so the base wraps them in a warning
+        and the teardown still completes.
+        """
+        user_index = await self._find_user_index_for_slot(slot)
+        if user_index is None:
+            LOGGER.debug(
+                "Lock %s: no LCM-owned user to release for slot %s",
+                self.lock.entity_id,
+                slot,
+            )
+            return
+        await self.async_delete_user(user_index)
+
     async def _send_set_credential(
         self,
         client: Any,
@@ -373,9 +425,15 @@ class MatterLock(BaseLock):
         code_slot: int,
         pin: str,
         user_id: int,
+        credential_index: int | None,
     ) -> None:
         """
-        Send set_lock_credential to the lock for the given slot, PIN, and user.
+        Send set_lock_credential to the lock for the given user and PIN.
+
+        ``credential_index=None`` auto-allocates the next free credential slot
+        (CREATE). Passing an existing index addresses the user's current PIN
+        credential for MODIFY. ``code_slot`` is the LCM slot only and is used
+        for error reporting; it is no longer pinned to the Matter index.
 
         Raises SetCredentialFailedError on lock rejection,
         CodeRejectedError on validation failure,
@@ -387,7 +445,7 @@ class MatterLock(BaseLock):
                 node,
                 credential_type="pin",
                 credential_data=pin,
-                credential_index=code_slot,
+                credential_index=credential_index,
                 user_index=user_id,
             )
         except SetCredentialFailedError:
@@ -406,6 +464,21 @@ class MatterLock(BaseLock):
                 f"Matter set_lock_credential failed for {self.lock.entity_id}: {err}"
             ) from err
 
+    async def _find_pin_credential_index_for_user(self, user_id: int) -> int | None:
+        """
+        Return the user's current PIN credential index, or ``None`` if none.
+
+        LCM no longer pins ``credential_index`` to the LCM slot; instead it
+        treats Matter's credential index as opaque and rediscovers it per
+        operation by walking the user's owned credentials.
+        """
+        for existing in await self.async_get_users():
+            if existing.user_id != user_id:
+                continue
+            for cred in existing.pin_credentials:
+                return cred.slot
+        return None
+
     async def async_set_credential(
         self,
         user_id: int,
@@ -418,9 +491,13 @@ class MatterLock(BaseLock):
         """
         Write a Personal Identification Number credential to the lock.
 
-        ``pin`` is the resolved PIN string the seam already validated as
-        non-None; surgical write path only. Handles the duplicate-slot
-        restart case for sync sources by clearing and retrying once.
+        Looks up the user's existing PIN credential index. If present this
+        is a MODIFY (same Matter credential index, new PIN value); if
+        absent this is a CREATE (Matter auto-allocates the next free
+        credential index). ``pin`` is the resolved PIN string the seam
+        already validated as non-None. Handles the duplicate-slot restart
+        case for sync sources by clearing the existing credential and
+        retrying with a fresh allocation.
 
         The base orchestration skips coordinator refresh for push providers.
         Matter does not emit LockUserChange for LCM-initiated writes, so an
@@ -428,9 +505,14 @@ class MatterLock(BaseLock):
         """
         client, node = self._require_client_and_node()
         slot = credential.slot
+        existing_credential_index = await self._find_pin_credential_index_for_user(
+            user_id
+        )
 
         try:
-            await self._send_set_credential(client, node, slot, pin, user_id)
+            await self._send_set_credential(
+                client, node, slot, pin, user_id, existing_credential_index
+            )
         except SetCredentialFailedError as err:
             status = (err.translation_placeholders or {}).get("status", "")
             if status != "duplicate":
@@ -444,16 +526,27 @@ class MatterLock(BaseLock):
                     code_slot=slot,
                     lock_entity_id=self.lock.entity_id,
                 ) from err
+            # Sync duplicate: only meaningful when WE own the credential.
+            # If we don't, the duplicate is external -- surface to the
+            # caller; clearing it would step on another controller's code.
+            if existing_credential_index is None:
+                raise DuplicateCodeError(
+                    code_slot=slot,
+                    lock_entity_id=self.lock.entity_id,
+                ) from err
 
-            # Sync duplicate: clear and retry once
             LOGGER.debug(
-                "Lock %s: duplicate on slot %s, clearing and retrying",
+                "Lock %s: duplicate on slot %s, clearing credential_index %s and retrying",
                 self.lock.entity_id,
                 slot,
+                existing_credential_index,
             )
             try:
                 await clear_lock_credential(
-                    client, node, credential_type="pin", credential_index=slot
+                    client,
+                    node,
+                    credential_type="pin",
+                    credential_index=existing_credential_index,
                 )
             except ServiceValidationError as clear_err:
                 raise LockOperationFailed(
@@ -466,7 +559,9 @@ class MatterLock(BaseLock):
                     f"{self.lock.entity_id} during sync-duplicate retry: {clear_err}"
                 ) from clear_err
             try:
-                await self._send_set_credential(client, node, slot, pin, user_id)
+                # Retry with credential_index=None so Matter auto-allocates a
+                # fresh slot; we cleared the old one above.
+                await self._send_set_credential(client, node, slot, pin, user_id, None)
             except SetCredentialFailedError as retry_err:
                 retry_status = (retry_err.translation_placeholders or {}).get(
                     "status", ""
@@ -489,17 +584,28 @@ class MatterLock(BaseLock):
         """
         Clear a Personal Identification Number credential from the lock.
 
-        Returns True on success. Pushes SlotCredential.empty() to the
-        coordinator immediately because Matter does not emit LockUserChange
-        for LCM-initiated clears.
+        Looks up the user's current PIN credential index and clears that
+        Matter credential. ``ref.slot`` is the LCM slot identifier; the
+        Matter credential index is rediscovered per call (LCM does not
+        pin the index to the LCM slot under the user-tag idempotency
+        design). Returns True when the user had a PIN to clear and the
+        clear succeeded; False when no PIN was present.
+
+        Pushes SlotCredential.empty() to the coordinator immediately
+        because Matter does not emit LockUserChange for LCM-initiated
+        clears.
         """
+        credential_index = await self._find_pin_credential_index_for_user(ref.user_id)
+        if credential_index is None:
+            return False
+
         client, node = self._require_client_and_node()
         try:
             await clear_lock_credential(
                 client,
                 node,
                 credential_type="pin",
-                credential_index=ref.slot,
+                credential_index=credential_index,
             )
         except ServiceValidationError as err:
             raise LockOperationFailed(

--- a/custom_components/lock_code_manager/providers/matter.py
+++ b/custom_components/lock_code_manager/providers/matter.py
@@ -70,6 +70,59 @@ _DATA_OP_CLEAR = 1
 _DATA_OP_MODIFY = 2
 
 
+def _lcm_slot_from_raw_users_by_user_index(
+    raw_users: list[dict[str, Any]], user_index: int | None
+) -> int | None:
+    """
+    Resolve the LCM slot by matching a raw lock user by ``user_index``.
+
+    Pure helper over the already-fetched user list -- the caller owns the
+    ``_raw_lock_users`` round-trip and the transport-error handling.
+    """
+    if user_index is None:
+        return None
+    name = next(
+        (
+            raw_user.get("user_name")
+            for raw_user in raw_users
+            if raw_user.get("user_index") == user_index
+        ),
+        None,
+    )
+    if not name:
+        return None
+    slot, _ = parse_tag(name)
+    return slot
+
+
+def _lcm_slot_from_raw_users_by_credential_index(
+    raw_users: list[dict[str, Any]], credential_index: int | None
+) -> int | None:
+    """
+    Resolve the LCM slot by finding the PIN credential at ``credential_index``.
+
+    Walks each raw user's credentials list for a Personal Identification
+    Number credential whose Matter index matches; if found, parses the
+    owning user's ``lcm:<slot>:`` tag. Used as a fallback when the
+    LockOperation event omits ``userIndex``.
+    """
+    if credential_index is None:
+        return None
+    name = next(
+        (
+            raw_user.get("user_name")
+            for raw_user in raw_users
+            for cred in raw_user.get("credentials", []) or []
+            if cred.get("type") == "pin" and cred.get("index") == credential_index
+        ),
+        None,
+    )
+    if not name:
+        return None
+    slot, _ = parse_tag(name)
+    return slot
+
+
 @dataclass(repr=False, eq=False)
 class MatterLock(BaseLock):
     """Class to represent a Matter lock."""
@@ -754,37 +807,96 @@ class MatterLock(BaseLock):
         Handle LockOperation events (event ID 2).
 
         Fires a code slot event when a PIN credential is used to lock/unlock.
-        Only PIN credentials (credentialType=1) trigger the event — other
+        Only PIN credentials (credentialType=1) trigger the event -- other
         credential types (RFID, fingerprint, etc.) are ignored.
+
+        The event's ``credentials[].credentialIndex`` is the Matter credential
+        index, which is no longer pinned to the LCM slot under the user-tag
+        model. To find the LCM slot we resolve via the event's top-level
+        ``userIndex`` -> user.name -> ``lcm:<slot>:`` tag, falling back to
+        walking the user list for a PIN credential at ``credentialIndex``
+        when ``userIndex`` is absent. The lookup is async so the callback
+        schedules a task rather than blocking the event loop.
         """
         data: dict[str, Any] = getattr(node_event, "data", None) or {}
         credentials = data.get("credentials")
-        lock_operation_type = data.get("lockOperationType")
 
-        # Must have credentials with a PIN type to fire
         if not credentials:
             return
 
-        # Find the PIN credential index (credentialType 1 = PIN)
-        code_slot: int | None = None
-        for cred in credentials:
-            if isinstance(cred, dict) and cred.get("credentialType") == 1:
-                code_slot = cred.get("credentialIndex")
-                break
-
-        if code_slot is None:
+        # Find the PIN credential index (credentialType 1 = PIN).
+        credential_index = next(
+            (
+                cred.get("credentialIndex")
+                for cred in credentials
+                if isinstance(cred, dict) and cred.get("credentialType") == 1
+            ),
+            None,
+        )
+        if credential_index is None:
             return
 
-        # lockOperationType: 0=Lock, 1=Unlock, 2=NonAccessUserEvent, 3=ForcedUserEvent, 4=Unlatch
+        user_index = parse_slot_num(data.get("userIndex"))
+
+        self.hass.async_create_task(
+            self._dispatch_lock_operation(user_index, credential_index, data),
+            f"Matter LockOperation dispatch for {self.lock.entity_id}",
+        )
+
+    async def _dispatch_lock_operation(
+        self,
+        user_index: int | None,
+        credential_index: int,
+        data: dict[str, Any],
+    ) -> None:
+        """
+        Resolve the LCM slot for a LockOperation event and fire it.
+
+        Primary path: lock-reported ``userIndex`` -> user.name -> tag.
+        Fallback path: walk the user list to find the PIN credential at
+        ``credentialIndex`` and parse the owning user's tag. Events whose
+        owning user isn't LCM-tagged are silently dropped so out-of-band
+        PIN uses on non-LCM credentials don't drive spurious code slot
+        events.
+        """
+        try:
+            raw_users = await self._raw_lock_users()
+        except (LockDisconnected, LockOperationFailed) as err:
+            LOGGER.debug(
+                "Lock %s: could not resolve LockOperation userIndex=%s "
+                "credentialIndex=%s: %s",
+                self.lock.entity_id,
+                user_index,
+                credential_index,
+                err,
+            )
+            return
+
+        code_slot = _lcm_slot_from_raw_users_by_user_index(
+            raw_users, user_index
+        ) or _lcm_slot_from_raw_users_by_credential_index(raw_users, credential_index)
+        if code_slot is None:
+            LOGGER.debug(
+                "Lock %s: LockOperation userIndex=%s credentialIndex=%s did not "
+                "resolve to an LCM-tagged user; ignoring",
+                self.lock.entity_id,
+                user_index,
+                credential_index,
+            )
+            return
+
+        # lockOperationType: 0=Lock, 1=Unlock, 2=NonAccessUserEvent,
+        # 3=ForcedUserEvent, 4=Unlatch
+        lock_operation_type = data.get("lockOperationType")
         if lock_operation_type == 0:
-            to_locked = True
+            to_locked: bool | None = True
         elif lock_operation_type == 1:
             to_locked = False
         else:
             to_locked = None
 
         LOGGER.debug(
-            "Lock %s: LockOperation event — slot=%s, locked=%s",
+            "Lock %s: LockOperation event -- slot=%s, locked=%s",
             self.lock.entity_id,
             code_slot,
             to_locked,
@@ -894,28 +1006,13 @@ class MatterLock(BaseLock):
             )
             return
 
-        user_name = next(
-            (
-                raw_user.get("user_name")
-                for raw_user in raw_users
-                if raw_user.get("user_index") == user_index
-            ),
-            None,
-        )
-        if not user_name:
-            LOGGER.debug(
-                "Lock %s: LockUserChange userIndex %s has no name; ignoring",
-                self.lock.entity_id,
-                user_index,
-            )
-            return
-        code_slot, _ = parse_tag(user_name)
+        code_slot = _lcm_slot_from_raw_users_by_user_index(raw_users, user_index)
         if code_slot is None:
             LOGGER.debug(
-                "Lock %s: LockUserChange userIndex %s name %r is not LCM-tagged; ignoring",
+                "Lock %s: LockUserChange userIndex %s did not resolve to an "
+                "LCM-tagged user; ignoring",
                 self.lock.entity_id,
                 user_index,
-                user_name,
             )
             return
 

--- a/custom_components/lock_code_manager/providers/matter.py
+++ b/custom_components/lock_code_manager/providers/matter.py
@@ -924,30 +924,20 @@ class MatterLock(BaseLock):
 
         Only PIN credentials (LockDataType=6) are handled.
 
-        The event's ``dataIndex`` is the Matter credential index, which is
-        no longer pinned to the LCM slot (Matter auto-allocates). To find
-        the LCM slot we use the event's ``userIndex`` to look up the
-        owning user's name and parse its ``lcm:<slot>:`` tag. The lookup
-        is async (a fresh ``_raw_lock_users`` round-trip) so the callback
-        schedules a task rather than blocking the event loop. Events for
-        users LCM doesn't own (untagged names) are ignored -- those
-        credentials don't belong to any LCM-managed slot.
+        The LCM slot is resolved by walking the event's ``userIndex`` to
+        the owning user's name and parsing its ``lcm:<slot>:`` tag --
+        ``userIndex`` alone is sufficient. ``dataIndex`` (the Matter
+        credential index) is captured best-effort for log context only;
+        it's no longer pinned to the LCM slot under the user-tag model
+        and dropping otherwise-resolvable events when it's missing or
+        malformed would silently lose state updates. The lookup is async
+        (a fresh ``_raw_lock_users`` round-trip) so the callback
+        schedules a task rather than blocking the event loop. Events
+        for users LCM doesn't own (untagged names) are ignored.
         """
         data: dict[str, Any] = getattr(node_event, "data", None) or {}
 
         if data.get("lockDataType") != _LOCK_DATA_TYPE_PIN:
-            return
-
-        raw_index = data.get("dataIndex")
-        if raw_index is None:
-            return
-        credential_index = parse_slot_num(raw_index)
-        if credential_index is None:
-            LOGGER.warning(
-                "Lock %s: LockUserChange has non-integer dataIndex %r, ignoring",
-                self.lock.entity_id,
-                raw_index,
-            )
             return
 
         user_index = parse_slot_num(data.get("userIndex"))
@@ -958,6 +948,10 @@ class MatterLock(BaseLock):
                 data.get("userIndex"),
             )
             return
+
+        # Best-effort: parsed for log context only; the LCM slot comes
+        # from the userIndex -> tag resolution in _dispatch_lock_user_change.
+        credential_index = parse_slot_num(data.get("dataIndex"))
 
         operation = data.get("dataOperationType")
         if operation == _DATA_OP_CLEAR:

--- a/custom_components/lock_code_manager/providers/matter.py
+++ b/custom_components/lock_code_manager/providers/matter.py
@@ -268,7 +268,7 @@ class MatterLock(BaseLock):
             if user_name:
                 lcm_slot_from_tag, _ = parse_tag(user_name)
             pin_credentials: list[Credential] = []
-            for cred in raw_user.get("credentials", []):
+            for cred in raw_user.get("credentials") or []:
                 credential_index = cred.get("index")
                 if cred.get("type") != "pin" or credential_index is None:
                     continue
@@ -575,7 +575,7 @@ class MatterLock(BaseLock):
                 cred.get("index")
                 for raw_user in await self._raw_lock_users()
                 if raw_user.get("user_index") == user_id
-                for cred in raw_user.get("credentials", [])
+                for cred in raw_user.get("credentials") or []
                 if cred.get("type") == "pin" and cred.get("index") is not None
             ),
             None,
@@ -824,14 +824,19 @@ class MatterLock(BaseLock):
         if not credentials:
             return
 
-        # Find the PIN credential index (credentialType 1 = PIN).
-        credential_index = next(
-            (
-                cred.get("credentialIndex")
-                for cred in credentials
-                if isinstance(cred, dict) and cred.get("credentialType") == 1
-            ),
-            None,
+        # Find the PIN credential index (credentialType 1 = PIN). Coerce
+        # via ``parse_slot_num`` because some Matter implementations send
+        # the index as a string -- the int-keyed comparison in the fallback
+        # walker would then never match.
+        credential_index = parse_slot_num(
+            next(
+                (
+                    cred.get("credentialIndex")
+                    for cred in credentials
+                    if isinstance(cred, dict) and cred.get("credentialType") == 1
+                ),
+                None,
+            )
         )
         if credential_index is None:
             return
@@ -872,9 +877,13 @@ class MatterLock(BaseLock):
             )
             return
 
-        code_slot = _lcm_slot_from_raw_users_by_user_index(
-            raw_users, user_index
-        ) or _lcm_slot_from_raw_users_by_credential_index(raw_users, credential_index)
+        # Explicit ``None`` check (not ``or``) so a valid LCM slot of 0
+        # from the primary resolver doesn't fall through to the fallback.
+        code_slot = _lcm_slot_from_raw_users_by_user_index(raw_users, user_index)
+        if code_slot is None:
+            code_slot = _lcm_slot_from_raw_users_by_credential_index(
+                raw_users, credential_index
+            )
         if code_slot is None:
             LOGGER.debug(
                 "Lock %s: LockOperation userIndex=%s credentialIndex=%s did not "

--- a/custom_components/lock_code_manager/providers/matter.py
+++ b/custom_components/lock_code_manager/providers/matter.py
@@ -162,13 +162,15 @@ class MatterLock(BaseLock):
 
     # -- Credential primitives -----------------------------------------------
 
-    async def async_get_users(self) -> list[User]:
+    async def _raw_lock_users(self) -> list[dict[str, Any]]:
         """
-        Read every user and their Personal Identification Number credentials from the lock.
+        Return the raw user list from ``get_lock_users``.
 
-        Matter PINs are write-only: each occupied credential slot is projected to
-        SlotCredential.unreadable(). Non-PIN credentials (for example RFID) are
-        filtered out because the coordinator and sync manager only manage PIN slots.
+        Internal helper for Matter-side lookups that need the unprojected
+        Matter credential index (e.g. set/clear lock-credential calls).
+        ``async_get_users`` consumes the same data but projects
+        credentials to the LCM slot via the owning user's tag; raw
+        callers want the lock's own identifiers.
         """
         client, node = self._require_client_and_node()
         try:
@@ -181,20 +183,47 @@ class MatterLock(BaseLock):
             raise LockDisconnected(
                 f"Matter get_lock_users failed for {self.lock.entity_id}: {err}"
             ) from err
+        return lock_data.get("users", [])
 
+    async def async_get_users(self) -> list[User]:
+        """
+        Read every user and their Personal Identification Number credentials from the lock.
+
+        Matter PINs are write-only: each occupied credential slot is projected to
+        SlotCredential.unreadable(). Non-PIN credentials (for example RFID) are
+        filtered out because the coordinator and sync manager only manage PIN slots.
+
+        Credential.slot is the LCM slot, NOT the Matter credential index.
+        The LCM slot is recovered from the owning user's ``lcm:<slot>:`` tag;
+        untagged users (legacy LCM 2.0) followed the
+        ``credential_index == LCM slot`` invariant, so for them the Matter
+        credential index doubles as the LCM slot. The translation keeps
+        the rest of LCM (``_project_users_to_slots``, sync manager,
+        coordinator) working in LCM-slot terms even though Matter now
+        auto-allocates the lock-side credential index.
+        """
         # A for-loop (not a comprehension) so the int-or-None user_index and
         # credential index are narrowed by explicit guards before use: the
         # Matter helper types both as ``int | None``.
         users: list[User] = []
-        for raw_user in lock_data.get("users", []):
+        for raw_user in await self._raw_lock_users():
             user_index = raw_user.get("user_index")
             if user_index is None:
                 continue
+            user_name = raw_user.get("user_name")
+            lcm_slot_from_tag: int | None = None
+            if user_name:
+                lcm_slot_from_tag, _ = parse_tag(user_name)
             pin_credentials: list[Credential] = []
             for cred in raw_user.get("credentials", []):
-                slot = cred.get("index")
-                if cred.get("type") != "pin" or slot is None:
+                credential_index = cred.get("index")
+                if cred.get("type") != "pin" or credential_index is None:
                     continue
+                slot = (
+                    lcm_slot_from_tag
+                    if lcm_slot_from_tag is not None
+                    else credential_index
+                )
                 pin_credentials.append(
                     Credential(
                         type=CredentialType.PIN,
@@ -205,7 +234,7 @@ class MatterLock(BaseLock):
             users.append(
                 User(
                     user_id=user_index,
-                    name=raw_user.get("user_name"),
+                    name=user_name,
                     active=True,
                     credentials=pin_credentials,
                 )
@@ -478,18 +507,23 @@ class MatterLock(BaseLock):
 
     async def _find_pin_credential_index_for_user(self, user_id: int) -> int | None:
         """
-        Return the user's current PIN credential index, or ``None`` if none.
+        Return the user's current Matter PIN credential index, or ``None``.
 
         LCM no longer pins ``credential_index`` to the LCM slot; instead it
         treats Matter's credential index as opaque and rediscovers it per
-        operation by walking the user's owned credentials.
+        operation. This helper deliberately walks the **raw** lock-side
+        user data (not ``async_get_users``) so the returned value is the
+        Matter credential index Matter expects for
+        ``set_lock_credential`` / ``clear_lock_credential`` -- not the
+        LCM-projected slot that ``async_get_users`` exposes upward.
         """
         return next(
             (
-                cred.slot
-                for existing in await self.async_get_users()
-                if existing.user_id == user_id
-                for cred in existing.pin_credentials
+                cred.get("index")
+                for raw_user in await self._raw_lock_users()
+                if raw_user.get("user_index") == user_id
+                for cred in raw_user.get("credentials", [])
+                if cred.get("type") == "pin" and cred.get("index") is not None
             ),
             None,
         )
@@ -773,11 +807,19 @@ class MatterLock(BaseLock):
         Handle LockUserChange events (event ID 4).
 
         Pushes occupancy updates to the coordinator when a PIN credential is
-        added, modified, or cleared. This provides real-time change detection
-        without waiting for the next poll cycle.
+        added, modified, or cleared. Real-time change detection without
+        waiting for the next poll cycle.
 
-        Only PIN credentials (LockDataType=6) are handled. The DataIndex field
-        maps to the credential index (code slot number).
+        Only PIN credentials (LockDataType=6) are handled.
+
+        The event's ``dataIndex`` is the Matter credential index, which is
+        no longer pinned to the LCM slot (Matter auto-allocates). To find
+        the LCM slot we use the event's ``userIndex`` to look up the
+        owning user's name and parse its ``lcm:<slot>:`` tag. The lookup
+        is async (a fresh ``_raw_lock_users`` round-trip) so the callback
+        schedules a task rather than blocking the event loop. Events for
+        users LCM doesn't own (untagged names) are ignored -- those
+        credentials don't belong to any LCM-managed slot.
         """
         data: dict[str, Any] = getattr(node_event, "data", None) or {}
 
@@ -787,8 +829,8 @@ class MatterLock(BaseLock):
         raw_index = data.get("dataIndex")
         if raw_index is None:
             return
-        code_slot = parse_slot_num(raw_index)
-        if code_slot is None:
+        credential_index = parse_slot_num(raw_index)
+        if credential_index is None:
             LOGGER.warning(
                 "Lock %s: LockUserChange has non-integer dataIndex %r, ignoring",
                 self.lock.entity_id,
@@ -796,18 +838,84 @@ class MatterLock(BaseLock):
             )
             return
 
-        operation = data.get("dataOperationType")
+        user_index = parse_slot_num(data.get("userIndex"))
+        if user_index is None:
+            LOGGER.debug(
+                "Lock %s: LockUserChange has non-integer userIndex %r, ignoring",
+                self.lock.entity_id,
+                data.get("userIndex"),
+            )
+            return
 
+        operation = data.get("dataOperationType")
         if operation == _DATA_OP_CLEAR:
             resolved = SlotCredential.empty()
         elif operation in (_DATA_OP_ADD, _DATA_OP_MODIFY):
             resolved = SlotCredential.unreadable()
         else:
             LOGGER.debug(
-                "Lock %s: LockUserChange event with unknown operation %s for slot %s",
+                "Lock %s: LockUserChange event with unknown operation %s "
+                "(userIndex=%s, credentialIndex=%s)",
                 self.lock.entity_id,
                 operation,
-                code_slot,
+                user_index,
+                credential_index,
+            )
+            return
+
+        self.hass.async_create_task(
+            self._dispatch_lock_user_change(user_index, resolved, operation),
+            f"Matter LockUserChange dispatch for {self.lock.entity_id}",
+        )
+
+    async def _dispatch_lock_user_change(
+        self,
+        user_index: int,
+        resolved: SlotCredential,
+        operation: int,
+    ) -> None:
+        """
+        Resolve the LCM slot for a LockUserChange and push the update.
+
+        Fetches the lock's current user list, finds the owner by
+        ``user_index``, parses its ``lcm:<slot>:`` tag, and pushes the
+        update. Events whose owning user isn't LCM-tagged are ignored so
+        out-of-band credential changes on non-LCM users don't drive
+        spurious coordinator updates.
+        """
+        try:
+            raw_users = await self._raw_lock_users()
+        except (LockDisconnected, LockOperationFailed) as err:
+            LOGGER.debug(
+                "Lock %s: could not resolve LockUserChange userIndex %s: %s",
+                self.lock.entity_id,
+                user_index,
+                err,
+            )
+            return
+
+        user_name = next(
+            (
+                raw_user.get("user_name")
+                for raw_user in raw_users
+                if raw_user.get("user_index") == user_index
+            ),
+            None,
+        )
+        if not user_name:
+            LOGGER.debug(
+                "Lock %s: LockUserChange userIndex %s has no name; ignoring",
+                self.lock.entity_id,
+                user_index,
+            )
+            return
+        code_slot, _ = parse_tag(user_name)
+        if code_slot is None:
+            LOGGER.debug(
+                "Lock %s: LockUserChange userIndex %s name %r is not LCM-tagged; ignoring",
+                self.lock.entity_id,
+                user_index,
+                user_name,
             )
             return
 
@@ -818,7 +926,6 @@ class MatterLock(BaseLock):
             operation,
             resolved,
         )
-
         self._push_credential_update(code_slot, resolved)
 
     async def async_hard_refresh_codes(self) -> dict[int, SlotCredential]:

--- a/custom_components/lock_code_manager/providers/matter.py
+++ b/custom_components/lock_code_manager/providers/matter.py
@@ -346,11 +346,11 @@ class MatterLock(BaseLock):
 
         1. **Canonical** -- a user whose name carries the
            ``lcm:<slot>:`` tag. This is the post-PR-B identity rule.
-        2. **Legacy adoption** -- a user owning a PIN credential at
-           ``credential_index == slot``. Pre-PR-B Matter LCM pinned
-           ``credential_index`` to the LCM slot, so an untagged user
-           owning a PIN at that index is almost certainly the LCM 2.0
-           user for this slot. Adopting it (the subsequent
+        2. **Legacy adoption** -- an *untagged* user owning a PIN
+           credential at ``credential_index == slot``. Pre-PR-B Matter
+           LCM pinned ``credential_index`` to the LCM slot, so an
+           untagged user owning a PIN at that index is almost certainly
+           the LCM 2.0 user for this slot. Adopting it (the subsequent
            ``set_lock_user`` rewrites the name to the tagged form, and
            ``set_lock_credential`` MODIFY'es the existing credential
            index in place) preserves a single, identifiable user per
@@ -358,20 +358,32 @@ class MatterLock(BaseLock):
            would CREATE a second user every time, silently leaving the
            pre-upgrade PIN active on the lock.
 
+           The legacy pass MUST skip users whose names already parse to
+           ANY LCM slot. Under the new model the Matter credential index
+           is auto-allocated, so a user tagged ``lcm:<A>:`` can own a
+           PIN at index ``B``; matching on ``cred.slot == slot`` alone
+           would mis-adopt slot-A's user as slot-B's anchor.
+
         Returns ``None`` when neither lookup matches.
         """
         users = await self.async_get_users()
-        for existing in users:
-            if existing.name is None:
-                continue
-            parsed_slot, _ = parse_tag(existing.name)
-            if parsed_slot == slot:
-                return existing.user_id
-        for existing in users:
-            for cred in existing.pin_credentials:
-                if cred.slot == slot:
-                    return existing.user_id
-        return None
+        try:
+            return next(
+                existing.user_id
+                for existing in users
+                if existing.name and parse_tag(existing.name)[0] == slot
+            )
+        except StopIteration:
+            return next(
+                (
+                    existing.user_id
+                    for existing in users
+                    if parse_tag(existing.name or "")[0] is None
+                    for cred in existing.pin_credentials
+                    if cred.slot == slot
+                ),
+                None,
+            )
 
     async def async_delete_user(self, user_id: int) -> None:
         """
@@ -472,12 +484,15 @@ class MatterLock(BaseLock):
         treats Matter's credential index as opaque and rediscovers it per
         operation by walking the user's owned credentials.
         """
-        for existing in await self.async_get_users():
-            if existing.user_id != user_id:
-                continue
-            for cred in existing.pin_credentials:
-                return cred.slot
-        return None
+        return next(
+            (
+                cred.slot
+                for existing in await self.async_get_users()
+                if existing.user_id == user_id
+                for cred in existing.pin_credentials
+            ),
+            None,
+        )
 
     async def async_set_credential(
         self,

--- a/tests/providers/matter/conftest.py
+++ b/tests/providers/matter/conftest.py
@@ -224,11 +224,6 @@ def matter_mock_helpers() -> dict[str, AsyncMock]:
     # set_lock_user: called by async_set_user
     helpers["set_lock_user"] = AsyncMock(return_value={"user_index": 1})
 
-    # get_lock_credential_status: called by async_set_user to detect create-vs-update
-    helpers["get_lock_credential_status"] = AsyncMock(
-        return_value={"credential_exists": True, "user_index": 1}
-    )
-
     # clear_lock_credential: called by async_delete_credential
     helpers["clear_lock_credential"] = AsyncMock(return_value={})
 
@@ -276,10 +271,6 @@ async def lcm_config_entry(
         patch(
             f"{_PROVIDER_MODULE}.set_lock_user",
             matter_mock_helpers["set_lock_user"],
-        ),
-        patch(
-            f"{_PROVIDER_MODULE}.get_lock_credential_status",
-            matter_mock_helpers["get_lock_credential_status"],
         ),
         patch(
             f"{_PROVIDER_MODULE}.clear_lock_credential",

--- a/tests/providers/matter/test_e2e.py
+++ b/tests/providers/matter/test_e2e.py
@@ -50,12 +50,12 @@ class TestSetAndClearUsercodes:
     ) -> None:
         """Set a code via the base orchestration and verify set_lock_credential was called."""
         matter_mock_helpers["set_lock_credential"].reset_mock()
-        matter_mock_helpers["get_lock_credential_status"].reset_mock()
+        matter_mock_helpers["get_lock_users"].reset_mock()
         matter_mock_helpers["set_lock_user"].reset_mock()
         with (
             patch(
-                f"{_PROVIDER_MODULE}.get_lock_credential_status",
-                matter_mock_helpers["get_lock_credential_status"],
+                f"{_PROVIDER_MODULE}.get_lock_users",
+                matter_mock_helpers["get_lock_users"],
             ),
             patch(
                 f"{_PROVIDER_MODULE}.set_lock_user",
@@ -114,8 +114,8 @@ class TestSetAndClearUsercodes:
         """
         with (
             patch(
-                f"{_PROVIDER_MODULE}.get_lock_credential_status",
-                matter_mock_helpers["get_lock_credential_status"],
+                f"{_PROVIDER_MODULE}.get_lock_users",
+                matter_mock_helpers["get_lock_users"],
             ),
             patch(
                 f"{_PROVIDER_MODULE}.set_lock_user",

--- a/tests/providers/matter/test_provider.py
+++ b/tests/providers/matter/test_provider.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Generator
 from datetime import timedelta
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -807,71 +808,175 @@ class TestEventSubscription:
 class TestLockUserChangeEvent:
     """Test _handle_lock_user_change callback and coordinator push updates."""
 
-    def test_pin_added_pushes_unknown(self, matter_lock_simple: MatterLock) -> None:
-        """Adding a PIN credential pushes SlotCredential.unreadable() to coordinator."""
+    @pytest.fixture(autouse=True)
+    def _stub_matter_client_and_node(
+        self, matter_lock_simple: MatterLock
+    ) -> Generator[None]:
+        """LockUserChange dispatch needs to reach _raw_lock_users."""
+        with (
+            patch.object(
+                matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+            ),
+            patch.object(
+                matter_lock_simple, "_get_matter_node", return_value=MagicMock()
+            ),
+        ):
+            yield
+
+    @staticmethod
+    def _patch_users(users: list[dict]) -> Any:
+        """Patch get_lock_users so the async dispatch can resolve owners."""
+        return patch(
+            f"{_PROVIDER_MODULE}.get_lock_users",
+            AsyncMock(return_value={"max_users": 10, "users": users}),
+        )
+
+    async def test_pin_added_pushes_unknown(
+        self, hass: HomeAssistant, matter_lock_simple: MatterLock
+    ) -> None:
+        """Adding a PIN credential pushes SlotCredential.unreadable() to the slot the user owns.
+
+        Resolution: the event's userIndex points at a user whose name carries
+        ``lcm:<slot>:``; the push targets that LCM slot, NOT the credential
+        index in dataIndex (which is now Matter-auto-allocated and opaque).
+        """
         mock_coordinator = MagicMock()
         mock_coordinator.data = {3: SlotCredential.empty()}
         matter_lock_simple.coordinator = mock_coordinator
 
-        matter_lock_simple._on_node_event(
-            None,
-            _make_node_event(
-                event_id=4,
-                data={
-                    "lockDataType": 6,  # PIN
-                    "dataOperationType": 0,  # Add
-                    "dataIndex": 3,
+        with self._patch_users(
+            [
+                {
+                    "user_index": 42,
+                    "user_name": "lcm:3:Carol",
+                    "credentials": [{"type": "pin", "index": 7}],
                 },
-            ),
-        )
+            ]
+        ):
+            matter_lock_simple._on_node_event(
+                None,
+                _make_node_event(
+                    event_id=4,
+                    data={
+                        "lockDataType": 6,  # PIN
+                        "dataOperationType": 0,  # Add
+                        "dataIndex": 7,  # Matter-auto-allocated credential index
+                        "userIndex": 42,
+                    },
+                ),
+            )
+            await hass.async_block_till_done()
 
         mock_coordinator.push_update.assert_called_once_with(
             {3: SlotCredential.unreadable()}
         )
 
-    def test_pin_modified_pushes_unknown(self, matter_lock_simple: MatterLock) -> None:
-        """Modifying a PIN credential pushes SlotCredential.unreadable() to coordinator."""
+    async def test_pin_modified_pushes_unknown(
+        self, hass: HomeAssistant, matter_lock_simple: MatterLock
+    ) -> None:
+        """Modifying a PIN credential pushes SlotCredential.unreadable() to the LCM slot."""
         mock_coordinator = MagicMock()
         mock_coordinator.data = {5: SlotCredential.unreadable()}
         matter_lock_simple.coordinator = mock_coordinator
 
-        matter_lock_simple._on_node_event(
-            None,
-            _make_node_event(
-                event_id=4,
-                data={
-                    "lockDataType": 6,  # PIN
-                    "dataOperationType": 2,  # Modify
-                    "dataIndex": 5,
+        with self._patch_users(
+            [
+                {
+                    "user_index": 19,
+                    "user_name": "lcm:5:Bob",
+                    "credentials": [{"type": "pin", "index": 2}],
                 },
-            ),
-        )
+            ]
+        ):
+            matter_lock_simple._on_node_event(
+                None,
+                _make_node_event(
+                    event_id=4,
+                    data={
+                        "lockDataType": 6,  # PIN
+                        "dataOperationType": 2,  # Modify
+                        "dataIndex": 2,
+                        "userIndex": 19,
+                    },
+                ),
+            )
+            await hass.async_block_till_done()
 
         mock_coordinator.push_update.assert_called_once_with(
             {5: SlotCredential.unreadable()}
         )
 
-    def test_pin_cleared_pushes_empty(self, matter_lock_simple: MatterLock) -> None:
-        """Clearing a PIN credential pushes SlotCredential.empty() to coordinator."""
+    async def test_pin_cleared_pushes_empty(
+        self, hass: HomeAssistant, matter_lock_simple: MatterLock
+    ) -> None:
+        """Clearing a PIN credential pushes SlotCredential.empty() to the LCM slot."""
         mock_coordinator = MagicMock()
         mock_coordinator.data = {2: SlotCredential.unreadable()}
         matter_lock_simple.coordinator = mock_coordinator
 
-        matter_lock_simple._on_node_event(
-            None,
-            _make_node_event(
-                event_id=4,
-                data={
-                    "lockDataType": 6,  # PIN
-                    "dataOperationType": 1,  # Clear
-                    "dataIndex": 2,
+        with self._patch_users(
+            [
+                {
+                    "user_index": 8,
+                    "user_name": "lcm:2:Alice",
+                    "credentials": [],
                 },
-            ),
-        )
+            ]
+        ):
+            matter_lock_simple._on_node_event(
+                None,
+                _make_node_event(
+                    event_id=4,
+                    data={
+                        "lockDataType": 6,  # PIN
+                        "dataOperationType": 1,  # Clear
+                        "dataIndex": 11,
+                        "userIndex": 8,
+                    },
+                ),
+            )
+            await hass.async_block_till_done()
 
         mock_coordinator.push_update.assert_called_once_with(
             {2: SlotCredential.empty()}
         )
+
+    async def test_pin_event_for_untagged_user_ignored(
+        self, hass: HomeAssistant, matter_lock_simple: MatterLock
+    ) -> None:
+        """Events on users without an ``lcm:<slot>:`` tag are ignored.
+
+        Out-of-band PIN changes on non-LCM users (e.g. another controller's
+        credentials, or keypad-enrolled credentials on a different user) must
+        not push spurious updates into LCM's coordinator.
+        """
+        mock_coordinator = MagicMock()
+        matter_lock_simple.coordinator = mock_coordinator
+
+        with self._patch_users(
+            [
+                {
+                    "user_index": 5,
+                    "user_name": "External Alice",  # untagged
+                    "credentials": [{"type": "pin", "index": 5}],
+                },
+            ]
+        ):
+            matter_lock_simple._on_node_event(
+                None,
+                _make_node_event(
+                    event_id=4,
+                    data={
+                        "lockDataType": 6,  # PIN
+                        "dataOperationType": 0,  # Add
+                        "dataIndex": 5,
+                        "userIndex": 5,
+                    },
+                ),
+            )
+            await hass.async_block_till_done()
+
+        mock_coordinator.push_update.assert_not_called()
 
     def test_non_pin_data_type_ignored(self, matter_lock_simple: MatterLock) -> None:
         """Non-PIN LockDataType (e.g. RFID=7) is ignored."""
@@ -1065,6 +1170,83 @@ class TestGetUsers:
         assert cred.type is CredentialType.PIN
         assert cred.slot == 1
         assert cred.state is SlotCredential.unreadable()
+
+    async def test_get_users_projects_lcm_slot_from_tag_when_credential_index_differs(
+        self, hass: HomeAssistant, matter_lock_simple: MatterLock
+    ) -> None:
+        """Tagged users carry their LCM slot in the name; Credential.slot is the LCM slot.
+
+        Regression for #1239 review. Under the new model the Matter credential
+        index is auto-allocated and no longer pinned to the LCM slot. The
+        projection must surface the LCM slot from the ``lcm:<slot>:`` tag --
+        otherwise the base seam's ``_project_users_to_slots`` (which keys
+        by ``credential.slot``) would attribute the credential to the wrong
+        LCM slot.
+        """
+        mock_get_lock_users = AsyncMock(
+            return_value={
+                "max_users": 10,
+                "users": [
+                    {
+                        "user_index": 42,
+                        "user_name": "lcm:5:Alice",
+                        # Matter-auto-allocated credential index 7, LCM slot 5.
+                        "credentials": [{"type": "pin", "index": 7}],
+                    },
+                ],
+            }
+        )
+        with (
+            patch.object(
+                matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+            ),
+            patch.object(
+                matter_lock_simple, "_get_matter_node", return_value=MagicMock()
+            ),
+            patch(f"{_PROVIDER_MODULE}.get_lock_users", mock_get_lock_users),
+        ):
+            users = await matter_lock_simple.async_get_users()
+
+        assert len(users) == 1
+        cred = users[0].credentials[0]
+        assert cred.slot == 5
+
+    async def test_get_users_untagged_user_falls_back_to_credential_index(
+        self, hass: HomeAssistant, matter_lock_simple: MatterLock
+    ) -> None:
+        """Untagged users keep ``credential_index == slot`` (the legacy invariant).
+
+        Pre-PR-B Matter LCM pinned ``credential_index`` to the LCM slot, so
+        untagged users (legacy LCM 2.0 installs that haven't migrated) get
+        their credential surfaced with ``Credential.slot = credential_index``
+        -- the projection is identity for them, which preserves continuity.
+        """
+        mock_get_lock_users = AsyncMock(
+            return_value={
+                "max_users": 10,
+                "users": [
+                    {
+                        "user_index": 1,
+                        "user_name": "Alice",  # untagged, legacy LCM 2.0
+                        "credentials": [{"type": "pin", "index": 5}],
+                    },
+                ],
+            }
+        )
+        with (
+            patch.object(
+                matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+            ),
+            patch.object(
+                matter_lock_simple, "_get_matter_node", return_value=MagicMock()
+            ),
+            patch(f"{_PROVIDER_MODULE}.get_lock_users", mock_get_lock_users),
+        ):
+            users = await matter_lock_simple.async_get_users()
+
+        assert len(users) == 1
+        cred = users[0].credentials[0]
+        assert cred.slot == 5
 
     async def test_get_users_non_pin_credentials_excluded(
         self, hass: HomeAssistant, matter_lock_simple: MatterLock

--- a/tests/providers/matter/test_provider.py
+++ b/tests/providers/matter/test_provider.py
@@ -978,6 +978,104 @@ class TestLockUserChangeEvent:
 
         mock_coordinator.push_update.assert_not_called()
 
+    async def test_pin_event_with_unknown_operation_ignored(
+        self, hass: HomeAssistant, matter_lock_simple: MatterLock
+    ) -> None:
+        """LockUserChange with an unrecognized dataOperationType is dropped.
+
+        Defends against a future Matter spec adding a data operation LCM
+        doesn't model yet; we ignore rather than push a stale resolved
+        state with the wrong semantics.
+        """
+        mock_coordinator = MagicMock()
+        matter_lock_simple.coordinator = mock_coordinator
+
+        matter_lock_simple._on_node_event(
+            None,
+            _make_node_event(
+                event_id=4,
+                data={
+                    "lockDataType": 6,  # PIN
+                    "dataOperationType": 99,  # unknown
+                    "dataIndex": 3,
+                    "userIndex": 1,
+                },
+            ),
+        )
+        await hass.async_block_till_done()
+
+        mock_coordinator.push_update.assert_not_called()
+
+    async def test_pin_event_dispatch_swallows_lock_disconnected(
+        self, hass: HomeAssistant, matter_lock_simple: MatterLock
+    ) -> None:
+        """If the owner lookup fails (LockDisconnected), the dispatch logs and returns.
+
+        The handler runs as a fire-and-forget task; a transport failure
+        during the userIndex -> tag lookup must not propagate out of the
+        task. The coordinator update is dropped; the next refresh will
+        surface the change.
+        """
+        mock_coordinator = MagicMock()
+        matter_lock_simple.coordinator = mock_coordinator
+
+        with patch(
+            f"{_PROVIDER_MODULE}.get_lock_users",
+            AsyncMock(side_effect=HomeAssistantError("transport down")),
+        ):
+            matter_lock_simple._on_node_event(
+                None,
+                _make_node_event(
+                    event_id=4,
+                    data={
+                        "lockDataType": 6,
+                        "dataOperationType": 0,
+                        "dataIndex": 3,
+                        "userIndex": 42,
+                    },
+                ),
+            )
+            await hass.async_block_till_done()
+
+        mock_coordinator.push_update.assert_not_called()
+
+    async def test_pin_event_for_user_with_no_name_ignored(
+        self, hass: HomeAssistant, matter_lock_simple: MatterLock
+    ) -> None:
+        """A nameless user-record yields no LCM tag -> ignore.
+
+        Some Matter locks return user records with a missing or empty
+        ``user_name`` field. There's no way to parse a tag without a name,
+        so the event is dropped (untagged-user contract).
+        """
+        mock_coordinator = MagicMock()
+        matter_lock_simple.coordinator = mock_coordinator
+
+        with self._patch_users(
+            [
+                {
+                    "user_index": 7,
+                    "user_name": None,  # lock returned an empty/None name
+                    "credentials": [{"type": "pin", "index": 2}],
+                },
+            ]
+        ):
+            matter_lock_simple._on_node_event(
+                None,
+                _make_node_event(
+                    event_id=4,
+                    data={
+                        "lockDataType": 6,
+                        "dataOperationType": 0,
+                        "dataIndex": 2,
+                        "userIndex": 7,
+                    },
+                ),
+            )
+            await hass.async_block_till_done()
+
+        mock_coordinator.push_update.assert_not_called()
+
     def test_non_pin_data_type_ignored(self, matter_lock_simple: MatterLock) -> None:
         """Non-PIN LockDataType (e.g. RFID=7) is ignored."""
         mock_coordinator = MagicMock()
@@ -1604,6 +1702,39 @@ class TestSetUser:
         call_kwargs = mock_set_user.call_args.kwargs
         assert call_kwargs["user_index"] == 99
         assert call_kwargs["user_name"] == "lcm:5:Carol"
+
+    async def test_set_user_falls_back_to_user_id_when_name_is_untagged(
+        self, hass: HomeAssistant, matter_lock_simple: MatterLock
+    ) -> None:
+        """``_slot_from_seam_user`` falls back to user.user_id for untagged names.
+
+        Defensive path -- the seam always passes a tagged name, but a
+        direct caller (test setup, future refactor) might pass a User
+        with an untagged name. The helper uses user.user_id as the slot
+        in that case so the rest of the logic still has a slot to work
+        with.
+        """
+        mock_set_user = AsyncMock(return_value={"user_index": 5})
+        # user.user_id = 9 is the LCM slot fallback; name has no lcm:<slot>: tag.
+        user = User(user_id=9, name="Unparseable name")
+        with (
+            patch.object(
+                matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+            ),
+            patch.object(
+                matter_lock_simple, "_get_matter_node", return_value=MagicMock()
+            ),
+            self._patch_users([]),
+            patch(f"{_PROVIDER_MODULE}.set_lock_user", mock_set_user),
+        ):
+            result = await matter_lock_simple.async_set_user(user)
+
+        # CREATE path runs because no canonical/legacy match for slot 9.
+        # The verbatim un-tagged name flows through to set_lock_user.
+        assert result == SetUserResult(user_id=5, created=True)
+        call_kwargs = mock_set_user.call_args.kwargs
+        assert call_kwargs["user_index"] is None
+        assert call_kwargs["user_name"] == "Unparseable name"
 
     async def test_set_user_legacy_pass_skips_users_tagged_for_other_slots(
         self, hass: HomeAssistant, matter_lock_simple: MatterLock
@@ -2402,6 +2533,48 @@ class TestDeleteCredential:
         ):
             result = await matter_lock_simple.async_delete_credential(ref)
         assert result is True
+
+    async def test_delete_credential_returns_false_when_user_has_no_pin(
+        self, hass: HomeAssistant, matter_lock_simple: MatterLock
+    ) -> None:
+        """Delete for a user with no PIN credential is a no-op (returns False).
+
+        The seam resolves a stale owner (e.g. coordinator refresh raced with
+        an out-of-band clear); the provider then finds no PIN at that user
+        and returns False without calling clear_lock_credential.
+        """
+        mock_clear = AsyncMock(return_value=None)
+        # Override the autouse fixture to seed a user with no PIN credential
+        # at ref.user_id=1.
+        with (
+            patch.object(
+                matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+            ),
+            patch.object(
+                matter_lock_simple, "_get_matter_node", return_value=MagicMock()
+            ),
+            patch(
+                f"{_PROVIDER_MODULE}.get_lock_users",
+                AsyncMock(
+                    return_value={
+                        "max_users": 10,
+                        "users": [
+                            {
+                                "user_index": 1,
+                                "user_name": "lcm:1:test",
+                                "credentials": [],
+                            },
+                        ],
+                    },
+                ),
+            ),
+            patch(f"{_PROVIDER_MODULE}.clear_lock_credential", mock_clear),
+        ):
+            result = await matter_lock_simple.async_delete_credential(
+                CredentialRef(user_id=1, type=CredentialType.PIN, slot=1)
+            )
+        assert result is False
+        mock_clear.assert_not_called()
 
     async def test_delete_credential_pushes_empty(
         self, hass: HomeAssistant, matter_lock_simple: MatterLock

--- a/tests/providers/matter/test_provider.py
+++ b/tests/providers/matter/test_provider.py
@@ -33,6 +33,8 @@ from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers.matter import (
     MatterLock,
     SetCredentialFailedError,
+    _lcm_slot_from_raw_users_by_credential_index,
+    _lcm_slot_from_raw_users_by_user_index,
 )
 from tests.providers.helpers import ServiceProviderConnectionTests
 
@@ -491,6 +493,55 @@ async def test_require_client_and_node_no_node(
 
 
 # =============================================================================
+# Tag resolver helpers (pure functions over the raw user list)
+# =============================================================================
+
+
+class TestLcmSlotResolvers:
+    """Unit tests for ``_lcm_slot_from_raw_users_by_*`` helpers."""
+
+    _USERS: list[dict[str, Any]] = [
+        {
+            "user_index": 1,
+            "user_name": "lcm:5:Alice",
+            "credentials": [{"type": "pin", "index": 7}],
+        },
+        {
+            "user_index": 2,
+            "user_name": "External",  # untagged
+            "credentials": [{"type": "pin", "index": 3}],
+        },
+        {
+            "user_index": 3,
+            "user_name": "lcm:8:Bob",
+            "credentials": [],  # no credentials -- persistent anchor
+        },
+    ]
+
+    def test_by_user_index_resolves_tagged(self) -> None:
+        assert _lcm_slot_from_raw_users_by_user_index(self._USERS, 1) == 5
+        assert _lcm_slot_from_raw_users_by_user_index(self._USERS, 3) == 8
+
+    def test_by_user_index_returns_none_for_untagged(self) -> None:
+        assert _lcm_slot_from_raw_users_by_user_index(self._USERS, 2) is None
+
+    def test_by_user_index_returns_none_for_unknown(self) -> None:
+        assert _lcm_slot_from_raw_users_by_user_index(self._USERS, 99) is None
+        assert _lcm_slot_from_raw_users_by_user_index(self._USERS, None) is None
+
+    def test_by_credential_index_resolves_tagged(self) -> None:
+        assert _lcm_slot_from_raw_users_by_credential_index(self._USERS, 7) == 5
+
+    def test_by_credential_index_returns_none_for_untagged_owner(self) -> None:
+        # credential index 3 belongs to "External" (untagged) -- resolves to None.
+        assert _lcm_slot_from_raw_users_by_credential_index(self._USERS, 3) is None
+
+    def test_by_credential_index_returns_none_for_unknown(self) -> None:
+        assert _lcm_slot_from_raw_users_by_credential_index(self._USERS, 99) is None
+        assert _lcm_slot_from_raw_users_by_credential_index(self._USERS, None) is None
+
+
+# =============================================================================
 # LockOperation event tests
 # =============================================================================
 
@@ -515,119 +566,358 @@ def _make_node_event(
 
 
 class TestLockOperationEvent:
-    """Test _on_node_event callback filtering and event firing."""
+    """Test _handle_lock_operation callback and code-slot event firing."""
 
-    def test_unlock_with_pin_credential(self, matter_lock_simple: MatterLock) -> None:
-        """Unlock with PIN credential fires code slot event."""
+    @pytest.fixture(autouse=True)
+    def _stub_matter_client_and_node(
+        self, matter_lock_simple: MatterLock
+    ) -> Generator[None]:
+        """LockOperation dispatch needs to reach ``_raw_lock_users``."""
+        with (
+            patch.object(
+                matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+            ),
+            patch.object(
+                matter_lock_simple, "_get_matter_node", return_value=MagicMock()
+            ),
+        ):
+            yield
+
+    @staticmethod
+    def _patch_users(users: list[dict]) -> Any:
+        """Patch get_lock_users so the async dispatch can resolve owners."""
+        return patch(
+            f"{_PROVIDER_MODULE}.get_lock_users",
+            AsyncMock(return_value={"max_users": 10, "users": users}),
+        )
+
+    async def test_unlock_with_pin_credential(
+        self, hass: HomeAssistant, matter_lock_simple: MatterLock
+    ) -> None:
+        """Unlock with PIN credential fires a code slot event.
+
+        Resolution: ``userIndex`` -> tagged user.name -> LCM slot. The
+        Matter ``credentialIndex`` may differ from the LCM slot and must
+        not be used as the code slot directly.
+        """
         fired: list[dict[str, Any]] = []
         matter_lock_simple.async_fire_code_slot_event = lambda **kw: fired.append(kw)
 
-        matter_lock_simple._on_node_event(
-            None,
-            _make_node_event(
-                data={
-                    "lockOperationType": 1,  # kUnlock
-                    "credentials": [
-                        {"credentialType": 1, "credentialIndex": 2},  # PIN, slot 2
-                    ],
-                }
-            ),
-        )
+        with self._patch_users(
+            [
+                {
+                    "user_index": 99,
+                    "user_name": "lcm:2:Alice",
+                    "credentials": [{"type": "pin", "index": 7}],
+                },
+            ]
+        ):
+            matter_lock_simple._on_node_event(
+                None,
+                _make_node_event(
+                    data={
+                        "lockOperationType": 1,  # kUnlock
+                        "userIndex": 99,
+                        "credentials": [
+                            # Matter credential index is opaque; the LCM slot
+                            # is resolved from the owning user's tag.
+                            {"credentialType": 1, "credentialIndex": 7},
+                        ],
+                    }
+                ),
+            )
+            await hass.async_block_till_done()
 
         assert len(fired) == 1
         assert fired[0]["code_slot"] == 2
         assert fired[0]["to_locked"] is False
         assert fired[0]["action_text"] == "unlocked"
 
-    def test_lock_with_pin_credential(self, matter_lock_simple: MatterLock) -> None:
-        """Lock with PIN credential fires code slot event."""
+    async def test_lock_with_pin_credential(
+        self, hass: HomeAssistant, matter_lock_simple: MatterLock
+    ) -> None:
+        """Lock with PIN credential fires a code slot event."""
         fired: list[dict[str, Any]] = []
         matter_lock_simple.async_fire_code_slot_event = lambda **kw: fired.append(kw)
 
-        matter_lock_simple._on_node_event(
-            None,
-            _make_node_event(
-                data={
-                    "lockOperationType": 0,  # kLock
-                    "credentials": [
-                        {"credentialType": 1, "credentialIndex": 5},
-                    ],
-                }
-            ),
-        )
+        with self._patch_users(
+            [
+                {
+                    "user_index": 4,
+                    "user_name": "lcm:5:Bob",
+                    "credentials": [{"type": "pin", "index": 2}],
+                },
+            ]
+        ):
+            matter_lock_simple._on_node_event(
+                None,
+                _make_node_event(
+                    data={
+                        "lockOperationType": 0,  # kLock
+                        "userIndex": 4,
+                        "credentials": [
+                            {"credentialType": 1, "credentialIndex": 2},
+                        ],
+                    }
+                ),
+            )
+            await hass.async_block_till_done()
 
         assert len(fired) == 1
         assert fired[0]["code_slot"] == 5
         assert fired[0]["to_locked"] is True
         assert fired[0]["action_text"] == "locked"
 
-    def test_rfid_credential_ignored(self, matter_lock_simple: MatterLock) -> None:
-        """RFID credential does not fire pin_used event."""
-        fired: list[dict[str, Any]] = []
-        matter_lock_simple.async_fire_code_slot_event = lambda **kw: fired.append(kw)
-
-        matter_lock_simple._on_node_event(
-            None,
-            _make_node_event(
-                data={
-                    "lockOperationType": 1,
-                    "credentials": [
-                        {"credentialType": 2, "credentialIndex": 3},  # RFID
-                    ],
-                }
-            ),
-        )
-
-        assert len(fired) == 0
-
-    def test_fingerprint_credential_ignored(
-        self, matter_lock_simple: MatterLock
+    async def test_projects_lcm_slot_from_tag_when_credential_index_differs(
+        self, hass: HomeAssistant, matter_lock_simple: MatterLock
     ) -> None:
-        """Fingerprint credential does not fire pin_used event."""
+        """The regression: Matter-auto-allocated credential index must not become the LCM slot.
+
+        Pre-PR-B, LCM pinned ``credentialIndex == LCM slot``, so firing
+        ``code_slot=credentialIndex`` was correct. Under the user-tag
+        model the Matter credential index is opaque and auto-allocated.
+        Here LCM slot 3 owns Matter credential index 11; the event must
+        fire on slot 3 (from the owning user's tag), NOT slot 11.
+        """
         fired: list[dict[str, Any]] = []
         matter_lock_simple.async_fire_code_slot_event = lambda **kw: fired.append(kw)
 
-        matter_lock_simple._on_node_event(
-            None,
-            _make_node_event(
-                data={
-                    "lockOperationType": 1,
-                    "credentials": [
-                        {"credentialType": 3, "credentialIndex": 1},  # Fingerprint
-                    ],
-                }
-            ),
-        )
+        with self._patch_users(
+            [
+                {
+                    "user_index": 1,
+                    "user_name": "lcm:3:Carol",
+                    "credentials": [{"type": "pin", "index": 11}],
+                },
+            ]
+        ):
+            matter_lock_simple._on_node_event(
+                None,
+                _make_node_event(
+                    data={
+                        "lockOperationType": 1,
+                        "userIndex": 1,
+                        "credentials": [
+                            {"credentialType": 1, "credentialIndex": 11},
+                        ],
+                    }
+                ),
+            )
+            await hass.async_block_till_done()
+
+        assert len(fired) == 1
+        assert fired[0]["code_slot"] == 3
+
+    async def test_falls_back_to_credential_index_walk_when_user_index_missing(
+        self, hass: HomeAssistant, matter_lock_simple: MatterLock
+    ) -> None:
+        """Matter spec allows ``userIndex`` to be omitted on LockOperation.
+
+        When it's absent we walk the user list to find the PIN credential at
+        ``credentialIndex`` and parse the owning user's tag. Without this
+        fallback the event would silently drop when a lock implementation
+        elides ``userIndex`` from PIN operations.
+        """
+        fired: list[dict[str, Any]] = []
+        matter_lock_simple.async_fire_code_slot_event = lambda **kw: fired.append(kw)
+
+        with self._patch_users(
+            [
+                {
+                    "user_index": 50,
+                    "user_name": "lcm:7:Dave",
+                    "credentials": [{"type": "pin", "index": 4}],
+                },
+            ]
+        ):
+            matter_lock_simple._on_node_event(
+                None,
+                _make_node_event(
+                    data={
+                        "lockOperationType": 1,
+                        # userIndex omitted -- fallback to credentialIndex walk.
+                        "credentials": [
+                            {"credentialType": 1, "credentialIndex": 4},
+                        ],
+                    }
+                ),
+            )
+            await hass.async_block_till_done()
+
+        assert len(fired) == 1
+        assert fired[0]["code_slot"] == 7
+
+    async def test_lock_op_for_untagged_user_ignored(
+        self, hass: HomeAssistant, matter_lock_simple: MatterLock
+    ) -> None:
+        """LockOperation on a non-LCM-tagged user fires no code slot event.
+
+        Another controller (or keypad-enrolled user) using a PIN must not
+        push a code slot event into LCM; firing with the wrong slot is
+        worse than not firing.
+        """
+        fired: list[dict[str, Any]] = []
+        matter_lock_simple.async_fire_code_slot_event = lambda **kw: fired.append(kw)
+
+        with self._patch_users(
+            [
+                {
+                    "user_index": 9,
+                    "user_name": "Visitor",  # untagged
+                    "credentials": [{"type": "pin", "index": 9}],
+                },
+            ]
+        ):
+            matter_lock_simple._on_node_event(
+                None,
+                _make_node_event(
+                    data={
+                        "lockOperationType": 1,
+                        "userIndex": 9,
+                        "credentials": [
+                            {"credentialType": 1, "credentialIndex": 9},
+                        ],
+                    }
+                ),
+            )
+            await hass.async_block_till_done()
 
         assert len(fired) == 0
 
-    def test_wrong_cluster_ignored(self, matter_lock_simple: MatterLock) -> None:
-        """Events from non-DoorLock clusters are ignored."""
+    async def test_lock_op_with_no_resolvable_owner_ignored(
+        self, hass: HomeAssistant, matter_lock_simple: MatterLock
+    ) -> None:
+        """Neither ``userIndex`` nor ``credentialIndex`` matches a known user."""
         fired: list[dict[str, Any]] = []
         matter_lock_simple.async_fire_code_slot_event = lambda **kw: fired.append(kw)
 
-        matter_lock_simple._on_node_event(
-            None,
-            _make_node_event(
-                cluster_id=6,  # OnOff cluster
-                data={"credentials": [{"credentialType": 1, "credentialIndex": 1}]},
-            ),
-        )
+        with self._patch_users([]):
+            matter_lock_simple._on_node_event(
+                None,
+                _make_node_event(
+                    data={
+                        "lockOperationType": 1,
+                        "userIndex": 42,
+                        "credentials": [
+                            {"credentialType": 1, "credentialIndex": 4},
+                        ],
+                    }
+                ),
+            )
+            await hass.async_block_till_done()
 
         assert len(fired) == 0
 
-    def test_wrong_event_id_ignored(self, matter_lock_simple: MatterLock) -> None:
-        """Non-LockOperation DoorLock events are ignored."""
+    async def test_lock_op_dispatch_swallows_lock_disconnected(
+        self, hass: HomeAssistant, matter_lock_simple: MatterLock
+    ) -> None:
+        """Transport failure during owner lookup logs and drops the event."""
         fired: list[dict[str, Any]] = []
         matter_lock_simple.async_fire_code_slot_event = lambda **kw: fired.append(kw)
 
-        matter_lock_simple._on_node_event(
-            None,
-            _make_node_event(
-                event_id=3,  # LockOperationError
-                data={"credentials": [{"credentialType": 1, "credentialIndex": 1}]},
-            ),
-        )
+        with patch(
+            f"{_PROVIDER_MODULE}.get_lock_users",
+            AsyncMock(side_effect=HomeAssistantError("transport down")),
+        ):
+            matter_lock_simple._on_node_event(
+                None,
+                _make_node_event(
+                    data={
+                        "lockOperationType": 1,
+                        "userIndex": 1,
+                        "credentials": [
+                            {"credentialType": 1, "credentialIndex": 1},
+                        ],
+                    }
+                ),
+            )
+            await hass.async_block_till_done()
+
+        assert len(fired) == 0
+
+    async def test_rfid_credential_ignored(
+        self, hass: HomeAssistant, matter_lock_simple: MatterLock
+    ) -> None:
+        """RFID (credentialType=2) does not fire a code slot event."""
+        fired: list[dict[str, Any]] = []
+        matter_lock_simple.async_fire_code_slot_event = lambda **kw: fired.append(kw)
+
+        with self._patch_users([]):
+            matter_lock_simple._on_node_event(
+                None,
+                _make_node_event(
+                    data={
+                        "lockOperationType": 1,
+                        "userIndex": 1,
+                        "credentials": [
+                            {"credentialType": 2, "credentialIndex": 3},  # RFID
+                        ],
+                    }
+                ),
+            )
+            await hass.async_block_till_done()
+
+        assert len(fired) == 0
+
+    async def test_fingerprint_credential_ignored(
+        self, hass: HomeAssistant, matter_lock_simple: MatterLock
+    ) -> None:
+        """Fingerprint (credentialType=3) does not fire a code slot event."""
+        fired: list[dict[str, Any]] = []
+        matter_lock_simple.async_fire_code_slot_event = lambda **kw: fired.append(kw)
+
+        with self._patch_users([]):
+            matter_lock_simple._on_node_event(
+                None,
+                _make_node_event(
+                    data={
+                        "lockOperationType": 1,
+                        "userIndex": 1,
+                        "credentials": [
+                            {"credentialType": 3, "credentialIndex": 1},
+                        ],
+                    }
+                ),
+            )
+            await hass.async_block_till_done()
+
+        assert len(fired) == 0
+
+    async def test_wrong_cluster_ignored(
+        self, hass: HomeAssistant, matter_lock_simple: MatterLock
+    ) -> None:
+        """Events from non-DoorLock clusters are ignored upstream of dispatch."""
+        fired: list[dict[str, Any]] = []
+        matter_lock_simple.async_fire_code_slot_event = lambda **kw: fired.append(kw)
+
+        with self._patch_users([]):
+            matter_lock_simple._on_node_event(
+                None,
+                _make_node_event(
+                    cluster_id=6,  # OnOff cluster
+                    data={"credentials": [{"credentialType": 1, "credentialIndex": 1}]},
+                ),
+            )
+            await hass.async_block_till_done()
+
+        assert len(fired) == 0
+
+    async def test_wrong_event_id_ignored(
+        self, hass: HomeAssistant, matter_lock_simple: MatterLock
+    ) -> None:
+        """Non-LockOperation DoorLock events are ignored upstream of dispatch."""
+        fired: list[dict[str, Any]] = []
+        matter_lock_simple.async_fire_code_slot_event = lambda **kw: fired.append(kw)
+
+        with self._patch_users([]):
+            matter_lock_simple._on_node_event(
+                None,
+                _make_node_event(
+                    event_id=3,  # LockOperationError
+                    data={"credentials": [{"credentialType": 1, "credentialIndex": 1}]},
+                ),
+            )
+            await hass.async_block_till_done()
 
         assert len(fired) == 0
 
@@ -655,30 +945,55 @@ class TestLockOperationEvent:
 
         assert len(fired) == 0
 
-    def test_no_operation_type(self, matter_lock_simple: MatterLock) -> None:
-        """Event without lockOperationType fires with to_locked=None."""
+    async def test_no_operation_type(
+        self, hass: HomeAssistant, matter_lock_simple: MatterLock
+    ) -> None:
+        """Event without ``lockOperationType`` fires with ``to_locked=None``.
+
+        Matter spec permits unknown / vendor-specific operation types; the
+        handler falls through to ``to_locked=None`` and ``action_text="operated"``
+        rather than dropping the event so downstream automations still see
+        the PIN use.
+        """
         fired: list[dict[str, Any]] = []
         matter_lock_simple.async_fire_code_slot_event = lambda **kw: fired.append(kw)
 
-        matter_lock_simple._on_node_event(
-            None,
-            _make_node_event(
-                data={
-                    "credentials": [{"credentialType": 1, "credentialIndex": 3}],
-                }
-            ),
-        )
+        with self._patch_users(
+            [
+                {
+                    "user_index": 1,
+                    "user_name": "lcm:3:Eve",
+                    "credentials": [{"type": "pin", "index": 3}],
+                },
+            ]
+        ):
+            matter_lock_simple._on_node_event(
+                None,
+                _make_node_event(
+                    data={
+                        "userIndex": 1,
+                        "credentials": [
+                            {"credentialType": 1, "credentialIndex": 3},
+                        ],
+                    }
+                ),
+            )
+            await hass.async_block_till_done()
 
         assert len(fired) == 1
+        assert fired[0]["code_slot"] == 3
         assert fired[0]["to_locked"] is None
         assert fired[0]["action_text"] == "operated"
 
-    def test_none_data_ignored(self, matter_lock_simple: MatterLock) -> None:
-        """Event with None data is ignored (no credentials)."""
+    async def test_none_data_ignored(
+        self, hass: HomeAssistant, matter_lock_simple: MatterLock
+    ) -> None:
+        """Event with ``None`` data is ignored (no credentials)."""
         fired: list[dict[str, Any]] = []
         matter_lock_simple.async_fire_code_slot_event = lambda **kw: fired.append(kw)
 
         matter_lock_simple._on_node_event(None, _make_node_event(data=None))
+        await hass.async_block_till_done()
 
         assert len(fired) == 0
 

--- a/tests/providers/matter/test_provider.py
+++ b/tests/providers/matter/test_provider.py
@@ -1321,15 +1321,22 @@ class TestGetCapabilities:
 
 
 class TestSetUser:
-    """Test async_set_user creates or updates lock users."""
+    """async_set_user find-or-create-by-tag (with legacy adoption fallback)."""
 
-    async def test_set_user_creates_new_user(
+    def _patch_users(self, users: list[dict]) -> Any:
+        """Patch get_lock_users to return the given user list."""
+        return patch(
+            f"{_PROVIDER_MODULE}.get_lock_users",
+            AsyncMock(return_value={"max_users": 10, "users": users}),
+        )
+
+    async def test_set_user_creates_when_no_tagged_or_legacy_user(
         self, hass: HomeAssistant, matter_lock_simple: MatterLock
     ) -> None:
-        """When credential slot is empty, set_user returns created=True."""
-        mock_get_status = AsyncMock(return_value={"credential_exists": False})
+        """No LCM-owned user exists for the slot -> auto-allocate."""
         mock_set_user = AsyncMock(return_value={"user_index": 1})
-        user = User(user_id=1, name="Alice")
+        # Seam passes user.name already tagged.
+        user = User(user_id=1, name="lcm:1:Alice")
         with (
             patch.object(
                 matter_lock_simple, "_get_matter_client", return_value=MagicMock()
@@ -1337,73 +1344,22 @@ class TestSetUser:
             patch.object(
                 matter_lock_simple, "_get_matter_node", return_value=MagicMock()
             ),
-            patch(f"{_PROVIDER_MODULE}.get_lock_credential_status", mock_get_status),
+            self._patch_users([]),
             patch(f"{_PROVIDER_MODULE}.set_lock_user", mock_set_user),
         ):
             result = await matter_lock_simple.async_set_user(user)
 
-        assert isinstance(result, SetUserResult)
-        assert result.user_id == 1
-        assert result.created is True
-        mock_set_user.assert_called_once()
-
-    async def test_set_user_updates_existing_user(
-        self, hass: HomeAssistant, matter_lock_simple: MatterLock
-    ) -> None:
-        """When credential slot is occupied, set_user updates that owner."""
-        mock_get_status = AsyncMock(
-            return_value={"credential_exists": True, "user_index": 2}
-        )
-        mock_set_user = AsyncMock(return_value={"user_index": 2})
-        user = User(user_id=2, name="Bob")
-        with (
-            patch.object(
-                matter_lock_simple, "_get_matter_client", return_value=MagicMock()
-            ),
-            patch.object(
-                matter_lock_simple, "_get_matter_node", return_value=MagicMock()
-            ),
-            patch(f"{_PROVIDER_MODULE}.get_lock_credential_status", mock_get_status),
-            patch(f"{_PROVIDER_MODULE}.set_lock_user", mock_set_user),
-        ):
-            result = await matter_lock_simple.async_set_user(user)
-
-        assert result.created is False
-        assert result.user_id == 2
-
-    async def test_set_user_create_auto_allocates_index_and_passes_name(
-        self, hass: HomeAssistant, matter_lock_simple: MatterLock
-    ) -> None:
-        """On create, set_lock_user is called with user_index=None (auto-allocate)."""
-        mock_get_status = AsyncMock(return_value={"credential_exists": False})
-        mock_set_user = AsyncMock(return_value={"user_index": 5})
-        user = User(user_id=5, name="Eve")
-        with (
-            patch.object(
-                matter_lock_simple, "_get_matter_client", return_value=MagicMock()
-            ),
-            patch.object(
-                matter_lock_simple, "_get_matter_node", return_value=MagicMock()
-            ),
-            patch(f"{_PROVIDER_MODULE}.get_lock_credential_status", mock_get_status),
-            patch(f"{_PROVIDER_MODULE}.set_lock_user", mock_set_user),
-        ):
-            result = await matter_lock_simple.async_set_user(user)
-
+        assert result == SetUserResult(user_id=1, created=True)
         call_kwargs = mock_set_user.call_args.kwargs
-        assert call_kwargs["user_index"] is None  # Matter allocates the index
-        assert call_kwargs["user_name"] == "Eve"
-        assert result.user_id == 5  # the allocated index is returned
+        assert call_kwargs["user_index"] is None  # auto-allocate
+        assert call_kwargs["user_name"] == "lcm:1:Alice"
 
-    async def test_set_user_name_none_preserved(
+    async def test_set_user_updates_when_tagged_user_already_exists(
         self, hass: HomeAssistant, matter_lock_simple: MatterLock
     ) -> None:
-        """name=None flows through unchanged (helper preserves the existing name)."""
-        mock_get_status = AsyncMock(
-            return_value={"credential_exists": True, "user_index": 7}
-        )
-        mock_set_user = AsyncMock(return_value={"user_index": 7})
-        user = User(user_id=7, name=None)
+        """An lcm:<slot>: tagged user is found -> UPDATE that user_index."""
+        mock_set_user = AsyncMock(return_value={"user_index": 42})
+        user = User(user_id=2, name="lcm:2:Bob-rename")
         with (
             patch.object(
                 matter_lock_simple, "_get_matter_client", return_value=MagicMock()
@@ -1411,20 +1367,35 @@ class TestSetUser:
             patch.object(
                 matter_lock_simple, "_get_matter_node", return_value=MagicMock()
             ),
-            patch(f"{_PROVIDER_MODULE}.get_lock_credential_status", mock_get_status),
+            self._patch_users(
+                [
+                    {
+                        "user_index": 42,
+                        "user_name": "lcm:2:Bob",
+                        "credentials": [{"type": "pin", "index": 7}],
+                    },
+                ]
+            ),
             patch(f"{_PROVIDER_MODULE}.set_lock_user", mock_set_user),
         ):
-            await matter_lock_simple.async_set_user(user)
+            result = await matter_lock_simple.async_set_user(user)
 
-        assert mock_set_user.call_args.kwargs["user_name"] is None
+        assert result == SetUserResult(user_id=42, created=False)
+        call_kwargs = mock_set_user.call_args.kwargs
+        assert call_kwargs["user_index"] == 42
+        assert call_kwargs["user_name"] == "lcm:2:Bob-rename"
 
-    async def test_set_user_disconnected(
+    async def test_set_user_adopts_untagged_legacy_user_owning_pin_at_slot(
         self, hass: HomeAssistant, matter_lock_simple: MatterLock
     ) -> None:
-        """HomeAssistantError from set_lock_user raises LockDisconnected."""
-        mock_get_status = AsyncMock(return_value={"credential_exists": False})
-        mock_set_user = AsyncMock(side_effect=HomeAssistantError("offline"))
-        user = User(user_id=1, name="Alice")
+        """Pre-PR-B Matter LCM pinned credential_index=slot. Adopt that user.
+
+        Without this adoption fallback, the upgrade would CREATE a fresh
+        user and leave the legacy user's PIN active on the lock as an
+        orphan.
+        """
+        mock_set_user = AsyncMock(return_value={"user_index": 99})
+        user = User(user_id=5, name="lcm:5:Carol")
         with (
             patch.object(
                 matter_lock_simple, "_get_matter_client", return_value=MagicMock()
@@ -1432,18 +1403,75 @@ class TestSetUser:
             patch.object(
                 matter_lock_simple, "_get_matter_node", return_value=MagicMock()
             ),
-            patch(f"{_PROVIDER_MODULE}.get_lock_credential_status", mock_get_status),
+            self._patch_users(
+                [
+                    {
+                        "user_index": 99,
+                        "user_name": "Carol",  # untagged, legacy LCM 2.0
+                        "credentials": [{"type": "pin", "index": 5}],
+                    },
+                ]
+            ),
+            patch(f"{_PROVIDER_MODULE}.set_lock_user", mock_set_user),
+        ):
+            result = await matter_lock_simple.async_set_user(user)
+
+        # The legacy user is adopted (not orphaned): existing user_index
+        # is reused, name gets rewritten to the tagged form.
+        assert result == SetUserResult(user_id=99, created=False)
+        call_kwargs = mock_set_user.call_args.kwargs
+        assert call_kwargs["user_index"] == 99
+        assert call_kwargs["user_name"] == "lcm:5:Carol"
+
+    async def test_set_user_create_auto_allocates_and_returns_allocated_index(
+        self, hass: HomeAssistant, matter_lock_simple: MatterLock
+    ) -> None:
+        """set_lock_user returns the Matter-assigned user_index on CREATE."""
+        mock_set_user = AsyncMock(return_value={"user_index": 5})
+        user = User(user_id=3, name="lcm:3:Eve")
+        with (
+            patch.object(
+                matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+            ),
+            patch.object(
+                matter_lock_simple, "_get_matter_node", return_value=MagicMock()
+            ),
+            self._patch_users([]),
+            patch(f"{_PROVIDER_MODULE}.set_lock_user", mock_set_user),
+        ):
+            result = await matter_lock_simple.async_set_user(user)
+
+        # The LCM slot is 3 but Matter allocated user_index=5; the
+        # provider returns the lock-side identifier so the seam can
+        # thread it through to async_set_credential.
+        assert result.user_id == 5
+        assert result.created is True
+
+    async def test_set_user_create_raises_lock_disconnected_on_ha_error(
+        self, hass: HomeAssistant, matter_lock_simple: MatterLock
+    ) -> None:
+        """HomeAssistantError from set_lock_user on CREATE -> LockDisconnected."""
+        mock_set_user = AsyncMock(side_effect=HomeAssistantError("offline"))
+        user = User(user_id=1, name="lcm:1:Alice")
+        with (
+            patch.object(
+                matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+            ),
+            patch.object(
+                matter_lock_simple, "_get_matter_node", return_value=MagicMock()
+            ),
+            self._patch_users([]),
             patch(f"{_PROVIDER_MODULE}.set_lock_user", mock_set_user),
             pytest.raises(LockDisconnected),
         ):
             await matter_lock_simple.async_set_user(user)
 
-    async def test_set_user_status_service_validation_error(
+    async def test_set_user_create_raises_operation_failed_on_validation(
         self, hass: HomeAssistant, matter_lock_simple: MatterLock
     ) -> None:
-        """ServiceValidationError from get_lock_credential_status raises LockOperationFailed."""
-        mock_get_status = AsyncMock(side_effect=ServiceValidationError("bad slot"))
-        user = User(user_id=99, name="Mallory")
+        """ServiceValidationError from set_lock_user on CREATE -> LockOperationFailed."""
+        mock_set_user = AsyncMock(side_effect=ServiceValidationError("bad name"))
+        user = User(user_id=1, name="lcm:1:Mallory")
         with (
             patch.object(
                 matter_lock_simple, "_get_matter_client", return_value=MagicMock()
@@ -1451,7 +1479,8 @@ class TestSetUser:
             patch.object(
                 matter_lock_simple, "_get_matter_node", return_value=MagicMock()
             ),
-            patch(f"{_PROVIDER_MODULE}.get_lock_credential_status", mock_get_status),
+            self._patch_users([]),
+            patch(f"{_PROVIDER_MODULE}.set_lock_user", mock_set_user),
             pytest.raises(LockOperationFailed, match="rejected input"),
         ):
             await matter_lock_simple.async_set_user(user)
@@ -1459,23 +1488,15 @@ class TestSetUser:
     async def test_set_user_update_tolerates_name_set_failure(
         self, hass: HomeAssistant, matter_lock_simple: MatterLock, caplog
     ) -> None:
-        """
-        UPDATE branch: name-set failure is logged as a warning and the
-        existing user_index is returned, so the orchestration still
-        proceeds to write the credential.
+        """UPDATE name-set failure is logged; the user_index is still returned.
 
-        This preserves the historical contract from PR #1077 — the
-        DoorLock SetUser command on an existing user is a metadata-only
-        update (the user already exists), and a transient 500 or a name
-        the lock rejects should not block the subsequent credential
-        write. Regression guard against treating that failure as
-        LockDisconnected and aborting _put_credential.
+        Preserves the historical contract from PR #1077 -- the DoorLock
+        SetUser command on an existing user is a metadata-only update,
+        and a transient 500 or a rejected name should not block the
+        subsequent credential write.
         """
-        mock_get_status = AsyncMock(
-            return_value={"credential_exists": True, "user_index": 7}
-        )
         mock_set_user = AsyncMock(side_effect=HomeAssistantError("500"))
-        user = User(user_id=2, name="Updated Name")
+        user = User(user_id=2, name="lcm:2:Updated Name")
         with (
             patch.object(
                 matter_lock_simple, "_get_matter_client", return_value=MagicMock()
@@ -1483,43 +1504,22 @@ class TestSetUser:
             patch.object(
                 matter_lock_simple, "_get_matter_node", return_value=MagicMock()
             ),
-            patch(f"{_PROVIDER_MODULE}.get_lock_credential_status", mock_get_status),
+            self._patch_users(
+                [
+                    {
+                        "user_index": 7,
+                        "user_name": "lcm:2:Original",
+                        "credentials": [{"type": "pin", "index": 3}],
+                    },
+                ]
+            ),
             patch(f"{_PROVIDER_MODULE}.set_lock_user", mock_set_user),
         ):
             result = await matter_lock_simple.async_set_user(user)
 
-        # Existing user_index returned; created=False so no rollback in
-        # the seam if the credential write itself fails downstream.
         assert result == SetUserResult(user_id=7, created=False)
         mock_set_user.assert_called_once()
         assert "failed to update user name" in caplog.text
-
-    async def test_set_user_orphan_guard_raises(
-        self, hass: HomeAssistant, matter_lock_simple: MatterLock
-    ) -> None:
-        """credential_exists=True but no user_index raises LockOperationFailed."""
-        # The lock reports the slot is occupied but does not surface the
-        # owning user; falling through to CREATE would orphan that user.
-        mock_get_status = AsyncMock(
-            return_value={"credential_exists": True, "user_index": None}
-        )
-        mock_set_user = AsyncMock()
-        user = User(user_id=4, name="Carol")
-        with (
-            patch.object(
-                matter_lock_simple, "_get_matter_client", return_value=MagicMock()
-            ),
-            patch.object(
-                matter_lock_simple, "_get_matter_node", return_value=MagicMock()
-            ),
-            patch(f"{_PROVIDER_MODULE}.get_lock_credential_status", mock_get_status),
-            patch(f"{_PROVIDER_MODULE}.set_lock_user", mock_set_user),
-            pytest.raises(
-                LockOperationFailed, match="credential_exists=True but no user_index"
-            ),
-        ):
-            await matter_lock_simple.async_set_user(user)
-        mock_set_user.assert_not_called()
 
 
 # =============================================================================
@@ -1587,12 +1587,131 @@ class TestDeleteUser:
 
 
 # =============================================================================
+# async_release_managed_slot tests
+# =============================================================================
+
+
+class TestReleaseManagedSlot:
+    """async_release_managed_slot tears down the user anchoring a removed slot."""
+
+    @staticmethod
+    def _patch_users(users: list[dict]) -> Any:
+        """Patch get_lock_users with the given user list."""
+        return patch(
+            f"{_PROVIDER_MODULE}.get_lock_users",
+            AsyncMock(return_value={"max_users": 10, "users": users}),
+        )
+
+    async def test_release_deletes_tagged_user(
+        self, hass: HomeAssistant, matter_lock_simple: MatterLock
+    ) -> None:
+        """Finds the lcm:<slot>: user and clears it via clear_lock_user."""
+        mock_clear_user = AsyncMock(return_value=None)
+        with (
+            patch.object(
+                matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+            ),
+            patch.object(
+                matter_lock_simple, "_get_matter_node", return_value=MagicMock()
+            ),
+            self._patch_users(
+                [
+                    {
+                        "user_index": 42,
+                        "user_name": "lcm:5:Carol",
+                        "credentials": [{"type": "pin", "index": 7}],
+                    },
+                ]
+            ),
+            patch(f"{_PROVIDER_MODULE}.clear_lock_user", mock_clear_user),
+        ):
+            await matter_lock_simple.async_release_managed_slot(5)
+
+        mock_clear_user.assert_called_once()
+        call = mock_clear_user.call_args
+        assert 42 in call.args or call.kwargs.get("user_index") == 42
+
+    async def test_release_adopts_legacy_untagged_user_at_credential_index(
+        self, hass: HomeAssistant, matter_lock_simple: MatterLock
+    ) -> None:
+        """A legacy user owning a PIN at credential_index=slot is treated as the slot's owner."""
+        mock_clear_user = AsyncMock(return_value=None)
+        with (
+            patch.object(
+                matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+            ),
+            patch.object(
+                matter_lock_simple, "_get_matter_node", return_value=MagicMock()
+            ),
+            self._patch_users(
+                [
+                    {
+                        "user_index": 99,
+                        "user_name": "Alice",  # untagged, legacy LCM 2.0
+                        "credentials": [{"type": "pin", "index": 3}],
+                    },
+                ]
+            ),
+            patch(f"{_PROVIDER_MODULE}.clear_lock_user", mock_clear_user),
+        ):
+            await matter_lock_simple.async_release_managed_slot(3)
+
+        mock_clear_user.assert_called_once()
+        call = mock_clear_user.call_args
+        assert 99 in call.args or call.kwargs.get("user_index") == 99
+
+    async def test_release_no_op_when_no_lcm_user(
+        self, hass: HomeAssistant, matter_lock_simple: MatterLock
+    ) -> None:
+        """No tagged or legacy user for the slot -> clear_lock_user not called."""
+        mock_clear_user = AsyncMock(return_value=None)
+        with (
+            patch.object(
+                matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+            ),
+            patch.object(
+                matter_lock_simple, "_get_matter_node", return_value=MagicMock()
+            ),
+            self._patch_users(
+                [
+                    # An unrelated user with a PIN at a different slot --
+                    # not LCM's, and not at this slot's credential_index.
+                    {
+                        "user_index": 7,
+                        "user_name": "Someone Else",
+                        "credentials": [{"type": "pin", "index": 99}],
+                    },
+                ]
+            ),
+            patch(f"{_PROVIDER_MODULE}.clear_lock_user", mock_clear_user),
+        ):
+            await matter_lock_simple.async_release_managed_slot(5)
+
+        mock_clear_user.assert_not_called()
+
+
+# =============================================================================
 # async_set_credential tests
 # =============================================================================
 
 
 class TestSetCredential:
     """Test async_set_credential writes Personal Identification Number credentials."""
+
+    @pytest.fixture(autouse=True)
+    def _empty_user_list(self) -> AsyncMock:
+        """Default get_lock_users to an empty list so the new CREATE path runs.
+
+        async_set_credential now looks up the user's existing PIN credential
+        index via async_get_users -> get_lock_users to decide MODIFY vs CREATE.
+        Tests that want to exercise the MODIFY path can override this patch
+        in their own context manager.
+        """
+        with patch(
+            f"{_PROVIDER_MODULE}.get_lock_users",
+            AsyncMock(return_value={"max_users": 10, "users": []}),
+        ) as mock:
+            yield mock
 
     def _make_credential(self, slot: int = 1, pin: str = "1234") -> Credential:
         """Build a readable PIN credential for the given slot."""
@@ -1677,10 +1796,37 @@ class TestSetCredential:
                 1, credential, "1234", name=None, source="direct"
             )
 
+    @staticmethod
+    def _patch_user_with_pin(user_id: int, credential_index: int) -> Any:
+        """Override the autouse empty-user fixture: seed a user owning a PIN.
+
+        Sync-duplicate tests require an existing PIN credential so the
+        clear-and-retry path runs (the new model only retries when LCM
+        owns the duplicate -- otherwise the duplicate is external and
+        surfaces immediately).
+        """
+        return patch(
+            f"{_PROVIDER_MODULE}.get_lock_users",
+            AsyncMock(
+                return_value={
+                    "max_users": 10,
+                    "users": [
+                        {
+                            "user_index": user_id,
+                            "user_name": f"lcm:{user_id}:test",
+                            "credentials": [
+                                {"type": "pin", "index": credential_index},
+                            ],
+                        },
+                    ],
+                },
+            ),
+        )
+
     async def test_set_credential_duplicate_sync_retries_and_succeeds(
         self, hass: HomeAssistant, matter_lock_simple: MatterLock
     ) -> None:
-        """Duplicate on sync source clears the slot and retries once."""
+        """Duplicate on sync source clears the existing credential and retries once."""
         mock_set_credential = AsyncMock(
             side_effect=[
                 _make_set_credential_failed_error("duplicate"),
@@ -1696,6 +1842,7 @@ class TestSetCredential:
             patch.object(
                 matter_lock_simple, "_get_matter_node", return_value=MagicMock()
             ),
+            self._patch_user_with_pin(user_id=1, credential_index=10),
             patch(f"{_PROVIDER_MODULE}.set_lock_credential", mock_set_credential),
             patch(f"{_PROVIDER_MODULE}.clear_lock_credential", mock_clear),
         ):
@@ -1706,6 +1853,13 @@ class TestSetCredential:
         assert result is True
         assert mock_set_credential.call_count == 2
         assert mock_clear.call_count == 1
+        # First call uses the existing credential_index (MODIFY); retry uses
+        # None (CREATE) because we just cleared the old one.
+        first_call = mock_set_credential.call_args_list[0]
+        retry_call = mock_set_credential.call_args_list[1]
+        assert first_call.kwargs["credential_index"] == 10
+        assert retry_call.kwargs["credential_index"] is None
+        assert mock_clear.call_args.kwargs["credential_index"] == 10
 
     async def test_set_credential_duplicate_sync_persistent_raises(
         self, hass: HomeAssistant, matter_lock_simple: MatterLock
@@ -1723,6 +1877,7 @@ class TestSetCredential:
             patch.object(
                 matter_lock_simple, "_get_matter_node", return_value=MagicMock()
             ),
+            self._patch_user_with_pin(user_id=1, credential_index=10),
             patch(f"{_PROVIDER_MODULE}.set_lock_credential", mock_set_credential),
             patch(f"{_PROVIDER_MODULE}.clear_lock_credential", mock_clear),
             pytest.raises(DuplicateCodeError),
@@ -1733,6 +1888,38 @@ class TestSetCredential:
 
         assert mock_set_credential.call_count == 2
         assert mock_clear.call_count == 1
+
+    async def test_set_credential_sync_duplicate_external_surfaces_immediately(
+        self, hass: HomeAssistant, matter_lock_simple: MatterLock
+    ) -> None:
+        """When LCM owns no PIN for the user, the duplicate must be external.
+
+        Clearing it would step on another controller's credential, so
+        DuplicateCodeError surfaces immediately without retry.
+        """
+        mock_set_credential = AsyncMock(
+            side_effect=_make_set_credential_failed_error("duplicate")
+        )
+        mock_clear = AsyncMock(return_value={})
+        credential = self._make_credential(slot=1, pin="1234")
+        with (
+            patch.object(
+                matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+            ),
+            patch.object(
+                matter_lock_simple, "_get_matter_node", return_value=MagicMock()
+            ),
+            # autouse empty-user fixture: user has no existing PIN credential.
+            patch(f"{_PROVIDER_MODULE}.set_lock_credential", mock_set_credential),
+            patch(f"{_PROVIDER_MODULE}.clear_lock_credential", mock_clear),
+            pytest.raises(DuplicateCodeError),
+        ):
+            await matter_lock_simple.async_set_credential(
+                1, credential, "1234", name=None, source="sync"
+            )
+        # No retry, no clear -- the duplicate is external and out of scope.
+        assert mock_set_credential.call_count == 1
+        mock_clear.assert_not_called()
 
     async def test_set_credential_sync_duplicate_clear_disconnected(
         self, hass: HomeAssistant, matter_lock_simple: MatterLock
@@ -1750,6 +1937,7 @@ class TestSetCredential:
             patch.object(
                 matter_lock_simple, "_get_matter_node", return_value=MagicMock()
             ),
+            self._patch_user_with_pin(user_id=1, credential_index=10),
             patch(f"{_PROVIDER_MODULE}.set_lock_credential", mock_set_credential),
             patch(f"{_PROVIDER_MODULE}.clear_lock_credential", mock_clear),
             pytest.raises(LockDisconnected, match="sync-duplicate retry"),
@@ -1776,6 +1964,7 @@ class TestSetCredential:
             patch.object(
                 matter_lock_simple, "_get_matter_node", return_value=MagicMock()
             ),
+            self._patch_user_with_pin(user_id=1, credential_index=10),
             patch(f"{_PROVIDER_MODULE}.set_lock_credential", mock_set_credential),
             patch(f"{_PROVIDER_MODULE}.clear_lock_credential", mock_clear),
             pytest.raises(LockOperationFailed, match="sync-duplicate retry"),
@@ -1849,14 +2038,20 @@ class TestSetCredential:
                 1, credential, "1234", name=None, source="direct"
             )
 
-    async def test_set_credential_passes_correct_args(
+    async def test_set_credential_create_passes_credential_index_none(
         self, hass: HomeAssistant, matter_lock_simple: MatterLock
     ) -> None:
-        """set_lock_credential receives credential_type='pin', data, index, user_index."""
+        """When the user has no PIN yet, set_lock_credential gets credential_index=None.
+
+        The CREATE path passes ``credential_index=None`` so Matter auto-allocates
+        the next free slot; the previous slot=credential_index invariant is gone.
+        """
         mock_set_credential = AsyncMock(
-            return_value={"credential_index": 3, "user_index": 3}
+            return_value={"credential_index": 7, "user_index": 3}
         )
         credential = self._make_credential(slot=3, pin="9999")
+        # _empty_user_list autouse fixture already gives no users -> no PIN
+        # for user_id 3, so the CREATE path runs.
         with (
             patch.object(
                 matter_lock_simple, "_get_matter_client", return_value=MagicMock()
@@ -1877,7 +2072,49 @@ class TestSetCredential:
         call_kwargs = mock_set_credential.call_args.kwargs
         assert call_kwargs["credential_type"] == "pin"
         assert call_kwargs["credential_data"] == "9999"
-        assert call_kwargs["credential_index"] == 3
+        assert call_kwargs["credential_index"] is None
+        assert call_kwargs["user_index"] == 3
+
+    async def test_set_credential_modify_passes_existing_credential_index(
+        self, hass: HomeAssistant, matter_lock_simple: MatterLock
+    ) -> None:
+        """When the user already owns a PIN, set_lock_credential MODIFY'es at that index."""
+        mock_set_credential = AsyncMock(
+            return_value={"credential_index": 11, "user_index": 3}
+        )
+        credential = self._make_credential(slot=3, pin="9999")
+        with (
+            patch.object(
+                matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+            ),
+            patch.object(
+                matter_lock_simple, "_get_matter_node", return_value=MagicMock()
+            ),
+            # Override the autouse empty-user fixture: user 3 already owns
+            # a PIN at credential_index 11.
+            patch(
+                f"{_PROVIDER_MODULE}.get_lock_users",
+                AsyncMock(
+                    return_value={
+                        "max_users": 10,
+                        "users": [
+                            {
+                                "user_index": 3,
+                                "user_name": "lcm:3:Carol",
+                                "credentials": [{"type": "pin", "index": 11}],
+                            },
+                        ],
+                    },
+                ),
+            ),
+            patch(f"{_PROVIDER_MODULE}.set_lock_credential", mock_set_credential),
+        ):
+            await matter_lock_simple.async_set_credential(
+                3, credential, "9999", name="Carol", source="direct"
+            )
+
+        call_kwargs = mock_set_credential.call_args.kwargs
+        assert call_kwargs["credential_index"] == 11
         assert call_kwargs["user_index"] == 3
 
 
@@ -1888,6 +2125,39 @@ class TestSetCredential:
 
 class TestDeleteCredential:
     """Test async_delete_credential clears Personal Identification Number credentials."""
+
+    @pytest.fixture(autouse=True)
+    def _user_owning_slot_pin(self) -> AsyncMock:
+        """Default the lock to a single user owning a PIN at the slot the tests address.
+
+        async_delete_credential now rediscovers the Matter credential index
+        by walking the owning user's credentials; tests that don't override
+        this fixture get a baseline lock state where ref.user_id=1 owns a
+        PIN whose Matter credential index is also 1 -- enough for the basic
+        positive-path tests. Tests that need different lock state can patch
+        get_lock_users in their own context manager.
+        """
+        with patch(
+            f"{_PROVIDER_MODULE}.get_lock_users",
+            AsyncMock(
+                return_value={
+                    "max_users": 10,
+                    "users": [
+                        {
+                            "user_index": 1,
+                            "user_name": "lcm:1:test",
+                            "credentials": [{"type": "pin", "index": 1}],
+                        },
+                        {
+                            "user_index": 4,
+                            "user_name": "lcm:4:test",
+                            "credentials": [{"type": "pin", "index": 4}],
+                        },
+                    ],
+                },
+            ),
+        ) as mock:
+            yield mock
 
     async def test_delete_credential_returns_true(
         self, hass: HomeAssistant, matter_lock_simple: MatterLock
@@ -1933,9 +2203,14 @@ class TestDeleteCredential:
     async def test_delete_credential_passes_correct_args(
         self, hass: HomeAssistant, matter_lock_simple: MatterLock
     ) -> None:
-        """clear_lock_credential receives credential_type='pin' and credential_index."""
+        """clear_lock_credential is addressed by the user's rediscovered PIN index.
+
+        ref.slot is the LCM slot; the Matter credential index is rediscovered
+        by walking the user's credentials. The autouse fixture seeds user 4 as
+        owning a PIN at credential_index 4, so the clear should target 4.
+        """
         mock_clear = AsyncMock(return_value=None)
-        ref = CredentialRef(user_id=7, type=CredentialType.PIN, slot=7)
+        ref = CredentialRef(user_id=4, type=CredentialType.PIN, slot=4)
         with (
             patch.object(
                 matter_lock_simple, "_get_matter_client", return_value=MagicMock()
@@ -1949,7 +2224,7 @@ class TestDeleteCredential:
 
         call_kwargs = mock_clear.call_args.kwargs
         assert call_kwargs["credential_type"] == "pin"
-        assert call_kwargs["credential_index"] == 7
+        assert call_kwargs["credential_index"] == 4
 
     async def test_delete_credential_transport_error_raises_lock_disconnected(
         self, hass: HomeAssistant, matter_lock_simple: MatterLock

--- a/tests/providers/matter/test_provider.py
+++ b/tests/providers/matter/test_provider.py
@@ -708,6 +708,93 @@ class TestLockOperationEvent:
         assert len(fired) == 1
         assert fired[0]["code_slot"] == 3
 
+    async def test_preserves_slot_zero_resolved_by_user_index(
+        self, hass: HomeAssistant, matter_lock_simple: MatterLock
+    ) -> None:
+        """Slot 0 from the primary resolver must not fall through to the fallback.
+
+        Pins the explicit ``None`` check that replaced an ``or``-chain in
+        ``_dispatch_lock_operation``: with ``or``, ``code_slot == 0`` is
+        falsy, so the fallback walker would run and likely return a
+        different slot. The fix is to gate on ``is None`` explicitly.
+        """
+        fired: list[dict[str, Any]] = []
+        matter_lock_simple.async_fire_code_slot_event = lambda **kw: fired.append(kw)
+
+        with self._patch_users(
+            [
+                # User at userIndex 1 maps to LCM slot 0 (legitimate primary hit).
+                {
+                    "user_index": 1,
+                    "user_name": "lcm:0:Zero",
+                    "credentials": [{"type": "pin", "index": 99}],
+                },
+                # Decoy at credentialIndex 99 owned by a different tagged slot.
+                # If the resolver falls through, this would yield slot 4.
+                {
+                    "user_index": 2,
+                    "user_name": "lcm:4:Decoy",
+                    "credentials": [{"type": "pin", "index": 99}],
+                },
+            ]
+        ):
+            matter_lock_simple._on_node_event(
+                None,
+                _make_node_event(
+                    data={
+                        "lockOperationType": 1,
+                        "userIndex": 1,
+                        "credentials": [
+                            {"credentialType": 1, "credentialIndex": 99},
+                        ],
+                    }
+                ),
+            )
+            await hass.async_block_till_done()
+
+        assert len(fired) == 1
+        assert fired[0]["code_slot"] == 0
+
+    async def test_credential_index_as_string_is_coerced(
+        self, hass: HomeAssistant, matter_lock_simple: MatterLock
+    ) -> None:
+        """Some Matter implementations send ``credentialIndex`` as a string.
+
+        The fallback walker compares against the raw user list's int
+        ``index`` field; without ``parse_slot_num`` coercion, the
+        comparison would never match and the event would silently drop
+        when ``userIndex`` is absent.
+        """
+        fired: list[dict[str, Any]] = []
+        matter_lock_simple.async_fire_code_slot_event = lambda **kw: fired.append(kw)
+
+        with self._patch_users(
+            [
+                {
+                    "user_index": 50,
+                    "user_name": "lcm:7:Dave",
+                    "credentials": [{"type": "pin", "index": 4}],
+                },
+            ]
+        ):
+            matter_lock_simple._on_node_event(
+                None,
+                _make_node_event(
+                    data={
+                        "lockOperationType": 1,
+                        # userIndex omitted to force the credentialIndex walk;
+                        # credentialIndex sent as a string.
+                        "credentials": [
+                            {"credentialType": 1, "credentialIndex": "4"},
+                        ],
+                    }
+                ),
+            )
+            await hass.async_block_till_done()
+
+        assert len(fired) == 1
+        assert fired[0]["code_slot"] == 7
+
     async def test_falls_back_to_credential_index_walk_when_user_index_missing(
         self, hass: HomeAssistant, matter_lock_simple: MatterLock
     ) -> None:

--- a/tests/providers/matter/test_provider.py
+++ b/tests/providers/matter/test_provider.py
@@ -1423,6 +1423,50 @@ class TestSetUser:
         assert call_kwargs["user_index"] == 99
         assert call_kwargs["user_name"] == "lcm:5:Carol"
 
+    async def test_set_user_legacy_pass_skips_users_tagged_for_other_slots(
+        self, hass: HomeAssistant, matter_lock_simple: MatterLock
+    ) -> None:
+        """A tagged user whose Matter credential index happens to equal our slot is NOT adopted.
+
+        Regression for #1239 review: under the new model the Matter credential
+        index is auto-allocated. A user tagged ``lcm:3:`` can legitimately
+        own a PIN at credential_index 7. ``_find_user_index_for_slot(7)``
+        must NOT match that user via the legacy fallback (it belongs to
+        slot 3) -- doing so would cause us to rename slot-3's user and
+        write slot-7's PIN onto slot-3's user record.
+        """
+        mock_set_user = AsyncMock(return_value={"user_index": 100})
+        user = User(user_id=7, name="lcm:7:Eve")
+        with (
+            patch.object(
+                matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+            ),
+            patch.object(
+                matter_lock_simple, "_get_matter_node", return_value=MagicMock()
+            ),
+            self._patch_users(
+                [
+                    # User tagged for slot 3, but its PIN credential happens
+                    # to live at Matter-auto-allocated index 7. Must not be
+                    # adopted as slot 7's anchor.
+                    {
+                        "user_index": 42,
+                        "user_name": "lcm:3:Alice",
+                        "credentials": [{"type": "pin", "index": 7}],
+                    },
+                ]
+            ),
+            patch(f"{_PROVIDER_MODULE}.set_lock_user", mock_set_user),
+        ):
+            result = await matter_lock_simple.async_set_user(user)
+
+        # CREATE (auto-allocate) because no canonical match for slot 7
+        # and the legacy pass correctly skipped the slot-3 user.
+        assert result == SetUserResult(user_id=100, created=True)
+        call_kwargs = mock_set_user.call_args.kwargs
+        assert call_kwargs["user_index"] is None
+        assert call_kwargs["user_name"] == "lcm:7:Eve"
+
     async def test_set_user_create_auto_allocates_and_returns_allocated_index(
         self, hass: HomeAssistant, matter_lock_simple: MatterLock
     ) -> None:

--- a/tests/providers/matter/test_provider.py
+++ b/tests/providers/matter/test_provider.py
@@ -1321,6 +1321,48 @@ class TestLockUserChangeEvent:
 
         mock_coordinator.push_update.assert_not_called()
 
+    async def test_pin_event_with_missing_data_index_still_fires(
+        self, hass: HomeAssistant, matter_lock_simple: MatterLock
+    ) -> None:
+        """Events with no ``dataIndex`` still push if ``userIndex`` resolves.
+
+        ``dataIndex`` (the Matter credential index) is no longer the LCM
+        slot under the user-tag model; it's only kept for log context.
+        Hard-rejecting events where ``dataIndex`` is absent or malformed
+        would silently lose otherwise-resolvable state updates -- the LCM
+        slot comes from ``userIndex`` -> tag.
+        """
+        mock_coordinator = MagicMock()
+        mock_coordinator.data = {3: SlotCredential.empty()}
+        matter_lock_simple.coordinator = mock_coordinator
+
+        with self._patch_users(
+            [
+                {
+                    "user_index": 42,
+                    "user_name": "lcm:3:Carol",
+                    "credentials": [{"type": "pin", "index": 7}],
+                },
+            ]
+        ):
+            matter_lock_simple._on_node_event(
+                None,
+                _make_node_event(
+                    event_id=4,
+                    data={
+                        "lockDataType": 6,
+                        "dataOperationType": 0,
+                        # dataIndex omitted -- previously would hard-reject.
+                        "userIndex": 42,
+                    },
+                ),
+            )
+            await hass.async_block_till_done()
+
+        mock_coordinator.push_update.assert_called_once_with(
+            {3: SlotCredential.unreadable()}
+        )
+
     async def test_pin_event_dispatch_swallows_lock_disconnected(
         self, hass: HomeAssistant, matter_lock_simple: MatterLock
     ) -> None:

--- a/tests/providers/test_seam.py
+++ b/tests/providers/test_seam.py
@@ -492,21 +492,37 @@ async def test_build_tagged_user_name_returns_none_when_max_zero(
     assert await lock._build_tagged_user_name(5, "alice") is None
 
 
-async def test_build_tagged_user_name_truncates_prefix_when_limit_below_overhead(
+async def test_build_tagged_user_name_falls_back_to_slot_only_when_prefix_overflows(
     hass: HomeAssistant,
 ) -> None:
-    """If even the prefix doesn't fit, return the prefix truncated to the limit.
+    """Below the canonical-prefix length, write just the slot number.
 
-    Pathological case -- a lock advertising ``max_user_name_length`` below
-    the prefix length (``lcm:255:`` = 8 chars) means we cannot encode the
-    slot recoverably. The helper still returns something rather than
-    crashing the write; the write path eats a degraded name.
+    On a lock whose ``max_user_name_length`` can't fit even the canonical
+    ``lcm:<slot>:`` prefix, truncating the prefix loses the slot binding
+    irrecoverably. The helper falls back to writing the slot number as
+    the user name; :func:`._util.parse_tag` recognizes digit-only names
+    as a length-constrained encoding of the slot binding.
     """
     lock = _make_lock(hass, _NativeStubLock, "seam_tag_under")
     lock._capabilities_cache = _caps(
         supports_user_management=True, max_user_name_length=3
     )
-    assert await lock._build_tagged_user_name(255, "alice") == "lcm"
+    # "lcm:255:" is 8 chars; the 3-char limit can't fit it. Fall back to
+    # the slot-only encoding -- "255" fits and the slot survives the read.
+    assert await lock._build_tagged_user_name(255, "alice") == "255"
+
+
+async def test_build_tagged_user_name_keeps_canonical_prefix_when_it_just_fits(
+    hass: HomeAssistant,
+) -> None:
+    """At exactly the prefix's length, keep the canonical prefix (display=empty)."""
+    lock = _make_lock(hass, _NativeStubLock, "seam_tag_just_fits")
+    # ``lcm:1:`` is 6 chars. With max_user_name_length=6 the prefix fits
+    # with zero display budget -- no fallback needed.
+    lock._capabilities_cache = _caps(
+        supports_user_management=True, max_user_name_length=6
+    )
+    assert await lock._build_tagged_user_name(1, "alice") == "lcm:1:"
 
 
 async def test_build_tagged_user_name_returns_none_when_caps_fetch_fails(

--- a/tests/providers/test_seam.py
+++ b/tests/providers/test_seam.py
@@ -27,6 +27,7 @@ from custom_components.lock_code_manager.domain.exceptions import (
     CodeRejectedError,
     LockCodeManagerProviderError,
     LockDisconnected,
+    LockOperationFailed,
     ProviderNotImplementedError,
 )
 from custom_components.lock_code_manager.domain.models import SlotCredential
@@ -894,3 +895,28 @@ async def test_set_usercode_keeps_pre_existing_user_on_failure(
         await lock.async_set_usercode(3, "9999", name="bob")
     assert ("delete_user", 3) not in lock.calls
     assert 3 in lock._users
+
+
+async def test_set_usercode_logs_warning_when_rollback_user_delete_fails(
+    hass: HomeAssistant, caplog
+) -> None:
+    """If the rollback ``async_delete_user`` itself raises, log and re-raise the original.
+
+    Pins the defensive log path in ``_set_credential``: the credential
+    write failed, the seam tried to roll back the newly-created user,
+    and that rollback ALSO failed. The original CodeRejectedError still
+    surfaces (it's what the caller cares about), but the warning
+    captures the leftover user so the operator has something to act on.
+    """
+
+    class _RollbackFailsLock(_CredentialWriteFailsLock):
+        async def async_delete_user(self, user_id: int) -> None:
+            self.calls.append(("delete_user", user_id))
+            raise LockOperationFailed("delete user transient failure")
+
+    lock = _make_lock(hass, _RollbackFailsLock, "seam_rollback_delete_fails")
+    with pytest.raises(CodeRejectedError):
+        await lock.async_set_usercode(3, "9999", name="alice")
+
+    assert ("delete_user", 3) in lock.calls
+    assert "failed to roll back newly created user 3" in caplog.text

--- a/tests/providers/test_seam.py
+++ b/tests/providers/test_seam.py
@@ -513,6 +513,39 @@ async def test_build_tagged_user_name_falls_back_to_slot_only_when_prefix_overfl
     assert await lock._build_tagged_user_name(255, "alice") == "255"
 
 
+async def test_build_tagged_user_name_returns_none_when_slot_digits_dont_fit(
+    hass: HomeAssistant,
+) -> None:
+    """If even the slot digits can't fit, return None rather than truncate.
+
+    Regression for #1239 review (Copilot). On a max_user_name_length
+    smaller than ``len(str(slot))`` (e.g. slot=255 on a 2-char lock),
+    slicing ``str(slot)`` would yield ``"25"`` -- the wrong slot. Better
+    to return ``None`` and let the seam treat it as "no name write" than
+    silently mis-bind the user to a different slot.
+    """
+    lock = _make_lock(hass, _NativeStubLock, "seam_tag_slot_too_big")
+    lock._capabilities_cache = _caps(
+        supports_user_management=True, max_user_name_length=2
+    )
+    # "255" is 3 chars, doesn't fit in a 2-char limit.
+    assert await lock._build_tagged_user_name(255, "alice") is None
+
+
+async def test_build_tagged_user_name_returns_none_when_supports_user_management_false(
+    hass: HomeAssistant,
+) -> None:
+    """``supports_user_management=False`` returns None even with a positive length.
+
+    Defensive guard for callers that bypass ``_supports_user_records``.
+    """
+    lock = _make_lock(hass, _NativeStubLock, "seam_tag_no_user_mgmt")
+    lock._capabilities_cache = _caps(
+        supports_user_management=False, max_user_name_length=16
+    )
+    assert await lock._build_tagged_user_name(5, "alice") is None
+
+
 async def test_build_tagged_user_name_keeps_canonical_prefix_when_it_just_fits(
     hass: HomeAssistant,
 ) -> None:
@@ -719,26 +752,28 @@ async def test_clear_usercode_native_resolves_owner_when_user_id_not_slot(
     assert 12 in lock._users
 
 
-async def test_clear_usercode_resolves_owner_by_tag_when_credential_index_not_slot(
+async def test_clear_usercode_resolves_owner_by_tag_when_user_id_not_slot(
     hass: HomeAssistant,
 ) -> None:
-    """Owner resolution prefers the LCM tag in user.name over credential.slot.
+    """Owner resolution prefers the LCM tag in user.name over the user_id heuristic.
 
-    Regression for #1239 review. After the PR drops the credential_index=slot
-    invariant for Matter, a user tagged ``lcm:5:`` may own a PIN whose
-    Credential.slot is the Matter-auto-allocated index (e.g. 1), not the
-    LCM slot. The owner resolution in async_clear_usercode must find the
-    user by the canonical tag in user.name, not by ``credential.slot ==
-    code_slot`` alone -- otherwise the loop yields nothing and the clear
-    silently no-ops.
+    Regression for #1239 review. After the PR drops the user_id == LCM
+    slot invariant for native-user providers, a user tagged ``lcm:5:``
+    can have any lock-side ``user_id`` (Matter auto-allocates). The
+    owner resolution in async_clear_usercode must find the user by the
+    canonical tag, not by anything tied to the lock-side user_id.
+
+    (The provider's ``async_get_users`` is responsible for projecting
+    ``Credential.slot`` to the LCM slot, so by the time this code runs,
+    ``credential.slot == code_slot`` is the right query for the
+    PIN-ownership guard.)
     """
     lock = _make_lock(hass, _NativeStubLock, "seam_clear_by_tag")
     lock._users = {
         42: User(
-            user_id=42,
+            user_id=42,  # Matter-auto-allocated; NOT the LCM slot.
             name="lcm:5:Alice",
-            # Matter-auto-allocated credential index 1, NOT the LCM slot 5.
-            credentials=[credential_from_slot(1, SlotCredential.known("1234"))],
+            credentials=[credential_from_slot(5, SlotCredential.known("1234"))],
         )
     }
     changed = await lock.async_clear_usercode(5)
@@ -747,6 +782,33 @@ async def test_clear_usercode_resolves_owner_by_tag_when_credential_index_not_sl
     # with the ref's slot=5 (LCM slot).
     assert lock.calls == [("delete_credential", 42, 5)]
     assert 42 in lock._users
+
+
+async def test_clear_usercode_no_op_when_tagged_user_has_no_pin_credential(
+    hass: HomeAssistant,
+) -> None:
+    """A tagged user with no PIN credential is not the slot's owner -> clear is no-op.
+
+    Regression for #1239 review (Copilot). Under the persistent-user-anchor
+    lifecycle, an ``lcm:<slot>:`` tagged user can exist with no PIN
+    (between writes, or after a previous clear). The canonical owner
+    pass must require the user to own a PIN at the slot before resolving
+    them as the owner -- otherwise ``_delete_credential`` would call the
+    provider's ``async_delete_credential`` which (for some providers, e.g.
+    zwave_js) unconditionally returns True and causes a spurious
+    coordinator refresh.
+    """
+    lock = _make_lock(hass, _NativeStubLock, "seam_clear_tagged_no_pin")
+    lock._users = {
+        42: User(
+            user_id=42,
+            name="lcm:5:Alice",  # tagged but no credentials
+            credentials=[],
+        )
+    }
+    changed = await lock.async_clear_usercode(5)
+    assert changed is False
+    assert lock.calls == []
 
 
 async def test_clear_usercode_legacy_pass_skips_users_tagged_for_other_slots(

--- a/tests/providers/test_seam.py
+++ b/tests/providers/test_seam.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import Literal
 from unittest.mock import AsyncMock, patch
 
@@ -957,6 +958,34 @@ async def test_set_usercode_keeps_pre_existing_user_on_failure(
         await lock.async_set_usercode(3, "9999", name="bob")
     assert ("delete_user", 3) not in lock.calls
     assert 3 in lock._users
+
+
+async def test_set_usercode_fails_loudly_when_tag_cant_be_encoded(
+    hass: HomeAssistant,
+) -> None:
+    """``_set_credential`` refuses to write a user with no recoverable slot tag.
+
+    Pins the safety check on a native-user provider whose
+    ``max_user_name_length`` can't fit even the slot digits:
+    ``_build_tagged_user_name`` returns ``None``, and the seam must
+    fail loudly rather than call ``async_set_user(name=None)`` --
+    writing a nameless user would break the find-or-create-by-tag
+    lookup the next operation needs and leave an unrecoverable
+    duplicate user on the lock.
+    """
+
+    class _TinyNameLock(_NativeStubLock):
+        async def async_get_capabilities(self) -> LockCapabilities:
+            base = await super().async_get_capabilities()
+            # max_user_name_length=1 -- slot 25 ("25") doesn't fit.
+            return replace(base, max_user_name_length=1)
+
+    lock = _make_lock(hass, _TinyNameLock, "seam_no_stable_tag")
+    with pytest.raises(LockOperationFailed, match="cannot encode a stable slot tag"):
+        await lock.async_set_usercode(25, "9999", name="alice")
+    # No user written, no credential written -- failure happened before either.
+    assert not any(c[0] == "set_user" for c in lock.calls)
+    assert not any(c[0] == "set_credential" for c in lock.calls)
 
 
 async def test_set_usercode_logs_warning_when_rollback_user_delete_fails(

--- a/tests/providers/test_seam.py
+++ b/tests/providers/test_seam.py
@@ -702,6 +702,62 @@ async def test_clear_usercode_native_resolves_owner_when_user_id_not_slot(
     assert 12 in lock._users
 
 
+async def test_clear_usercode_resolves_owner_by_tag_when_credential_index_not_slot(
+    hass: HomeAssistant,
+) -> None:
+    """Owner resolution prefers the LCM tag in user.name over credential.slot.
+
+    Regression for #1239 review. After the PR drops the credential_index=slot
+    invariant for Matter, a user tagged ``lcm:5:`` may own a PIN whose
+    Credential.slot is the Matter-auto-allocated index (e.g. 1), not the
+    LCM slot. The owner resolution in async_clear_usercode must find the
+    user by the canonical tag in user.name, not by ``credential.slot ==
+    code_slot`` alone -- otherwise the loop yields nothing and the clear
+    silently no-ops.
+    """
+    lock = _make_lock(hass, _NativeStubLock, "seam_clear_by_tag")
+    lock._users = {
+        42: User(
+            user_id=42,
+            name="lcm:5:Alice",
+            # Matter-auto-allocated credential index 1, NOT the LCM slot 5.
+            credentials=[credential_from_slot(1, SlotCredential.known("1234"))],
+        )
+    }
+    changed = await lock.async_clear_usercode(5)
+    assert changed is True
+    # Owner resolved via the lcm:5: tag; delete targets user_id=42
+    # with the ref's slot=5 (LCM slot).
+    assert lock.calls == [("delete_credential", 42, 5)]
+    assert 42 in lock._users
+
+
+async def test_clear_usercode_legacy_pass_skips_users_tagged_for_other_slots(
+    hass: HomeAssistant,
+) -> None:
+    """Legacy ``credential.slot == code_slot`` fallback ignores tagged owners.
+
+    Regression for #1239 review. A user tagged ``lcm:3:`` whose Matter-
+    auto-allocated credential index lands at 7 must NOT be picked up by
+    ``async_clear_usercode(7)``'s legacy fallback. Doing so would resolve
+    the owner of slot-7 as slot-3's user, and the subsequent delete would
+    target the wrong slot.
+    """
+    lock = _make_lock(hass, _NativeStubLock, "seam_clear_legacy_skips_tagged")
+    lock._users = {
+        99: User(
+            user_id=99,
+            name="lcm:3:Alice",
+            credentials=[credential_from_slot(7, SlotCredential.known("1234"))],
+        )
+    }
+    # No user owns slot 7 under the canonical-tag lookup, and the legacy
+    # fallback must skip the lcm:3:-tagged owner -> clear is a no-op.
+    changed = await lock.async_clear_usercode(7)
+    assert changed is False
+    assert lock.calls == []
+
+
 async def test_clear_usercode_native_only_clears_the_targeted_credential(
     hass: HomeAssistant,
 ) -> None:

--- a/tests/providers/test_seam.py
+++ b/tests/providers/test_seam.py
@@ -27,7 +27,6 @@ from custom_components.lock_code_manager.domain.exceptions import (
     CodeRejectedError,
     LockCodeManagerProviderError,
     LockDisconnected,
-    LockOperationFailed,
     ProviderNotImplementedError,
 )
 from custom_components.lock_code_manager.domain.models import SlotCredential
@@ -447,55 +446,80 @@ async def test_supports_user_records_false_when_management_disabled(
     assert await lock._supports_user_records() is False
 
 
-async def test_truncate_user_name_within_limit_is_unchanged(
+async def test_build_tagged_user_name_within_limit_keeps_full_display(
     hass: HomeAssistant,
 ) -> None:
-    """A name within ``max_user_name_length`` passes through unchanged."""
-    lock = _make_lock(hass, _NativeStubLock, "seam_truncate_within")
+    """``lcm:<slot>:<display>`` fits the lock's limit -- everything stays."""
+    lock = _make_lock(hass, _NativeStubLock, "seam_tag_within")
     lock._capabilities_cache = _caps(
         supports_user_management=True, max_user_name_length=16
     )
-    assert await lock._truncate_user_name("alice") == "alice"
+    assert await lock._build_tagged_user_name(5, "alice") == "lcm:5:alice"
 
 
-async def test_truncate_user_name_truncates_to_limit(hass: HomeAssistant) -> None:
-    """A name longer than ``max_user_name_length`` is truncated."""
-    lock = _make_lock(hass, _NativeStubLock, "seam_truncate_long")
-    lock._capabilities_cache = _caps(
-        supports_user_management=True, max_user_name_length=5
-    )
-    assert await lock._truncate_user_name("alexandra") == "alexa"
-
-
-async def test_truncate_user_name_returns_none_when_max_zero(
+async def test_build_tagged_user_name_truncates_only_display(
     hass: HomeAssistant,
 ) -> None:
-    """Locks without named users drop the name entirely."""
-    lock = _make_lock(hass, _NativeStubLock, "seam_truncate_zero")
+    """When the total exceeds the limit, only the display portion is cut."""
+    lock = _make_lock(hass, _NativeStubLock, "seam_tag_truncate")
+    # "lcm:5:" is 6 chars, limit 10 → 4 chars of display ("alex").
+    lock._capabilities_cache = _caps(
+        supports_user_management=True, max_user_name_length=10
+    )
+    assert await lock._build_tagged_user_name(5, "alexandra") == "lcm:5:alex"
+
+
+async def test_build_tagged_user_name_handles_none_display(
+    hass: HomeAssistant,
+) -> None:
+    """A ``None`` display becomes the synthetic ``Code Slot <n>`` placeholder."""
+    lock = _make_lock(hass, _NativeStubLock, "seam_tag_none")
+    lock._capabilities_cache = _caps(
+        supports_user_management=True, max_user_name_length=32
+    )
+    # make_tagged_name uses "Code Slot <n>" when display is falsy.
+    assert await lock._build_tagged_user_name(5, None) == "lcm:5:Code Slot 5"
+
+
+async def test_build_tagged_user_name_returns_none_when_max_zero(
+    hass: HomeAssistant,
+) -> None:
+    """Locks without named users return None so the seam skips the user write."""
+    lock = _make_lock(hass, _NativeStubLock, "seam_tag_zero")
     lock._capabilities_cache = _caps(
         supports_user_management=True, max_user_name_length=0
     )
-    assert await lock._truncate_user_name("alice") is None
+    assert await lock._build_tagged_user_name(5, "alice") is None
 
 
-async def test_truncate_user_name_none_input_is_none(hass: HomeAssistant) -> None:
-    """A ``None`` name stays ``None`` without touching the capability cache."""
-    lock = _make_lock(hass, _NativeStubLock, "seam_truncate_none")
-    # No capabilities cache primed; helper short-circuits on None input.
-    assert await lock._truncate_user_name(None) is None
+async def test_build_tagged_user_name_truncates_prefix_when_limit_below_overhead(
+    hass: HomeAssistant,
+) -> None:
+    """If even the prefix doesn't fit, return the prefix truncated to the limit.
+
+    Pathological case -- a lock advertising ``max_user_name_length`` below
+    the prefix length (``lcm:255:`` = 8 chars) means we cannot encode the
+    slot recoverably. The helper still returns something rather than
+    crashing the write; the write path eats a degraded name.
+    """
+    lock = _make_lock(hass, _NativeStubLock, "seam_tag_under")
+    lock._capabilities_cache = _caps(
+        supports_user_management=True, max_user_name_length=3
+    )
+    assert await lock._build_tagged_user_name(255, "alice") == "lcm"
 
 
-async def test_truncate_user_name_returns_none_when_caps_fetch_fails(
+async def test_build_tagged_user_name_returns_none_when_caps_fetch_fails(
     hass: HomeAssistant,
 ) -> None:
     """Caps-read failure falls back to None instead of blocking the write."""
-    lock = _make_lock(hass, _NativeStubLock, "seam_truncate_fail")
+    lock = _make_lock(hass, _NativeStubLock, "seam_tag_fail")
     with patch.object(
         type(lock),
         "async_get_capabilities",
         AsyncMock(side_effect=LockDisconnected("unreachable")),
     ):
-        assert await lock._truncate_user_name("alice") is None
+        assert await lock._build_tagged_user_name(5, "alice") is None
     # Cache stays unset so the next call retries.
     assert lock._capabilities_cache is None
 
@@ -558,10 +582,9 @@ async def test_delete_credential_rejects_unsupported_credential_type(
 ) -> None:
     """``_delete_credential`` asserts the ref's type before any delete call."""
     lock = _make_lock(hass, _NativeStubLock, "seam_drop_reject_type")
-    owner = User(user_id=1, credentials=[])
     ref = CredentialRef(user_id=1, type=CredentialType.RFID, slot=3)
     with pytest.raises(CodeRejectedError):
-        await lock._delete_credential(owner, ref)
+        await lock._delete_credential(ref)
     assert lock.calls == []
 
 
@@ -592,7 +615,7 @@ async def test_set_usercode_native_user_first_and_threads_id(
     changed = await lock.async_set_usercode(3, "9999", name="alice")
     assert changed is True
     assert lock.calls == [
-        ("set_user", 3, "alice"),
+        ("set_user", 3, "lcm:3:alice"),
         ("set_credential", 3, 3),
     ]
     assert lock._users[3].credentials[0].matches("9999")
@@ -607,68 +630,23 @@ async def test_set_usercode_degenerate_skips_user(hass: HomeAssistant) -> None:
     assert lock._slots[3].matches("9999")
 
 
-async def test_clear_usercode_native_deletes_user_on_last_credential(
+async def test_clear_usercode_native_preserves_user_record(
     hass: HomeAssistant,
 ) -> None:
-    """Native clear removes the credential then the now-empty user."""
+    """Native clear removes the credential and leaves the slot's user in place.
+
+    The lock-side user is now an LCM-managed slot anchor: it persists for
+    the slot's whole lifetime so the slot keeps the same identity across
+    PIN cycles. Teardown happens only when the slot itself is removed
+    from LCM config (see ``async_release_managed_slot``).
+    """
     lock = _make_lock(hass, _NativeStubLock, "seam_clear_native")
     await lock.async_set_usercode(3, "9999", name="alice")
     lock.calls.clear()
     changed = await lock.async_clear_usercode(3)
     assert changed is True
-    assert lock.calls == [
-        ("delete_credential", 3, 3),
-        ("delete_user", 3),
-    ]
-    assert 3 not in lock._users
-
-
-async def test_clear_usercode_implicit_user_skips_delete_user(
-    hass: HomeAssistant,
-) -> None:
-    """
-    Implicit-user lock (e.g. Z-Wave User Code CC) skips the cleanup
-    ``async_delete_user`` call after a credential delete.
-
-    The credential delete already removed the user implicitly, so the
-    base lifecycle has nothing to clean up. Without this gate the base
-    would log a spurious warning on every clear because the driver
-    reports the user as already gone. Mirrors ``_set_credential``'s
-    ``_supports_user_records()`` gate on the set side.
-    """
-
-    class _ImplicitUserStubLock(_NativeStubLock):
-        async def async_get_capabilities(self) -> LockCapabilities:
-            # supports_user_management True (hardcoded by the driver for
-            # all Z-Wave locks), max_user_name_length 0 (UC has no
-            # names) -- the implicit-user signal.
-            return LockCapabilities(
-                supports_user_management=True,
-                max_users=30,
-                credential_types={
-                    CredentialType.PIN: CredentialTypeCapability(
-                        num_slots=30,
-                        min_length=4,
-                        max_length=8,
-                        supports_learn=False,
-                    ),
-                },
-                max_user_name_length=0,
-            )
-
-    lock = _make_lock(hass, _ImplicitUserStubLock, "seam_clear_implicit_user")
-    # Directly seed an implicit user; on a real User Code CC lock the
-    # driver creates this record inside the credential-write call.
-    lock._users[3] = User(
-        user_id=3,
-        credentials=[credential_from_slot(3, SlotCredential.known("9999"))],
-    )
-
-    changed = await lock.async_clear_usercode(3)
-
-    assert changed is True
-    # delete_credential ran; delete_user did NOT.
     assert lock.calls == [("delete_credential", 3, 3)]
+    assert 3 in lock._users
 
 
 async def test_clear_usercode_degenerate_no_user_op(hass: HomeAssistant) -> None:
@@ -717,17 +695,23 @@ async def test_clear_usercode_native_resolves_owner_when_user_id_not_slot(
     }
     changed = await lock.async_clear_usercode(5)
     assert changed is True
-    assert lock.calls == [
-        ("delete_credential", 12, 5),
-        ("delete_user", 12),
-    ]
-    assert 12 not in lock._users
+    # The ref is built from the resolved owner, so the credential delete
+    # targets user_id=12 / slot=5, not the slot index alone.
+    assert lock.calls == [("delete_credential", 12, 5)]
+    # User stays put -- lifecycle is decoupled from credential presence.
+    assert 12 in lock._users
 
 
-async def test_clear_usercode_native_keeps_user_with_other_credentials(
+async def test_clear_usercode_native_only_clears_the_targeted_credential(
     hass: HomeAssistant,
 ) -> None:
-    """Native clear deletes only the credential when the user has others."""
+    """Native clear touches only the targeted credential, never the user.
+
+    Verifies the multi-credential case: even when the lock-side user has
+    credentials beyond the one LCM is clearing (e.g. coexisting fingerprint
+    or RFID enrolled out-of-band), only the targeted PIN credential is
+    deleted. The user record and its other credentials stay put.
+    """
     lock = _make_lock(hass, _NativeStubLock, "seam_clear_multi_cred")
     lock._users = {
         4: User(
@@ -742,6 +726,7 @@ async def test_clear_usercode_native_keeps_user_with_other_credentials(
     assert changed is True
     assert lock.calls == [("delete_credential", 4, 4)]
     assert ("delete_user", 4) not in lock.calls
+    assert 4 in lock._users
 
 
 async def test_internal_set_usercode_drives_orchestration(
@@ -754,7 +739,7 @@ async def test_internal_set_usercode_drives_orchestration(
     # only the connection gate needs forcing to reach the orchestration.
     with patch.object(BaseLock, "async_is_integration_connected", return_value=True):
         await lock.async_internal_set_usercode(4, "4321", "carol")
-    assert ("set_user", 4, "carol") in lock.calls
+    assert ("set_user", 4, "lcm:4:carol") in lock.calls
     assert ("set_credential", 4, 4) in lock.calls
 
 
@@ -814,7 +799,7 @@ async def test_set_usercode_rolls_back_newly_created_user_on_failure(
     with pytest.raises(CodeRejectedError):
         await lock.async_set_usercode(3, "9999", name="alice")
     assert lock.calls == [
-        ("set_user", 3, "alice"),
+        ("set_user", 3, "lcm:3:alice"),
         ("set_credential", 3, 3),
         ("delete_user", 3),
     ]
@@ -837,28 +822,3 @@ async def test_set_usercode_keeps_pre_existing_user_on_failure(
         await lock.async_set_usercode(3, "9999", name="bob")
     assert ("delete_user", 3) not in lock.calls
     assert 3 in lock._users
-
-
-class _UserDeleteFailsLock(_NativeStubLock):
-    """Native stub whose user delete always fails."""
-
-    async def async_delete_user(self, user_id: int) -> None:
-        self.calls.append(("delete_user", user_id))
-        raise LockOperationFailed("user delete failed")
-
-
-async def test_clear_usercode_tolerates_user_delete_failure(
-    hass: HomeAssistant,
-) -> None:
-    """Clear still reports the credential change when the user delete fails."""
-    lock = _make_lock(hass, _UserDeleteFailsLock, "seam_clear_deluser_fail")
-    lock._users = {
-        4: User(
-            user_id=4,
-            credentials=[credential_from_slot(4, SlotCredential.known("1234"))],
-        )
-    }
-    changed = await lock.async_clear_usercode(4)
-    assert changed is True
-    assert ("delete_credential", 4, 4) in lock.calls
-    assert ("delete_user", 4) in lock.calls

--- a/tests/providers/test_util.py
+++ b/tests/providers/test_util.py
@@ -85,6 +85,10 @@ class TestParseTagWithRewrite:
             pytest.param(
                 "[LCM:5]Tight", (5, "Tight", True), id="legacy-no-space-after-bracket"
             ),
+            # Slot-only fallback -- written when the lock's
+            # max_user_name_length can't fit the canonical prefix.
+            pytest.param("5", (5, "", False), id="slot-only-single-digit"),
+            pytest.param("255", (255, "", False), id="slot-only-multi-digit"),
             # Untagged or malformed -- no match, no rewrite.
             pytest.param("Guest Code", (None, "Guest Code", False), id="untagged"),
             pytest.param("", (None, "", False), id="empty-string"),
@@ -137,6 +141,7 @@ class TestParseTag:
         [
             pytest.param("lcm:5:Alice", (5, "Alice"), id="new-format"),
             pytest.param("[LCM:5] Alice", (5, "Alice"), id="legacy-format"),
+            pytest.param("42", (42, ""), id="slot-only"),
             pytest.param("Alice", (None, "Alice"), id="untagged"),
             pytest.param("", (None, ""), id="empty"),
         ],

--- a/tests/providers/zwave_js/test_provider.py
+++ b/tests/providers/zwave_js/test_provider.py
@@ -347,11 +347,13 @@ async def test_async_internal_clear_usercode_calls_delete_primitives(
     zwave_integration: MockConfigEntry,
 ) -> None:
     """
-    Test that async_internal_clear_usercode drives the base drop-credential lifecycle.
+    Test that async_internal_clear_usercode deletes only the credential.
 
-    With supports_native_users=True, the base class resolves the credential owner
-    from async_get_users, then calls async_delete_credential and (when the user has no
-    remaining credentials) async_delete_user.
+    With supports_native_users=True the base class resolves the credential
+    owner from async_get_users and calls async_delete_credential. The user
+    record is now an LCM-managed slot anchor (per the user-tag idempotency
+    design) and survives PIN clear cycles -- teardown happens only via
+    async_release_managed_slot when the slot itself is removed from LCM.
     """
     lcm_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -384,10 +386,7 @@ async def test_async_internal_clear_usercode_calls_delete_primitives(
     await zwave_js_lock.async_internal_clear_usercode(1, source="sync")
 
     mock_lock_helpers["async_delete_credential"].assert_called_once()
-    # The user had exactly one credential so it should be deleted too
-    mock_lock_helpers["async_delete_user"].assert_called_once_with(
-        zwave_js_lock.node, 1
-    )
+    mock_lock_helpers["async_delete_user"].assert_not_called()
 
 
 # Device availability tests
@@ -1009,13 +1008,18 @@ async def test_async_set_user_writes_name_verbatim(
     )
 
 
-async def test_async_set_usercode_truncates_name_to_lock_limit(
+async def test_async_set_usercode_builds_tagged_name_within_lock_limit(
     hass: HomeAssistant,
     zwave_js_lock: ZWaveJSLock,
     mock_access_control: MagicMock,
     mock_lock_helpers: dict,
 ) -> None:
-    """End-to-end: ``async_set_usercode`` truncates per the cached limit."""
+    """End-to-end: ``async_set_usercode`` writes the LCM-tagged user name.
+
+    The base seam builds ``lcm:<slot>:<display>`` via
+    ``_build_tagged_user_name``, truncating the display so the full
+    tagged name fits the lock's advertised ``max_user_name_length``.
+    """
     lcm_entry = MockConfigEntry(
         domain=DOMAIN,
         data={
@@ -1029,7 +1033,8 @@ async def test_async_set_usercode_truncates_name_to_lock_limit(
         "supports_user_management": True,
         "max_users": 30,
         "supported_user_types": [],
-        "max_user_name_length": 5,
+        # "lcm:1:" prefix is 6 chars; 10-char limit leaves 4 for the display.
+        "max_user_name_length": 10,
         "supported_credential_rules": [],
         "supported_credential_types": {
             pin_type_str: {
@@ -1043,13 +1048,14 @@ async def test_async_set_usercode_truncates_name_to_lock_limit(
     mock_access_control.get_user_cached.return_value = None
     mock_lock_helpers["async_set_user"].return_value = {"user_id": 1}
 
-    # "alexandra" (9 chars) → truncated to "alexa" (5 chars) by the base.
+    # "alexandra" (9 chars) is the display; only "alex" fits after the
+    # tag prefix, so the lock-side name becomes "lcm:1:alex".
     await zwave_js_lock.async_set_usercode(1, "1234", name="alexandra")
 
     mock_lock_helpers["async_set_user"].assert_called_once_with(
         zwave_js_lock.node,
         user_id=1,
-        user_name="alexa",
+        user_name="lcm:1:alex",
         active=True,
     )
 


### PR DESCRIPTION
## Proposed change

Matter migrates to the canonical user-tag identity model from [project_user_tag_idempotency](../#) and the base seam decouples the lock-side user lifecycle from per-PIN clear cycles. The lock-side user is now a persistent slot anchor: created when a slot is first written, torn down only when the slot is removed from LCM config.

### Base / seam changes (commit 1)

- \`_truncate_user_name\` becomes \`_build_tagged_user_name(slot, display)\`. The seam now emits \`lcm:<slot>:<display>\` as the lock-stored user name, truncating only the display portion so the canonical prefix that \`parse_tag\` recovers stays intact.
- \`_delete_credential\` drops the \`was_only_credential\` / \`async_delete_user\` cleanup. Clear-and-rewrite cycles keep the user; only slot removal tears it down. Its \`owner\` parameter is removed (major release, internal API).
- New \`async_release_managed_slot(slot)\` BaseLock method: default no-op for slot-only providers; native-user providers override to delete the LCM-tagged user that anchors the slot.
- \`__init__.py\` wires the slot-teardown path: iterates \`diff.pairs_removed\` (previously unconsumed) inside the existing \`slots_to_remove\` block and calls \`async_release_managed_slot\` per (lock, slot) pair, tolerating \`LockDisconnected\` / \`LockOperationFailed\` so transient lock-side failures don't block teardown.

### Matter provider changes (commit 2)

- **\`async_set_user\` — find-or-create-by-tag** walks \`async_get_users()\` for a user whose \`user_name\` parses to the LCM slot (canonical \`lcm:<slot>:\` prefix). If found, UPDATE that \`user_index\`. If not, allocate a fresh \`user_index\` via \`set_lock_user(user_index=None)\` and return the Matter-assigned index.
- **Legacy adoption fallback prevents orphan PINs.** Before allocating fresh, fall back to "user owning a PIN at \`credential_index == slot\`" — pre-PR-B Matter LCM pinned \`credential_index\` to the LCM slot, so an untagged user owning a PIN at that index is almost certainly the LCM 2.0 user for this slot. Adopting it (rename in place, MODIFY the credential index) preserves a single user per slot across the upgrade. **Without this fallback, every upgrade would silently leave a pre-upgrade PIN active on the lock as an orphan.**
- **\`async_set_credential\` / \`async_delete_credential\` drop the \`credential_index = slot\` invariant.** The Matter credential index is rediscovered per call by walking the owning user's credentials. Set passes \`credential_index=existing\` for MODIFY or \`credential_index=None\` for CREATE (Matter auto-allocates). Delete clears at the rediscovered index.
- **Sync-duplicate retry only fires when LCM owns the duplicate.** An external duplicate (LCM has no PIN for the user) surfaces as \`DuplicateCodeError\` immediately — clearing it would step on another controller's credential.
- **\`async_release_managed_slot\` override** finds the LCM-owned user via the same find-or-adopt logic and deletes it. Matter's ClearUser cascade removes the PIN credential.

### Z-Wave UC, U3C, and slot-only providers

Unchanged in this PR. PR C will flip Z-Wave User Credential CC onto the same model and migrate the Schlage/Akuvox name-tag format. Z-Wave User Code CC stays implicit-user (no name field to tag).

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

This is **PR B** of the three-PR sequence laid out in the user-tag-idempotency design.

- **PR A** ([#1238](https://github.com/raman325/lock_code_manager/pull/1238), merged) — tolerant tag parser + canonical \`make_tagged_name\` / legacy \`make_legacy_tagged_name\` helpers in \`_util.py\`.
- **PR B (this PR)** — seam-level helper + lifecycle decoupling + Matter adoption + legacy-adoption migration.
- **PR C (next)** — Z-Wave User Credential CC migrates onto find-or-create-by-tag, Akuvox/Schlage write paths switch to the canonical format with read-time detect-and-rewrite.

**No startup migration in this PR** — the inline legacy-adoption fallback handles the orphan-PIN concern. Dormant slots (LCM-managed but never touched after upgrade) keep their untagged user names but are still correctly resolved on every operation via the legacy fallback. Cosmetic rename of dormant users can land as a follow-up if real-world feedback shows confusion.

Full suite: 1115/1115 pass.

- This PR is related to issue: continues the user-tag idempotency rollout (see \`project_user_tag_idempotency.md\`)