### PR TITLE
fix(matter): route MatterClientException at user/read sites to retry (#1257)

### DIFF
--- a/custom_components/lock_code_manager/providers/matter.py
+++ b/custom_components/lock_code_manager/providers/matter.py
@@ -402,7 +402,11 @@ class MatterLock(BaseLock):
             raise LockOperationFailed(
                 f"Matter get_lock_users rejected input for {self.lock.entity_id}: {err}"
             ) from err
-        except HomeAssistantError as err:
+        except (HomeAssistantError, MatterError, MatterClientException) as err:
+            # MatterError / MatterClientException are independent of
+            # HomeAssistantError (e.g. ``InvalidState: Not connected`` while the
+            # client reconnects at startup, issue #1257); catch them explicitly
+            # or they escape to the sync catchall and suspend the slot.
             raise LockDisconnected(
                 f"Matter get_lock_users failed for {self.lock.entity_id}: {err}"
             ) from err
@@ -480,7 +484,10 @@ class MatterLock(BaseLock):
             raise LockOperationFailed(
                 f"Matter get_lock_info rejected input for {self.lock.entity_id}: {err}"
             ) from err
-        except HomeAssistantError as err:
+        except (HomeAssistantError, MatterError, MatterClientException) as err:
+            # Independent of HomeAssistantError (issue #1257): a startup
+            # ``InvalidState: Not connected`` must route to retry, not escape
+            # the read site and suspend the slot.
             raise LockDisconnected(
                 f"Matter get_lock_info failed for {self.lock.entity_id}: {err}"
             ) from err
@@ -690,7 +697,12 @@ class MatterLock(BaseLock):
                     f"Matter set_lock_user rejected input for "
                     f"{self.lock.entity_id} (user_name={name!r}): {err}"
                 ) from err
-            except HomeAssistantError as err:
+            except (HomeAssistantError, MatterClientException) as err:
+                # Transport failures (incl. ``InvalidState: Not connected`` at
+                # startup, issue #1257) are not charset-recoverable -- the next
+                # candidate name hits the same closed connection -- so short-
+                # circuit to retry instead of falling through. MatterClientException
+                # is independent of HomeAssistantError, hence the explicit catch.
                 raise LockDisconnected(
                     f"Matter set_lock_user failed for {self.lock.entity_id} "
                     f"(user_name={name!r}): {err}"
@@ -780,7 +792,11 @@ class MatterLock(BaseLock):
             raise LockOperationFailed(
                 f"Matter clear_lock_user rejected input for {self.lock.entity_id}: {err}"
             ) from err
-        except HomeAssistantError as err:
+        except (HomeAssistantError, MatterError, MatterClientException) as err:
+            # The original #1257 report's signature: ``Unexpected error during
+            # clear usercode ... InvalidState: Not connected``. MatterError /
+            # MatterClientException are independent of HomeAssistantError, so
+            # route them to retry rather than the sync catchall suspend.
             raise LockDisconnected(
                 f"Matter clear_lock_user failed for {self.lock.entity_id}: {err}"
             ) from err

--- a/tests/providers/matter/test_provider.py
+++ b/tests/providers/matter/test_provider.py
@@ -342,6 +342,23 @@ async def test_get_usercodes_get_lock_users_communication_error(
             await matter_lock.async_get_usercodes()
 
 
+async def test_get_usercodes_get_lock_users_client_exception(
+    hass: HomeAssistant, matter_lock: MatterLock
+) -> None:
+    """``MatterClientException`` from get_lock_users routes to LockDisconnected.
+
+    ``InvalidState: Not connected`` (a ``MatterClientException``, raised
+    by the matter-server client before its websocket is connected at
+    startup) is independent of ``HomeAssistantError`` -- so a read site
+    that only catches ``HomeAssistantError`` lets it escape to the sync
+    catchall and spuriously suspends the slot (issue #1257).
+    """
+    mock_get_lock_users = AsyncMock(side_effect=MatterClientException("Not connected"))
+    with patch(f"{_PROVIDER_MODULE}.get_lock_users", mock_get_lock_users):
+        with pytest.raises(LockDisconnected, match="get_lock_users failed"):
+            await matter_lock.async_get_usercodes()
+
+
 async def test_get_usercodes_multiple_credential_types(
     hass: HomeAssistant,
     e2e_matter_lock: MatterLock,
@@ -2012,6 +2029,24 @@ class TestGetCapabilities:
         ):
             await matter_lock.async_get_capabilities()
 
+    async def test_get_capabilities_client_exception(
+        self, hass: HomeAssistant, matter_lock: MatterLock
+    ) -> None:
+        """``MatterClientException`` from get_lock_info raises LockDisconnected.
+
+        Independent of ``HomeAssistantError`` (issue #1257): a startup
+        ``InvalidState: Not connected`` must route to retry, not escape
+        the read site and suspend the slot.
+        """
+        mock_get_lock_info = AsyncMock(
+            side_effect=MatterClientException("Not connected")
+        )
+        with (
+            patch(f"{_PROVIDER_MODULE}.get_lock_info", mock_get_lock_info),
+            pytest.raises(LockDisconnected, match="get_lock_info failed"),
+        ):
+            await matter_lock.async_get_capabilities()
+
 
 # =============================================================================
 # async_set_user tests
@@ -2443,6 +2478,34 @@ class TestSetUser:
 
         assert mock_set_user.call_count == 2
 
+    async def test_set_user_create_routes_client_exception_during_fallback(
+        self, hass: HomeAssistant, matter_lock: MatterLock
+    ) -> None:
+        """A ``MatterClientException`` during the cascade maps to ``LockDisconnected``.
+
+        ``InvalidState: Not connected`` is a transport failure, not a
+        charset rejection, so it short-circuits the cascade (trying the
+        next candidate name would hit the same closed connection) and
+        routes to retry rather than escaping to the catchall suspend
+        (issue #1257). It is independent of ``HomeAssistantError``, so
+        the prior fix that only added ``MatterError`` did not cover it.
+        """
+        mock_set_user = AsyncMock(
+            side_effect=[
+                UnknownError("InvalidCommand (0x85)"),
+                MatterClientException("Not connected"),
+            ]
+        )
+        user = User(user_id=1, name="lcm:1:Alice")
+        with (
+            self._patch_users([]),
+            patch(f"{_PROVIDER_MODULE}.set_lock_user", mock_set_user),
+            pytest.raises(LockDisconnected, match="Not connected"),
+        ):
+            await matter_lock.async_set_user(user)
+
+        assert mock_set_user.call_count == 2
+
     async def test_set_user_update_falls_back_to_compact_on_charset_rejection(
         self, hass: HomeAssistant, matter_lock: MatterLock, caplog
     ) -> None:
@@ -2563,6 +2626,24 @@ class TestDeleteUser:
         with (
             patch(f"{_PROVIDER_MODULE}.clear_lock_user", mock_clear_user),
             pytest.raises(LockOperationFailed, match="rejected input"),
+        ):
+            await matter_lock.async_delete_user(3)
+
+    async def test_delete_user_client_exception(
+        self, hass: HomeAssistant, matter_lock: MatterLock
+    ) -> None:
+        """``MatterClientException`` from clear_lock_user raises LockDisconnected.
+
+        This is the exact path behind the original #1257 report:
+        ``Unexpected error during clear usercode ... InvalidState: Not
+        connected``. The clear-user site only caught ``HomeAssistantError``,
+        so the client exception escaped to the sync catchall and
+        suspended the slot instead of being retried.
+        """
+        mock_clear_user = AsyncMock(side_effect=MatterClientException("Not connected"))
+        with (
+            patch(f"{_PROVIDER_MODULE}.clear_lock_user", mock_clear_user),
+            pytest.raises(LockDisconnected, match="clear_lock_user failed"),
         ):
             await matter_lock.async_delete_user(3)
 


### PR DESCRIPTION
## Proposed change

`matter_server` exposes three independent exception hierarchies:
`MatterClientException`/`InvalidState` (`matter_server.client.exceptions`),
`MatterError` (`matter_server.common.errors`), and HA's `HomeAssistantError`.
None subclass each other — `InvalidState.__mro__` is
`[InvalidState, MatterClientException, Exception, ...]`.

The #1257 fix taught only the **two credential sites** (`_send_set_credential`,
`async_delete_credential`) to catch all three. Four other matter SDK call sites
still caught only `(ServiceValidationError, HomeAssistantError[, MatterError])`:

| Site | SDK call | Reached during |
|------|----------|----------------|
| `_raw_lock_users` | `get_lock_users` | every read / sync |
| `async_get_capabilities` | `get_lock_info` | setup |
| `_try_set_lock_user_with_fallbacks` | `set_lock_user` | **set** sync (user CREATE) |
| `async_delete_user` | `clear_lock_user` | **clear** sync |

At startup the matter client raises `InvalidState: Not connected` before its
websocket connects. At these four sites it escaped every handler and reached
`sync.py`'s catch-all `except Exception` → `_suspend_slot` with
`_code_suspend_target` set. That suspension is the user-visible repair, and it
does **not** self-heal on reconnect (only on a target change or coincidental
in-sync) — which is why recovery took "several minutes" in the report. The
original log's `Unexpected error during clear usercode … InvalidState: Not
connected` is exactly the `clear_lock_user` site.

This PR routes these transient errors to `LockDisconnected` (matching the
already-working credential sites), so they retry via the lock connectivity
breaker instead of suspending the slot. On the `set_lock_user` cascade only
`MatterClientException` short-circuits to `LockDisconnected`; `MatterError`
keeps its charset-fallthrough semantics (a dead connection won't be fixed by
trying a different user name).

Verified with 4 new TDD tests (one per site, red→green) and the full suite
(1283 passed); `ruff`/`mypy`/`pydocstyle`/`flake8` clean.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #1257
