### PR TITLE
refactor(zwave_js): hoist push event handlers to private methods

### DIFF
--- a/custom_components/lock_code_manager/providers/zwave_js.py
+++ b/custom_components/lock_code_manager/providers/zwave_js.py
@@ -436,38 +436,39 @@ class ZWaveJSLock(BaseLock):
         if not ready:
             raise LockDisconnected(reason)
 
-        @callback
-        def on_credential_changed(event: dict[str, Any]) -> None:
-            """Handle credential added/modified events from the node."""
-            args = event["args"]  # CredentialChangedArgs (pre-parsed by the library)
-            if args.credential_type != UserCredentialType.PIN_CODE:
-                return
-            # The event carries the value when the lock includes it (e.g. an
-            # out-of-band keypad change), so push the readable state rather than
-            # always unreadable -- otherwise the slot would be stranded as
-            # unreadable until the next set/clear or hard refresh.
-            self._push_credential_update(
-                args.credential_slot, self._pin_state(args.data)
-            )
-
-        @callback
-        def on_credential_deleted(event: dict[str, Any]) -> None:
-            """Handle credential deleted events from the node."""
-            args = event["args"]  # CredentialDeletedArgs (pre-parsed by the library)
-            if args.credential_type != UserCredentialType.PIN_CODE:
-                return
-            self._push_credential_update(args.credential_slot, SlotCredential.empty())
-
         try:
             for name, handler in (
-                ("credential added", on_credential_changed),
-                ("credential modified", on_credential_changed),
-                ("credential deleted", on_credential_deleted),
+                ("credential added", self._on_credential_changed),
+                ("credential modified", self._on_credential_changed),
+                ("credential deleted", self._on_credential_deleted),
             ):
                 self._register_push_unsub(self.node.on(name, handler))
         except ValueError as err:
             self._clear_push_unsubs()
             raise LockDisconnected(f"node not ready: {err}") from err
+
+    @callback
+    def _on_credential_changed(self, event: dict[str, Any]) -> None:
+        """
+        Handle credential added/modified events from the node.
+
+        The event carries the value when the lock includes it (e.g. an
+        out-of-band keypad change), so push the readable state rather
+        than always unreadable -- otherwise the slot would be stranded
+        as unreadable until the next set/clear or hard refresh.
+        """
+        args = event["args"]  # CredentialChangedArgs (pre-parsed by the library)
+        if args.credential_type != UserCredentialType.PIN_CODE:
+            return
+        self._push_credential_update(args.credential_slot, self._pin_state(args.data))
+
+    @callback
+    def _on_credential_deleted(self, event: dict[str, Any]) -> None:
+        """Handle credential deleted events from the node."""
+        args = event["args"]  # CredentialDeletedArgs (pre-parsed by the library)
+        if args.credential_type != UserCredentialType.PIN_CODE:
+            return
+        self._push_credential_update(args.credential_slot, SlotCredential.empty())
 
     @callback
     def teardown_push_subscription(self) -> None:


### PR DESCRIPTION
## Proposed change

The \`on_credential_changed\` and \`on_credential_deleted\` closures inside \`setup_push_subscription\` captured \`self\` implicitly via lexical scope. Hoist them to bound private methods (\`self._on_credential_changed\`, \`self._on_credential_deleted\`) so:

1. The handler surface is explicit in the class layout (visible to type checkers and to \`grep\`).
2. They match how the Matter provider already structures its push handlers (\`_handle_lock_operation\`, \`_handle_lock_user_change\`, \`_dispatch_lock_user_change\`).
3. Future test mocking / introspection can patch them by name rather than monkey-patching the parent method.

Pure refactor — handler bodies are identical, \`@callback\` decorator preserved. The \`setup_push_subscription\` body now wires the bound methods directly into \`self.node.on(...)\` registrations.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Test plan

- [x] All 76 existing zwave_js provider tests pass without modification
- [x] Full suite passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)