### PR TITLE
fix: stop wiping persistent repair issues on unload + LOADING

### DIFF
--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -751,23 +751,6 @@ async def async_unload_entry(
     if unload_ok:
         await async_unload_lock(hass, config_entry)
 
-        # Clean up repair issues for this config entry.
-        entry_id = config_entry.entry_id
-        config = get_entry_config(config_entry)
-        for slot_num in config.slots:
-            async_delete_issue(hass, DOMAIN, f"slot_disabled_{entry_id}_{slot_num}")
-            async_delete_issue(hass, DOMAIN, f"pin_required_{entry_id}_{slot_num}")
-        for lock_entity_id in config.locks:
-            # Only delete lock_offline if no other LCM entry manages this lock
-            if not _lock_managed_by_other_entry(hass, config_entry, lock_entity_id):
-                async_delete_issue(hass, DOMAIN, f"lock_offline_{lock_entity_id}")
-            for slot_num in config.slots:
-                async_delete_issue(
-                    hass,
-                    DOMAIN,
-                    f"slot_suspended_{entry_id}_{lock_entity_id}_{slot_num}",
-                )
-
     # Only clean up the strategy resource if no other Lock Code Manager
     # entries remain loaded. The current entry is still listed (in
     # UNLOAD_IN_PROGRESS / NOT_LOADED state at this point) so filter it
@@ -783,6 +766,38 @@ async def async_unload_entry(
         await _async_cleanup_strategy_resource(hass, hass_data)
 
     return unload_ok
+
+
+async def async_remove_entry(
+    hass: HomeAssistant, config_entry: LockCodeManagerConfigEntry
+) -> None:
+    """
+    Clean up persistent repair issues when the entry is fully removed.
+
+    Called by Home Assistant only on entry deletion -- not on unload,
+    reload, disable, or HA restart. The repair issues created by this
+    integration are flagged ``is_persistent=True`` precisely so they
+    survive restarts and reloads; deleting them in ``async_unload_entry``
+    (the previous behavior) wiped them on every restart, causing the
+    "click an issue and it says repaired" short-circuit. With cleanup
+    moved here, persistent issues persist until the user actually
+    removes the entry.
+    """
+    entry_id = config_entry.entry_id
+    config = get_entry_config(config_entry)
+    for slot_num in config.slots:
+        async_delete_issue(hass, DOMAIN, f"slot_disabled_{entry_id}_{slot_num}")
+        async_delete_issue(hass, DOMAIN, f"pin_required_{entry_id}_{slot_num}")
+    for lock_entity_id in config.locks:
+        # Only delete lock_offline if no other LCM entry manages this lock.
+        if not _lock_managed_by_other_entry(hass, config_entry, lock_entity_id):
+            async_delete_issue(hass, DOMAIN, f"lock_offline_{lock_entity_id}")
+        for slot_num in config.slots:
+            async_delete_issue(
+                hass,
+                DOMAIN,
+                f"slot_suspended_{entry_id}_{lock_entity_id}_{slot_num}",
+            )
 
 
 async def _async_setup_new_locks(

--- a/custom_components/lock_code_manager/domain/sync.py
+++ b/custom_components/lock_code_manager/domain/sync.py
@@ -686,8 +686,8 @@ class SlotSyncManager:
                 # observing that the slot LOOKS in-sync on startup (e.g.
                 # a disabled slot trivially matches "no PIN expected, no
                 # PIN on lock") does not constitute a fix. The next
-                # genuine OUT_OF_SYNC -> IN_SYNC transition through
-                # _perform_sync will clear the issues at line 700-706.
+                # genuine recovery (OUT_OF_SYNC -> IN_SYNC), including the
+                # post-_perform_sync verification path, will clear issues.
             else:
                 self._state = SyncState.OUT_OF_SYNC
 

--- a/custom_components/lock_code_manager/domain/sync.py
+++ b/custom_components/lock_code_manager/domain/sync.py
@@ -679,7 +679,15 @@ class SlotSyncManager:
 
             if expected_in_sync:
                 self._state = SyncState.IN_SYNC
-                self._clear_resolved_issues(slot_state)
+                # Deliberately NOT calling _clear_resolved_issues here:
+                # LOADING is an initial-state observation, not a recovery
+                # event. A pre-existing slot_disabled / slot_suspended
+                # issue represents a state the user hasn't acknowledged;
+                # observing that the slot LOOKS in-sync on startup (e.g.
+                # a disabled slot trivially matches "no PIN expected, no
+                # PIN on lock") does not constitute a fix. The next
+                # genuine OUT_OF_SYNC -> IN_SYNC transition through
+                # _perform_sync will clear the issues at line 700-706.
             else:
                 self._state = SyncState.OUT_OF_SYNC
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -29,7 +29,10 @@ from homeassistant.helpers import (
     issue_registry as ir,
 )
 
-from custom_components.lock_code_manager import _setup_entry_after_start
+from custom_components.lock_code_manager import (
+    _setup_entry_after_start,
+    async_remove_entry,
+)
 from custom_components.lock_code_manager.const import (
     ATTR_ACTIVE,
     ATTR_IN_SYNC,
@@ -942,16 +945,24 @@ async def test_async_create_fix_flow_unknown():
         await async_create_fix_flow(None, "unknown_issue", None)
 
 
-async def test_unload_cleans_up_repair_issues(
+async def test_unload_preserves_persistent_repair_issues(
     hass: HomeAssistant,
     mock_lock_config_entry,
     lock_code_manager_config_entry,
 ):
-    """Test that unloading an entry deletes slot_disabled and pin_required repair issues."""
+    """Unloading an entry must NOT delete persistent repair issues.
+
+    Persistent issues (``is_persistent=True``) are flagged that way
+    precisely so they survive HA restarts, reloads, and integration
+    disable. ``async_unload_entry`` runs in all three of those cases
+    plus the actual entry-removal case; wiping issues there caused
+    the "click a repair and it says repaired" short-circuit after
+    every HA restart. Cleanup now lives in ``async_remove_entry``
+    which runs only on entry deletion -- see the next test.
+    """
     entry_id = lock_code_manager_config_entry.entry_id
     issue_reg = ir.async_get(hass)
 
-    # Create repair issues that should be cleaned up on unload
     for slot_num in (1, 2):
         ir.async_create_issue(
             hass,
@@ -977,7 +988,6 @@ async def test_unload_cleans_up_repair_issues(
             },
         )
 
-    # Create lock_offline issues for both locks
     for lock_id in (LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID):
         ir.async_create_issue(
             hass,
@@ -990,7 +1000,6 @@ async def test_unload_cleans_up_repair_issues(
             translation_placeholders={"lock_entity_id": lock_id},
         )
 
-    # Verify issues exist
     assert issue_reg.async_get_issue(DOMAIN, f"slot_disabled_{entry_id}_1") is not None
     assert issue_reg.async_get_issue(DOMAIN, f"pin_required_{entry_id}_2") is not None
     assert (
@@ -1001,7 +1010,74 @@ async def test_unload_cleans_up_repair_issues(
     await hass.config_entries.async_unload(lock_code_manager_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    # All issues for this entry should be deleted
+    # Every issue still in the registry; unload preserves them.
+    for slot_num in (1, 2):
+        assert (
+            issue_reg.async_get_issue(DOMAIN, f"slot_disabled_{entry_id}_{slot_num}")
+            is not None
+        )
+        assert (
+            issue_reg.async_get_issue(DOMAIN, f"pin_required_{entry_id}_{slot_num}")
+            is not None
+        )
+    for lock_id in (LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID):
+        assert issue_reg.async_get_issue(DOMAIN, f"lock_offline_{lock_id}") is not None
+
+
+async def test_remove_entry_cleans_up_repair_issues(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """Removing the entry deletes its repair issues (canonical cleanup path)."""
+    entry_id = lock_code_manager_config_entry.entry_id
+    issue_reg = ir.async_get(hass)
+
+    for slot_num in (1, 2):
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            f"slot_disabled_{entry_id}_{slot_num}",
+            is_fixable=True,
+            is_persistent=True,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key="slot_disabled",
+            translation_placeholders={"slot_num": str(slot_num), "reason": "test"},
+        )
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            f"pin_required_{entry_id}_{slot_num}",
+            is_fixable=True,
+            is_persistent=True,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key="pin_required",
+            translation_placeholders={
+                "slot_num": str(slot_num),
+                "config_entry_title": "test",
+            },
+        )
+
+    for lock_id in (LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID):
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            f"lock_offline_{lock_id}",
+            is_fixable=False,
+            is_persistent=True,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key="lock_offline",
+            translation_placeholders={"lock_entity_id": lock_id},
+        )
+
+    # Call the remove hook directly so the fixture teardown (which
+    # async_unloads the entry) still sees a registered entry. HA calls
+    # this hook only on actual entry deletion -- not on unload, reload,
+    # disable, or HA restart -- which is precisely the property we want
+    # to pin.
+    await async_remove_entry(hass, lock_code_manager_config_entry)
+    await hass.async_block_till_done()
+
     for slot_num in (1, 2):
         assert (
             issue_reg.async_get_issue(DOMAIN, f"slot_disabled_{entry_id}_{slot_num}")

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -395,6 +395,69 @@ class TestSlotDisabledIssueCleanup:
         # The issue should be deleted since slot is back in sync
         assert issue_registry.async_get_issue(DOMAIN, issue_id) is None
 
+    async def test_loading_branch_does_not_auto_clear_stale_issues(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """Repair issues persist across LOADING -> IN_SYNC observation.
+
+        Pins the short-circuit fix: when LCM (re)starts and the sync
+        manager's first tick observes the slot to be in sync, it
+        transitions LOADING -> IN_SYNC. That transition is NOT a
+        recovery event -- the slot may be "in sync" only because it
+        was previously disabled (switch OFF, no PIN expected, no PIN
+        on lock = trivially in_sync). Pre-existing repair issues
+        (slot_disabled, slot_suspended) reflect state the user has
+        not acknowledged and must survive this observation. Only an
+        actual OUT_OF_SYNC -> IN_SYNC transition through _perform_sync
+        clears them.
+        """
+        entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
+        manager = entity_obj._sync_manager
+        entry_id = lock_code_manager_config_entry.entry_id
+        slot_num = manager._slot_num
+        lock_entity_id = manager._lock.lock.entity_id
+
+        slot_disabled_id = f"slot_disabled_{entry_id}_{slot_num}"
+        slot_suspended_id = f"slot_suspended_{entry_id}_{lock_entity_id}_{slot_num}"
+        for issue_id, translation_key in (
+            (slot_disabled_id, "slot_disabled"),
+            (slot_suspended_id, "slot_suspended"),
+        ):
+            async_create_issue(
+                hass,
+                DOMAIN,
+                issue_id,
+                is_fixable=True,
+                is_persistent=True,
+                severity=IssueSeverity.WARNING,
+                translation_key=translation_key,
+                translation_placeholders={
+                    "slot_num": str(slot_num),
+                    "reason": "test",
+                    "lock_name": lock_entity_id,
+                    "lock_entity_id": lock_entity_id,
+                },
+            )
+
+        issue_registry = async_get_issue_registry(hass)
+        assert issue_registry.async_get_issue(DOMAIN, slot_disabled_id) is not None
+        assert issue_registry.async_get_issue(DOMAIN, slot_suspended_id) is not None
+
+        # Simulate the startup path: the manager is in LOADING.
+        manager._state = SyncState.LOADING
+
+        await async_trigger_sync_tick(hass, SLOT_1_IN_SYNC_ENTITY)
+
+        # LOADING -> IN_SYNC transition should NOT touch the issues.
+        # The user must either acknowledge them via the UI or trigger
+        # a real recovery sync to clear them.
+        assert manager._state is SyncState.IN_SYNC
+        assert issue_registry.async_get_issue(DOMAIN, slot_disabled_id) is not None
+        assert issue_registry.async_get_issue(DOMAIN, slot_suspended_id) is not None
+
 
 class TestLockOperationFailedRetry:
     """Tests that LockOperationFailed triggers retry, not slot disable."""


### PR DESCRIPTION
## Proposed change

Found while triaging an LCM repair issue that auto-resolved on click after the user noticed it post-HA-restart. Two cooperating short-circuits where \`is_persistent=True\` repair issues were silently auto-resolved against the user's intent.

### Bug 1 — \`async_unload_entry\` wiped issues on every unload

\`async_unload_entry\` runs in **four** scenarios:
- HA shutdown
- Reload (user-triggered)
- Disable (user-triggered)
- Removal (user-triggered)

The old cleanup loop ran in all four:

\`\`\`python
if unload_ok:
    for slot_num in config.slots:
        async_delete_issue(hass, DOMAIN, f\"slot_disabled_{entry_id}_{slot_num}\")
        async_delete_issue(hass, DOMAIN, f\"pin_required_{entry_id}_{slot_num}\")
    for lock_entity_id in config.locks:
        if not _lock_managed_by_other_entry(...):
            async_delete_issue(hass, DOMAIN, f\"lock_offline_{lock_entity_id}\")
        for slot_num in config.slots:
            async_delete_issue(hass, DOMAIN, f\"slot_suspended_{entry_id}_{lock_entity_id}_{slot_num}\")
\`\`\`

The issues are flagged \`is_persistent=True\` precisely so they survive restarts, reloads, and disable. Wiping them on every unload defeated that intent — after every HA restart, the user lost any unacknowledged repair notification, even though the underlying state (a disabled slot, an offline lock) was still unchanged.

**Fix**: move the cleanup loop to a new \`async_remove_entry\` hook. HA calls that only on actual entry deletion. No \`disabled_by\` check needed — the lifecycle hooks already encode the right intent.

### Bug 2 — \`_async_tick_impl\` LOADING branch auto-cleared issues

On startup, the sync manager enters \`SyncState.LOADING\`. The first tick evaluates initial state. If the slot looks in-sync (which is trivially true for a disabled slot: switch OFF, no PIN expected, no PIN on lock), the LOADING branch transitioned to \`IN_SYNC\` AND called \`_clear_resolved_issues\`.

\`_clear_resolved_issues\` gates \`slot_disabled\` deletion on \`active_state == STATE_ON\` (good — a disabled slot shouldn't auto-clear its repair), but always deletes \`slot_suspended\`. So even with Bug 1 fixed, a startup-time LOADING → IN_SYNC observation would still wipe any \`slot_suspended\` issue.

**Fix**: drop the \`_clear_resolved_issues\` call from the LOADING branch entirely. LOADING is an initial-state observation, not a recovery event. The next genuine OUT_OF_SYNC → IN_SYNC transition through \`_perform_sync\` (lines 700-706, untouched) clears the issues — but only when a real recovery has happened.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Test plan

- [x] Full suite passes locally (1155/1155)
- [x] New \`test_unload_preserves_persistent_repair_issues\` pins that unload no longer touches issues
- [x] New \`test_remove_entry_cleans_up_repair_issues\` pins that \`async_remove_entry\` (and only that hook) deletes them
- [x] New \`test_loading_branch_does_not_auto_clear_stale_issues\` pins that a LOADING → IN_SYNC transition leaves pre-existing \`slot_disabled\` and \`slot_suspended\` issues intact
- [x] Existing \`test_slot_disabled_issue_deleted_when_back_in_sync\` still passes (the OUT_OF_SYNC → IN_SYNC recovery path is untouched)
- [ ] Live HA restart: a previously-disabled slot's repair stays visible across restart and can be acknowledged via the dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)