### PR TITLE
fix(coordinator): stop cold-start failures masquerading as success (#1268)

### DIFF
--- a/custom_components/lock_code_manager/domain/coordinator.py
+++ b/custom_components/lock_code_manager/domain/coordinator.py
@@ -373,12 +373,16 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator[dict[int, SlotCredenti
             data = await self._lock.async_internal_get_usercodes()
         except LockCodeManagerError as err:
             self._apply_backoff()
-            # During cold start (before the first successful poll), do not
-            # raise UpdateFailed. That would fail the initial refresh and
-            # keep coordinator-backed entities unavailable until a
-            # successful poll completes.
-            if not self.last_update_success:
-                return {}
+            # Always surface the failure. Returning {} here would be recorded
+            # by DataUpdateCoordinator as a successful (empty) update -- flipping
+            # last_update_success to True, logging a misleading "recovered", and
+            # feeding empty data to the sync layer while the lock is still
+            # unreachable (issue #1268). The initial-refresh caller in
+            # BaseLock.async_setup_internal already catches UpdateFailed so a
+            # cold-start failure leaves entities unavailable without aborting
+            # setup; coordinator-backed entities key on slot presence in
+            # ``data`` (still the initialized {} either way), so raising changes
+            # no user-visible state -- it only keeps the coordinator honest.
             raise UpdateFailed from err
 
         self._reset_backoff()

--- a/custom_components/lock_code_manager/domain/coordinator.py
+++ b/custom_components/lock_code_manager/domain/coordinator.py
@@ -373,16 +373,9 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator[dict[int, SlotCredenti
             data = await self._lock.async_internal_get_usercodes()
         except LockCodeManagerError as err:
             self._apply_backoff()
-            # Always surface the failure. Returning {} here would be recorded
-            # by DataUpdateCoordinator as a successful (empty) update -- flipping
-            # last_update_success to True, logging a misleading "recovered", and
-            # feeding empty data to the sync layer while the lock is still
-            # unreachable (issue #1268). The initial-refresh caller in
-            # BaseLock.async_setup_internal already catches UpdateFailed so a
-            # cold-start failure leaves entities unavailable without aborting
-            # setup; coordinator-backed entities key on slot presence in
-            # ``data`` (still the initialized {} either way), so raising changes
-            # no user-visible state -- it only keeps the coordinator honest.
+            # Don't swallow into {}: DataUpdateCoordinator records any return as
+            # a success, so an empty return fakes a "recovered" while the lock
+            # is still unreachable (#1268).
             raise UpdateFailed from err
 
         self._reset_backoff()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -477,20 +477,51 @@ async def test_backoff_failure_counter_increments(
             assert poll_coordinator._lock_breaker.failure_count == i
 
 
-async def test_backoff_first_failure_returns_empty_dict(
+async def test_cold_start_failure_raises_update_failed(
     poll_coordinator: LockUsercodeUpdateCoordinator,
     poll_lock: MockLCMLock,
 ) -> None:
-    """Test that first failure returns empty dict when no prior success."""
-    # No successful update yet
+    """A failure before any successful poll raises UpdateFailed, never a false success.
+
+    Returning {} here would be recorded by DataUpdateCoordinator as a successful
+    update, flipping last_update_success to True and logging a misleading
+    "recovered" while the lock is still unreachable (issue #1268). The breaker
+    still records the failure.
+    """
+    # No successful update yet (cold start).
     poll_coordinator.last_update_success = False
 
     mock_get = AsyncMock(side_effect=LockDisconnected("Lock offline"))
     with patch.object(poll_lock, "async_internal_get_usercodes", mock_get):
-        result = await poll_coordinator.async_get_usercodes()
+        with pytest.raises(UpdateFailed):
+            await poll_coordinator.async_get_usercodes()
 
-    assert result == {}
     assert poll_coordinator._lock_breaker.failure_count == 1
+
+
+async def test_cold_start_repeated_failures_keep_raising(
+    poll_coordinator: LockUsercodeUpdateCoordinator,
+    poll_lock: MockLCMLock,
+) -> None:
+    """Sustained cold-start failures keep raising; no tick masquerades as success.
+
+    Regression for issue #1268: the old guard returned {} whenever
+    last_update_success was False. DataUpdateCoordinator records that as a
+    successful empty update -- flipping last_update_success True (logged
+    "recovered" / "success: True" in 0.000s), feeding empty data to the sync
+    layer ("Slot not in coordinator data, skipping"), then failing again next
+    tick. With the guard gone, last_update_success staying False never diverts
+    a failure into a fake success: every tick raises and the breaker counts it.
+    """
+    # Lock never reached; last_update_success stays False across the outage.
+    poll_coordinator.last_update_success = False
+
+    mock_get = AsyncMock(side_effect=LockDisconnected("Lock offline"))
+    with patch.object(poll_lock, "async_internal_get_usercodes", mock_get):
+        for i in range(1, 6):
+            with pytest.raises(UpdateFailed):
+                await poll_coordinator.async_get_usercodes()
+            assert poll_coordinator._lock_breaker.failure_count == i
 
 
 async def test_backoff_subsequent_failure_raises_update_failed(


### PR DESCRIPTION
## Proposed change

Fixes **Bug 2** from #1268: a Matter lock coordinator that, after a joint HA + matter-server restart, logs a contradictory "Update failed N consecutive times" immediately followed by "recovered" / "Finished fetching ... in 0.000 seconds (success: True)", then "Slot not in coordinator data, skipping" for every slot.

Root cause is in `domain/coordinator.py::async_get_usercodes`. The cold-start guard returned `{}` on any failure before the first successful poll:

```python
if not self.last_update_success:
    return {}
raise UpdateFailed from err
```

`DataUpdateCoordinator` records *any returned value* as a successful update. So returning `{}`:

- flipped `last_update_success` to `True` and logged a misleading **"recovered" / "success: True in 0.000s"** while the lock was still unreachable;
- notified the sync layer with **empty data**, producing "Slot not in coordinator data, skipping" for every slot;
- and, because the guard keyed on `last_update_success` (which it itself flipped), made the coordinator **oscillate** between raising `UpdateFailed` and faking a recovery on alternating ticks.

The fix is to always `raise UpdateFailed`. The initial-refresh caller in `BaseLock.async_setup_internal` already catches `UpdateFailed`/`ConfigEntryNotReady`, so a cold-start failure still leaves entities created-but-unavailable **without aborting setup**. Coordinator-backed entities key on slot presence in `data` (the initialized `{}` whether we raise or return `{}`), so this changes **no user-visible state** — it only keeps the coordinator's success/failure signal honest.

### Scope

This addresses Bug 2 only. The underlying **Bug 1** in #1268 — the Matter provider's `async_is_device_available` returning a persistent false negative ("Matter client or node unavailable") even though `matter.get_lock_users` works — is what actually blocks recovery and is tracked separately. This PR does not make an affected lock recover on its own; it removes the misleading success/empty-data behavior so the real failure is visible and honest in the logs.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue: #1268 (fixes Bug 2; Bug 1 remains open)

### Testing

- Repurposed `test_backoff_first_failure_returns_empty_dict` → `test_cold_start_failure_raises_update_failed` to assert a cold-start failure now raises `UpdateFailed` (never a false success) while still recording the breaker failure.
- Added `test_cold_start_repeated_failures_keep_raising` as a regression for the oscillation: sustained failures with `last_update_success` staying `False` all raise and the breaker counts each tick.
- Full suite: `1269 passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)