### PR TITLE
refactor(zwave_js): drop the periodic hard-refresh drift poll

### DIFF
--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -149,7 +149,13 @@ class BaseLock:
         hard_refresh_interval = None
         connection_check_interval = timedelta(seconds=30)
 
-    Push with drift detection (recommended for Z-Wave JS):
+    Push only (e.g. Z-Wave JS), trusting the event stream without a drift poll:
+        supports_push = True
+        hard_refresh_interval = None
+        connection_check_interval = None
+        # Override subscribe_push_updates() to handle value events
+
+    Push with drift detection (e.g. Matter):
         supports_push = True
         hard_refresh_interval = timedelta(hours=1)
         connection_check_interval = None
@@ -991,9 +997,9 @@ class BaseLock:
             # stacks send no confirming push for an ambiguous write (node-zwave-js
             # emits no credential event when its post-write verify fails on a
             # masked lock), so waiting passively would let the breaker suspend a
-            # slot whose code actually landed before the hourly drift refresh can
-            # run. The read confirms a present-but-masked slot; a genuinely-absent
-            # slot stays pending and the sync tick re-syncs after the TTL.
+            # slot whose code actually landed. The active read confirms a
+            # present-but-masked slot; a genuinely-absent slot stays pending and
+            # the sync tick re-syncs after the TTL.
             self._record_optimistic_write(code_slot, str(usercode))
             if self.coordinator is not None:
                 await self.coordinator.async_confirm_pending_writes()

--- a/custom_components/lock_code_manager/providers/_zwave_js_uc.py
+++ b/custom_components/lock_code_manager/providers/_zwave_js_uc.py
@@ -456,8 +456,9 @@ class ZWaveJSUserCodeFallbackSupport(BaseLock):
         true post-write state, so the coordinator already has the
         truth. Failing the whole operation here turns a flaky lock into
         a slot-suspension feedback loop -- the exact pathology the
-        fallback is meant to dodge. The hourly hard-refresh backstop
-        reconciles any genuine cache drift.
+        fallback is meant to dodge. The on-demand refresh on missing or
+        unknown slots, plus the next sync tick, reconcile any genuine
+        cache drift.
 
         Non-Z-Wave exceptions (programming bugs) still propagate.
         """

--- a/custom_components/lock_code_manager/providers/zwave_js.py
+++ b/custom_components/lock_code_manager/providers/zwave_js.py
@@ -142,13 +142,18 @@ class ZWaveJSLock(ZWaveJSUserCodeFallbackSupport):
     @property
     def hard_refresh_interval(self) -> timedelta | None:
         """
-        Re-read all credentials hourly to recover from missed push events.
+        Disable periodic drift detection: Z-Wave is event-driven end to end.
 
-        Credentials are normally kept current by the access-control node-event
-        push, but a missed or value-less event would otherwise strand a slot
-        (for example as unreadable). This periodic drift refresh is the backstop.
+        Both User Code CC and User Credential CC push change notifications, so a
+        periodic re-read would only catch out-of-band programming that arrived
+        with no event -- and on a masking lock a re-read cannot recover the value
+        anyway, so it would not even resolve the slot it claims to protect. LCM
+        does not chase silent out-of-band changes, so the hourly poll earned its
+        keep for neither readability nor occupancy. Hard refresh is still used on
+        demand (initial load, missing/unknown slots) and by the per-write
+        confirmation read -- just not on a timer.
         """
-        return timedelta(hours=1)
+        return None
 
     @property
     def supports_native_users(self) -> bool:

--- a/tests/providers/zwave_js/test_provider.py
+++ b/tests/providers/zwave_js/test_provider.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -1001,9 +1000,9 @@ async def test_async_delete_credential_maps_failed_command_to_lock_disconnected(
         )
 
 
-async def test_hard_refresh_interval_is_hourly(zwave_js_lock: ZWaveJSLock) -> None:
-    """The drift-recovery backstop is scheduled (not disabled)."""
-    assert zwave_js_lock.hard_refresh_interval == timedelta(hours=1)
+async def test_hard_refresh_interval_disabled(zwave_js_lock: ZWaveJSLock) -> None:
+    """No periodic drift poll: Z-Wave trusts its event stream end to end."""
+    assert zwave_js_lock.hard_refresh_interval is None
 
 
 async def test_async_delete_user_calls_helper(

--- a/tests/providers/zwave_js/test_uc_fallback.py
+++ b/tests/providers/zwave_js/test_uc_fallback.py
@@ -1100,8 +1100,9 @@ async def test_uc_v1_set_verify_failure_is_non_fatal(
     ``_push_credential_update`` delivers the truth to the coordinator.
     Failing here turns a flaky-interview lock (issue #1251) into a
     slot-suspension feedback loop -- the exact pathology the fallback
-    is meant to dodge. The hourly hard-refresh backstop reconciles any
-    cache drift that genuinely matters.
+    is meant to dodge. The on-demand refresh on missing/unknown slots,
+    plus the next sync tick, reconcile any cache drift that genuinely
+    matters.
     """
     mock_coordinator = MagicMock()
     mock_coordinator.data = {}


### PR DESCRIPTION
## Proposed change

Z-Wave is event-driven end to end: both User Code CC and User Credential CC push change notifications. The hourly drift poll only ever caught out-of-band programming that arrived with *no* event — and on a masking lock a re-read cannot recover the value anyway, so it could not even resolve the "unreadable" slot it was framed to protect. LCM deliberately does not chase silent out-of-band changes, so the poll earned its keep for neither readability nor occupancy.

Adding User Credential CC support did not change what the drift poll captures, so this sets `hard_refresh_interval = None` for the Z-Wave provider.

`async_hard_refresh_codes` itself is untouched — only the *periodic scheduling* is removed. Hard refresh stays in use on demand (initial load, missing/unknown slots) and via the per-write confirmation read; the coordinator's drift timer simply never gets installed.

Docstrings/comments that leaned on "the hourly backstop" are updated to point at the remaining reconciliation paths (on-demand refresh on missing/unknown slots, the per-write confirmation read, and the next sync tick): the `_zwave_js_uc` verify-write rationale, the base optimistic-write comment, and the base configuration-examples block.

Matter / ZHA / zigbee2mqtt drift refreshes are left untouched — the reasoning here is Z-Wave-specific.

**Behavioral note:** an externally-added or -deleted code on a *readable* lock is no longer auto-reconciled within an hour; it's picked up on the next write, restart, or missing/unknown-slot refresh. This is the out-of-band-programming gap LCM already chose not to chase.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: