### PR TITLE
feat(zwave_js): adopt user-tag identity for User Credential CC locks

### DIFF
--- a/custom_components/lock_code_manager/providers/zwave_js.py
+++ b/custom_components/lock_code_manager/providers/zwave_js.py
@@ -59,6 +59,7 @@ from ..domain.exceptions import (
 )
 from ..domain.models import SlotCredential
 from ._base import BaseLock
+from ._util import parse_tag
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -237,26 +238,109 @@ class ZWaveJSLock(BaseLock):
 
     async def async_set_user(self, user: User) -> SetUserResult:
         """
-        Create or update the lock user; report whether it was created.
+        Find-or-create the lock user for the LCM slot encoded in ``user.name``.
 
-        ``created`` reflects whether the user existed BEFORE this call so
-        the base orchestration can roll back a user only newly created
-        here. Receives ``user`` with a name already truncated to the
-        lock's advertised limit by the base orchestration.
+        The base seam passes a tagged ``user.name`` (``lcm:<slot>:<display>``)
+        whose slot is the LCM-side identity for this credential. The Z-Wave
+        lock's own ``user_id`` is whatever Z-Wave happens to allocate; LCM
+        no longer pins it to the slot. Discovery on every call:
+
+        1. Scan the lock's current user list for a user whose name carries
+           the same ``lcm:<slot>:`` tag.
+        2. If found (UPDATE): rename via ``async_set_user`` with the
+           existing ``user_id``, return that id.
+        3. If not (legacy adoption): scan for an *untagged* user whose
+           ``user_id == slot`` that also owns a PIN at ``credential.slot
+           == slot``. Pre-PR-C LCM pinned ``user_id`` to the slot, so
+           such a user is almost certainly the LCM 2.0 user for this
+           slot. Adopting it preserves a single per-slot anchor across
+           the upgrade.
+        4. Otherwise (CREATE): allocate a fresh ``user_id`` via
+           ``async_set_user(user_id=None)`` (Z-Wave finds first free).
+
+        ``user.user_id`` set by the seam is used only as the slot identity
+        when ``user.name`` is untagged (defensive fallback; the seam
+        always passes a tagged name on this code path).
         """
+        slot = self._slot_from_seam_user(user)
+        existing_user_id = await self._find_user_index_for_slot(slot)
+        write_user_id: int | None = existing_user_id
         try:
-            existing = await self.node.access_control.get_user_cached(user.user_id)
             result = await lock_helpers.async_set_user(
                 self.node,
-                user_id=user.user_id,
+                user_id=write_user_id,
                 user_name=user.name,
                 active=user.active,
             )
         except BaseZwaveJSServerError as err:
-            raise LockDisconnected(f"set user {user.user_id} failed: {err}") from err
+            raise LockDisconnected(f"set user for slot {slot} failed: {err}") from err
         except HomeAssistantError as err:
-            raise LockOperationFailed(f"set user {user.user_id} failed: {err}") from err
-        return SetUserResult(user_id=result["user_id"], created=existing is None)
+            raise LockOperationFailed(
+                f"set user for slot {slot} failed: {err}"
+            ) from err
+        return SetUserResult(
+            user_id=result["user_id"], created=existing_user_id is None
+        )
+
+    def _slot_from_seam_user(self, user: User) -> int:
+        """
+        Return the LCM slot encoded in ``user.name`` or fall back to ``user_id``.
+
+        The base seam always passes a tagged name; this helper centralizes
+        the fallback so the rest of the provider can treat the resolved
+        slot as a single value.
+        """
+        if user.name:
+            slot, _ = parse_tag(user.name)
+            if slot is not None:
+                return slot
+        return user.user_id
+
+    async def _find_user_index_for_slot(self, slot: int) -> int | None:
+        """
+        Return the lock ``user_id`` LCM owns for ``slot``, if any.
+
+        Two lookups, in priority order:
+
+        1. **Canonical** -- a user whose name carries the ``lcm:<slot>:``
+           tag. This is the post-PR-C identity rule.
+        2. **Legacy adoption** -- an *untagged* user whose ``user_id ==
+           slot`` AND who owns a Personal Identification Number
+           credential at ``credential.slot == slot``. Pre-PR-C LCM pinned
+           ``user_id`` to the slot, so a user matching both halves of the
+           old invariant is almost certainly the LCM 2.0 user for this
+           slot. Adopting it (the subsequent ``async_set_user`` rewrites
+           the name to the tagged form) preserves a single identifiable
+           user per slot across the upgrade. Without this fallback the
+           new model would CREATE a second user every time, silently
+           leaving the pre-upgrade Personal Identification Number active
+           on the lock.
+
+           The legacy pass MUST skip users whose names already parse to
+           ANY LCM slot, so a user tagged for slot A is never adopted as
+           slot B's anchor.
+
+        Returns ``None`` when neither lookup matches.
+        """
+        users = await self.async_get_users()
+        try:
+            return next(
+                existing.user_id
+                for existing in users
+                if existing.name and parse_tag(existing.name)[0] == slot
+            )
+        except StopIteration:
+            return next(
+                (
+                    existing.user_id
+                    for existing in users
+                    if existing.user_id == slot
+                    and parse_tag(existing.name or "")[0] is None
+                    for cred in existing.pin_credentials
+                    if cred.slot == slot
+                ),
+                None,
+            )
 
     async def async_delete_user(self, user_id: int) -> None:
         """Delete the lock user (cascades its credentials)."""

--- a/tests/providers/zwave_js/test_provider.py
+++ b/tests/providers/zwave_js/test_provider.py
@@ -638,56 +638,157 @@ async def test_async_get_capabilities_maps_lock_helpers_response(
 # Write primitive tests (Task 2)
 
 
-async def test_async_set_user_returns_created_when_user_absent(
+async def test_async_set_user_returns_created_when_no_tagged_user_exists(
     zwave_js_lock: ZWaveJSLock,
     mock_access_control: MagicMock,
     mock_lock_helpers: dict,
 ) -> None:
     """
-    Test async_set_user reports created=True when no existing user is found.
+    ``async_set_user`` reports ``created=True`` and allocates a new user_id.
 
-    When get_user_cached returns None the user does not yet exist on the lock,
-    so SetUserResult.created must be True. The helper is called with the correct
-    node, user_id, user_name, and active values.
+    With no existing tagged user for slot 5 (and no legacy adoption
+    target), the provider delegates to the upstream helper with
+    ``user_id=None`` so Z-Wave finds the first free user_id. The
+    returned ``user_id`` carries the allocated value.
     """
-    mock_access_control.get_user_cached.return_value = None
-    mock_lock_helpers["async_set_user"].return_value = {"user_id": 5}
+    mock_access_control.get_users_cached.return_value = []
+    mock_access_control.get_all_credentials_cached.return_value = []
+    mock_lock_helpers["async_set_user"].return_value = {"user_id": 12}
 
-    user = User(user_id=5, name="alice", active=True)
+    user = User(user_id=5, name="lcm:5:alice", active=True)
     result = await zwave_js_lock.async_set_user(user)
 
-    assert result == SetUserResult(user_id=5, created=True)
+    assert result == SetUserResult(user_id=12, created=True)
     mock_lock_helpers["async_set_user"].assert_called_once_with(
         zwave_js_lock.node,
-        user_id=5,
-        user_name="alice",
+        user_id=None,
+        user_name="lcm:5:alice",
         active=True,
     )
 
 
-async def test_async_set_user_returns_not_created_when_user_exists(
+async def test_async_set_user_returns_not_created_when_tagged_user_exists(
     zwave_js_lock: ZWaveJSLock,
     mock_access_control: MagicMock,
     mock_lock_helpers: dict,
 ) -> None:
     """
-    Test async_set_user reports created=False when the user already exists.
+    ``async_set_user`` reports ``created=False`` when a tagged user already exists.
 
-    When get_user_cached returns a UserData object the slot is being updated,
-    not created, so SetUserResult.created must be False.
+    Seeds a lock user at ``user_id=17`` whose name carries the
+    ``lcm:3:`` tag; the provider must discover it via the tag (NOT via
+    ``user_id == slot``) and dispatch an UPDATE to that user_id, not a
+    CREATE.
     """
-    mock_access_control.get_user_cached.return_value = UserData(
-        user_id=3,
-        active=True,
-        user_type=UserCredentialUserType.GENERAL,
-        user_name="bob",
-    )
-    mock_lock_helpers["async_set_user"].return_value = {"user_id": 3}
+    mock_access_control.get_users_cached.return_value = [
+        UserData(
+            user_id=17,
+            active=True,
+            user_type=UserCredentialUserType.GENERAL,
+            user_name="lcm:3:bob",
+        ),
+    ]
+    mock_access_control.get_all_credentials_cached.return_value = []
+    mock_lock_helpers["async_set_user"].return_value = {"user_id": 17}
 
-    user = User(user_id=3, name="bob", active=True)
+    user = User(user_id=3, name="lcm:3:bob", active=True)
     result = await zwave_js_lock.async_set_user(user)
 
-    assert result == SetUserResult(user_id=3, created=False)
+    assert result == SetUserResult(user_id=17, created=False)
+    mock_lock_helpers["async_set_user"].assert_called_once_with(
+        zwave_js_lock.node,
+        user_id=17,
+        user_name="lcm:3:bob",
+        active=True,
+    )
+
+
+async def test_async_set_user_adopts_legacy_user_at_user_id_equals_slot(
+    zwave_js_lock: ZWaveJSLock,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
+) -> None:
+    """
+    Pre-PR-C upgrade path: adopt an untagged user at ``user_id == slot``.
+
+    Pre-PR-C LCM pinned ``user_id`` to the LCM slot. On the first
+    write after upgrade, the new code must find that legacy user (it
+    has no tag, but it sits at the old invariant) and UPDATE it rather
+    than CREATE a second user, preserving the existing PIN credential.
+    """
+    mock_access_control.get_users_cached.return_value = [
+        UserData(
+            user_id=4,  # legacy user_id == LCM slot
+            active=True,
+            user_type=UserCredentialUserType.GENERAL,
+            user_name="Carol",  # untagged
+        ),
+    ]
+    mock_access_control.get_all_credentials_cached.return_value = [
+        CredentialData(
+            user_id=4,
+            type=UserCredentialType.PIN_CODE,
+            slot=4,  # legacy credential.slot == LCM slot
+            data="1234",
+        ),
+    ]
+    mock_lock_helpers["async_set_user"].return_value = {"user_id": 4}
+
+    user = User(user_id=4, name="lcm:4:carol", active=True)
+    result = await zwave_js_lock.async_set_user(user)
+
+    assert result == SetUserResult(user_id=4, created=False)
+    mock_lock_helpers["async_set_user"].assert_called_once_with(
+        zwave_js_lock.node,
+        user_id=4,
+        user_name="lcm:4:carol",
+        active=True,
+    )
+
+
+async def test_async_set_user_legacy_pass_skips_users_tagged_for_other_slots(
+    zwave_js_lock: ZWaveJSLock,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
+) -> None:
+    """
+    Legacy adoption must not steal a user already tagged for a different slot.
+
+    The legacy probe matches ``user_id == slot`` AND a PIN at the same
+    slot. A user that happens to satisfy both halves but already
+    carries an LCM tag for a *different* slot is NOT the slot's legacy
+    anchor; adopting it would re-bind one slot's user as another
+    slot's anchor and silently corrupt both slots' state.
+    """
+    mock_access_control.get_users_cached.return_value = [
+        UserData(
+            user_id=2,
+            active=True,
+            user_type=UserCredentialUserType.GENERAL,
+            user_name="lcm:9:elsewhere",  # tagged for slot 9, not 2
+        ),
+    ]
+    mock_access_control.get_all_credentials_cached.return_value = [
+        CredentialData(
+            user_id=2,
+            type=UserCredentialType.PIN_CODE,
+            slot=2,
+            data="0000",
+        ),
+    ]
+    mock_lock_helpers["async_set_user"].return_value = {"user_id": 88}
+
+    user = User(user_id=2, name="lcm:2:newcomer", active=True)
+    result = await zwave_js_lock.async_set_user(user)
+
+    # Legacy pass skipped -> CREATE, not adoption.
+    assert result == SetUserResult(user_id=88, created=True)
+    mock_lock_helpers["async_set_user"].assert_called_once_with(
+        zwave_js_lock.node,
+        user_id=None,
+        user_name="lcm:2:newcomer",
+        active=True,
+    )
 
 
 async def test_async_set_credential_returns_true_on_success(
@@ -986,24 +1087,25 @@ async def test_async_set_user_writes_name_verbatim(
     mock_lock_helpers: dict,
 ) -> None:
     """
-    Provider primitive writes user.name as-is.
+    Provider primitive writes ``user.name`` as-is.
 
-    Truncation is the base orchestration's responsibility (applied in
-    ``_set_credential`` before the call); the provider receives a User
-    with the name already shaped to the lock's limit and writes it
-    verbatim. End-to-end truncation behavior is covered through
-    ``async_set_usercode`` below.
+    Truncation and tagging are the base orchestration's responsibility
+    (applied in ``_set_credential`` via ``_build_tagged_user_name``);
+    the provider receives a User with the name already shaped and
+    writes it verbatim. End-to-end truncation behavior is covered
+    through ``async_set_usercode`` below.
     """
-    mock_access_control.get_user_cached.return_value = None
-    mock_lock_helpers["async_set_user"].return_value = {"user_id": 1}
+    mock_access_control.get_users_cached.return_value = []
+    mock_access_control.get_all_credentials_cached.return_value = []
+    mock_lock_helpers["async_set_user"].return_value = {"user_id": 7}
 
-    user = User(user_id=1, name="alice", active=True)
+    user = User(user_id=1, name="lcm:1:alice", active=True)
     await zwave_js_lock.async_set_user(user)
 
     mock_lock_helpers["async_set_user"].assert_called_once_with(
         zwave_js_lock.node,
-        user_id=1,
-        user_name="alice",
+        user_id=None,
+        user_name="lcm:1:alice",
         active=True,
     )
 
@@ -1045,7 +1147,8 @@ async def test_async_set_usercode_builds_tagged_name_within_lock_limit(
             }
         },
     }
-    mock_access_control.get_user_cached.return_value = None
+    mock_access_control.get_users_cached.return_value = []
+    mock_access_control.get_all_credentials_cached.return_value = []
     mock_lock_helpers["async_set_user"].return_value = {"user_id": 1}
 
     # "alexandra" (9 chars) is the display; only "alex" fits after the
@@ -1054,7 +1157,7 @@ async def test_async_set_usercode_builds_tagged_name_within_lock_limit(
 
     mock_lock_helpers["async_set_user"].assert_called_once_with(
         zwave_js_lock.node,
-        user_id=1,
+        user_id=None,
         user_name="lcm:1:alex",
         active=True,
     )


### PR DESCRIPTION
## Proposed change

Completes the user-tag idempotency rollout for Z-Wave User Credential CC (U3C) locks, mirroring the Matter work landed in #1239.

The Z-Wave provider now identifies its own lock users by the canonical `lcm:<slot>:<display>` tag instead of pinning `user_id == LCM slot`. On every write, `async_set_user` scans the lock's user list:

1. **Canonical** — if a user already carries the `lcm:<slot>:` tag, UPDATE that user's name in place (preserves its `user_id` and any existing credentials).
2. **Legacy adoption** — otherwise, scan for an *untagged* user at `user_id == slot` owning a PIN at `credential.slot == slot`. Such a user is almost certainly an LCM 2.0 user; adopting it preserves the per-slot identity (and its existing PIN) across the upgrade. The legacy pass skips users already tagged for any LCM slot so a slot-A user is never re-bound as slot-B's anchor.
3. **CREATE** — if neither matches, delegate to `lock_helpers.async_set_user(user_id=None)` so Z-Wave auto-allocates the first free `user_id`.

Unlike Matter, Z-Wave U3C credential indices stay bound to LCM slots (the upstream API doesn't auto-allocate `credential.slot` the way Matter auto-allocates `credential_index`). This PR therefore does **not** need a projection layer in `async_get_users` or any rework of the push event handler — `credential.slot` is already the LCM slot the seam expects.

Regression coverage:
- find tagged user (UPDATE with a non-matching `user_id`, pinning that the lookup is by tag, not by `user_id`)
- CREATE path (no tagged or legacy user → `user_id=None` to Z-Wave)
- legacy adoption (untagged user at `user_id == slot` owning a PIN at the same slot → UPDATE)
- cross-slot contamination (a user tagged for slot 9 sitting at `user_id == 2` with a PIN at slot 2 must NOT be adopted as slot 2's anchor → CREATE, not UPDATE)

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- Part of the user-tag idempotency rollout (#1238, #1239 already merged)
- Schlage/Akuvox legacy-format detect-and-rewrite migration ships as a follow-up (PR C2)

## Test plan

- [x] Full suite passes locally (1151/1151)
- [ ] Live Z-Wave U3C lock — find-or-create-by-tag round-trip on a clean install
- [ ] Live Z-Wave U3C lock — legacy adoption on an upgraded install (LCM 2.0 user present at \`user_id == slot\`)
- [ ] Live Z-Wave UC (User Code CC, legacy) lock — unchanged behavior (no user-name field; capability gate short-circuits to the slot-only path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)