### PR TITLE
fix(zwave_js,matter): tolerate ambiguous credential writes; universal masked read projection (#1251, #1257)

### DIFF
--- a/custom_components/lock_code_manager/providers/_zwave_js_uc.py
+++ b/custom_components/lock_code_manager/providers/_zwave_js_uc.py
@@ -133,6 +133,16 @@ class ZWaveJSUserCodeFallbackSupport(BaseLock):
         """Return the Z-Wave JS node; the concrete provider supplies this."""
         raise NotImplementedError
 
+    def _pin_state(self, data: str | bytes | None) -> SlotCredential:
+        """
+        Project raw credential data to a SlotCredential.
+
+        Universal masked/withheld-aware projection, implemented by the
+        concrete provider (``ZWaveJSLock._pin_state``) and reused here so
+        the UC fallback's read path matches the unified path exactly.
+        """
+        raise NotImplementedError
+
     def _node_supports_user_code_cc(self) -> bool:
         """Return whether the node's endpoint 0 advertises User Code CC."""
         return any(cc.id == CommandClass.USER_CODE for cc in self.node.command_classes)
@@ -173,15 +183,14 @@ class ZWaveJSUserCodeFallbackSupport(BaseLock):
 
     def _uc_fallback_capabilities(self) -> LockCapabilities | None:
         """
-        Detect the fallback and build slot-only capabilities for it.
+        Build slot-only capabilities for a degenerate-capability lock.
 
-        Called by ``async_get_capabilities`` after the unified API
-        reported no usable PIN support. Only falls back when the node
-        advertises User Code CC -- without it the legacy utilities
-        cannot work either, and the lock genuinely has no PIN support
-        LCM can manage -- and when the User Code CC value DB walk finds
-        slots. Sets ``_uc_fallback`` accordingly and returns None when
-        no fallback is possible.
+        Called by ``async_get_capabilities`` only when the unified API
+        reports no usable PIN slots (the #1251 zero-slot variant). Falls
+        back to the legacy User Code CC value-DB walk for the slot count.
+        Returns None -- and clears ``_uc_fallback`` -- when the node has
+        no User Code CC, so a true U3C lock with degenerate caps (which
+        the legacy utilities can't help) is not mis-routed here.
 
         ``get_usercodes`` walks slot 1, 2, 3, ... in the value DB until
         ``NotFoundError``, so the returned list length is the lock's
@@ -190,18 +199,19 @@ class ZWaveJSUserCodeFallbackSupport(BaseLock):
         walking, so we let any unexpected exception surface rather
         than silently mis-routing the lock to "no PIN support".
         """
-        uc_slots = (
-            get_usercodes(self.node) if self._node_supports_user_code_cc() else []
-        )
-        if not uc_slots:
+        if not self._node_supports_user_code_cc():
             self._uc_fallback = False
             return None
-        _LOGGER.warning(
-            "Lock %s: unified access-control API reports no usable PIN "
-            "capabilities but the node supports User Code CC with %s slots; "
-            "falling back to legacy User Code CC handling (see issue #1251)",
+        num_slots = len(get_usercodes(self.node))
+        if not num_slots:
+            self._uc_fallback = False
+            return None
+        _LOGGER.debug(
+            "Lock %s: unified API reports no usable PIN slots but the node "
+            "supports User Code CC (%s slots); using the legacy User Code "
+            "CC value path (see issue #1251)",
             self.lock.entity_id,
-            len(uc_slots),
+            num_slots,
         )
         self._uc_fallback = True
         return LockCapabilities(
@@ -214,7 +224,7 @@ class ZWaveJSUserCodeFallbackSupport(BaseLock):
             max_users=0,
             credential_types={
                 CredentialType.PIN: CredentialTypeCapability(
-                    num_slots=len(uc_slots),
+                    num_slots=num_slots,
                     # UC spec allows 4-10 ASCII digits per User Code CC v1+.
                     min_length=4,
                     max_length=10,
@@ -224,18 +234,20 @@ class ZWaveJSUserCodeFallbackSupport(BaseLock):
             max_user_name_length=0,
         )
 
-    @staticmethod
-    def _uc_slot_state(in_use: bool | None, usercode: str | None) -> SlotCredential:
+    def _uc_slot_state(
+        self, in_use: bool | None, usercode: str | None
+    ) -> SlotCredential:
         """
         Project a User Code CC slot to a ``SlotCredential``.
 
-        Slots count as empty only when ``in_use`` is explicitly ``False``,
-        or when ``in_use`` is unknown (``None``) with no cached value --
-        the latter matches the legacy 3.x reader. Masked codes (all
-        asterisks) and occupied slots without a cached value count as
-        unreadable; an unknown ``in_use`` with a present value is treated
-        as occupied so a partially populated cache cannot erase a live
-        PIN (mirrors the push-path rule at ``_handle_uc_value_update``).
+        Adds the User Code CC ``in_use`` (userIdStatus) gate on top of the
+        shared ``_pin_state`` projection. Slots count as empty only when
+        ``in_use`` is explicitly ``False``, or when ``in_use`` is unknown
+        (``None``) with no cached value -- the latter matches the legacy
+        3.x reader. An occupied (or unknown-but-present) slot defers to
+        ``_pin_state`` so masked/withheld codes map to unreadable exactly
+        as on the unified path, and a partially populated cache cannot
+        erase a live PIN.
         """
         if in_use is False:
             return SlotCredential.empty()
@@ -245,10 +257,7 @@ class ZWaveJSUserCodeFallbackSupport(BaseLock):
                 if in_use is None
                 else SlotCredential.unreadable()
             )
-        code = str(usercode)
-        if code == "*" * len(code):
-            return SlotCredential.unreadable()
-        return SlotCredential.known(code)
+        return self._pin_state(usercode)
 
     async def _async_uc_users_from_value_db(self) -> list[User]:
         """

--- a/custom_components/lock_code_manager/providers/matter.py
+++ b/custom_components/lock_code_manager/providers/matter.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass
 from datetime import timedelta
 from typing import Any, Literal
 
+from matter_server.client.exceptions import MatterClientException
 from matter_server.common.errors import MatterError
 from matter_server.common.models import EventType
 
@@ -69,6 +70,20 @@ _LOCK_DATA_TYPE_PIN = 6
 _DATA_OP_ADD = 0
 _DATA_OP_CLEAR = 1
 _DATA_OP_MODIFY = 2
+
+
+def _is_transient_credential_status(status: str) -> bool:
+    """
+    Return True for a SetCredential status that should be retried, not rejected.
+
+    HA's matter ``lock_helpers`` maps recognized DlStatus values to names
+    (``success`` / ``failure`` / ``duplicate`` / ``occupied``) and formats
+    anything else as ``unknown(<code>)``. An unmapped status is treated as
+    transient (route to the retry path) -- notably ``unknown(133)`` observed
+    while a lock is not fully ready right after startup (issue #1257) --
+    rather than a definitive rejection that permanently disables the slot.
+    """
+    return status.startswith("unknown(")
 
 
 def _lcm_slot_from_raw_users_by_user_index(
@@ -684,8 +699,12 @@ class MatterLock(BaseLock):
                 lock_entity_id=self.lock.entity_id,
                 reason=str(err),
             ) from err
-        except HomeAssistantError as err:
-            # Transport / endpoint failure -> route to the retry path.
+        except (HomeAssistantError, MatterError, MatterClientException) as err:
+            # Transport / connectivity / server failure -> route to the retry
+            # path. MatterError and MatterClientException are independent of
+            # HomeAssistantError (e.g. ``InvalidState: Not connected`` during
+            # startup, issue #1257), so they must be caught explicitly or they
+            # escape to the generic handler and suspend the slot.
             raise LockDisconnected(
                 f"Matter set_lock_credential failed for {self.lock.entity_id}: {err}"
             ) from err
@@ -749,6 +768,16 @@ class MatterLock(BaseLock):
             )
         except SetCredentialFailedError as err:
             status = (err.translation_placeholders or {}).get("status", "")
+            if _is_transient_credential_status(status):
+                # Unmapped/unknown status (e.g. ``unknown(133)`` seen while the
+                # lock is not fully ready at startup, issue #1257). Route to the
+                # retry path rather than permanently disabling the slot: a later
+                # tick after Matter is ready will succeed. Recognized rejections
+                # (occupied/failure) fall through to CodeRejectedError below.
+                raise LockDisconnected(
+                    f"Matter set_lock_credential returned a transient status "
+                    f"'{status}' for {self.lock.entity_id} slot {slot}"
+                ) from err
             if status != "duplicate":
                 raise CodeRejectedError(
                     code_slot=slot,
@@ -805,6 +834,11 @@ class MatterLock(BaseLock):
                         code_slot=slot,
                         lock_entity_id=self.lock.entity_id,
                     ) from retry_err
+                if _is_transient_credential_status(retry_status):
+                    raise LockDisconnected(
+                        f"Matter set_lock_credential returned a transient status "
+                        f"'{retry_status}' for {self.lock.entity_id} slot {slot}"
+                    ) from retry_err
                 raise CodeRejectedError(
                     code_slot=slot,
                     lock_entity_id=self.lock.entity_id,
@@ -846,7 +880,9 @@ class MatterLock(BaseLock):
                 f"Matter clear_lock_credential rejected input for "
                 f"{self.lock.entity_id}: {err}"
             ) from err
-        except HomeAssistantError as err:
+        except (HomeAssistantError, MatterError, MatterClientException) as err:
+            # Connectivity/server failure (incl. ``InvalidState: Not connected``
+            # at startup, issue #1257) -> retry rather than suspend.
             raise LockDisconnected(
                 f"Matter clear_lock_credential failed for {self.lock.entity_id}: {err}"
             ) from err

--- a/custom_components/lock_code_manager/providers/matter.py
+++ b/custom_components/lock_code_manager/providers/matter.py
@@ -76,14 +76,33 @@ def _is_transient_credential_status(status: str) -> bool:
     """
     Return True for a SetCredential status that should be retried, not rejected.
 
-    HA's matter ``lock_helpers`` maps recognized DlStatus values to names
-    (``success`` / ``failure`` / ``duplicate`` / ``occupied``) and formats
-    anything else as ``unknown(<code>)``. An unmapped status is treated as
-    transient (route to the retry path) -- notably ``unknown(133)`` observed
-    while a lock is not fully ready right after startup (issue #1257) --
+    HA's matter ``lock_helpers.set_lock_credential`` maps recognized DlStatus
+    values to names (``success`` / ``failure`` / ``duplicate`` / ``occupied``)
+    and formats anything else as ``unknown(<code>)`` --
+    ``SET_CREDENTIAL_STATUS_MAP.get(status_code, f"unknown({status_code})")`` --
+    discarding the raw code. So ``unknown(`` is the only signal LCM has for "the
+    lock returned a status the helper did not recognize", and an unmapped status
+    is treated as transient (route to the retry path) -- notably ``unknown(133)``
+    observed while a lock is not fully ready right after startup (issue #1257) --
     rather than a definitive rejection that permanently disables the slot.
+
+    FRAGILE COUPLING: this depends on HA's private ``unknown(<code>)`` format,
+    which has no stability contract. If that helper ever changes the format or
+    starts mapping a code we rely on (e.g. 133 -> a real name), this predicate
+    silently returns False and the #1257 not-ready case regresses to a permanent
+    suspend. ``tests/providers/matter/test_provider.py`` pins the current format.
     """
     return status.startswith("unknown(")
+
+
+def _transient_status_disconnect(
+    entity_id: str, slot: int, status: str
+) -> LockDisconnected:
+    """Build the LockDisconnected raised for a transient SetCredential status."""
+    return LockDisconnected(
+        f"Matter set_lock_credential returned a transient status "
+        f"'{status}' for {entity_id} slot {slot}"
+    )
 
 
 def _lcm_slot_from_raw_users_by_user_index(
@@ -774,9 +793,8 @@ class MatterLock(BaseLock):
                 # retry path rather than permanently disabling the slot: a later
                 # tick after Matter is ready will succeed. Recognized rejections
                 # (occupied/failure) fall through to CodeRejectedError below.
-                raise LockDisconnected(
-                    f"Matter set_lock_credential returned a transient status "
-                    f"'{status}' for {self.lock.entity_id} slot {slot}"
+                raise _transient_status_disconnect(
+                    self.lock.entity_id, slot, status
                 ) from err
             if status != "duplicate":
                 raise CodeRejectedError(
@@ -816,7 +834,15 @@ class MatterLock(BaseLock):
                     f"Matter clear_lock_credential rejected input for "
                     f"{self.lock.entity_id} during sync-duplicate retry: {clear_err}"
                 ) from clear_err
-            except HomeAssistantError as clear_err:
+            except (
+                HomeAssistantError,
+                MatterError,
+                MatterClientException,
+            ) as clear_err:
+                # Same connectivity-vs-HomeAssistantError split as the other
+                # clear/set sites (issue #1257): a MatterClientException here
+                # (e.g. ``InvalidState: Not connected`` mid-retry) must route to
+                # retry, not escape to the generic handler and suspend the slot.
                 raise LockDisconnected(
                     f"Matter clear_lock_credential failed for "
                     f"{self.lock.entity_id} during sync-duplicate retry: {clear_err}"
@@ -835,9 +861,8 @@ class MatterLock(BaseLock):
                         lock_entity_id=self.lock.entity_id,
                     ) from retry_err
                 if _is_transient_credential_status(retry_status):
-                    raise LockDisconnected(
-                        f"Matter set_lock_credential returned a transient status "
-                        f"'{retry_status}' for {self.lock.entity_id} slot {slot}"
+                    raise _transient_status_disconnect(
+                        self.lock.entity_id, slot, retry_status
                     ) from retry_err
                 raise CodeRejectedError(
                     code_slot=slot,

--- a/custom_components/lock_code_manager/providers/zwave_js.py
+++ b/custom_components/lock_code_manager/providers/zwave_js.py
@@ -242,27 +242,30 @@ class ZWaveJSLock(ZWaveJSUserCodeFallbackSupport):
         """
         Report the lock's user/credential capabilities.
 
-        Routes the lock to the right write path based on which credential
-        command class it implements:
+        Routes the lock based on whether the unified API can express its PIN
+        capabilities:
 
-        - **User Credential CC (U3C) with usable PIN capabilities** -> the
-          unified ``access_control`` API (full user lifecycle).
-        - **Everything else that has User Code CC** -> the legacy User
-          Code CC fallback (slot-only). This covers both UC-only locks
-          and dual-CC locks whose U3C capabilities are degenerate.
+        - **Usable PIN capabilities reported** (``num_slots > 0``) -> the
+          unified ``access_control`` API. This is the common path for both
+          U3C locks and healthy User Code CC-only locks. Masked-code locks
+          stay correct here via the universal read projection (``_pin_state``
+          maps a withheld code to ``unreadable``) and tolerant write handling
+          (a driver ``ERROR_UNKNOWN`` from the masked read-back verification
+          is treated as a completed set in ``async_set_credential``, not a
+          rejection) -- see issue #1251.
+        - **Degenerate capabilities** (PIN missing or ``num_slots == 0``) ->
+          the legacy User Code CC fallback (slot-only), which addresses slots
+          directly because the unified API can't even express them. Only the
+          zero-slot variant needs this; a node with no User Code CC at all has
+          no PIN support LCM can manage.
 
-        Every User Code CC-only lock uses the legacy path even when the
-        unified API reports healthy capabilities, because the driver's
-        unified UC write verifies by reading the code back and comparing
-        it to what was written -- which fails for locks that report
-        masked user codes, turning an accepted write into a phantom
-        ``ERROR_UNKNOWN`` rejection (issue #1251; the same path is also
-        where degenerate zero-slot capabilities originate). The legacy
-        ``set_usercode`` path is exactly what LCM 3.x used for these
-        locks and does not do that equality check. Once the upstream
-        driver fixes both the verification and the capability reporting
-        (zwave-js/zwave-js#8873), only true U3C locks need the unified
-        API and this fallback can be removed (see ``_zwave_js_uc.py``).
+        Note: this method does NOT route by command class -- a User Code
+        CC-only lock with healthy capabilities uses the unified path, relying
+        on the projection + tolerant-write handling above rather than the
+        legacy fallback. Only degenerate capabilities trigger the fallback.
+        Once the upstream driver fixes the masked-read verification and the
+        capability reporting (zwave-js/zwave-js#8873), the fallback can be
+        removed entirely (see ``_zwave_js_uc.py``).
         """
         try:
             caps = await lock_helpers.async_get_credential_capabilities(self.node)

--- a/custom_components/lock_code_manager/providers/zwave_js.py
+++ b/custom_components/lock_code_manager/providers/zwave_js.py
@@ -157,12 +157,26 @@ class ZWaveJSLock(ZWaveJSUserCodeFallbackSupport):
         return True
 
     def _pin_state(self, data: str | bytes | None) -> SlotCredential:
-        """Project Z-Wave credential data to a SlotCredential (readable when present)."""
+        """
+        Project Z-Wave credential data to a SlotCredential.
+
+        Universal across both command classes (User Code CC and User
+        Credential CC): a present slot whose code we can read becomes
+        ``known``; a present slot whose code is withheld becomes
+        ``unreadable``. Many locks report the PIN back masked (all
+        asterisks) or omit it entirely for security -- those carry no
+        comparable value, so they are unreadable, NOT ``known`` of the
+        masked string (which would surface a wrong PIN and never
+        reconcile against the configured one).
+        """
         if not data:
             return SlotCredential.unreadable()
         # CredentialData.data is str | bytes; decode bytes so a Personal
         # Identification Number is the digit string, not "b'1234'".
-        return SlotCredential.known(data if isinstance(data, str) else data.decode())
+        code = data if isinstance(data, str) else data.decode()
+        if not code or code == "*" * len(code):
+            return SlotCredential.unreadable()
+        return SlotCredential.known(code)
 
     async def async_get_users(self) -> list[User]:
         """
@@ -228,27 +242,27 @@ class ZWaveJSLock(ZWaveJSUserCodeFallbackSupport):
         """
         Report the lock's user/credential capabilities.
 
-        Auto-detects User Code CC (UC) vs User Credential CC (U3C) and
-        returns capabilities shaped so the seam routes through the right
-        code path.
+        Routes the lock to the right write path based on which credential
+        command class it implements:
 
-        The unified ``access_control`` API in node-zwave-js computes its
-        capabilities from cached interview data; on some locks that data
-        is degenerate -- the PIN credential type comes back either
-        missing or advertising ``num_slots=0`` even though the lock
-        manages codes fine through the legacy User Code CC (issue
-        #1251, upstream fix in zwave-js/zwave-js#8873). When that
-        happens AND the node actually advertises User Code CC, we fall
-        back to reading the lock's UC slot count from the value DB and
-        return slot-only capabilities: ``supports_user_management=False``
-        and ``max_user_name_length=0``, which the seam recognizes as a
-        slot-only lock and routes through the credential-only
-        primitives (``async_set_credential`` / ``async_delete_credential``
-        / ``async_get_users``) without the user lifecycle. All
-        credential operations then use the User Code CC utilities
-        directly. Once the upstream fix ships and the unified API
-        reports usable PIN capabilities for these locks, the fallback
-        detection stops triggering on its own.
+        - **User Credential CC (U3C) with usable PIN capabilities** -> the
+          unified ``access_control`` API (full user lifecycle).
+        - **Everything else that has User Code CC** -> the legacy User
+          Code CC fallback (slot-only). This covers both UC-only locks
+          and dual-CC locks whose U3C capabilities are degenerate.
+
+        Every User Code CC-only lock uses the legacy path even when the
+        unified API reports healthy capabilities, because the driver's
+        unified UC write verifies by reading the code back and comparing
+        it to what was written -- which fails for locks that report
+        masked user codes, turning an accepted write into a phantom
+        ``ERROR_UNKNOWN`` rejection (issue #1251; the same path is also
+        where degenerate zero-slot capabilities originate). The legacy
+        ``set_usercode`` path is exactly what LCM 3.x used for these
+        locks and does not do that equality check. Once the upstream
+        driver fixes both the verification and the capability reporting
+        (zwave-js/zwave-js#8873), only true U3C locks need the unified
+        API and this fallback can be removed (see ``_zwave_js_uc.py``).
         """
         try:
             caps = await lock_helpers.async_get_credential_capabilities(self.node)
@@ -259,7 +273,10 @@ class ZWaveJSLock(ZWaveJSUserCodeFallbackSupport):
         pin = caps["supported_credential_types"].get(_PIN_TYPE_STR)
 
         if pin and pin["num_slots"] > 0:
-            # The unified API advertises real PIN credential slots.
+            # The unified API advertises real PIN credential slots. Use it;
+            # the universal read projection (``_pin_state``) and tolerant
+            # write handling below keep masked-code locks working on this
+            # path regardless of which CC the driver dispatches to.
             self._uc_fallback = False
             return LockCapabilities(
                 supports_user_management=caps["supports_user_management"],
@@ -275,11 +292,14 @@ class ZWaveJSLock(ZWaveJSUserCodeFallbackSupport):
                 max_user_name_length=caps.get("max_user_name_length", 0),
             )
 
-        # Degenerate unified capabilities (issue #1251): try the User Code
-        # CC fallback layer; when it does not apply either, the lock has
-        # no PIN support LCM can manage.
+        # Degenerate unified capabilities (issue #1251 zero-slot variant):
+        # the unified API can't even express the lock's PIN slots, so it
+        # can't write through them. Fall back to the legacy User Code CC
+        # utilities, which address slots directly. When the node has no
+        # User Code CC either, the lock genuinely has no PIN support.
         if uc_caps := self._uc_fallback_capabilities():
             return uc_caps
+        self._uc_fallback = False
         return LockCapabilities(
             supports_user_management=False,
             max_users=0,
@@ -420,6 +440,17 @@ class ZWaveJSLock(ZWaveJSUserCodeFallbackSupport):
         Otherwise the write goes through HA's
         ``lock_helpers.async_set_credential``, whose translation-key
         errors are mapped to LCM's typed exceptions.
+
+        A driver ``ERROR_UNKNOWN`` (HA key ``credential_rejected_unknown``)
+        is treated as a COMPLETED set rather than a rejection: the driver
+        returns it when its post-write verification can't confirm the
+        code, which notably happens for locks that report the user code
+        back masked/withheld -- there the write actually succeeded
+        (``userIdStatus`` -> Enabled). Reconciliation (the sync manager's
+        last-set tracking + the masked-as-unreadable read-back) verifies
+        it, instead of permanently disabling an accepted write (#1251).
+        Definitive rejections (duplicate, occupied, manufacturer rules,
+        validation) still surface as typed errors.
         """
         if await self._async_uc_fallback_active():
             return await self._async_uc_set_usercode(credential.slot, pin)
@@ -438,11 +469,22 @@ class ZWaveJSLock(ZWaveJSUserCodeFallbackSupport):
                 f"set credential slot {credential.slot} failed: {err}"
             ) from err
         except HomeAssistantError as err:
-            if getattr(err, "translation_key", None) == "credential_rejected_duplicate":
+            key = getattr(err, "translation_key", None)
+            if key == "credential_rejected_duplicate":
                 raise DuplicateCodeError(
                     code_slot=credential.slot,
                     lock_entity_id=self.lock.entity_id,
                 ) from err
+            if key == "credential_rejected_unknown":
+                _LOGGER.debug(
+                    "Lock %s slot %s: driver returned ERROR_UNKNOWN; treating "
+                    "as a completed set pending reconciliation (the lock may "
+                    "report the code back masked -- see issue #1251): %s",
+                    self.lock.entity_id,
+                    credential.slot,
+                    err,
+                )
+                return True
             raise CodeRejectedError(
                 code_slot=credential.slot,
                 lock_entity_id=self.lock.entity_id,

--- a/tests/providers/matter/test_provider.py
+++ b/tests/providers/matter/test_provider.py
@@ -8,6 +8,7 @@ import logging
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from matter_server.client.exceptions import MatterClientException
 from matter_server.common.errors import UnknownError
 from matter_server.common.models import EventType, MatterNodeEvent
 import pytest
@@ -3174,6 +3175,59 @@ class TestSetCredential:
                 1, credential, "1234", name=None, source="direct"
             )
 
+    async def test_set_credential_unknown_status_routes_to_retry(
+        self, hass: HomeAssistant, matter_lock_simple: MatterLock
+    ) -> None:
+        """An unmapped ``unknown(N)`` status routes to retry, not disable (#1257).
+
+        Seen when a lock is not fully ready right after startup: the write
+        must retry on a later tick rather than permanently disabling the slot.
+        """
+        mock_set_credential = AsyncMock(
+            side_effect=_make_set_credential_failed_error("unknown(133)")
+        )
+        credential = self._make_credential(slot=1, pin="1234")
+        with (
+            patch.object(
+                matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+            ),
+            patch.object(
+                matter_lock_simple, "_get_matter_node", return_value=MagicMock()
+            ),
+            patch(f"{_PROVIDER_MODULE}.set_lock_credential", mock_set_credential),
+            pytest.raises(LockDisconnected),
+        ):
+            await matter_lock_simple.async_set_credential(
+                1, credential, "1234", name=None, source="sync"
+            )
+
+    async def test_set_credential_matter_client_exception_routes_to_retry(
+        self, hass: HomeAssistant, matter_lock_simple: MatterLock
+    ) -> None:
+        """``InvalidState: Not connected`` at startup routes to retry (#1257).
+
+        MatterClientException is independent of HomeAssistantError, so without
+        an explicit catch it would escape to the generic handler and suspend
+        the slot instead of retrying.
+        """
+        mock_set_credential = AsyncMock(
+            side_effect=MatterClientException("Not connected")
+        )
+        credential = self._make_credential(slot=1, pin="1234")
+        with (
+            patch.object(
+                matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+            ),
+            patch.object(
+                matter_lock_simple, "_get_matter_node", return_value=MagicMock()
+            ),
+            patch(f"{_PROVIDER_MODULE}.set_lock_credential", mock_set_credential),
+            pytest.raises(LockDisconnected),
+        ):
+            await matter_lock_simple.async_set_credential(
+                1, credential, "1234", name=None, source="sync"
+            )
+
     async def test_set_credential_create_passes_credential_index_none(
         self, hass: HomeAssistant, matter_lock_simple: MatterLock
     ) -> None:
@@ -3416,6 +3470,29 @@ class TestDeleteCredential:
             ),
             patch.object(
                 matter_lock_simple, "_get_matter_node", return_value=MagicMock()
+            ),
+            patch(f"{_PROVIDER_MODULE}.clear_lock_credential", mock_clear),
+            pytest.raises(LockDisconnected),
+        ):
+            await matter_lock_simple.async_delete_credential(ref)
+
+    async def test_delete_credential_matter_client_exception_routes_to_retry(
+        self, hass: HomeAssistant, matter_lock_simple: MatterLock
+    ) -> None:
+        """``InvalidState: Not connected`` during clear routes to retry (#1257)."""
+        mock_clear = AsyncMock(side_effect=MatterClientException("Not connected"))
+        ref = CredentialRef(user_id=1, type=CredentialType.PIN, slot=1)
+        with (
+            patch.object(
+                matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+            ),
+            patch.object(
+                matter_lock_simple, "_get_matter_node", return_value=MagicMock()
+            ),
+            patch.object(
+                matter_lock_simple,
+                "_find_pin_credential_index_for_user",
+                AsyncMock(return_value=5),
             ),
             patch(f"{_PROVIDER_MODULE}.clear_lock_credential", mock_clear),
             pytest.raises(LockDisconnected),

--- a/tests/providers/matter/test_provider.py
+++ b/tests/providers/matter/test_provider.py
@@ -3188,6 +3188,38 @@ class TestSetCredential:
         # First set raised duplicate; clear failed; no retry attempt is made.
         assert mock_set_credential.call_count == 1
 
+    async def test_set_credential_sync_duplicate_clear_matter_client_exception(
+        self, hass: HomeAssistant, matter_lock_simple: MatterLock
+    ) -> None:
+        """A MatterClientException during the duplicate-retry clear routes to retry.
+
+        Regression guard (#1257): this clear path is independent of the main
+        clear and both set paths; a MatterClientException here must map to
+        LockDisconnected rather than escape to the generic handler and suspend
+        the slot.
+        """
+        mock_set_credential = AsyncMock(
+            side_effect=_make_set_credential_failed_error("duplicate")
+        )
+        mock_clear = AsyncMock(side_effect=MatterClientException("Not connected"))
+        credential = self._make_credential(slot=1, pin="1234")
+        with (
+            patch.object(
+                matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+            ),
+            patch.object(
+                matter_lock_simple, "_get_matter_node", return_value=MagicMock()
+            ),
+            self._patch_user_with_pin(user_id=1, credential_index=10),
+            patch(f"{_PROVIDER_MODULE}.set_lock_credential", mock_set_credential),
+            patch(f"{_PROVIDER_MODULE}.clear_lock_credential", mock_clear),
+            pytest.raises(LockDisconnected, match="sync-duplicate retry"),
+        ):
+            await matter_lock_simple.async_set_credential(
+                1, credential, "1234", name=None, source="sync"
+            )
+        assert mock_set_credential.call_count == 1
+
     async def test_set_credential_sync_duplicate_clear_service_validation_error(
         self, hass: HomeAssistant, matter_lock_simple: MatterLock
     ) -> None:

--- a/tests/providers/matter/test_provider.py
+++ b/tests/providers/matter/test_provider.py
@@ -1685,6 +1685,36 @@ class TestGetUsers:
             users = await matter_lock_simple.async_get_users()
         assert users == []
 
+    async def test_get_users_skips_raw_user_without_user_index(
+        self, hass: HomeAssistant, matter_lock_simple: MatterLock
+    ) -> None:
+        """A raw lock user with no user_index is skipped (cannot be projected)."""
+        mock_get_lock_users = AsyncMock(
+            return_value={
+                "max_users": 10,
+                "users": [
+                    {"user_index": None, "credentials": [{"type": "pin", "index": 1}]},
+                    {
+                        "user_index": 2,
+                        "user_name": "Bob",
+                        "credentials": [{"type": "pin", "index": 2}],
+                    },
+                ],
+            }
+        )
+        with (
+            patch.object(
+                matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+            ),
+            patch.object(
+                matter_lock_simple, "_get_matter_node", return_value=MagicMock()
+            ),
+            patch(f"{_PROVIDER_MODULE}.get_lock_users", mock_get_lock_users),
+        ):
+            users = await matter_lock_simple.async_get_users()
+
+        assert [user.user_id for user in users] == [2]
+
     async def test_get_users_pin_credentials_become_unreadable(
         self, hass: HomeAssistant, matter_lock_simple: MatterLock
     ) -> None:
@@ -3018,6 +3048,79 @@ class TestSetCredential:
             patch(f"{_PROVIDER_MODULE}.set_lock_credential", mock_set_credential),
             patch(f"{_PROVIDER_MODULE}.clear_lock_credential", mock_clear),
             pytest.raises(DuplicateCodeError),
+        ):
+            await matter_lock_simple.async_set_credential(
+                1, credential, "1234", name=None, source="sync"
+            )
+
+        assert mock_set_credential.call_count == 2
+        assert mock_clear.call_count == 1
+
+    async def test_set_credential_duplicate_sync_retry_transient_routes_to_retry(
+        self, hass: HomeAssistant, matter_lock_simple: MatterLock
+    ) -> None:
+        """A transient status on the post-clear retry routes to retry (#1257).
+
+        The sync-duplicate path clears the existing credential and retries;
+        if that retry returns an unmapped ``unknown(N)`` status (lock not
+        ready), it must route to LockDisconnected rather than permanently
+        disabling the slot.
+        """
+        mock_set_credential = AsyncMock(
+            side_effect=[
+                _make_set_credential_failed_error("duplicate"),
+                _make_set_credential_failed_error("unknown(133)"),
+            ]
+        )
+        mock_clear = AsyncMock(return_value={})
+        credential = self._make_credential(slot=1, pin="1234")
+        with (
+            patch.object(
+                matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+            ),
+            patch.object(
+                matter_lock_simple, "_get_matter_node", return_value=MagicMock()
+            ),
+            self._patch_user_with_pin(user_id=1, credential_index=10),
+            patch(f"{_PROVIDER_MODULE}.set_lock_credential", mock_set_credential),
+            patch(f"{_PROVIDER_MODULE}.clear_lock_credential", mock_clear),
+            pytest.raises(LockDisconnected),
+        ):
+            await matter_lock_simple.async_set_credential(
+                1, credential, "1234", name=None, source="sync"
+            )
+
+        assert mock_set_credential.call_count == 2
+        assert mock_clear.call_count == 1
+
+    async def test_set_credential_duplicate_sync_retry_definitive_rejection_raises(
+        self, hass: HomeAssistant, matter_lock_simple: MatterLock
+    ) -> None:
+        """A definitive rejection on the post-clear retry raises CodeRejectedError.
+
+        Distinct from the transient (``unknown(N)``) retry, a recognized
+        rejection such as ``occupied`` is permanent, so it surfaces as a
+        code rejection rather than routing to retry.
+        """
+        mock_set_credential = AsyncMock(
+            side_effect=[
+                _make_set_credential_failed_error("duplicate"),
+                _make_set_credential_failed_error("occupied"),
+            ]
+        )
+        mock_clear = AsyncMock(return_value={})
+        credential = self._make_credential(slot=1, pin="1234")
+        with (
+            patch.object(
+                matter_lock_simple, "_get_matter_client", return_value=MagicMock()
+            ),
+            patch.object(
+                matter_lock_simple, "_get_matter_node", return_value=MagicMock()
+            ),
+            self._patch_user_with_pin(user_id=1, credential_index=10),
+            patch(f"{_PROVIDER_MODULE}.set_lock_credential", mock_set_credential),
+            patch(f"{_PROVIDER_MODULE}.clear_lock_credential", mock_clear),
+            pytest.raises(CodeRejectedError),
         ):
             await matter_lock_simple.async_set_credential(
                 1, credential, "1234", name=None, source="sync"

--- a/tests/providers/zwave_js/test_provider.py
+++ b/tests/providers/zwave_js/test_provider.py
@@ -442,6 +442,34 @@ async def test_is_device_available_returns_false_on_exception(
 # Credential API tests (Option B: readable PINs via node.access_control)
 
 
+@pytest.mark.parametrize(
+    ("data", "expected"),
+    [
+        ("1234", SlotCredential.known("1234")),
+        (b"1234", SlotCredential.known("1234")),
+        (None, SlotCredential.unreadable()),
+        ("", SlotCredential.unreadable()),
+        # Masked/withheld codes carry no usable value -> unreadable, NOT
+        # known("****") (which would surface a wrong PIN and never reconcile).
+        ("****", SlotCredential.unreadable()),
+        ("**********", SlotCredential.unreadable()),
+    ],
+    ids=["known_str", "known_bytes", "none", "empty", "masked", "masked_long"],
+)
+async def test_pin_state_projects_masked_codes_as_unreadable(
+    zwave_js_lock: ZWaveJSLock,
+    data: str | bytes | None,
+    expected: SlotCredential,
+) -> None:
+    """The unified read projection maps masked/withheld codes to unreadable.
+
+    Mirrors the UC fallback's _uc_slot_state so a masked code read through
+    the unified access-control path is not mistaken for a readable PIN
+    (issue #1251 working-capability variant).
+    """
+    assert zwave_js_lock._pin_state(data) == expected
+
+
 async def test_async_get_users_returns_all_mappable_credential_types(
     zwave_js_lock: ZWaveJSLock,
     mock_access_control: MagicMock,
@@ -870,13 +898,13 @@ async def test_async_set_credential_raises_code_rejected_error_on_other_ha_error
     mock_lock_helpers: dict,
 ) -> None:
     """
-    Test async_set_credential raises CodeRejectedError for non-duplicate rejections.
+    Test async_set_credential raises CodeRejectedError for definitive rejections.
 
-    When the lock_helpers helper raises HomeAssistantError with any other
-    translation_key (for example "credential_rejected_unknown"), the provider
-    must re-raise as CodeRejectedError.
+    When the lock_helpers helper raises HomeAssistantError with a definitive
+    rejection translation_key (for example "credential_rejected_manufacturer_rules"),
+    the provider must re-raise as CodeRejectedError.
     """
-    err = HomeAssistantError(translation_key="credential_rejected_unknown")
+    err = HomeAssistantError(translation_key="credential_rejected_manufacturer_rules")
     mock_lock_helpers["async_set_credential"].side_effect = err
 
     credential = Credential(
@@ -893,6 +921,39 @@ async def test_async_set_credential_raises_code_rejected_error_on_other_ha_error
 
     assert exc_info.value.code_slot == 4
     assert not isinstance(exc_info.value, DuplicateCodeError)
+
+
+async def test_async_set_credential_tolerates_error_unknown_as_completed_set(
+    zwave_js_lock: ZWaveJSLock,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
+) -> None:
+    """
+    A driver ERROR_UNKNOWN (credential_rejected_unknown) is treated as a
+    completed set, not a rejection.
+
+    The driver returns ERROR_UNKNOWN when its post-write verification can't
+    confirm the code -- notably for locks that report the user code back
+    masked, where the write actually succeeded (issue #1251). The provider
+    must return True and let reconciliation verify, instead of raising
+    CodeRejectedError (which would permanently disable an accepted write).
+    """
+    mock_lock_helpers["async_set_credential"].side_effect = HomeAssistantError(
+        translation_key="credential_rejected_unknown"
+    )
+
+    credential = Credential(
+        type=CredentialType.PIN, slot=4, state=SlotCredential.known("2222")
+    )
+    result = await zwave_js_lock.async_set_credential(
+        user_id=1,
+        credential=credential,
+        pin="2222",
+        name=None,
+        source="sync",
+    )
+
+    assert result is True
 
 
 async def test_async_set_credential_maps_failed_command_to_lock_disconnected(

--- a/tests/providers/zwave_js/test_uc_fallback.py
+++ b/tests/providers/zwave_js/test_uc_fallback.py
@@ -880,6 +880,16 @@ async def test_support_layer_node_stub_raises() -> None:
         ZWaveJSUserCodeFallbackSupport.node.fget(None)
 
 
+async def test_support_layer_pin_state_stub_raises() -> None:
+    """The support layer's _pin_state must be overridden by the provider.
+
+    It exists only so the UC fallback's read path can reuse the concrete
+    provider's universal masked/withheld projection.
+    """
+    with pytest.raises(NotImplementedError):
+        ZWaveJSUserCodeFallbackSupport._pin_state(None, "1234")
+
+
 async def test_usercode_cc_version_defaults_to_v1_when_cc_missing(
     zwave_js_lock: ZWaveJSLock,
 ) -> None:

--- a/tests/providers/zwave_js/test_uc_fallback.py
+++ b/tests/providers/zwave_js/test_uc_fallback.py
@@ -1302,7 +1302,10 @@ async def test_uc_value_update_duplicate_value_skipped(
     ],
 )
 def test_uc_slot_state_projection(
-    in_use: bool | None, usercode: str | None, expected: SlotCredential
+    zwave_js_lock: ZWaveJSLock,
+    in_use: bool | None,
+    usercode: str | None,
+    expected: SlotCredential,
 ) -> None:
     """_uc_slot_state must distinguish None (unknown) from False (cleared)."""
-    assert ZWaveJSUserCodeFallbackSupport._uc_slot_state(in_use, usercode) == expected
+    assert zwave_js_lock._uc_slot_state(in_use, usercode) == expected


### PR DESCRIPTION
## Proposed change

Two distinct variants of the same regression — 4.x permanently disables lock slots on ambiguous/transient credential-write results that 3.x tolerated — unified by one principle, with the correct mechanism differing by whether the write actually *reached* the lock.

### zwave_js (#1251, working-capability variant — e.g. Schlage BE469/BE469ZP)

Separate from the already-fixed zero-slot-capability variant. Here the lock's capabilities are healthy, but the driver's unified User Code CC `setCredential` verifies a write by reading the code back and comparing it to what was written. Locks that report the user code back **masked/withheld** return `ERROR_UNKNOWN` for a write the lock actually **accepted** (`userIdStatus` → Enabled). HA surfaces `credential_rejected_unknown`; LCM mapped it to `CodeRejectedError` and disabled the slot. Evidence from a reporter's Z-Wave logs: the code lands (`userIdStatus[N]: 1`) and is removed ~96 ms later when LCM disables+clears it; on 3.2.1 the same codes persist. (Upstream driver bug reported separately; the verify-by-code-equality should be verify-by-status.)

- Treat `credential_rejected_unknown` as a **completed set** (the write landed; the sync manager's last-set tracking + read-back reconcile it) instead of a rejection. Definitive rejections (duplicate / occupied / manufacturer-rules / validation) are unchanged.
- `_pin_state` now maps masked/withheld codes (empty or all-asterisks) to **unreadable** on the unified path, matching the UC fallback's `_uc_slot_state` (which now delegates to it). A masked code is no longer mistaken for a readable (wrong) PIN that can never reconcile against the configured one.
- Reverted an interim UC write-routing broadening: with the universal projection + tolerant writes, healthy-capability UC-only locks work on the unified path. The legacy User Code CC fallback is retained only for the zero-slot capability variant.

### matter (#1257 — e.g. Aqara U200)

The same "don't permanently disable a transient failure" principle, but the failure is "not reached" rather than "reached but unverifiable," so the fix routes to **retry**, not completed-set (retry converges once Matter is ready; treating a not-reached write as completed would risk a silent no-code lockout).

- `MatterClientException` (e.g. `InvalidState: Not connected` during startup) is independent of `HomeAssistantError` and was escaping to the generic handler, which suspended the slot. It (and `MatterError`) are now caught on set/clear → `LockDisconnected` (retry).
- An unmapped SetCredential status (`unknown(N)`, observed while a lock isn't ready right after startup) routes to retry (`LockDisconnected`) rather than a permanent disable. Recognized rejections (`occupied`) still surface as `CodeRejectedError`.

### Not included (deliberately)

A push-as-commit / pending-confirmation model that would also close a narrow, pre-existing (3.x-equivalent) silent-failure window for genuine unsupervised rejections. It interacts with shared `calculate_in_sync` / coordinator-merge semantics that other providers depend on (Schlage's eventual-consistency convergence relies on the empty-branch last-set trust; no-downgrade conflicts with out-of-band change detection), so it needs its own per-provider-aware design and PR. Tracked as a follow-up.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #1251, fixes #1257
- Full suite passes locally (1243) + prek clean. New tests: `_pin_state` masked-projection parametrization; zwave `credential_rejected_unknown` → completed set; matter `unknown(N)` and `MatterClientException` → retry on set and clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)