### PR TITLE
feat(matter): add compact lcm<slot> tier between canonical and slot-only

### DIFF
--- a/custom_components/lock_code_manager/providers/_util.py
+++ b/custom_components/lock_code_manager/providers/_util.py
@@ -7,17 +7,26 @@ identify codes by user-name rather than by slot number (Schlage, Akuvox,
 and -- once the unified-user migration lands -- Matter and Z-Wave User
 Credential CC).
 
-Three tag formats coexist during the migration window:
+Four tag formats coexist during the migration window:
 
 * Canonical ``lcm:<slot>:<name>`` -- the consolidated format every new
   write uses when the lock's ``max_user_name_length`` can fit the full
   ``lcm:<slot>:`` prefix. Two colons delimit the slot field clearly for
   visual parseability on the lock UI.
-* Slot-only ``<digits>`` -- the length-constrained fallback, used when
-  the lock's name field is too small to fit even the canonical prefix.
-  Just the slot number, written as ``str(slot)``. Ambiguous with any
-  external user named with only digits, but only encountered on locks
-  with absurdly small name limits, so the tradeoff is accepted.
+* Compact ``lcm<slot>`` -- the charset-constrained fallback, used when
+  the lock's firmware rejects the colons (Matter spec is permissive but
+  many firmwares restrict ``userName`` to alphanumeric). Drops the
+  display portion but keeps the LCM ownership marker, so the lock-side
+  name is unambiguous about who owns the user record. Strictly better
+  than the slot-only fallback for coexistence with other controllers,
+  which is why providers try this tier first before falling all the way
+  back to ``str(slot)``.
+* Slot-only ``<digits>`` -- the deepest fallback, used when neither
+  canonical nor compact fit. Just the slot number, written as
+  ``str(slot)``. Ambiguous with any external user named with only
+  digits, but only encountered on locks with absurdly small name limits
+  or firmwares that reject even ``lcm<slot>``, so the tradeoff is
+  accepted.
 * Legacy ``[LCM:<slot>] <name>`` -- written by Schlage/Akuvox today.
   Still emitted by ``make_legacy_tagged_name`` while those providers
   migrate; their reads tolerate it via ``parse_tag_with_rewrite``, which
@@ -33,6 +42,7 @@ import re
 
 _LEGACY_SLOT_TAG_RE = re.compile(r"^\[LCM:(\d+)\]\s*(.*)")
 _TAG_RE = re.compile(r"^lcm:(\d+):\s*(.*)")
+_COMPACT_TAG_RE = re.compile(r"^lcm(\d+)$")
 _SLOT_ONLY_RE = re.compile(r"^(\d+)$")
 
 
@@ -40,6 +50,19 @@ def make_tagged_name(slot_num: int, name: str | None = None) -> str:
     """Return a code name in the canonical ``lcm:<slot>:`` format."""
     base = name or f"Code Slot {slot_num}"
     return f"lcm:{slot_num}:{base}"
+
+
+def make_compact_tagged_name(slot_num: int) -> str:
+    """
+    Return a code name in the compact ``lcm<slot>`` format.
+
+    Charset-safe (alphanumeric only) fallback used when a lock's
+    firmware rejects the colons in the canonical format. Drops the
+    display portion but preserves the LCM ownership marker so the
+    on-lock name doesn't collide with externally-created users in the
+    way that the bare slot-only fallback would.
+    """
+    return f"lcm{slot_num}"
 
 
 def make_legacy_tagged_name(slot_num: int, name: str | None = None) -> str:
@@ -78,14 +101,15 @@ def parse_tag_with_rewrite(name: str) -> tuple[int | None, str, bool]:
     ``lcm:<slot>:`` format, the slot-only fallback, and untagged names
     all return ``needs_rewrite=False``.
 
-    Match priority: canonical, then legacy, then slot-only digits. The
-    slot-only branch is the length-constrained encoding emitted by
-    :func:`._base.BaseLock._build_tagged_user_name` when the lock's
-    ``max_user_name_length`` cannot fit the canonical prefix; the
-    display portion is empty. Bare digits being treated as a slot tag
-    is intentional but ambiguous with external users whose names
-    happen to be digit-only -- the ambiguity is the cost of preserving
-    the slot binding on length-constrained locks.
+    Match priority: canonical, then legacy, then compact, then
+    slot-only digits. The compact and slot-only branches are
+    charset-/length-constrained fallbacks emitted by Matter (and
+    eventually other providers) when the lock rejects the canonical
+    name. The display portion is empty for both fallbacks because the
+    name only carries the slot binding. Bare digits being treated as
+    a slot tag is intentional but ambiguous with external users whose
+    names happen to be digit-only -- the ambiguity is the cost of
+    preserving the slot binding on constrained locks.
     """
     match = _TAG_RE.match(name)
     if match:
@@ -93,6 +117,9 @@ def parse_tag_with_rewrite(name: str) -> tuple[int | None, str, bool]:
     match = _LEGACY_SLOT_TAG_RE.match(name)
     if match:
         return int(match.group(1)), match.group(2), True
+    match = _COMPACT_TAG_RE.match(name)
+    if match:
+        return int(match.group(1)), "", False
     match = _SLOT_ONLY_RE.match(name)
     if match:
         return int(match.group(1)), "", False

--- a/custom_components/lock_code_manager/providers/matter.py
+++ b/custom_components/lock_code_manager/providers/matter.py
@@ -52,7 +52,7 @@ from ..domain.exceptions import (
 )
 from ..domain.models import SlotCredential
 from ._base import BaseLock
-from ._util import parse_slot_num, parse_tag
+from ._util import make_compact_tagged_name, parse_slot_num, parse_tag
 from .const import LOGGER
 
 # DoorLock cluster ID (0x0101 = 257)
@@ -366,143 +366,177 @@ class MatterLock(BaseLock):
             #
             # set_lock_user here is a metadata-only name update. The
             # historical Matter contract (PR #1077) tolerated name-set
-            # failures so a transient 500 or a name the lock rejects does
-            # not block the subsequent credential write; the user still
-            # exists at the known index, the only thing lost is the name
-            # update. Log a warning and fall through.
+            # failures so a transient 500 or a name the lock rejects
+            # does not block the subsequent credential write; the user
+            # still exists at the known index, the only thing lost is
+            # the name update. If every candidate in the cascade fails
+            # with MatterError we log a warning and fall through.
+            candidates = self._user_name_candidates(slot, user.name)
             try:
-                await set_lock_user(
+                (
+                    _,
+                    name_used,
+                    prior_failures,
+                ) = await self._try_set_lock_user_with_fallbacks(
                     client,
                     node,
                     user_index=existing_user_index,
-                    user_name=user.name,
+                    candidate_names=candidates,
                 )
-            except (HomeAssistantError, MatterError) as err:
-                # Matter SDK raises ``matter_server.common.errors.MatterError``
-                # subclasses (e.g. ``UnknownError`` carrying
-                # ``InteractionModelError: InvalidCommand (0x85)``); those are
-                # NOT ``HomeAssistantError`` subclasses. Some Matter lock
-                # firmwares reject rename-on-existing-user when the new
-                # name contains non-alphanumeric characters (the colons in
-                # the canonical ``lcm:<slot>:`` prefix). Retry with the
-                # slot-only fallback (``str(slot)``), which the tolerant
-                # parser still recognizes as the slot binding. If the
-                # second attempt also fails, fall through to the
-                # historical "tolerate name-set failures" contract -- the
-                # user record itself remains valid at ``existing_user_index``
-                # so the credential write can still proceed.
-                slot_only_name = str(slot)
-                try:
-                    await set_lock_user(
-                        client,
-                        node,
-                        user_index=existing_user_index,
-                        user_name=slot_only_name,
-                    )
-                except (HomeAssistantError, MatterError) as fallback_err:
-                    LOGGER.warning(
-                        "Lock %s: failed to update user name on slot %s "
-                        "(user_index=%s); continuing without name update. "
-                        "Canonical attempt: %s. Slot-only fallback: %s",
-                        self.lock.entity_id,
-                        slot,
-                        existing_user_index,
-                        err,
-                        fallback_err,
-                    )
-                else:
-                    # DEBUG (not INFO): for a lock that consistently rejects
-                    # the canonical tag, this fires on every set_user run
-                    # (every credential write -- see _base._set_credential).
-                    # We don't want to spam the user's log; the warning
-                    # path on full failure is what they actually need to
-                    # see. DEBUG keeps the diagnostic available without
-                    # the noise.
+            except (LockDisconnected, LockOperationFailed, MatterError) as err:
+                # UPDATE's historical contract (PR #1077): tolerate any
+                # rename failure so the subsequent credential write still
+                # proceeds. The user record is still valid at
+                # ``existing_user_index`` -- the only thing lost is the
+                # cosmetic name update. The helper raises typed seam
+                # exceptions (LockDisconnected for transport failures,
+                # LockOperationFailed for validation rejections,
+                # MatterError when every candidate hit a lock-side
+                # rejection); we swallow all three here on the UPDATE
+                # path and log a warning instead.
+                LOGGER.warning(
+                    "Lock %s: failed to update user name on slot %s "
+                    "(user_index=%s); continuing without name update. "
+                    "Tried %s; last error: %s",
+                    self.lock.entity_id,
+                    slot,
+                    existing_user_index,
+                    candidates,
+                    err,
+                )
+            else:
+                if prior_failures:
+                    # DEBUG (not INFO): for a lock that consistently
+                    # rejects the canonical tag, this fires on every
+                    # set_user run (every credential write -- see
+                    # _base._set_credential). DEBUG keeps the
+                    # diagnostic available without the noise.
                     LOGGER.debug(
-                        "Lock %s: lock rejected canonical tag %r for slot %s "
-                        "(%s); renamed to slot-only %r so the slot binding "
-                        "survives the read",
+                        "Lock %s: lock rejected %d earlier name "
+                        "candidate(s) for slot %s (%s); renamed to %r "
+                        "so the slot binding survives the read",
                         self.lock.entity_id,
-                        user.name,
+                        len(prior_failures),
                         slot,
-                        err,
-                        slot_only_name,
+                        ", ".join(f"{name!r}: {err}" for name, err in prior_failures),
+                        name_used,
                     )
             return SetUserResult(user_id=existing_user_index, created=False)
 
-        # CREATE: no LCM-tagged user exists for this slot yet — let Matter
-        # auto-allocate a free user_index.
+        # CREATE: no LCM-tagged user exists for this slot yet — let
+        # Matter auto-allocate a free user_index. Same cascade as
+        # UPDATE; failure handling differs because we need an allocated
+        # user_index for the subsequent credential write, so a full
+        # exhaustion escalates to LockOperationFailed.
+        candidates = self._user_name_candidates(slot, user.name)
         try:
-            result = await set_lock_user(
+            (
+                result,
+                name_used,
+                prior_failures,
+            ) = await self._try_set_lock_user_with_fallbacks(
                 client,
                 node,
                 user_index=None,
-                user_name=user.name,
+                candidate_names=candidates,
             )
-        except ServiceValidationError as err:
-            raise LockOperationFailed(
-                f"Matter set_lock_user rejected input for {self.lock.entity_id}: {err}"
-            ) from err
-        except HomeAssistantError as err:
-            raise LockDisconnected(
-                f"Matter set_lock_user failed for {self.lock.entity_id}: {err}"
-            ) from err
         except MatterError as err:
-            # Matter SDK error on CREATE with the canonical tagged name.
-            # Some lock firmwares restrict ``userName`` to alphanumeric
-            # characters and reject the colons in ``lcm:<slot>:``. Retry
-            # once with the slot-only fallback (``str(slot)``) -- the
-            # tolerant parser recognizes digit-only names as the slot
-            # binding, so the find-or-create-by-tag lookup still works on
-            # subsequent operations.
-            slot_only_name = str(slot)
+            raise LockOperationFailed(
+                f"Matter set_lock_user failed for {self.lock.entity_id} on "
+                f"all fallback names {candidates}: {err}"
+            ) from err
+        if prior_failures:
+            LOGGER.debug(
+                "Lock %s: lock rejected %d earlier name candidate(s) for "
+                "slot %s (%s); created with %r so the slot binding "
+                "survives the read",
+                self.lock.entity_id,
+                len(prior_failures),
+                slot,
+                ", ".join(f"{name!r}: {err}" for name, err in prior_failures),
+                name_used,
+            )
+        return SetUserResult(user_id=result["user_index"], created=True)
+
+    @staticmethod
+    def _user_name_candidates(slot: int, primary_name: str | None) -> list[str]:
+        """
+        Return the cascade of ``set_lock_user`` userName candidates.
+
+        Order: canonical (carries display) -> compact ``lcm<slot>``
+        (alphanumeric ownership marker, charset-safe) -> slot-only
+        ``str(slot)`` (deepest fallback). Deduplicated while preserving
+        order so a primary_name that already equals one of the
+        fallbacks isn't retried; this avoids wasting a round-trip when
+        ``_build_tagged_user_name`` already collapsed to a fallback for
+        length reasons.
+
+        ``primary_name`` is typed ``str | None`` because the base
+        seam's ``User.name`` field is nullable, but ``_set_credential``
+        in the base already refuses to call us when it would be None;
+        the guard here is defensive.
+        """
+        candidates: list[str] = []
+        if primary_name is not None:
+            candidates.append(primary_name)
+        candidates.extend([make_compact_tagged_name(slot), str(slot)])
+        return list(dict.fromkeys(candidates))
+
+    async def _try_set_lock_user_with_fallbacks(
+        self,
+        client: Any,
+        node: Any,
+        *,
+        user_index: int | None,
+        candidate_names: list[str],
+    ) -> tuple[dict[str, Any], str, list[tuple[str, MatterError]]]:
+        """
+        Try each candidate userName in order; return on first success.
+
+        Returns ``(result, name_used, prior_failures)`` where
+        ``prior_failures`` is the list of ``(name, error)`` tuples for
+        every candidate the lock rejected before this one succeeded
+        (empty when the very first candidate worked).
+
+        ``ServiceValidationError`` and ``HomeAssistantError`` are NOT
+        charset-recoverable -- they signal "validation failed entirely"
+        or "transport closed." Trying the next candidate would hit the
+        same wall, so they raise immediately as ``LockOperationFailed``
+        / ``LockDisconnected``. Only ``MatterError`` (which carries the
+        lock firmware's specific rejection) triggers a fall-through to
+        the next candidate. If every candidate raises ``MatterError``,
+        the last error is re-raised so the caller can decide whether
+        to tolerate or escalate.
+        """
+        failures: list[tuple[str, MatterError]] = []
+        last_matter_error: MatterError | None = None
+        for name in candidate_names:
             try:
                 result = await set_lock_user(
                     client,
                     node,
-                    user_index=None,
-                    user_name=slot_only_name,
+                    user_index=user_index,
+                    user_name=name,
                 )
-            except ServiceValidationError as fallback_err:
-                # Same routing as the primary CREATE attempt -- input
-                # validation failures get LockOperationFailed regardless of
-                # which name attempt triggered them.
+            except ServiceValidationError as err:
                 raise LockOperationFailed(
-                    f"Matter set_lock_user rejected slot-only fallback for "
-                    f"{self.lock.entity_id}: {fallback_err}"
-                ) from fallback_err
-            except HomeAssistantError as fallback_err:
-                # Transport / disconnect during the fallback retry -- same
-                # routing as the primary attempt.
+                    f"Matter set_lock_user rejected input for "
+                    f"{self.lock.entity_id} (user_name={name!r}): {err}"
+                ) from err
+            except HomeAssistantError as err:
                 raise LockDisconnected(
-                    f"Matter set_lock_user failed on slot-only fallback for "
-                    f"{self.lock.entity_id}: {fallback_err}"
-                ) from fallback_err
-            except MatterError as fallback_err:
-                # Both attempts hit lock-side rejections (the original
-                # MatterError and a second MatterError on the slot-only
-                # retry). The lock is rejecting more than just the
-                # charset; surface as LockOperationFailed so the seam
-                # routes through retry rather than the catchall suspend.
-                raise LockOperationFailed(
                     f"Matter set_lock_user failed for {self.lock.entity_id} "
-                    f"on both canonical and slot-only fallback names: "
-                    f"canonical={err}, slot-only={fallback_err}"
-                ) from fallback_err
-            # See the UPDATE-path comment above: DEBUG (not INFO) so a
-            # lock that consistently needs the fallback doesn't flood
-            # the log on every credential write.
-            LOGGER.debug(
-                "Lock %s: lock rejected canonical tag %r for slot %s (%s); "
-                "created with slot-only %r so the slot binding survives the "
-                "read",
-                self.lock.entity_id,
-                user.name,
-                slot,
-                err,
-                slot_only_name,
-            )
-        return SetUserResult(user_id=result["user_index"], created=True)
+                    f"(user_name={name!r}): {err}"
+                ) from err
+            except MatterError as err:
+                failures.append((name, err))
+                last_matter_error = err
+                continue
+            return result, name, failures
+        # Every candidate hit a MatterError -- re-raise the last one so
+        # the caller can choose to tolerate (UPDATE) or escalate (CREATE).
+        assert last_matter_error is not None
+        raise last_matter_error
 
     def _slot_from_seam_user(self, user: User) -> int:
         """

--- a/tests/providers/matter/test_provider.py
+++ b/tests/providers/matter/test_provider.py
@@ -2297,11 +2297,12 @@ class TestSetUser:
         SetUser command on an existing user is a metadata-only update,
         and a transient 500 or a rejected name should not block the
         subsequent credential write.
+
+        ``HomeAssistantError`` short-circuits the cascade (the helper
+        raises ``LockDisconnected`` immediately because transport
+        failures aren't charset-recoverable); UPDATE swallows that
+        per the historical contract.
         """
-        # AsyncMock(side_effect=Error) raises the same error on every call.
-        # The new fallback path attempts canonical then slot-only; both raise
-        # here, so the test exercises the "both fail -> tolerate" branch
-        # while keeping the historical HomeAssistantError contract.
         mock_set_user = AsyncMock(side_effect=HomeAssistantError("500"))
         user = User(user_id=2, name="lcm:2:Updated Name")
         with (
@@ -2325,7 +2326,9 @@ class TestSetUser:
             result = await matter_lock_simple.async_set_user(user)
 
         assert result == SetUserResult(user_id=7, created=False)
-        assert mock_set_user.call_count == 2
+        # HomeAssistantError short-circuits the cascade -- only one
+        # attempt is made before LockDisconnected is raised + tolerated.
+        assert mock_set_user.call_count == 1
         assert "failed to update user name" in caplog.text
 
     async def test_set_user_update_tolerates_matter_sdk_error(
@@ -2342,10 +2345,11 @@ class TestSetUser:
         and let MatterError bubble past, causing the seam's catchall to
         spuriously suspend the slot and create a repair issue.
         """
-        # Both canonical and slot-only attempts raise the same error here;
-        # the test exercises the "both attempts fail -> tolerate" branch
-        # for a MatterError specifically. A dedicated test
-        # (test_set_user_update_falls_back_to_slot_only_on_charset_rejection)
+        # All cascade candidates (canonical, compact, slot-only) raise
+        # the same MatterError here; the test exercises the
+        # "all candidates fail -> tolerate" branch for a MatterError
+        # specifically. A dedicated test
+        # (test_set_user_update_falls_back_to_compact_on_charset_rejection)
         # covers the success-on-fallback case.
         mock_set_user = AsyncMock(
             side_effect=UnknownError("InteractionModelError: InvalidCommand (0x85)")
@@ -2375,22 +2379,23 @@ class TestSetUser:
         # subsequent credential write to the right user; only the name
         # update was dropped.
         assert result == SetUserResult(user_id=7, created=False)
-        assert mock_set_user.call_count == 2
+        # MatterError falls through all 3 candidates: canonical -> compact -> slot-only.
+        assert mock_set_user.call_count == 3
         assert "failed to update user name" in caplog.text
         assert "InvalidCommand (0x85)" in caplog.text
 
-    async def test_set_user_create_falls_back_to_slot_only_on_charset_rejection(
+    async def test_set_user_create_falls_back_to_compact_on_charset_rejection(
         self, hass: HomeAssistant, matter_lock_simple: MatterLock, caplog
     ) -> None:
-        """CREATE retries with the slot-only fallback when canonical is rejected.
+        """CREATE retries with the compact ``lcm<slot>`` fallback on canonical rejection.
 
         Some Matter lock firmwares restrict ``userName`` to alphanumeric
-        and reject the colons in ``lcm:<slot>:``. The provider retries
-        once with the slot-only fallback (``str(slot)``); the tolerant
-        parser recognizes digit-only names as the slot binding, so the
-        slot identity survives subsequent reads.
+        and reject the colons in ``lcm:<slot>:``. The cascade tries the
+        compact ``lcm<slot>`` form first (alphanumeric AND keeps the
+        ownership marker) before falling all the way back to bare
+        ``str(slot)``.
         """
-        # First call fails with InvalidCommand; second succeeds.
+        # First call (canonical) fails; second call (compact) succeeds.
         mock_set_user = AsyncMock(
             side_effect=[
                 UnknownError("InteractionModelError: InvalidCommand (0x85)"),
@@ -2420,25 +2425,61 @@ class TestSetUser:
         first_call_kwargs = mock_set_user.call_args_list[0].kwargs
         second_call_kwargs = mock_set_user.call_args_list[1].kwargs
         assert first_call_kwargs["user_name"] == "lcm:1:Alice"
-        assert second_call_kwargs["user_name"] == "1"
-        assert "rejected canonical tag" in caplog.text
-        assert "InvalidCommand (0x85)" in caplog.text
+        # Compact tier wins; we don't fall all the way to slot-only.
+        assert second_call_kwargs["user_name"] == "lcm1"
+        assert "rejected" in caplog.text and "lcm:1:Alice" in caplog.text
 
-    async def test_set_user_create_raises_when_both_attempts_fail(
-        self, hass: HomeAssistant, matter_lock_simple: MatterLock
+    async def test_set_user_create_falls_back_to_slot_only_when_compact_also_rejected(
+        self, hass: HomeAssistant, matter_lock_simple: MatterLock, caplog
     ) -> None:
-        """CREATE surfaces ``LockOperationFailed`` only after BOTH names fail.
+        """When the compact tier also fails, the cascade falls through to slot-only.
 
-        If the lock rejects the canonical AND the slot-only fallback,
-        the failure is more than just a charset issue. Surfacing as
-        ``LockOperationFailed`` lets the seam route through the normal
-        retry path rather than the catchall suspend (which would create
-        a spurious repair issue).
+        A lock that rejects both the colons and the ``lcm`` prefix
+        characters (very restrictive firmware) still gets a working
+        write via the bare digit fallback. The slot binding is still
+        recoverable via the tolerant parser's digit-only arm.
         """
         mock_set_user = AsyncMock(
             side_effect=[
-                UnknownError("InvalidCommand (0x85)"),
-                UnknownError("InvalidCommand again"),
+                UnknownError("colons rejected"),
+                UnknownError("lcm prefix rejected"),
+                {"user_index": 4},
+            ]
+        )
+        user = User(user_id=1, name="lcm:1:Alice")
+        caplog.set_level(logging.DEBUG, logger=_PROVIDER_MODULE)
+        with (
+            patch.object(
+                matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+            ),
+            patch.object(
+                matter_lock_simple, "_get_matter_node", return_value=MagicMock()
+            ),
+            self._patch_users([]),
+            patch(f"{_PROVIDER_MODULE}.set_lock_user", mock_set_user),
+        ):
+            result = await matter_lock_simple.async_set_user(user)
+
+        assert result == SetUserResult(user_id=4, created=True)
+        assert mock_set_user.call_count == 3
+        names_tried = [c.kwargs["user_name"] for c in mock_set_user.call_args_list]
+        assert names_tried == ["lcm:1:Alice", "lcm1", "1"]
+
+    async def test_set_user_create_raises_when_all_attempts_fail(
+        self, hass: HomeAssistant, matter_lock_simple: MatterLock
+    ) -> None:
+        """CREATE surfaces ``LockOperationFailed`` only after every name fails.
+
+        If the lock rejects canonical, compact, AND slot-only, the
+        failure is more than a charset issue. Surfacing as
+        ``LockOperationFailed`` lets the seam route through the normal
+        retry path rather than the catchall suspend.
+        """
+        mock_set_user = AsyncMock(
+            side_effect=[
+                UnknownError("canonical rejected"),
+                UnknownError("compact rejected"),
+                UnknownError("slot-only rejected"),
             ]
         )
         user = User(user_id=1, name="lcm:1:Alice")
@@ -2451,25 +2492,27 @@ class TestSetUser:
             ),
             self._patch_users([]),
             patch(f"{_PROVIDER_MODULE}.set_lock_user", mock_set_user),
-            pytest.raises(LockOperationFailed, match="both canonical and slot-only"),
+            pytest.raises(LockOperationFailed, match="all fallback names"),
         ):
             await matter_lock_simple.async_set_user(user)
 
-        assert mock_set_user.call_count == 2
+        assert mock_set_user.call_count == 3
 
     async def test_set_user_create_routes_validation_error_during_fallback(
         self, hass: HomeAssistant, matter_lock_simple: MatterLock
     ) -> None:
-        """A ``ServiceValidationError`` during the slot-only fallback gets typed routing.
+        """A ``ServiceValidationError`` during the cascade gets typed routing.
 
-        Mirrors the primary CREATE attempt's exception handling: the
-        slot-only retry must map ``ServiceValidationError`` to
-        ``LockOperationFailed`` and ``HomeAssistantError`` to
-        ``LockDisconnected`` so a transient validation or disconnect
-        during the fallback doesn't slip past as an untyped exception
-        (which would route to the seam's catchall suspend path and
-        create a spurious repair issue).
+        The helper raises typed seam exceptions immediately on
+        ``ServiceValidationError`` and ``HomeAssistantError`` because
+        those aren't charset-recoverable; trying the next candidate
+        would hit the same wall. Routing them through
+        ``LockOperationFailed`` / ``LockDisconnected`` keeps the seam's
+        retry path in play instead of dropping into the catchall
+        suspend.
         """
+        # Canonical hits MatterError -> falls through; compact hits
+        # ServiceValidationError -> immediate LockOperationFailed.
         mock_set_user = AsyncMock(
             side_effect=[
                 UnknownError("InvalidCommand (0x85)"),
@@ -2486,7 +2529,7 @@ class TestSetUser:
             ),
             self._patch_users([]),
             patch(f"{_PROVIDER_MODULE}.set_lock_user", mock_set_user),
-            pytest.raises(LockOperationFailed, match="rejected slot-only fallback"),
+            pytest.raises(LockOperationFailed, match="rejected input"),
         ):
             await matter_lock_simple.async_set_user(user)
 
@@ -2495,7 +2538,7 @@ class TestSetUser:
     async def test_set_user_create_routes_disconnect_during_fallback(
         self, hass: HomeAssistant, matter_lock_simple: MatterLock
     ) -> None:
-        """A ``HomeAssistantError`` during the slot-only fallback maps to ``LockDisconnected``."""
+        """A ``HomeAssistantError`` during the cascade maps to ``LockDisconnected``."""
         mock_set_user = AsyncMock(
             side_effect=[
                 UnknownError("InvalidCommand (0x85)"),
@@ -2512,22 +2555,20 @@ class TestSetUser:
             ),
             self._patch_users([]),
             patch(f"{_PROVIDER_MODULE}.set_lock_user", mock_set_user),
-            pytest.raises(LockDisconnected, match="slot-only fallback"),
+            pytest.raises(LockDisconnected, match="transport closed"),
         ):
             await matter_lock_simple.async_set_user(user)
 
         assert mock_set_user.call_count == 2
 
-    async def test_set_user_update_falls_back_to_slot_only_on_charset_rejection(
+    async def test_set_user_update_falls_back_to_compact_on_charset_rejection(
         self, hass: HomeAssistant, matter_lock_simple: MatterLock, caplog
     ) -> None:
-        """UPDATE retries with the slot-only fallback so the slot tag survives.
+        """UPDATE prefers the compact ``lcm<slot>`` tier over bare slot-only.
 
         UPDATE's contract is "tolerate name-set failures," but a
-        successful slot-only rename preserves the slot binding across
-        reads (the digit-only name parses to the same slot). Strictly
-        better than letting the name drift to whatever pre-LCM string
-        the lock had.
+        successful compact rename preserves both the slot binding AND
+        the LCM ownership marker -- strictly better than bare digits.
         """
         mock_set_user = AsyncMock(
             side_effect=[
@@ -2561,24 +2602,25 @@ class TestSetUser:
 
         assert result == SetUserResult(user_id=7, created=False)
         assert mock_set_user.call_count == 2
-        assert mock_set_user.call_args_list[1].kwargs["user_name"] == "2"
-        assert "rejected canonical tag" in caplog.text
-        assert "renamed to slot-only" in caplog.text
+        # Compact tier (lcm2), not bare slot-only (2).
+        assert mock_set_user.call_args_list[1].kwargs["user_name"] == "lcm2"
+        assert "rejected" in caplog.text and "lcm:2:Updated Name" in caplog.text
 
-    async def test_set_user_update_tolerates_when_both_attempts_fail(
+    async def test_set_user_update_tolerates_when_all_attempts_fail(
         self, hass: HomeAssistant, matter_lock_simple: MatterLock, caplog
     ) -> None:
-        """UPDATE still tolerates the failure when both attempts fail.
+        """UPDATE tolerates the failure when every cascade candidate fails.
 
         The user record at ``existing_user_index`` is still valid; only
         the rename was lost. The subsequent credential write can still
         proceed, so we return the resolved user_id and log a single
-        warning carrying both error messages for diagnosis.
+        warning carrying the last error and the list of tried names.
         """
         mock_set_user = AsyncMock(
             side_effect=[
                 UnknownError("canonical rejected"),
-                UnknownError("slot-only rejected too"),
+                UnknownError("compact rejected"),
+                UnknownError("slot-only rejected"),
             ]
         )
         user = User(user_id=2, name="lcm:2:Bob")
@@ -2603,10 +2645,10 @@ class TestSetUser:
             result = await matter_lock_simple.async_set_user(user)
 
         assert result == SetUserResult(user_id=9, created=False)
-        assert mock_set_user.call_count == 2
+        assert mock_set_user.call_count == 3
         assert "failed to update user name" in caplog.text
-        assert "canonical rejected" in caplog.text
-        assert "slot-only rejected too" in caplog.text
+        # The warning carries the LAST error message + the list of names.
+        assert "slot-only rejected" in caplog.text
 
 
 # =============================================================================

--- a/tests/providers/test_util.py
+++ b/tests/providers/test_util.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 from custom_components.lock_code_manager.providers._util import (
+    make_compact_tagged_name,
     make_legacy_tagged_name,
     make_tagged_name,
     parse_slot_num,
@@ -28,6 +29,21 @@ class TestMakeTaggedName:
     )
     def test_make_tagged_name(self, slot: int, name: str | None, expected: str) -> None:
         assert make_tagged_name(slot, name) == expected
+
+
+class TestMakeCompactTaggedName:
+    """Compact ``lcm<slot>`` builder for charset-restrictive locks."""
+
+    @pytest.mark.parametrize(
+        ("slot", "expected"),
+        [
+            pytest.param(1, "lcm1", id="single-digit"),
+            pytest.param(42, "lcm42", id="multi-digit"),
+            pytest.param(255, "lcm255", id="max-slot"),
+        ],
+    )
+    def test_make_compact_tagged_name(self, slot: int, expected: str) -> None:
+        assert make_compact_tagged_name(slot) == expected
 
 
 class TestMakeLegacyTaggedName:
@@ -85,8 +101,13 @@ class TestParseTagWithRewrite:
             pytest.param(
                 "[LCM:5]Tight", (5, "Tight", True), id="legacy-no-space-after-bracket"
             ),
-            # Slot-only fallback -- written when the lock's
-            # max_user_name_length can't fit the canonical prefix.
+            # Compact fallback -- written when the lock firmware
+            # rejects the colons in the canonical prefix.
+            pytest.param("lcm1", (1, "", False), id="compact-single-digit"),
+            pytest.param("lcm42", (42, "", False), id="compact-multi-digit"),
+            pytest.param("lcm255", (255, "", False), id="compact-max-slot"),
+            # Slot-only fallback -- written when neither canonical nor
+            # compact tier survives the lock's constraints.
             pytest.param("5", (5, "", False), id="slot-only-single-digit"),
             pytest.param("255", (255, "", False), id="slot-only-multi-digit"),
             # Untagged or malformed -- no match, no rewrite.
@@ -119,6 +140,17 @@ class TestParseTagWithRewrite:
     ) -> None:
         assert parse_tag_with_rewrite(input_name) == expected
 
+    def test_compact_regex_does_not_match_canonical(self) -> None:
+        """Anchored regexes prevent the compact arm from claiming a canonical match.
+
+        The compact regex is ``^lcm(\\d+)$`` (full-anchored) and would
+        not match ``lcm:5:Alice`` (the trailing ``:5:Alice`` violates
+        the ``$`` anchor). Pinning this in a dedicated test so a future
+        edit that relaxes the anchor (or drops it entirely) gets
+        caught.
+        """
+        assert parse_tag_with_rewrite("lcm:5:Alice") == (5, "Alice", False)
+
     def test_canonical_prefix_wins_when_display_contains_legacy_text(self) -> None:
         """The canonical prefix is consumed first; the display is taken verbatim.
 
@@ -141,6 +173,7 @@ class TestParseTag:
         [
             pytest.param("lcm:5:Alice", (5, "Alice"), id="new-format"),
             pytest.param("[LCM:5] Alice", (5, "Alice"), id="legacy-format"),
+            pytest.param("lcm42", (42, ""), id="compact"),
             pytest.param("42", (42, ""), id="slot-only"),
             pytest.param("Alice", (None, "Alice"), id="untagged"),
             pytest.param("", (None, ""), id="empty"),


### PR DESCRIPTION
## Proposed change

Adds an intermediate \`lcm<slot>\` tier to the matter \`set_lock_user\` cascade. For locks that reject the colons in \`lcm:<slot>:<name>\`, the previous fallback was bare \`str(slot)\` — which works but loses the LCM ownership marker, making collisions possible if another controller writes a digit-only user on the same lock. The compact form is alphanumeric (charset-safe) AND keeps the \`lcm\` prefix (ownership-marked), so it's strictly better as the first fallback.

### Cascade

1. \`lcm:<slot>:<display>\` — canonical, carries display.
2. \`lcm<slot>\` — compact, charset-safe, ownership-marked. **New.**
3. \`<slot>\` — deepest fallback, digit-only.

### Builds on #1248

Depends on #1248 (review fixes for the original two-tier fallback). The cascade-helper introduced here subsumes the per-call try/except blocks from #1248; both PRs touch the same code so this should merge after #1248.

### Implementation

- New \`make_compact_tagged_name(slot)\` in \`_util.py\`.
- New \`_COMPACT_TAG_RE = r\"^lcm(\\d+)$\"\` parser arm, placed before the slot-only arm in \`parse_tag_with_rewrite\`. The two arms are mutually exclusive via anchors; order is for intent clarity.
- New \`_try_set_lock_user_with_fallbacks\` helper on \`MatterLock\` owns the cascade. \`ServiceValidationError\` / \`HomeAssistantError\` short-circuit immediately (not charset-recoverable); \`MatterError\` falls through to the next candidate.
- \`_user_name_candidates\` dedupes via \`dict.fromkeys\` to preserve order and skip redundant retries when \`_build_tagged_user_name\` already collapsed the primary to a fallback for length reasons.

UPDATE tolerates any cascade exhaustion (historical PR #1077 contract — the rename is metadata-only). CREATE escalates to \`LockOperationFailed\` (we need an allocated user_index).

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Test plan

- [x] Full suite passes locally (1171/1171; net +11 from new cases)
- [x] 17 \`TestSetUser\` cases cover each cascade outcome (first-attempt success, compact-tier success, slot-only success, all-fail tolerate on UPDATE, all-fail escalate on CREATE, short-circuit on transport/validation)
- [x] \`TestParseTag*\` gains compact-tier cases + an adversarial test pinning the \`^...$\` anchors so future relaxations don't let the compact arm claim canonical matches
- [ ] Live Matter lock (raman_office): confirm slot 1 PIN gets written with \`userName=\"lcm1\"\` (was suspending repeatedly with the previous canonical attempt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)