### PR TITLE
test(providers): enforce native-transport-exception contract across providers

### DIFF
--- a/tests/providers/akuvox/test_provider.py
+++ b/tests/providers/akuvox/test_provider.py
@@ -34,6 +34,7 @@ from custom_components.lock_code_manager.providers.akuvox import (
     _parse_tag,
 )
 from tests.providers.helpers import (
+    ProviderNativeTransportContractTests,
     ServiceProviderConnectionTests,
     register_mock_service,
 )
@@ -158,6 +159,25 @@ class TestProperties:
 
 class TestConnection(ServiceProviderConnectionTests):
     """Connection tests for Akuvox provider using shared mixin."""
+
+
+class TestNativeTransportContract(ProviderNativeTransportContractTests):
+    """Akuvox routes a native ``OSError`` from ``list_users`` to LockDisconnected."""
+
+    # Reaches local_akuvox through BaseLock.async_call_service, whose native
+    # transport exception is OSError (an unwrapped ConnectionError/ReadTimeout).
+    native_transport_read_service = "list_users"
+
+    @pytest.fixture
+    def provider_lock(
+        self, akuvox_lock: AkuvoxLock, lcm_config_entry: MockConfigEntry
+    ) -> AkuvoxLock:
+        """A lock with managed slots, so the read actually calls the service.
+
+        ``async_get_users`` short-circuits with no managed slots, never
+        reaching the service seam, so the contract needs an LCM entry.
+        """
+        return akuvox_lock
 
 
 # ---------------------------------------------------------------------------

--- a/tests/providers/helpers.py
+++ b/tests/providers/helpers.py
@@ -17,6 +17,8 @@ Required fixtures for mixins (define in conftest.py or test module):
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import AbstractContextManager, contextmanager, nullcontext
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -27,7 +29,10 @@ from homeassistant.core import HomeAssistant, SupportsResponse
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
-from custom_components.lock_code_manager.domain.exceptions import LockCodeManagerError
+from custom_components.lock_code_manager.domain.exceptions import (
+    LockCodeManagerError,
+    LockDisconnected,
+)
 from custom_components.lock_code_manager.providers import BaseLock
 
 
@@ -136,3 +141,90 @@ class ServiceProviderDeviceAvailabilityTests:
             hass, provider_lock.domain, self.availability_service, handler
         )
         assert await provider_lock.async_is_device_available() is False
+
+
+class ProviderNativeTransportContractTests:
+    """
+    Enforce that a native transport exception surfaces as ``LockDisconnected``.
+
+    The provider seam contract is that read-path provider methods raise only
+    typed ``LockCodeManagerProviderError`` subclasses. The sync layer routes
+    ``LockDisconnected`` to a safe retry, but any untyped exception that escapes
+    a provider hits the catch-all ``except Exception`` and suspends the slot
+    (creating a repair, not self-healing on reconnect).
+
+    The recurring bug (issue #1257, fixed for Matter in PR #1286) is a provider
+    that wraps its client's exceptions but misses a NATIVE transport/connection
+    exception type that is independent of ``HomeAssistantError`` -- so the read
+    path lets it escape unmapped. This mixin injects that native exception at
+    the provider's lowest read seam and asserts the read path surfaces
+    ``LockDisconnected``.
+
+    Service-based providers (Akuvox, Schlage) reach their integration through
+    ``BaseLock.async_call_service``, whose native transport exception is
+    ``OSError`` (e.g. a ``ConnectionError`` from an integration that does not
+    wrap it in ``HomeAssistantError``). Such providers set
+    ``native_transport_read_service`` to the read service name and inherit the
+    default injection, which registers that service to raise the native
+    exception.
+
+    Client/library-based providers (Matter, Z-Wave JS) instead override
+    ``inject_native_transport_error`` to patch their lowest SDK call (or its
+    mock) to raise their native exception type.
+    """
+
+    # Default native transport exception for service-based providers. Override
+    # with the provider's own native non-HomeAssistantError exception instance.
+    native_transport_exception: Exception = OSError("connection refused")
+
+    # Service-based providers set this to the read service name; the default
+    # injection registers it to raise ``native_transport_exception``.
+    native_transport_read_service: str | None = None
+
+    def inject_native_transport_error(
+        self, hass: HomeAssistant, provider_lock: BaseLock
+    ) -> AbstractContextManager[None] | None:
+        """
+        Wire the native transport exception into the provider's read seam.
+
+        Return a context manager active for the duration of the read call, or
+        ``None`` when the injection is an in-place mutation (e.g. setting a
+        mock's ``side_effect``).
+
+        The default targets service-based providers via
+        ``native_transport_read_service``. Client/library providers override
+        this to patch their lowest SDK call instead.
+        """
+        service = self.native_transport_read_service
+        assert service is not None, (
+            "Set native_transport_read_service or override "
+            "inject_native_transport_error"
+        )
+
+        @contextmanager
+        def _inject() -> Iterator[None]:
+            register_mock_service(
+                hass,
+                provider_lock.domain,
+                service,
+                AsyncMock(side_effect=self.native_transport_exception),
+            )
+            yield
+
+        return _inject()
+
+    async def test_get_usercodes_surfaces_lock_disconnected_on_native_transport_error(
+        self, hass: HomeAssistant, provider_lock: BaseLock
+    ) -> None:
+        """
+        Native transport exception in the read path surfaces as LockDisconnected.
+
+        Guards the issue #1257 bug class: a transport exception independent of
+        ``HomeAssistantError`` must NOT escape the read path unmapped (where the
+        sync catch-all would suspend the slot) -- the provider has to route it to
+        ``LockDisconnected`` so sync retries safely on reconnect.
+        """
+        injection = self.inject_native_transport_error(hass, provider_lock)
+        with injection if injection is not None else nullcontext():
+            with pytest.raises(LockDisconnected):
+                await provider_lock.async_get_usercodes()

--- a/tests/providers/matter/test_provider.py
+++ b/tests/providers/matter/test_provider.py
@@ -42,7 +42,10 @@ from custom_components.lock_code_manager.providers.matter import (
     _lcm_slot_from_raw_users_by_credential_index,
     _lcm_slot_from_raw_users_by_user_index,
 )
-from tests.providers.helpers import ServiceProviderConnectionTests
+from tests.providers.helpers import (
+    ProviderNativeTransportContractTests,
+    ServiceProviderConnectionTests,
+)
 
 # Module path where lock_helpers functions are imported in the provider
 _PROVIDER_MODULE = "custom_components.lock_code_manager.providers.matter"
@@ -114,6 +117,35 @@ async def test_hard_refresh_interval(matter_lock_simple: MatterLock) -> None:
 
 class TestConnection(ServiceProviderConnectionTests):
     """Connection tests for Matter provider using shared mixin."""
+
+
+class TestNativeTransportContract(ProviderNativeTransportContractTests):
+    """Matter routes a native ``MatterClientException`` to LockDisconnected.
+
+    ``InvalidState: Not connected`` (a ``MatterClientException``) is raised by
+    the matter-server client before its websocket connects at startup and is
+    independent of ``HomeAssistantError`` (issue #1257, PR #1286). The
+    provider-specific read sites (get_lock_users / get_lock_info / set / clear)
+    are also covered individually below.
+    """
+
+    native_transport_exception = MatterClientException("Not connected")
+
+    @pytest.fixture
+    def provider_lock(self, matter_lock: MatterLock) -> MatterLock:
+        """A lock with a wired client/node so the read reaches ``get_lock_users``.
+
+        ``matter_lock_simple`` has no node, so ``_require_client_and_node``
+        raises before the patched SDK call -- a false pass for this contract.
+        """
+        return matter_lock
+
+    def inject_native_transport_error(self, hass, provider_lock):
+        """Patch the lowest read-path SDK call (``get_lock_users``)."""
+        return patch(
+            f"{_PROVIDER_MODULE}.get_lock_users",
+            AsyncMock(side_effect=self.native_transport_exception),
+        )
 
 
 class TestDeviceAvailability:

--- a/tests/providers/schlage/test_provider.py
+++ b/tests/providers/schlage/test_provider.py
@@ -32,6 +32,7 @@ from custom_components.lock_code_manager.providers.schlage import (
     _parse_tag,
 )
 from tests.providers.helpers import (
+    ProviderNativeTransportContractTests,
     ServiceProviderConnectionTests,
     ServiceProviderDeviceAvailabilityTests,
     register_mock_service,
@@ -121,6 +122,25 @@ class TestDeviceAvailability(ServiceProviderDeviceAvailabilityTests):
     """Device availability tests for Schlage provider using shared mixin."""
 
     availability_service = "get_codes"
+
+
+class TestNativeTransportContract(ProviderNativeTransportContractTests):
+    """Schlage routes a native ``OSError`` from ``get_codes`` to LockDisconnected."""
+
+    # Reaches the schlage integration through BaseLock.async_call_service, whose
+    # native transport exception is OSError (an unwrapped ConnectionError).
+    native_transport_read_service = "get_codes"
+
+    @pytest.fixture
+    def provider_lock(
+        self, schlage_lock: SchlageLock, simple_lcm_config_entry: MockConfigEntry
+    ) -> SchlageLock:
+        """A lock with managed slots, so the read actually calls the service.
+
+        ``async_get_users`` short-circuits with no managed slots, never
+        reaching the service seam, so the contract needs an LCM entry.
+        """
+        return schlage_lock
 
 
 # ---------------------------------------------------------------------------

--- a/tests/providers/virtual/test_provider.py
+++ b/tests/providers/virtual/test_provider.py
@@ -1,5 +1,7 @@
 """Test the Virtual lock platform."""
 
+import pytest
+
 from custom_components.lock_code_manager.domain.credentials import (
     Credential,
     CredentialRef,
@@ -11,6 +13,16 @@ from custom_components.lock_code_manager.domain.credentials import (
 )
 from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers.virtual import VirtualLock
+from tests.providers.helpers import ProviderNativeTransportContractTests
+
+
+@pytest.mark.skip(
+    reason="The virtual provider has no transport layer -- async_get_users "
+    "reads in-memory state with no SDK/client call -- so there is no native "
+    "transport exception and the issue #1257 contract does not apply."
+)
+class TestNativeTransportContract(ProviderNativeTransportContractTests):
+    """Documents that the native-transport contract does not apply to virtual."""
 
 
 async def test_set_credential_returns_changed_status(virtual_lock: VirtualLock):

--- a/tests/providers/zha/test_provider.py
+++ b/tests/providers/zha/test_provider.py
@@ -26,6 +26,22 @@ from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers.zha import (
     ZHALock,
 )
+from tests.providers.helpers import ProviderNativeTransportContractTests
+
+
+@pytest.mark.skip(
+    reason="ZHA's read path deliberately degrades per-slot: a native zigpy "
+    "error (DeliveryError / TimeoutError) from cluster.get_pin_code is caught "
+    "and the slot marked unreadable, so the coordinator does not treat a "
+    "transient error as confirmed-empty. There is no native non-"
+    "HomeAssistantError exception that maps to LockDisconnected at a read seam "
+    "(the cluster gate raises LockDisconnected only when the cluster is "
+    "absent, not from a native exception), so the issue #1257 contract does "
+    "not apply."
+)
+class TestNativeTransportContract(ProviderNativeTransportContractTests):
+    """Documents that the native-transport contract does not apply to ZHA reads."""
+
 
 # ---------------------------------------------------------------------------
 # Property tests

--- a/tests/providers/zigbee2mqtt/test_provider.py
+++ b/tests/providers/zigbee2mqtt/test_provider.py
@@ -27,8 +27,22 @@ from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers.zigbee2mqtt import (
     Zigbee2MQTTLock,
 )
+from tests.providers.helpers import ProviderNativeTransportContractTests
 
 from .conftest import _minimal_lock
+
+
+@pytest.mark.skip(
+    reason="Zigbee2MQTT's read path deliberately degrades per-slot: a native "
+    "OSError on MQTT publish or an asyncio TimeoutError waiting for the bridge "
+    "response is caught and the slot marked unreadable, so a transient MQTT "
+    "error is not treated as confirmed-empty. Its connection gates raise "
+    "LockDisconnected from boolean checks (MQTT enabled / connected / "
+    "available), not from a native exception, so the issue #1257 contract does "
+    "not apply to a read seam."
+)
+class TestNativeTransportContract(ProviderNativeTransportContractTests):
+    """Documents that the native-transport contract does not apply to Z2M reads."""
 
 
 def test_zigbee2mqtt_provider_properties_and_no_device_entry_skips_name() -> None:

--- a/tests/providers/zwave_js/test_provider.py
+++ b/tests/providers/zwave_js/test_provider.py
@@ -44,8 +44,41 @@ from custom_components.lock_code_manager.domain.exceptions import (
 )
 from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers.zwave_js import ZWaveJSLock
+from tests.providers.helpers import ProviderNativeTransportContractTests
 
 # Properties tests
+
+
+class TestNativeTransportContract(ProviderNativeTransportContractTests):
+    """Z-Wave JS routes a native ``BaseZwaveJSServerError`` to LockDisconnected.
+
+    The unified ``access_control`` read raises ``zwave_js_server`` errors (e.g.
+    ``FailedZWaveCommand``) that are independent of ``HomeAssistantError``; they
+    must surface as ``LockDisconnected`` rather than escaping to the sync
+    catch-all (issue #1257).
+    """
+
+    native_transport_exception = FailedZWaveCommand("cmd", 1, "node gone")
+
+    @pytest.fixture
+    def provider_lock(
+        self,
+        zwave_js_lock: ZWaveJSLock,
+        mock_access_control: MagicMock,
+        mock_lock_helpers: dict,
+    ) -> ZWaveJSLock:
+        """A lock on the unified path with empty data and mocked capabilities."""
+        mock_access_control.get_users_cached.return_value = []
+        mock_access_control.get_all_credentials_cached.return_value = []
+        return zwave_js_lock
+
+    def inject_native_transport_error(self, hass, provider_lock):
+        """Fail the lowest unified read call (``get_users_cached``)."""
+        # ``node.access_control`` is the class-patched mock_access_control.
+        provider_lock.node.access_control.get_users_cached.side_effect = (
+            self.native_transport_exception
+        )
+        return
 
 
 async def test_domain(zwave_js_lock: ZWaveJSLock) -> None:

--- a/tests/providers/zwave_js/test_uc_fallback.py
+++ b/tests/providers/zwave_js/test_uc_fallback.py
@@ -50,8 +50,41 @@ from custom_components.lock_code_manager.providers._zwave_js_uc import (
     ZWaveJSUserCodeFallbackSupport,
 )
 from custom_components.lock_code_manager.providers.zwave_js import ZWaveJSLock
+from tests.providers.helpers import ProviderNativeTransportContractTests
 
 from .conftest import get_zwave_lock, uc_only_caps_response, uc_slot_walk
+
+_UC_MODULE = "custom_components.lock_code_manager.providers._zwave_js_uc"
+
+
+class TestUCNativeTransportContract(ProviderNativeTransportContractTests):
+    """UC fallback routes a native ``BaseZwaveJSServerError`` to LockDisconnected.
+
+    The value-DB walk (``get_usercodes``) on the User Code CC fallback path
+    raises ``zwave_js_server`` errors independent of ``HomeAssistantError``;
+    they must surface as ``LockDisconnected`` rather than escaping the read
+    path to the sync catch-all (issue #1257).
+    """
+
+    native_transport_exception = FailedZWaveCommand("cmd", 1, "node gone")
+
+    @pytest.fixture
+    async def provider_lock(
+        self, uc_fallback_lock: ZWaveJSLock, mock_uc_utils: dict
+    ) -> ZWaveJSLock:
+        """A lock with UC fallback already detected (capabilities cached)."""
+        # Establish UC mode first; detection itself walks the value DB, so the
+        # native error must be injected only into the subsequent read.
+        await uc_fallback_lock.async_get_capabilities()
+        return uc_fallback_lock
+
+    def inject_native_transport_error(self, hass, provider_lock):
+        """Fail the post-detection value-DB walk (``get_usercodes``)."""
+        return patch(
+            f"{_UC_MODULE}.get_usercodes",
+            MagicMock(side_effect=self.native_transport_exception),
+        )
+
 
 # ---------------------------------------------------------------------------
 # User Code CC fallback (issue #1251)


### PR DESCRIPTION
## Proposed change

Generalizes the shared provider test harness (`tests/providers/helpers.py`) to enforce the lock-provider seam contract across all providers: a provider's read path must surface `LockDisconnected` (a typed `LockCodeManagerProviderError`) when its underlying SDK/client raises that provider's **native transport/connection exception** — specifically one that is **not** a subclass of `homeassistant.exceptions.HomeAssistantError`.

This is the recurring bug class behind issue #1257 and fixed for Matter in PR #1286: the sync layer routes `LockDisconnected` to a safe retry, but any other (untyped) exception escaping a provider hits the catch-all `except Exception` → `_suspend_slot` (suspends the slot, creates a repair, does not self-heal on reconnect). A provider that wraps its client's errors but misses a native transport exception independent of `HomeAssistantError` (for Matter: `MatterClientException`/`InvalidState`) silently regresses into this trap.

### What the harness adds

A new mixin `ProviderNativeTransportContractTests` with a single contract test that injects the native exception at the provider's lowest read seam and asserts `async_get_usercodes()` raises `LockDisconnected`. The injection mechanism is provider-shaped but DRY:

- **Service-based providers (akuvox, schlage)** inherit the default injection, which registers the read service (`list_users` / `get_codes`) to raise `OSError` — the native non-`HomeAssistantError` transport exception that `BaseLock.async_call_service` maps to `LockDisconnected`.
- **Client/library providers** override `inject_native_transport_error` to patch their lowest SDK call:
  - **matter** — `get_lock_users` raising `MatterClientException`
  - **zwave_js** (unified `access_control`) — `get_users_cached` raising `BaseZwaveJSServerError`
  - **zwave_js User Code CC fallback** — `get_usercodes` raising `BaseZwaveJSServerError`

### Providers covered vs. intentionally skipped

| Provider | Status | Native transport exception |
|---|---|---|
| matter | covered | `MatterClientException` |
| zwave_js | covered | `BaseZwaveJSServerError` |
| zwave_js User Code CC fallback | covered | `BaseZwaveJSServerError` |
| akuvox | covered | `OSError` (via `async_call_service`) |
| schlage | covered | `OSError` (via `async_call_service`) |
| zha | skipped (documented) | read path deliberately degrades per-slot to `unreadable`; gate raises `LockDisconnected` from a boolean check, not a native exception |
| zigbee2mqtt | skipped (documented) | same per-slot degrade design; gates raise from boolean checks |
| virtual | skipped (documented) | no transport layer (in-memory state) |

The three skipped providers carry an explicitly `@pytest.mark.skip`-ped contract class with the reason recorded, so the decision is auditable in the suite (3 skips).

### No provider leak found

All five covered providers already map their native transport exceptions to `LockDisconnected` correctly — the matter fix in #1286 was the only real instance of this bug. This PR is therefore test infrastructure only; no production code changed.

### Verification

- Full suite: `1288 passed, 3 skipped`.
- Each contract test was **mutation-verified**: temporarily removing a provider's native-exception handling makes its contract test fail, confirming the harness exercises the real seam (this also caught and fixed a would-be false positive in the matter wiring, where `matter_lock_simple` has no node and short-circuits before the SDK call — the contract now uses the node-backed `matter_lock`).

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue: #1257
- Follow-up to #1286 — enforces the provider seam contract (native transport exceptions surface as LockDisconnected) across all providers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)