### PR TITLE
fix(matter): tolerate MatterError on set_lock_user UPDATE; map on CREATE

### DIFF
--- a/custom_components/lock_code_manager/providers/matter.py
+++ b/custom_components/lock_code_manager/providers/matter.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass
 from datetime import timedelta
 from typing import Any, Literal
 
+from matter_server.common.errors import MatterError
 from matter_server.common.models import EventType
 
 from homeassistant.components.matter.helpers import (
@@ -376,7 +377,17 @@ class MatterLock(BaseLock):
                     user_index=existing_user_index,
                     user_name=user.name,
                 )
-            except HomeAssistantError as err:
+            except (HomeAssistantError, MatterError) as err:
+                # Matter SDK raises ``matter_server.common.errors.MatterError``
+                # subclasses (e.g. ``UnknownError`` carrying
+                # ``InteractionModelError: InvalidCommand (0x85)``); those are
+                # NOT ``HomeAssistantError`` subclasses, so they slipped past
+                # the original catch. Some Matter lock firmwares reject
+                # rename-on-existing-user with InvalidCommand even though the
+                # user record itself is valid -- the user still exists at the
+                # known index, the only thing lost is the name update. The
+                # subsequent credential write proceeds against the resolved
+                # user_id.
                 LOGGER.warning(
                     "Lock %s: failed to update user name on slot %s "
                     "(user_index=%s); continuing without name update: %s",
@@ -402,6 +413,15 @@ class MatterLock(BaseLock):
             ) from err
         except HomeAssistantError as err:
             raise LockDisconnected(
+                f"Matter set_lock_user failed for {self.lock.entity_id}: {err}"
+            ) from err
+        except MatterError as err:
+            # Matter SDK error on CREATE -- unlike UPDATE we can't tolerate
+            # this because without an allocated user_index the credential
+            # write has no target. Surface as LockOperationFailed so the
+            # seam routes it through retry rather than the catchall
+            # _suspend_slot path (which would create a spurious repair).
+            raise LockOperationFailed(
                 f"Matter set_lock_user failed for {self.lock.entity_id}: {err}"
             ) from err
         return SetUserResult(user_id=result["user_index"], created=True)

--- a/tests/providers/matter/test_provider.py
+++ b/tests/providers/matter/test_provider.py
@@ -7,6 +7,7 @@ from datetime import timedelta
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from matter_server.common.errors import UnknownError
 from matter_server.common.models import EventType, MatterNodeEvent
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -2321,6 +2322,79 @@ class TestSetUser:
         assert result == SetUserResult(user_id=7, created=False)
         mock_set_user.assert_called_once()
         assert "failed to update user name" in caplog.text
+
+    async def test_set_user_update_tolerates_matter_sdk_error(
+        self, hass: HomeAssistant, matter_lock_simple: MatterLock, caplog
+    ) -> None:
+        """UPDATE swallows ``matter_server.common.errors.MatterError``.
+
+        Production regression: ``set_lock_user`` on an existing user
+        sometimes throws ``UnknownError: InteractionModelError:
+        InvalidCommand (0x85)`` (a ``MatterError`` subclass that is NOT a
+        ``HomeAssistantError`` subclass). The historical contract is to
+        tolerate any name-set failure on UPDATE so the credential write
+        still proceeds; the old code only caught ``HomeAssistantError``
+        and let MatterError bubble past, causing the seam's catchall to
+        spuriously suspend the slot and create a repair issue.
+        """
+        mock_set_user = AsyncMock(
+            side_effect=UnknownError("InteractionModelError: InvalidCommand (0x85)")
+        )
+        user = User(user_id=2, name="lcm:2:Updated Name")
+        with (
+            patch.object(
+                matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+            ),
+            patch.object(
+                matter_lock_simple, "_get_matter_node", return_value=MagicMock()
+            ),
+            self._patch_users(
+                [
+                    {
+                        "user_index": 7,
+                        "user_name": "lcm:2:Original",
+                        "credentials": [{"type": "pin", "index": 3}],
+                    },
+                ]
+            ),
+            patch(f"{_PROVIDER_MODULE}.set_lock_user", mock_set_user),
+        ):
+            result = await matter_lock_simple.async_set_user(user)
+
+        # The user_index is still returned so the seam can route the
+        # subsequent credential write to the right user; only the name
+        # update was dropped.
+        assert result == SetUserResult(user_id=7, created=False)
+        mock_set_user.assert_called_once()
+        assert "failed to update user name" in caplog.text
+        assert "InvalidCommand (0x85)" in caplog.text
+
+    async def test_set_user_create_raises_operation_failed_on_matter_sdk_error(
+        self, hass: HomeAssistant, matter_lock_simple: MatterLock
+    ) -> None:
+        """CREATE maps ``MatterError`` to ``LockOperationFailed``.
+
+        Unlike UPDATE, a CREATE failure cannot be tolerated -- without an
+        allocated user_index the subsequent credential write has no
+        target. Routing to ``LockOperationFailed`` ensures the seam
+        retries through the normal backoff path rather than dropping
+        into the catchall suspend (which would create a spurious repair
+        issue without giving the lock a chance to recover).
+        """
+        mock_set_user = AsyncMock(side_effect=UnknownError("transient failure"))
+        user = User(user_id=1, name="lcm:1:Alice")
+        with (
+            patch.object(
+                matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+            ),
+            patch.object(
+                matter_lock_simple, "_get_matter_node", return_value=MagicMock()
+            ),
+            self._patch_users([]),
+            patch(f"{_PROVIDER_MODULE}.set_lock_user", mock_set_user),
+            pytest.raises(LockOperationFailed, match="transient failure"),
+        ):
+            await matter_lock_simple.async_set_user(user)
 
 
 # =============================================================================


### PR DESCRIPTION
## Proposed change

Production regression observed on a real Matter lock (\`lock.raman_office\`, slot 1): \`set_lock_user\` on an existing user occasionally throws \`matter_server.common.errors.UnknownError: InteractionModelError: InvalidCommand (0x85)\`. \`UnknownError\` is a \`MatterError\` subclass, **not** a \`HomeAssistantError\` subclass, so the original \`except HomeAssistantError\` at \`matter.py:379\` silently let it bubble past. The seam's catchall in \`_async_tick_impl\` then routed every failure to \`_suspend_slot\`, creating a spurious \`slot_suspended_*\` repair issue even though the lock user record was fine and the credential write would have succeeded.

The docstring at the catch site already documented the right intent:

> \`set_lock_user\` here is a metadata-only name update. The historical contract (PR #1077) tolerated name-set failures so a transient 500 or a name the lock rejects does not block the subsequent credential write.

The fix widens the catch to \`(HomeAssistantError, MatterError)\` so the contract holds for Matter-SDK-side rejections too.

For the **CREATE** path we cannot tolerate the failure — without an allocated \`user_index\` the subsequent credential write has no target. The fix adds a \`MatterError → LockOperationFailed\` mapping so the seam retries through the normal backoff path rather than the catchall suspend (which would still spuriously create a repair issue without giving the lock a chance to recover).

### Production traceback

\`\`\`
ERROR [custom_components.lcm.domain.sync] Raman's Office: lock.raman_office slot 1:
  Unexpected error during set usercode. Sync suspended for this lock to prevent
  infinite retry loop. Error: UnknownError: InteractionModelError: InvalidCommand (0x85)

  File \"/config/custom_components/lcm/providers/matter.py\", line 373, in async_set_user
    await set_lock_user(client, node, user_index=existing_user_index, user_name=user.name)
  File \"matter_server/client/client.py\", line 611, in send_command
    return await future
matter_server.common.errors.UnknownError: InteractionModelError: InvalidCommand (0x85)
\`\`\`

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Test plan

- [x] Full suite passes locally (1157/1157)
- [x] New \`test_set_user_update_tolerates_matter_sdk_error\` pins that \`UnknownError(\"InvalidCommand (0x85)\")\` on UPDATE is logged and the \`user_index\` is still returned for the credential write
- [x] New \`test_set_user_create_raises_operation_failed_on_matter_sdk_error\` pins that \`UnknownError\` on CREATE surfaces as \`LockOperationFailed\` instead of bubbling raw
- [ ] Live Matter lock: confirm the slot_suspended repair issue stops re-firing after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)