### PR TITLE
feat(akuvox, schlage): converge legacy tag format to canonical lcm:<slot>:

### DIFF
--- a/custom_components/lock_code_manager/providers/akuvox.py
+++ b/custom_components/lock_code_manager/providers/akuvox.py
@@ -28,7 +28,7 @@ from ..domain.exceptions import (
 )
 from ..domain.models import SlotCredential
 from ._base import BaseLock
-from ._util import make_legacy_tagged_name as _make_tagged_name, parse_tag as _parse_tag
+from ._util import make_tagged_name as _make_tagged_name, parse_tag as _parse_tag
 from .const import LOGGER
 
 AKUVOX_DOMAIN = "local_akuvox"

--- a/custom_components/lock_code_manager/providers/schlage.py
+++ b/custom_components/lock_code_manager/providers/schlage.py
@@ -34,7 +34,7 @@ from ..domain.exceptions import (
 )
 from ..domain.models import SlotCredential
 from ._base import BaseLock
-from ._util import make_legacy_tagged_name as _make_tagged_name, parse_tag as _parse_tag
+from ._util import make_tagged_name as _make_tagged_name, parse_tag as _parse_tag
 from .const import LOGGER
 
 SCHLAGE_DOMAIN = "schlage"

--- a/tests/providers/akuvox/test_e2e.py
+++ b/tests/providers/akuvox/test_e2e.py
@@ -83,7 +83,7 @@ class TestSetAndClearCredentials:
         akuvox_mock_services["list_users"] = AsyncMock(
             return_value={
                 entity_id: {
-                    "users": [make_user("100", "[LCM:1] Existing", "1234")],
+                    "users": [make_user("100", "lcm:1:Existing", "1234")],
                 },
             }
         )
@@ -117,7 +117,7 @@ class TestSetAndClearCredentials:
         akuvox_mock_services["list_users"] = AsyncMock(
             return_value={
                 entity_id: {
-                    "users": [make_user("100", "[LCM:1] Guest", "1234")],
+                    "users": [make_user("100", "lcm:1:Guest", "1234")],
                 },
             }
         )
@@ -159,7 +159,7 @@ class TestSetAndClearCredentials:
         akuvox_mock_services["list_users"] = AsyncMock(
             return_value={
                 entity_id: {
-                    "users": [make_user("100", "[LCM:1] Guest", "1234")],
+                    "users": [make_user("100", "lcm:1:Guest", "1234")],
                 },
             }
         )
@@ -196,7 +196,7 @@ class TestGetUsers:
         akuvox_mock_services["list_users"] = AsyncMock(
             return_value={
                 entity_id: {
-                    "users": [make_user("100", "[LCM:1] Guest", "4321")],
+                    "users": [make_user("100", "lcm:1:Guest", "4321")],
                 },
             }
         )
@@ -223,7 +223,7 @@ class TestGetUsers:
         akuvox_mock_services["list_users"] = AsyncMock(
             return_value={
                 entity_id: {
-                    "users": [make_user("100", "[LCM:1] Guest", "4321")],
+                    "users": [make_user("100", "lcm:1:Guest", "4321")],
                 },
             }
         )

--- a/tests/providers/akuvox/test_provider.py
+++ b/tests/providers/akuvox/test_provider.py
@@ -61,9 +61,9 @@ class TestHelperFunctions:
     @pytest.mark.parametrize(
         ("slot", "name", "expected"),
         [
-            pytest.param(1, "Guest", "[LCM:1] Guest", id="with-name"),
-            pytest.param(5, None, "[LCM:5] Code Slot 5", id="without-name"),
-            pytest.param(3, None, "[LCM:3] Code Slot 3", id="none-name"),
+            pytest.param(1, "Guest", "lcm:1:Guest", id="with-name"),
+            pytest.param(5, None, "lcm:5:Code Slot 5", id="without-name"),
+            pytest.param(3, None, "lcm:3:Code Slot 3", id="none-name"),
         ],
     )
     def test_make_tagged_name(self, slot: int, name: str | None, expected: str) -> None:
@@ -275,7 +275,7 @@ class TestGetUsers:
         mock_response = {
             LOCK_ENTITY_ID: {
                 "users": [
-                    make_user("400", "[LCM:1] Empty Slot", ""),
+                    make_user("400", "lcm:1:Empty Slot", ""),
                 ],
             },
         }
@@ -297,7 +297,7 @@ class TestGetUsers:
         mock_response = {
             LOCK_ENTITY_ID: {
                 "users": [
-                    make_user("500", "[LCM:99] Outside", "5555"),
+                    make_user("500", "lcm:99:Outside", "5555"),
                 ],
             },
         }
@@ -322,7 +322,7 @@ class TestGetUsers:
         mock_response = {
             LOCK_ENTITY_ID: {
                 "users": [
-                    make_user("100", "[LCM:1] Guest", "4321"),
+                    make_user("100", "lcm:1:Guest", "4321"),
                 ],
             },
         }
@@ -348,6 +348,50 @@ class TestSetCredential:
         self, hass: HomeAssistant, akuvox_lock: AkuvoxLock
     ) -> None:
         """Test setting a credential without a name preserves the existing name."""
+        list_response = {
+            LOCK_ENTITY_ID: {
+                "users": [
+                    make_user("100", "lcm:1:Guest", "1234"),
+                ],
+            },
+        }
+        register_mock_service(
+            hass, AKUVOX_DOMAIN, "list_users", AsyncMock(return_value=list_response)
+        )
+
+        modify_calls: list[dict[str, Any]] = []
+
+        async def _capture_modify(call):
+            modify_calls.append(dict(call.data))
+
+        register_mock_service(
+            hass, AKUVOX_DOMAIN, "modify_user", AsyncMock(side_effect=_capture_modify)
+        )
+
+        result = await akuvox_lock.async_set_credential(
+            1,
+            _pin_cred(1, "9999"),
+            "9999",
+            name=None,
+            source="direct",
+        )
+
+        assert result is True
+        assert modify_calls[0]["name"] == "lcm:1:Guest"
+
+    async def test_set_credential_migrates_legacy_format_tag_on_write(
+        self, hass: HomeAssistant, akuvox_lock: AkuvoxLock
+    ) -> None:
+        """
+        Touching a legacy ``[LCM:<slot>]``-tagged user rewrites it to canonical.
+
+        Pre-PR-C installs have users named ``[LCM:1] Guest``. The
+        tolerant parser (added in #1238) discovers them by slot, so
+        the provider finds the user at slot 1; the rewrite happens
+        implicitly because ``_make_tagged_name`` now produces the
+        canonical format. The next modify_user call carries the
+        canonical name, completing the per-user migration.
+        """
         list_response = {
             LOCK_ENTITY_ID: {
                 "users": [
@@ -377,7 +421,8 @@ class TestSetCredential:
         )
 
         assert result is True
-        assert modify_calls[0]["name"] == "[LCM:1] Guest"
+        # Friendly portion preserved verbatim; only the format changed.
+        assert modify_calls[0]["name"] == "lcm:1:Guest"
 
     async def test_set_credential_service_failure(
         self, hass: HomeAssistant, akuvox_lock: AkuvoxLock
@@ -431,7 +476,7 @@ class TestDeleteCredential:
         list_response = {
             LOCK_ENTITY_ID: {
                 "users": [
-                    make_user("100", "[LCM:1] Guest", "1234"),
+                    make_user("100", "lcm:1:Guest", "1234"),
                 ],
             },
         }
@@ -557,7 +602,7 @@ class TestAutoTagging:
 
         assert len(modify_calls) == 1
         assert modify_calls[0]["id"] == "200"
-        assert modify_calls[0]["name"] == "[LCM:1] Visitor"
+        assert modify_calls[0]["name"] == "lcm:1:Visitor"
 
     async def test_failed_modify_does_not_consume_slot(
         self,
@@ -596,7 +641,7 @@ class TestAutoTagging:
         # First modify failed so slot 1 should be reused for the second user
         assert len(modify_calls) == 1
         assert modify_calls[0]["id"] == "201"
-        assert modify_calls[0]["name"] == "[LCM:1] Visitor B"
+        assert modify_calls[0]["name"] == "lcm:1:Visitor B"
 
     async def test_no_managed_slots_is_noop(
         self,
@@ -730,7 +775,7 @@ class TestHardRefresh:
         }
         tagged_response = {
             LOCK_ENTITY_ID: {
-                "users": [make_user("200", "[LCM:1] Visitor", "9999")],
+                "users": [make_user("200", "lcm:1:Visitor", "9999")],
             },
         }
         list_handler = AsyncMock(side_effect=[untagged_response, tagged_response])
@@ -777,7 +822,7 @@ class TestBaseOrchestration:
         # After setting, the mock now returns the tagged user with the PIN
         after_response = {
             LOCK_ENTITY_ID: {
-                "users": [make_user("100", "[LCM:1] base_test", "7777")],
+                "users": [make_user("100", "lcm:1:base_test", "7777")],
             },
         }
         register_mock_service(
@@ -797,7 +842,7 @@ class TestBaseOrchestration:
         """async_delete_credential + async_get_usercodes base projection shows empty."""
         with_user = {
             LOCK_ENTITY_ID: {
-                "users": [make_user("100", "[LCM:1] Guest", "1234")],
+                "users": [make_user("100", "lcm:1:Guest", "1234")],
             },
         }
         register_mock_service(

--- a/tests/providers/schlage/test_e2e.py
+++ b/tests/providers/schlage/test_e2e.py
@@ -67,7 +67,7 @@ class TestSetAndClearCredentials:
         assert result is True
         assert schlage_mock_services["add_code"].call_count >= 1
         add_call = schlage_mock_services["add_code"].call_args[0][0]
-        assert add_call.data["name"] == "[LCM:1] Test User"
+        assert add_call.data["name"] == "lcm:1:Test User"
         assert add_call.data["code"] == "9999"
 
     async def test_delete_credential(
@@ -84,7 +84,7 @@ class TestSetAndClearCredentials:
         schlage_mock_services["get_codes"] = AsyncMock(
             return_value={
                 entity_id: {
-                    "code1": {"name": "[LCM:1] Guest", "code": "****"},
+                    "code1": {"name": "lcm:1:Guest", "code": "****"},
                 },
             }
         )
@@ -113,7 +113,7 @@ class TestSetAndClearCredentials:
         # internal returns None (fires coordinator refresh) — check service call
         assert schlage_mock_services["add_code"].call_count >= 1
         add_call = schlage_mock_services["add_code"].call_args[0][0]
-        assert add_call.data["name"] == "[LCM:1] Test User"
+        assert add_call.data["name"] == "lcm:1:Test User"
         assert add_call.data["code"] == "9999"
 
     async def test_coordinator_reflects_set_credential(
@@ -135,7 +135,7 @@ class TestSetAndClearCredentials:
         schlage_mock_services["get_codes"] = AsyncMock(
             return_value={
                 entity_id: {
-                    "code1": {"name": "[LCM:1] Test User", "code": "****"},
+                    "code1": {"name": "lcm:1:Test User", "code": "****"},
                 },
             }
         )
@@ -193,7 +193,7 @@ class TestGetUsers:
         schlage_mock_services["get_codes"] = AsyncMock(
             return_value={
                 entity_id: {
-                    "code1": {"name": "[LCM:1] Guest", "code": "****"},
+                    "code1": {"name": "lcm:1:Guest", "code": "****"},
                 },
             }
         )
@@ -225,7 +225,7 @@ class TestGetUsers:
         schlage_mock_services["get_codes"] = AsyncMock(
             return_value={
                 entity_id: {
-                    "code1": {"name": "[LCM:1] Guest", "code": "****"},
+                    "code1": {"name": "lcm:1:Guest", "code": "****"},
                 },
             }
         )

--- a/tests/providers/schlage/test_provider.py
+++ b/tests/providers/schlage/test_provider.py
@@ -60,9 +60,9 @@ class TestMakeTaggedName:
     @pytest.mark.parametrize(
         ("slot", "name", "expected"),
         [
-            pytest.param(1, "Guest", "[LCM:1] Guest", id="with-name"),
-            pytest.param(5, None, "[LCM:5] Code Slot 5", id="without-name"),
-            pytest.param(3, None, "[LCM:3] Code Slot 3", id="none-name"),
+            pytest.param(1, "Guest", "lcm:1:Guest", id="with-name"),
+            pytest.param(5, None, "lcm:5:Code Slot 5", id="without-name"),
+            pytest.param(3, None, "lcm:3:Code Slot 3", id="none-name"),
         ],
     )
     def test_make_tagged_name(self, slot: int, name: str | None, expected: str) -> None:
@@ -213,8 +213,8 @@ async def test_get_users_duplicate_tag_uses_first(
     """Test that duplicate tags for the same slot use the first (by code_id sort)."""
     mock_response = {
         LOCK_ENTITY_ID: {
-            "code_a": {"name": "[LCM:1] First", "code": "****"},
-            "code_b": {"name": "[LCM:1] Second", "code": "****"},
+            "code_a": {"name": "lcm:1:First", "code": "****"},
+            "code_b": {"name": "lcm:1:Second", "code": "****"},
         },
     }
     handler = AsyncMock(return_value=mock_response)
@@ -235,7 +235,7 @@ async def test_get_users_ignores_tags_outside_managed_range(
     """Test that tagged codes outside managed slots are ignored."""
     mock_response = {
         LOCK_ENTITY_ID: {
-            "code1": {"name": "[LCM:99] Outside", "code": "****"},
+            "code1": {"name": "lcm:99:Outside", "code": "****"},
         },
     }
     handler = AsyncMock(return_value=mock_response)
@@ -276,7 +276,7 @@ async def test_tag_unmanaged_codes(
     # Verify add_code was called with the tagged name
     assert add_handler.call_count == 1
     add_call = add_handler.call_args[0][0]
-    assert add_call.data["name"] == "[LCM:1] Guest"
+    assert add_call.data["name"] == "lcm:1:Guest"
     assert add_call.data["code"] == "1234"
 
     # Verify delete_code was called to remove the original
@@ -521,7 +521,7 @@ async def test_set_credential_replaces_existing(
     """Test async_set_credential replaces an existing code on the same slot."""
     get_response = {
         LOCK_ENTITY_ID: {
-            "code1": {"name": "[LCM:1] Old Name", "code": "****"},
+            "code1": {"name": "lcm:1:Old Name", "code": "****"},
         },
     }
     get_handler = AsyncMock(return_value=get_response)
@@ -542,12 +542,12 @@ async def test_set_credential_replaces_existing(
     assert result is True
     # add_code called with new tagged name
     add_call = add_handler.call_args[0][0]
-    assert add_call.data["name"] == "[LCM:1] New Name"
+    assert add_call.data["name"] == "lcm:1:New Name"
     assert add_call.data["code"] == "5678"
     # Both old name and new tagged name deleted (eventual consistency guard)
     assert delete_handler.call_count == 2
     deleted_names = {call[0][0].data["name"] for call in delete_handler.call_args_list}
-    assert deleted_names == {"[LCM:1] Old Name", "[LCM:1] New Name"}
+    assert deleted_names == {"lcm:1:Old Name", "lcm:1:New Name"}
 
 
 async def test_set_credential_preserves_existing_name(
@@ -561,7 +561,7 @@ async def test_set_credential_preserves_existing_name(
     """
     get_response = {
         LOCK_ENTITY_ID: {
-            "code1": {"name": "[LCM:1] Guest", "code": "****"},
+            "code1": {"name": "lcm:1:Guest", "code": "****"},
         },
     }
     get_handler = AsyncMock(return_value=get_response)
@@ -588,12 +588,59 @@ async def test_set_credential_preserves_existing_name(
     # Name unchanged so existing_full_name == tagged_name, deduplicated to 1 delete
     assert delete_handler.call_count == 1
     delete_call = delete_handler.call_args[0][0]
-    assert delete_call.data["name"] == "[LCM:1] Guest"
+    assert delete_call.data["name"] == "lcm:1:Guest"
     assert add_handler.call_count == 1
     add_call = add_handler.call_args[0][0]
-    assert add_call.data["name"] == "[LCM:1] Guest"
+    assert add_call.data["name"] == "lcm:1:Guest"
     assert add_call.data["code"] == "9999"
     assert call_order == ["delete", "add"]
+
+
+async def test_set_credential_migrates_legacy_format_tag_on_write(
+    hass: HomeAssistant, schlage_lock: SchlageLock
+) -> None:
+    """
+    Touching a legacy ``[LCM:<slot>]``-tagged code rewrites it to ``lcm:<slot>:`` on the next write.
+
+    Pre-PR-C installs have codes named ``[LCM:1] Old``. The tolerant
+    parser already discovers them by slot (via #1238), so the provider
+    finds the code at slot 1; the rewrite happens implicitly because
+    ``_make_tagged_name`` now produces the canonical format. The lock
+    sees a delete of the legacy name and an add of the canonical
+    name, completing the per-code migration.
+    """
+    get_response = {
+        LOCK_ENTITY_ID: {
+            "code1": {"name": "[LCM:1] Guest", "code": "****"},
+        },
+    }
+    get_handler = AsyncMock(return_value=get_response)
+    add_handler = AsyncMock(return_value=None)
+    delete_handler = AsyncMock(return_value=None)
+    register_mock_service(hass, SCHLAGE_DOMAIN, "get_codes", get_handler)
+    register_mock_service(hass, SCHLAGE_DOMAIN, "add_code", add_handler)
+    register_mock_service(hass, SCHLAGE_DOMAIN, "delete_code", delete_handler)
+
+    deleted_names: set[str] = set()
+    delete_handler.side_effect = lambda call: deleted_names.add(call.data["name"])
+
+    result = await schlage_lock.async_set_credential(
+        1,
+        _pin_cred(1, "9999"),
+        "9999",
+        name=None,
+        source="direct",
+    )
+
+    assert result is True
+    add_call = add_handler.call_args[0][0]
+    # The new value is written under the canonical tag, NOT the legacy tag.
+    assert add_call.data["name"] == "lcm:1:Guest"
+    # The legacy-tagged code is cleaned up. (Both names show up if the
+    # provider deletes the pre-existing legacy entry and the new entry
+    # in a single transaction; the important assertion is that the
+    # legacy name is gone after the write completes.)
+    assert "[LCM:1] Guest" in deleted_names
 
 
 async def test_set_credential_already_exists_treated_as_success(
@@ -610,7 +657,7 @@ async def test_set_credential_already_exists_treated_as_success(
     get_handler = AsyncMock(return_value=get_response)
     add_handler = AsyncMock(
         side_effect=HomeAssistantError(
-            'A PIN code with the name "[LCM:1] Guest" already exists on the lock'
+            'A PIN code with the name "lcm:1:Guest" already exists on the lock'
         )
     )
     delete_handler = AsyncMock(return_value=None)
@@ -695,7 +742,7 @@ async def test_delete_credential_service_failure(
     """Test that async_delete_credential raises LockOperationFailed on service failure."""
     get_response = {
         LOCK_ENTITY_ID: {
-            "code1": {"name": "[LCM:1] Guest", "code": "****"},
+            "code1": {"name": "lcm:1:Guest", "code": "****"},
         },
     }
     get_handler = AsyncMock(return_value=get_response)
@@ -720,7 +767,7 @@ async def test_hard_refresh_codes(
     """Test hard_refresh_codes calls tagging then returns usercodes via base projection."""
     mock_response = {
         LOCK_ENTITY_ID: {
-            "code1": {"name": "[LCM:2] Family", "code": "****"},
+            "code1": {"name": "lcm:2:Family", "code": "****"},
         },
     }
     handler = AsyncMock(return_value=mock_response)
@@ -810,7 +857,7 @@ async def test_base_orchestration_set_and_get(
     )
 
     # After setting, the lock reports the slot as unreadable (write-only Personal Identification Number)
-    mock_after = {LOCK_ENTITY_ID: {"c1": {"name": "[LCM:1] test", "code": "****"}}}
+    mock_after = {LOCK_ENTITY_ID: {"c1": {"name": "lcm:1:test", "code": "****"}}}
     register_mock_service(
         hass, SCHLAGE_DOMAIN, "get_codes", AsyncMock(return_value=mock_after)
     )
@@ -826,7 +873,7 @@ async def test_base_orchestration_clear(
     simple_lcm_config_entry: MockConfigEntry,
 ) -> None:
     """async_delete_credential + async_get_usercodes (base projection) shows empty after clear."""
-    get_response = {LOCK_ENTITY_ID: {"c1": {"name": "[LCM:1] Guest", "code": "****"}}}
+    get_response = {LOCK_ENTITY_ID: {"c1": {"name": "lcm:1:Guest", "code": "****"}}}
     register_mock_service(
         hass, SCHLAGE_DOMAIN, "get_codes", AsyncMock(return_value=get_response)
     )


### PR DESCRIPTION
## Proposed change

Final piece of the user-tag idempotency rollout. Akuvox and Schlage have used a slot-encoding tag (`[LCM:<slot>] <friendly name>`) since they identify codes by name rather than slot — same purpose, same mechanism, different format from what Matter and Z-Wave now use. This PR converges them on the canonical `lcm:<slot>:<friendly name>` format introduced in #1239, so every provider that needs a name-side tag uses the same convention.

### How it works

A single import swap per provider: the local `_make_tagged_name` alias now points at the canonical builder (`make_tagged_name`) instead of the deprecated legacy builder (`make_legacy_tagged_name`). Every existing call site that writes a tagged name now emits canonical format; no other code changes needed.

### Migration

Migration is implicit and per-code/per-user, not a one-shot sweep:

1. `_parse_tag` already accepts **both** formats (the tolerant parser landed in #1238), so legacy-tagged codes are still discovered correctly by slot.
2. On the next write that touches a code/user (set, replace, name change), the provider's `async_set_credential` recomputes the tagged name via `_make_tagged_name` (now canonical) and rewrites the lock-stored name.
3. The friendly portion is preserved verbatim.

For a code LCM never touches after the upgrade, the legacy tag stays — and continues to work because the parser accepts it. The format converges as installs see normal LCM activity.

### Regression coverage

- **Schlage** `test_set_credential_migrates_legacy_format_tag_on_write` — seeds a `[LCM:1] Guest` code, asserts the post-write code is named `lcm:1:Guest` and the legacy entry is cleaned up.
- **Akuvox** same shape — the `modify_user` call carries the canonical name.

Existing tests were swept: per-provider fixture seeds were converted from legacy to canonical format (representing the post-migration steady state). The `parse_tag` parametrize tests intentionally **keep** the legacy strings so the tolerant parser's back-compat behavior stays pinned; if the legacy branch is ever removed from `_util.py`, those tests will catch it.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- Closes the user-tag idempotency rollout: #1238 (tolerant parser + canonical builder) → #1239 (Matter adoption) → #1240 (Z-Wave U3C adoption) → this PR (Akuvox/Schlage format convergence)
- The legacy `make_legacy_tagged_name` helper in `_util.py` is no longer referenced by any provider. Keeping it for the upgrade window; can be removed in a future release once existing installs have rotated.

## Test plan

- [x] Full suite passes locally (1151/1151)
- [ ] Live Akuvox lock — set a PIN on a slot that previously had a `[LCM:<slot>]` tagged user; verify the user's name is rewritten to `lcm:<slot>:` form after the write
- [ ] Live Schlage lock — same as above for a Schlage code
- [ ] Live Akuvox/Schlage lock — verify codes never re-touched by LCM after upgrade still register as occupied (legacy parser still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)