### PR TITLE
fix(matter): address #1246 review — log noise, fallback routing, test caplog level

### DIFF
--- a/custom_components/lock_code_manager/providers/matter.py
+++ b/custom_components/lock_code_manager/providers/matter.py
@@ -411,7 +411,14 @@ class MatterLock(BaseLock):
                         fallback_err,
                     )
                 else:
-                    LOGGER.info(
+                    # DEBUG (not INFO): for a lock that consistently rejects
+                    # the canonical tag, this fires on every set_user run
+                    # (every credential write -- see _base._set_credential).
+                    # We don't want to spam the user's log; the warning
+                    # path on full failure is what they actually need to
+                    # see. DEBUG keeps the diagnostic available without
+                    # the noise.
+                    LOGGER.debug(
                         "Lock %s: lock rejected canonical tag %r for slot %s "
                         "(%s); renamed to slot-only %r so the slot binding "
                         "survives the read",
@@ -456,17 +463,36 @@ class MatterLock(BaseLock):
                     user_index=None,
                     user_name=slot_only_name,
                 )
+            except ServiceValidationError as fallback_err:
+                # Same routing as the primary CREATE attempt -- input
+                # validation failures get LockOperationFailed regardless of
+                # which name attempt triggered them.
+                raise LockOperationFailed(
+                    f"Matter set_lock_user rejected slot-only fallback for "
+                    f"{self.lock.entity_id}: {fallback_err}"
+                ) from fallback_err
+            except HomeAssistantError as fallback_err:
+                # Transport / disconnect during the fallback retry -- same
+                # routing as the primary attempt.
+                raise LockDisconnected(
+                    f"Matter set_lock_user failed on slot-only fallback for "
+                    f"{self.lock.entity_id}: {fallback_err}"
+                ) from fallback_err
             except MatterError as fallback_err:
-                # Second attempt also failed -- the lock is rejecting more
-                # than just the charset. Surface as LockOperationFailed so
-                # the seam routes through retry rather than the catchall
-                # suspend path (which would create a spurious repair issue).
+                # Both attempts hit lock-side rejections (the original
+                # MatterError and a second MatterError on the slot-only
+                # retry). The lock is rejecting more than just the
+                # charset; surface as LockOperationFailed so the seam
+                # routes through retry rather than the catchall suspend.
                 raise LockOperationFailed(
                     f"Matter set_lock_user failed for {self.lock.entity_id} "
                     f"on both canonical and slot-only fallback names: "
                     f"canonical={err}, slot-only={fallback_err}"
                 ) from fallback_err
-            LOGGER.info(
+            # See the UPDATE-path comment above: DEBUG (not INFO) so a
+            # lock that consistently needs the fallback doesn't flood
+            # the log on every credential write.
+            LOGGER.debug(
                 "Lock %s: lock rejected canonical tag %r for slot %s (%s); "
                 "created with slot-only %r so the slot binding survives the "
                 "read",

--- a/tests/providers/matter/test_provider.py
+++ b/tests/providers/matter/test_provider.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Generator
 from datetime import timedelta
+import logging
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -2397,6 +2398,11 @@ class TestSetUser:
             ]
         )
         user = User(user_id=1, name="lcm:1:Alice")
+        # The success-on-fallback diagnostic log is at DEBUG (intentionally
+        # quiet for locks that always need the fallback). Enable DEBUG
+        # capture for this provider so the test asserts on the message
+        # without depending on global pytest logging configuration.
+        caplog.set_level(logging.DEBUG, logger=_PROVIDER_MODULE)
         with (
             patch.object(
                 matter_lock_simple, "_get_matter_client", return_value=MagicMock()
@@ -2451,6 +2457,67 @@ class TestSetUser:
 
         assert mock_set_user.call_count == 2
 
+    async def test_set_user_create_routes_validation_error_during_fallback(
+        self, hass: HomeAssistant, matter_lock_simple: MatterLock
+    ) -> None:
+        """A ``ServiceValidationError`` during the slot-only fallback gets typed routing.
+
+        Mirrors the primary CREATE attempt's exception handling: the
+        slot-only retry must map ``ServiceValidationError`` to
+        ``LockOperationFailed`` and ``HomeAssistantError`` to
+        ``LockDisconnected`` so a transient validation or disconnect
+        during the fallback doesn't slip past as an untyped exception
+        (which would route to the seam's catchall suspend path and
+        create a spurious repair issue).
+        """
+        mock_set_user = AsyncMock(
+            side_effect=[
+                UnknownError("InvalidCommand (0x85)"),
+                ServiceValidationError("validation"),
+            ]
+        )
+        user = User(user_id=1, name="lcm:1:Alice")
+        with (
+            patch.object(
+                matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+            ),
+            patch.object(
+                matter_lock_simple, "_get_matter_node", return_value=MagicMock()
+            ),
+            self._patch_users([]),
+            patch(f"{_PROVIDER_MODULE}.set_lock_user", mock_set_user),
+            pytest.raises(LockOperationFailed, match="rejected slot-only fallback"),
+        ):
+            await matter_lock_simple.async_set_user(user)
+
+        assert mock_set_user.call_count == 2
+
+    async def test_set_user_create_routes_disconnect_during_fallback(
+        self, hass: HomeAssistant, matter_lock_simple: MatterLock
+    ) -> None:
+        """A ``HomeAssistantError`` during the slot-only fallback maps to ``LockDisconnected``."""
+        mock_set_user = AsyncMock(
+            side_effect=[
+                UnknownError("InvalidCommand (0x85)"),
+                HomeAssistantError("transport closed"),
+            ]
+        )
+        user = User(user_id=1, name="lcm:1:Alice")
+        with (
+            patch.object(
+                matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+            ),
+            patch.object(
+                matter_lock_simple, "_get_matter_node", return_value=MagicMock()
+            ),
+            self._patch_users([]),
+            patch(f"{_PROVIDER_MODULE}.set_lock_user", mock_set_user),
+            pytest.raises(LockDisconnected, match="slot-only fallback"),
+        ):
+            await matter_lock_simple.async_set_user(user)
+
+        assert mock_set_user.call_count == 2
+
     async def test_set_user_update_falls_back_to_slot_only_on_charset_rejection(
         self, hass: HomeAssistant, matter_lock_simple: MatterLock, caplog
     ) -> None:
@@ -2469,6 +2536,9 @@ class TestSetUser:
             ]
         )
         user = User(user_id=2, name="lcm:2:Updated Name")
+        # Same as the CREATE variant: the success-on-fallback log is at
+        # DEBUG, so enable DEBUG capture explicitly.
+        caplog.set_level(logging.DEBUG, logger=_PROVIDER_MODULE)
         with (
             patch.object(
                 matter_lock_simple, "_get_matter_client", return_value=MagicMock()


### PR DESCRIPTION
## Proposed change

Addresses Copilot's four review comments on #1246. All four were valid.

### Comment #3393233004 — INFO log spam on affected locks

> The success-on-fallback path logs at INFO every time async_set_user runs on a lock that consistently rejects the canonical tag. Since BaseLock calls async_set_user on every credential write, this can spam logs in normal operation for affected locks.

**Fix**: demote both UPDATE-path and CREATE-path success-on-fallback messages from \`LOGGER.info\` to \`LOGGER.debug\`. The diagnostic remains available when the user enables debug logging; the full-failure warning path is unchanged.

### Comment #3393232929 — Fallback exception routing was narrow

> CREATE fallback retry only catches MatterError. If the slot-only retry raises HomeAssistantError (disconnect/offline) or ServiceValidationError, it will currently bubble out as an unexpected exception type rather than being mapped to LockDisconnected/LockOperationFailed like the primary CREATE attempt. This can reintroduce the same "catchall suspend" behavior the MatterError mapping was meant to avoid.

**Fix**: mirror the primary CREATE attempt's typed routing on the fallback retry:
- \`ServiceValidationError → LockOperationFailed\`
- \`HomeAssistantError → LockDisconnected\`
- \`MatterError → LockOperationFailed\` (after both attempts)

Two new regression tests pin these mappings:
- \`test_set_user_create_routes_validation_error_during_fallback\`
- \`test_set_user_create_routes_disconnect_during_fallback\`

### Comments #3393232961 + #3393232981 — Tests didn't set caplog level

> This test asserts on INFO-level log text but doesn't set caplog's capture level. Make the test self-contained by explicitly enabling INFO logging for the provider module before exercising the behavior.

**Fix**: both fallback-success tests now call \`caplog.set_level(logging.DEBUG, logger=_PROVIDER_MODULE)\` before exercising the behavior. (DEBUG, not INFO, because of fix #1 above.) The tests are now self-contained and don't depend on the global pytest logging config.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Test plan

- [x] Full suite passes locally (1162/1162; +2 new tests for the fallback-routing fix)
- [x] Existing fallback-success tests still pass with the explicit \`caplog.set_level\` call
- [x] DEBUG log path verified locally — the success-on-fallback message is only emitted at DEBUG, so locks that consistently need the fallback no longer flood the log

🤖 Generated with [Claude Code](https://claude.com/claude-code)