### PR TITLE
fix(matter): base availability on entity state, not node re-derivation (#1268)

### DIFF
--- a/custom_components/lock_code_manager/providers/matter.py
+++ b/custom_components/lock_code_manager/providers/matter.py
@@ -32,6 +32,7 @@ from homeassistant.components.matter.lock_helpers import (
     set_lock_user,
 )
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 
@@ -48,7 +49,6 @@ from ..domain.credentials import (
 from ..domain.exceptions import (
     CodeRejectedError,
     DuplicateCodeError,
-    LockCodeManagerProviderError,
     LockDisconnected,
     LockOperationFailed,
 )
@@ -240,12 +240,25 @@ class MatterLock(BaseLock):
             return None
 
     def _require_client_and_node(self) -> tuple[Any, Any]:
-        """Get client and node, raising LockDisconnected if unavailable."""
+        """
+        Get client and node, raising LockDisconnected if either is unavailable.
+
+        The two failures are reported separately because they mean different
+        things: a missing client is the Matter integration not being loaded,
+        while an unresolved node is the device not being in the client's current
+        node set -- which happens transiently while the client rebuilds that set
+        on reconnect (issue #1268).
+        """
         client = self._get_matter_client()
-        node = self._get_matter_node()
-        if not client or not node:
+        if not client:
             raise LockDisconnected(
-                f"Matter client or node unavailable for {self.lock.entity_id}"
+                f"Matter client unavailable for {self.lock.entity_id}"
+            )
+        node = self._get_matter_node()
+        if not node:
+            raise LockDisconnected(
+                f"Matter node not found for {self.lock.entity_id}; device is not "
+                "in the Matter client's current node set"
             )
         return client, node
 
@@ -917,18 +930,25 @@ class MatterLock(BaseLock):
         """No matter-specific setup; base validates required capabilities."""
 
     async def async_is_device_available(self) -> bool:
-        """Return whether the Matter lock device is available for commands."""
-        try:
-            client, node = self._require_client_and_node()
-            await get_lock_info(client, node)
-        except (LockCodeManagerProviderError, HomeAssistantError) as err:
-            LOGGER.debug(
-                "Lock %s: availability check failed: %s",
-                self.lock.entity_id,
-                err,
-            )
-            return False
-        return True
+        """
+        Return whether the Matter lock device is available for commands.
+
+        Defers to the lock entity's Home Assistant availability -- the same
+        signal the Matter integration derives from ``node.available`` -- rather
+        than re-deriving the node from the device registry and round-tripping
+        ``get_lock_info``. Re-derivation matches the device against
+        ``matter_client.get_nodes()``, which the client wipes and rebuilds while
+        reconnecting to the server (e.g. a joint Home Assistant + matter-server
+        restart); during that window the lookup returns None even though the lock
+        is reachable and its entity is available, tripping the breaker on a
+        transient (issue #1268). Entity availability is sticky across that window,
+        and the read primitives still surface a genuine outage as LockDisconnected.
+        """
+        state = self.hass.states.get(self.lock.entity_id)
+        return state is not None and state.state not in (
+            STATE_UNAVAILABLE,
+            STATE_UNKNOWN,
+        )
 
     # -- Event subscription via push framework --------------------------------
 

--- a/custom_components/lock_code_manager/providers/matter.py
+++ b/custom_components/lock_code_manager/providers/matter.py
@@ -931,18 +931,18 @@ class MatterLock(BaseLock):
 
     async def async_is_device_available(self) -> bool:
         """
-        Return whether the Matter lock device is available for commands.
+        Return whether the Matter lock is reachable, per the lock entity's state.
 
-        Defers to the lock entity's Home Assistant availability -- the same
-        signal the Matter integration derives from ``node.available`` -- rather
-        than re-deriving the node from the device registry and round-tripping
-        ``get_lock_info``. Re-derivation matches the device against
-        ``matter_client.get_nodes()``, which the client wipes and rebuilds while
-        reconnecting to the server (e.g. a joint Home Assistant + matter-server
-        restart); during that window the lookup returns None even though the lock
-        is reachable and its entity is available, tripping the breaker on a
-        transient (issue #1268). Entity availability is sticky across that window,
-        and the read primitives still surface a genuine outage as LockDisconnected.
+        Matter reachability is layered: Home Assistant to the matter-server
+        (websocket transport), then the matter-server to the lock (IP / Thread /
+        Bluetooth Low Energy). The lock entity's availability (``node.available``)
+        is the integration's own answer to "can the server reach this lock",
+        computed after it sorts those layers out, and it survives a transport blip
+        -- unlike re-deriving the node from the device registry, which transiently
+        fails while the matter client rebuilds its node set on reconnect and would
+        trip the breaker on a fault that isn't about the lock (issue #1268). The
+        read primitives still resolve the node, so a genuine outage surfaces as
+        LockDisconnected.
         """
         state = self.hass.states.get(self.lock.entity_id)
         return state is not None and state.state not in (

--- a/tests/providers/matter/test_provider.py
+++ b/tests/providers/matter/test_provider.py
@@ -14,6 +14,7 @@ from matter_server.common.models import EventType, MatterNodeEvent
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 
@@ -117,44 +118,46 @@ class TestConnection(ServiceProviderConnectionTests):
 class TestDeviceAvailability:
     """Device availability tests for Matter provider."""
 
-    async def test_is_device_available_success(
+    async def test_is_device_available_follows_entity_state(
         self, hass: HomeAssistant, matter_lock_simple: MatterLock
     ) -> None:
-        """Test device availability returns True on successful helper call."""
-        mock_get_lock_info = AsyncMock(return_value={})
-        with (
-            patch.object(
-                matter_lock_simple, "_get_matter_client", return_value=MagicMock()
-            ),
-            patch.object(
-                matter_lock_simple, "_get_matter_node", return_value=MagicMock()
-            ),
-            patch(f"{_PROVIDER_MODULE}.get_lock_info", mock_get_lock_info),
-        ):
+        """Availability is True when the lock entity reports a usable state."""
+        hass.states.async_set(matter_lock_simple.lock.entity_id, "locked")
+        assert await matter_lock_simple.async_is_device_available() is True
+
+    async def test_is_device_available_false_when_entity_unavailable(
+        self, hass: HomeAssistant, matter_lock_simple: MatterLock
+    ) -> None:
+        """Availability is False when the lock entity is unavailable."""
+        hass.states.async_set(matter_lock_simple.lock.entity_id, STATE_UNAVAILABLE)
+        assert await matter_lock_simple.async_is_device_available() is False
+
+    async def test_is_device_available_false_when_entity_unknown(
+        self, hass: HomeAssistant, matter_lock_simple: MatterLock
+    ) -> None:
+        """Availability is False when the lock entity state is unknown."""
+        hass.states.async_set(matter_lock_simple.lock.entity_id, STATE_UNKNOWN)
+        assert await matter_lock_simple.async_is_device_available() is False
+
+    async def test_is_device_available_false_when_entity_missing(
+        self, hass: HomeAssistant, matter_lock_simple: MatterLock
+    ) -> None:
+        """Availability is False when the lock entity has no state yet."""
+        assert await matter_lock_simple.async_is_device_available() is False
+
+    async def test_is_device_available_ignores_node_resolution(
+        self, hass: HomeAssistant, matter_lock_simple: MatterLock
+    ) -> None:
+        """Availability follows entity state, not node re-derivation (issue #1268).
+
+        During a Matter server reconnect the client wipes and rebuilds its node
+        set, so ``get_node_from_device_entry`` transiently returns None while the
+        lock entity stays available. The gate must not trip on that transient --
+        otherwise the breaker suspends a reachable lock for a full backoff cycle.
+        """
+        hass.states.async_set(matter_lock_simple.lock.entity_id, "locked")
+        with patch.object(matter_lock_simple, "_get_matter_node", return_value=None):
             assert await matter_lock_simple.async_is_device_available() is True
-
-    async def test_is_device_available_error(
-        self, hass: HomeAssistant, matter_lock_simple: MatterLock
-    ) -> None:
-        """Test device availability returns False when helper call fails."""
-        mock_get_lock_info = AsyncMock(side_effect=HomeAssistantError("device offline"))
-        with (
-            patch.object(
-                matter_lock_simple, "_get_matter_client", return_value=MagicMock()
-            ),
-            patch.object(
-                matter_lock_simple, "_get_matter_node", return_value=MagicMock()
-            ),
-            patch(f"{_PROVIDER_MODULE}.get_lock_info", mock_get_lock_info),
-        ):
-            assert await matter_lock_simple.async_is_device_available() is False
-
-    async def test_is_device_available_no_client(
-        self, hass: HomeAssistant, matter_lock_simple: MatterLock
-    ) -> None:
-        """Test device availability returns False when client unavailable."""
-        with patch.object(matter_lock_simple, "_get_matter_client", return_value=None):
-            assert await matter_lock_simple.async_is_device_available() is False
 
 
 # ---------------------------------------------------------------------------
@@ -361,7 +364,7 @@ async def test_get_usercodes_client_unavailable(
 ) -> None:
     """Test async_get_usercodes raises LockDisconnected when client/node unavailable."""
     with patch.object(matter_lock_simple, "_get_matter_client", return_value=None):
-        with pytest.raises(LockDisconnected, match="client or node unavailable"):
+        with pytest.raises(LockDisconnected, match="Matter client unavailable"):
             await matter_lock_simple.async_get_usercodes()
 
 
@@ -485,7 +488,7 @@ async def test_require_client_and_node_no_client(
 ) -> None:
     """Test _require_client_and_node raises LockDisconnected when client is None."""
     with patch.object(matter_lock_simple, "_get_matter_client", return_value=None):
-        with pytest.raises(LockDisconnected, match="client or node unavailable"):
+        with pytest.raises(LockDisconnected, match="Matter client unavailable"):
             matter_lock_simple._require_client_and_node()
 
 
@@ -499,7 +502,7 @@ async def test_require_client_and_node_no_node(
         ),
         patch.object(matter_lock_simple, "_get_matter_node", return_value=None),
     ):
-        with pytest.raises(LockDisconnected, match="client or node unavailable"):
+        with pytest.raises(LockDisconnected, match="Matter node not found"):
             matter_lock_simple._require_client_and_node()
 
 


### PR DESCRIPTION
## Proposed change

Addresses **Bug 1** from #1268: after a joint HA + matter-server restart, LCM's Matter coordinator reports the lock unreachable and never recovers within a reasonable window — even though the lock entity shows `locked`, lock/unlock works, and `matter.get_lock_users` returns all users.

### Root cause: Matter reachability is layered; the gate modeled it like Z-Wave

**Z-Wave — 2 tightly-coupled hops:** (1) HA ↔ controller (the Z-Wave JS driver), (2) controller ↔ lock (RF). Losing the driver reloads the whole entry, so a single "integration connected + node reachable" check faithfully models reachability — entry state `LOADED` *is* a good proxy.

**Matter — 3 layers, the bottom one ambiguous:**
1. HA/fabric ↔ matter-server (websocket transport — matter reloads the entry on drop)
2. matter-server ↔ lock (operational network: IP / Thread-via-border-router / BLE)
3. if #2 fails: is it **the lock** (dead/asleep/decommissioned) or the **transport** (border router / AP / partition)?

These layers warrant *different* responses (an L1 transport blip shouldn't alarm; an L2 transport fault shouldn't declare the lock offline; only a genuine L3 outage should). LCM's old `async_is_device_available` collapsed all of them into one boolean: it re-derived the node via `get_node_from_device_entry` (matching the device against `matter_client.get_nodes()`) and round-tripped `get_lock_info` on every operation. The matter client wipes and rebuilds its node set on reconnect (`client.py:659`) with `server_info` briefly `None`, so that re-derivation returns `None` during the reconnect window — an **L1 transport transient that isn't about the lock** — tripping the breaker out to the 30-min backoff cap. Combined with the now-fixed Bug 2 noise (#1270) and reloads landing back in the window, it presented as a permanent stall.

### Fix

Gate on the lock **entity's** HA availability (`hass.states.get(entity_id)` not `unavailable`/`unknown`). `entity.available` = `node.available ∧ bridged_reachable` is the matter integration's *own* L2 answer ("can the server reach this lock"), computed after it sorts out L1/L3, and it's sticky across the transport blip. The read primitives still resolve the node and surface a genuine outage as `LockDisconnected`, so no safety is lost — we just stop gating on a re-derived signal that conflates the layers, and drop a per-operation round-trip.

The gate deliberately does **not** distinguish L3 lock-vs-transport: for "attempt the operation or not" it doesn't change the answer, and over-alarming is already gated by the `lock_offline` repair's `POLL_FAILURE_ALERT_THRESHOLD` + `_reached_once`. Differentiating L2/L3 responses is resilience-layer work, out of scope here.

Also splits `_require_client_and_node` into distinct **"Matter client unavailable"** vs **"Matter node not found"** messages so any recurrence is diagnosable to the exact branch.

### Honest caveat

I could not reproduce the joint-restart locally, so I can't 100% exclude a deterministic device-id mismatch. But the installed matter client/entity source and Kyle's diagnostic snapshot (entity available + service works + LCM unreachable) all fit the layered explanation, and the fix is robust regardless of the exact trigger. Worth confirming with the reporter before closing #1268 — hence "related to", not "fixes".

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue: #1268 (addresses Bug 1; pairs with #1270 which fixed Bug 2)

### Testing

- Rewrote `TestDeviceAvailability` to assert availability follows entity state: `True` when `locked`; `False` when `unavailable`/`unknown`/missing.
- Added `test_is_device_available_ignores_node_resolution` — the Bug 1 regression: availability stays `True` when `_get_matter_node` returns `None` (the reconnect-window transient) as long as the entity is available.
- Updated the `_require_client_and_node` message assertions for the split diagnostics.
- Full suite: `1271 passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)