### PR TITLE
refactor(matter): funnel SDK calls through a single exception choke point

### DIFF
--- a/custom_components/lock_code_manager/providers/matter.py
+++ b/custom_components/lock_code_manager/providers/matter.py
@@ -383,6 +383,36 @@ class MatterLock(BaseLock):
                 exc_info=True,
             )
 
+    async def _invoke_sdk(self, operation: str, coro: Any) -> Any:
+        """
+        Translate raw Matter SDK exceptions into typed seam exceptions.
+
+        Single choke point so individual call sites cannot forget the
+        translation. The three Matter exception families do not subclass each
+        other -- ``MatterError`` and ``MatterClientException`` are independent of
+        ``HomeAssistantError`` -- so a startup ``InvalidState: Not connected``
+        (issue #1257) escapes any site that catches only one family, reaching the
+        sync catchall and suspending the slot. Routing every SDK call through
+        here makes a missed family structurally impossible:
+        ``test_sdk_exception_translation`` fails the build if a new SDK call
+        bypasses this method.
+
+        ``operation`` is the SDK function name woven into the error messages so
+        they stay diagnosable. ``ServiceValidationError`` is a subclass of
+        ``HomeAssistantError`` and maps to ``LockOperationFailed`` (the input was
+        rejected, not the transport), so it MUST be caught first.
+        """
+        try:
+            return await coro
+        except ServiceValidationError as err:
+            raise LockOperationFailed(
+                f"Matter {operation} rejected input for {self.lock.entity_id}: {err}"
+            ) from err
+        except (HomeAssistantError, MatterError, MatterClientException) as err:
+            raise LockDisconnected(
+                f"Matter {operation} failed for {self.lock.entity_id}: {err}"
+            ) from err
+
     # -- Credential primitives -----------------------------------------------
 
     async def _raw_lock_users(self) -> list[dict[str, Any]]:
@@ -396,20 +426,9 @@ class MatterLock(BaseLock):
         callers want the lock's own identifiers.
         """
         client, node = self._require_client_and_node()
-        try:
-            lock_data = await get_lock_users(client, node)
-        except ServiceValidationError as err:
-            raise LockOperationFailed(
-                f"Matter get_lock_users rejected input for {self.lock.entity_id}: {err}"
-            ) from err
-        except (HomeAssistantError, MatterError, MatterClientException) as err:
-            # MatterError / MatterClientException are independent of
-            # HomeAssistantError (e.g. ``InvalidState: Not connected`` while the
-            # client reconnects at startup, issue #1257); catch them explicitly
-            # or they escape to the sync catchall and suspend the slot.
-            raise LockDisconnected(
-                f"Matter get_lock_users failed for {self.lock.entity_id}: {err}"
-            ) from err
+        lock_data = await self._invoke_sdk(
+            "get_lock_users", get_lock_users(client, node)
+        )
         return lock_data.get("users", [])
 
     async def async_get_users(self) -> list[User]:
@@ -478,19 +497,7 @@ class MatterLock(BaseLock):
         to 0 (unknown capacity) rather than raising.
         """
         client, node = self._require_client_and_node()
-        try:
-            info = await get_lock_info(client, node)
-        except ServiceValidationError as err:
-            raise LockOperationFailed(
-                f"Matter get_lock_info rejected input for {self.lock.entity_id}: {err}"
-            ) from err
-        except (HomeAssistantError, MatterError, MatterClientException) as err:
-            # Independent of HomeAssistantError (issue #1257): a startup
-            # ``InvalidState: Not connected`` must route to retry, not escape
-            # the read site and suspend the slot.
-            raise LockDisconnected(
-                f"Matter get_lock_info failed for {self.lock.entity_id}: {err}"
-            ) from err
+        info = await self._invoke_sdk("get_lock_info", get_lock_info(client, node))
 
         credential_types: dict[CredentialType, CredentialTypeCapability] = {}
         if "pin" in (info.get("supported_credential_types") or []):
@@ -786,20 +793,9 @@ class MatterLock(BaseLock):
         credentials and schedules for the user per the Matter specification.
         """
         client, node = self._require_client_and_node()
-        try:
-            await clear_lock_user(client, node, user_id)
-        except ServiceValidationError as err:
-            raise LockOperationFailed(
-                f"Matter clear_lock_user rejected input for {self.lock.entity_id}: {err}"
-            ) from err
-        except (HomeAssistantError, MatterError, MatterClientException) as err:
-            # The original #1257 report's signature: ``Unexpected error during
-            # clear usercode ... InvalidState: Not connected``. MatterError /
-            # MatterClientException are independent of HomeAssistantError, so
-            # route them to retry rather than the sync catchall suspend.
-            raise LockDisconnected(
-                f"Matter clear_lock_user failed for {self.lock.entity_id}: {err}"
-            ) from err
+        await self._invoke_sdk(
+            "clear_lock_user", clear_lock_user(client, node, user_id)
+        )
 
     async def async_release_managed_slot(self, slot: int) -> None:
         """
@@ -1041,24 +1037,15 @@ class MatterLock(BaseLock):
             return False
 
         client, node = self._require_client_and_node()
-        try:
-            await clear_lock_credential(
+        await self._invoke_sdk(
+            "clear_lock_credential",
+            clear_lock_credential(
                 client,
                 node,
                 credential_type="pin",
                 credential_index=credential_index,
-            )
-        except ServiceValidationError as err:
-            raise LockOperationFailed(
-                f"Matter clear_lock_credential rejected input for "
-                f"{self.lock.entity_id}: {err}"
-            ) from err
-        except (HomeAssistantError, MatterError, MatterClientException) as err:
-            # Connectivity/server failure (incl. ``InvalidState: Not connected``
-            # at startup, issue #1257) -> retry rather than suspend.
-            raise LockDisconnected(
-                f"Matter clear_lock_credential failed for {self.lock.entity_id}: {err}"
-            ) from err
+            ),
+        )
 
         self._push_credential_update(ref.slot, SlotCredential.empty())
         return True

--- a/tests/providers/matter/test_sdk_exception_translation.py
+++ b/tests/providers/matter/test_sdk_exception_translation.py
@@ -1,0 +1,132 @@
+"""
+Structural guard: every Matter SDK call must translate its exceptions.
+
+The three Matter exception families (``HomeAssistantError`` /
+``ServiceValidationError``, ``matter_server.common.errors.MatterError``, and
+``matter_server.client.exceptions.MatterClientException``) do not subclass each
+other, so a call site that catches only one lets the others escape to the sync
+catchall, which suspends the slot (issue #1257). ``MatterLock._invoke_sdk`` is
+the single choke point that catches all three. This test parses the provider
+source and asserts every awaited SDK call either flows through
+``self._invoke_sdk(...)`` or lives in a function on the bespoke allowlist that
+translates exceptions itself, converting a silent omission into a reviewed
+allowlist edit.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from custom_components.lock_code_manager.providers import matter as matter_module
+
+# Matter lock-helper functions whose exceptions must be translated.
+_SDK_FUNCTION_NAMES = frozenset(
+    {
+        "get_lock_users",
+        "get_lock_info",
+        "set_lock_user",
+        "clear_lock_user",
+        "set_lock_credential",
+        "clear_lock_credential",
+    }
+)
+
+# Functions that translate SDK exceptions with bespoke semantics and so are
+# allowed to call the SDK directly instead of routing through _invoke_sdk:
+# - _send_set_credential: SetCredentialFailedError passthrough + CodeRejectedError
+# - _try_set_lock_user_with_fallbacks: MatterError is a charset-recovery
+#   fall-through signal, not an immediate raise
+# - async_set_credential: the sync-duplicate retry clears with a distinct
+#   "during sync-duplicate retry" message
+# Adding a name here must be a conscious, reviewed decision.
+_ALLOWLIST = frozenset(
+    {
+        "_send_set_credential",
+        "_try_set_lock_user_with_fallbacks",
+        "async_set_credential",
+    }
+)
+
+
+def _called_name(node: ast.Call) -> str | None:
+    """Resolve the called function's bare name for Name or Attribute calls."""
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
+
+
+def _is_invoke_sdk_call(node: ast.Call) -> bool:
+    """Return True when ``node`` is a ``self._invoke_sdk(...)`` call."""
+    func = node.func
+    return (
+        isinstance(func, ast.Attribute)
+        and func.attr == "_invoke_sdk"
+        and isinstance(func.value, ast.Name)
+        and func.value.id == "self"
+    )
+
+
+def _enclosing_function_by_node(tree: ast.Module) -> dict[ast.AST, str]:
+    """Map each descendant node to the name of its nearest enclosing function."""
+    mapping: dict[ast.AST, str] = {}
+    # ast.walk is breadth-first, so an outer function is visited before any
+    # function nested in it. Stamping every descendant and always overwriting
+    # therefore leaves each node mapped to its CLOSEST enclosing function: the
+    # inner def's later pass re-stamps its own body with the inner name.
+    for func in ast.walk(tree):
+        if isinstance(func, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            for child in ast.walk(func):
+                mapping[child] = func.name
+    return mapping
+
+
+def _invoke_sdk_second_positional_args(tree: ast.Module) -> set[int]:
+    """Return ``id()`` of every node passed as _invoke_sdk's 2nd positional arg."""
+    wrapped: set[int] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and _is_invoke_sdk_call(node):
+            # _invoke_sdk(operation, coro): the coro is the 2nd positional arg.
+            if len(node.args) >= 2:
+                wrapped.add(id(node.args[1]))
+    return wrapped
+
+
+def test_every_sdk_call_translates_exceptions() -> None:
+    """Assert each SDK call goes through _invoke_sdk or the allowlist.
+
+    A wrapped call (``await self._invoke_sdk("op", get_lock_users(...))``) is not
+    itself awaited -- only ``_invoke_sdk`` is -- so the SDK call is recognized by
+    identity as _invoke_sdk's 2nd positional argument. A bespoke call is awaited
+    directly inside an allowlisted function. Any other SDK call is an offender.
+    """
+    source = Path(matter_module.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    enclosing = _enclosing_function_by_node(tree)
+    wrapped = _invoke_sdk_second_positional_args(tree)
+
+    offenders: list[str] = []
+    for call in ast.walk(tree):
+        if not isinstance(call, ast.Call):
+            continue
+        name = _called_name(call)
+        if name not in _SDK_FUNCTION_NAMES:
+            continue
+        if id(call) in wrapped:
+            continue
+        enclosing_func = enclosing.get(call, "<module>")
+        if enclosing_func in _ALLOWLIST:
+            continue
+        offenders.append(f"{name} (in {enclosing_func}, line {call.lineno})")
+
+    assert not offenders, (
+        "Matter SDK calls bypass exception translation: "
+        + ", ".join(offenders)
+        + ". A new matter SDK call must go through `self._invoke_sdk(...)`; if "
+        "the enclosing function translates exceptions itself, add it to "
+        "ALLOWLIST in this test."
+    )


### PR DESCRIPTION
## Proposed change

`matter_server` exposes three independent exception hierarchies that do **not** subclass each other: `MatterClientException` / `InvalidState` (from `matter_server.client.exceptions`), `MatterError` (from `matter_server.common.errors`), and Home Assistant's `HomeAssistantError`. Several matter SDK call sites in `providers/matter.py` translate raw SDK exceptions into the typed seam exceptions (`LockOperationFailed`, `LockDisconnected`, `CodeRejectedError`). The recurring bug (#1257) was that a call site forgot to catch one of the three hierarchies, so e.g. `InvalidState: Not connected` at startup escaped to `sync.py`'s catch-all `except Exception` → `_suspend_slot` (suspends the slot, creates a repair, does not self-heal on reconnect). Six sites have now been patched one-by-one.

This PR makes it **structurally impossible** for a new matter SDK call site to silently skip the translation:

- **Single choke point.** New `MatterLock._invoke_sdk(operation, coro)` catches all three families in the correct order (`ServiceValidationError` first → `LockOperationFailed`; everything else → `LockDisconnected`).
- **Pure-pattern sites converted.** `_raw_lock_users`, `async_get_capabilities`, `async_delete_user`, and `async_delete_credential` now route through `_invoke_sdk`. The `operation` names are chosen so the resulting error messages are byte-identical to the current ones; existing tests pass unchanged.
- **Bespoke sites left as-is.** `_send_set_credential` (`SetCredentialFailedError` passthrough + `CodeRejectedError` mapping), `_try_set_lock_user_with_fallbacks` (`MatterError` is a charset-recovery fall-through, not an immediate raise), and the sync-duplicate-retry `clear_lock_credential` inside `async_set_credential` (distinct "during sync-duplicate retry" message) keep their special semantics.
- **AST guard test.** `tests/providers/matter/test_sdk_exception_translation.py` parses the provider source and asserts every awaited matter SDK call either flows through `self._invoke_sdk(...)` or lives in an explicit allowlist of bespoke exception-translating functions. A new unwrapped call fails the build, converting a silent omission into a conscious, reviewed allowlist edit.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue: #1257
- Follow-up to #1286 — prevents recurrence of the missed-exception-translation bug class in `matter.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
