### PR TITLE
fix(providers): recover backoff on device-level reconnect, not just integration (#1257)

### DIFF
--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -870,7 +870,7 @@ async def _async_setup_new_locks(
 
         added_locks.append(result)
 
-        if not await result.async_internal_is_integration_connected():
+        if not await result.async_internal_is_reachable():
             _LOGGER.debug(
                 "%s (%s): Lock %s is not connected yet. Entities will be created "
                 "but will be unavailable until the lock comes online. This is normal "

--- a/custom_components/lock_code_manager/domain/coordinator.py
+++ b/custom_components/lock_code_manager/domain/coordinator.py
@@ -431,7 +431,7 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator[dict[int, SlotCredenti
     async def _async_connection_check(self, now: datetime) -> None:
         """Poll connection state so providers can resubscribe on reconnect."""
         try:
-            await self._lock.async_internal_is_integration_connected()
+            await self._lock.async_internal_is_reachable()
         except LockCodeManagerError as err:
             _LOGGER.debug(
                 "Connection check failed for %s: %s", self._lock.lock.entity_id, err

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -137,7 +137,7 @@ class BaseLock:
        - Set hard_refresh_interval = None to disable
 
     4. Poll connection state:
-       - Periodic async_internal_is_integration_connected() at connection_check_interval
+       - Periodic async_internal_is_reachable() at connection_check_interval
        - Helps detect reconnects for integrations without config entry state signals
        - Set connection_check_interval = None to disable
 
@@ -254,12 +254,18 @@ class BaseLock:
         pre_execute runs inside the lock before the operation, for checks
         that must be atomic with the operation (e.g., duplicate detection).
         """
-        if not await self.async_internal_is_integration_connected():
+        # Evaluate both layers, feed the combined reachability to the
+        # transition handler, then raise the layer-specific message. The two
+        # checks are kept distinct for diagnostics; the transition only cares
+        # whether the lock is reachable end-to-end.
+        integration_up = await self.async_is_integration_connected()
+        device_up = await self.async_is_device_available()
+        self._note_reachability(integration_up and device_up)
+        if not integration_up:
             raise LockDisconnected(
                 f"Cannot {_OPERATION_MESSAGES[operation_type]} {self.lock.entity_id} - integration not connected"
             )
-
-        if not await self.async_is_device_available():
+        if not device_up:
             raise LockDisconnected(
                 f"Cannot {_OPERATION_MESSAGES[operation_type]} {self.lock.entity_id} - device not available"
             )
@@ -878,12 +884,32 @@ class BaseLock:
         return self.lock_config_entry.state == ConfigEntryState.LOADED
 
     @final
-    async def async_internal_is_integration_connected(self) -> bool:
-        """Return whether the integration's client/driver/broker is connected."""
-        is_up = await self.async_is_integration_connected()
+    async def async_internal_is_reachable(self) -> bool:
+        """
+        Return whether the lock is reachable end-to-end right now.
+
+        Combines the integration/transport signal
+        (``async_is_integration_connected``) with the device/node signal
+        (``async_is_device_available``): the lock is reachable only when both
+        layers are up. Recovery is therefore detected uniformly whether the
+        outage was at the network or the device layer -- a node that comes
+        back while the integration stayed connected drives the same
+        resubscribe/refresh transition as an integration reconnect, instead of
+        waiting out the connectivity breaker's backoff probe (issue #1257).
+        """
+        is_up = (
+            await self.async_is_integration_connected()
+            and await self.async_is_device_available()
+        )
+        self._note_reachability(is_up)
+        return is_up
+
+    @final
+    @callback
+    def _note_reachability(self, is_up: bool) -> None:
+        """Feed a reachability observation to the transition handler and remember it."""
         self._handle_connection_transition(is_up)
         self._last_connection_up = is_up
-        return is_up
 
     @final
     @callback

--- a/tests/common.py
+++ b/tests/common.py
@@ -63,6 +63,7 @@ class MockLCMLock(BaseLock):
         """Initialize mock lock."""
         super().__init__(*args, **kwargs)
         self._connected = True
+        self._device_available = True
         self._hard_refresh_interval: timedelta | None = None
         self.codes: dict[int, str] = {1: "1234", 2: "5678"}
         self.service_calls: defaultdict[str, list] = defaultdict(list)
@@ -81,9 +82,17 @@ class MockLCMLock(BaseLock):
         """Set connection state for testing."""
         self._connected = connected
 
+    def set_device_available(self, available: bool) -> None:
+        """Set device (node) availability for testing."""
+        self._device_available = available
+
     async def async_is_integration_connected(self) -> bool:
         """Return whether the integration's client/driver/broker is connected."""
         return self._connected
+
+    async def async_is_device_available(self) -> bool:
+        """Return whether the physical device (node) is reachable."""
+        return self._device_available
 
     async def async_hard_refresh_codes(self) -> dict[int, SlotCredential]:
         """Perform hard refresh of all codes."""

--- a/tests/providers/test_base.py
+++ b/tests/providers/test_base.py
@@ -95,9 +95,10 @@ async def test_base(hass: HomeAssistant):
     assert lock.usercode_scan_interval == timedelta(minutes=1)
     with pytest.raises(NotImplementedError):
         assert lock.domain
-    # async_is_integration_connected has a sensible default — it returns
-    # False here because the test config entry isn't in the LOADED state.
-    assert await lock.async_internal_is_integration_connected() is False
+    # async_internal_is_reachable combines the integration and device
+    # signals — it returns False here because the test config entry isn't in
+    # the LOADED state (integration down short-circuits the combined check).
+    assert await lock.async_internal_is_reachable() is False
     # hard_refresh / set / clear / get all check connection first via
     # _execute_rate_limited; since the default connection check returned
     # False above, they raise LockDisconnected before reaching the abstract
@@ -209,6 +210,53 @@ async def test_connection_transition_resubscribes(
         lock.set_connected(True)
         await lock.coordinator.async_refresh()
         assert lock.subscribe_calls == 1
+
+        await hass.config_entries.async_unload(lcm_config_entry.entry_id)
+
+
+async def test_connection_transition_on_device_availability(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+):
+    """A device-level (node) outage drives the same resubscribe/refresh path.
+
+    Recovery must be detected uniformly whether the outage was at the
+    integration/transport layer or the device/node layer: with the
+    integration still connected, toggling device availability alone must
+    unsubscribe on the drop and resubscribe + refresh on recovery
+    (issue #1257 recovery latency).
+    """
+    with patch(
+        "custom_components.lock_code_manager.domain.locks.INTEGRATIONS_CLASS_MAP",
+        {"test": MockLCMLockWithPush},
+    ):
+        lcm_config_entry = MockConfigEntry(
+            domain=DOMAIN, data=BASE_CONFIG, unique_id="Mock Title"
+        )
+        lcm_config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(lcm_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        lock = lcm_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
+        assert isinstance(lock, MockLCMLockWithPush)
+
+        lock.subscribe_calls = 0
+        lock.unsubscribe_calls = 0
+        lock._min_operation_delay = 0.0
+        lock._last_operation_time = 0.0
+
+        await lock.coordinator.async_refresh()
+
+        # Integration stays connected; only the node drops.
+        lock.set_device_available(False)
+        await lock.coordinator.async_refresh()
+        assert lock.unsubscribe_calls == 1
+
+        lock.set_device_available(True)
+        lock.coordinator.async_request_refresh = AsyncMock()
+        await lock.coordinator.async_refresh()
+        assert lock.subscribe_calls == 1
+        lock.coordinator.async_request_refresh.assert_awaited()
 
         await hass.config_entries.async_unload(lcm_config_entry.entry_id)
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -655,7 +655,7 @@ async def test_no_slot_coordinator_warning_during_initial_setup(
     Before the fix, per-lock entities (``code`` sensor, ``in_sync`` binary
     sensor) were scheduled by ``_async_setup_new_locks`` while the slot
     coordinators had not yet been created. The await on
-    ``async_internal_is_integration_connected`` between locks let the event
+    ``async_internal_is_reachable`` between locks let the event
     loop drain the entity-add tasks for prior locks, whose
     ``async_added_to_hass`` then warned about the missing coordinator.
 


### PR DESCRIPTION
## Proposed change

Final piece of the #1257 follow-up: fix the "Matter codes start working again only after several minutes" recovery latency.

The lock connectivity breaker's `unreachable` state is reset quickly by the connection-transition handler (`_handle_connection_transition`), which kicks a coordinator refresh + push resubscribe on a False→True transition. But that handler was driven **only** by the integration signal (`async_is_integration_connected`). For Matter, the matter-*server* config entry stays `LOADED` through a node-only outage, so a node reconnect was never detected by that path — recovery fell through to the escalating backoff probe (`60s → 120 → 240 → … → 1800s`), i.e. up to 30 minutes.

Failures already feed the breaker uniformly (any `LockDisconnected`, network- or device-level, via `note_connectivity_failure`/`_apply_backoff`). This makes **recovery** uniform too, by unifying on a single end-to-end reachability signal:

- Rename `async_internal_is_integration_connected` → **`async_internal_is_reachable`**, computing `integration_connected AND device_available` and feeding that to the transition handler.
- Extract `_note_reachability()` so both the 30s connection check **and** the operation gate (`_execute_rate_limited`) drive the transition off the combined signal. The gate keeps its layer-specific `LockDisconnected` messages for diagnostics.
- Net effect: a device/node reconnect now resets the backoff at the ~30s connection-check cadence, for **any** push provider — not just on an integration-level reconnect.

Resubscribing on a node blip is effectively free: `MatterClient.subscribe_events` is local callback registration (one persistent server websocket, no per-call round-trip), and `setup_push_subscription` is idempotent — so unifying the signal for the subscription lifecycle too carries no real cost and is strictly safer (never relies on a stale subscription).

### Tests
- New `test_connection_transition_on_device_availability` (TDD, red→green): with the integration still connected, a device-availability drop unsubscribes and recovery resubscribes + refreshes — the path that previously only fired for integration-level transitions.
- Full suite: 1290 passed, 3 skipped. `ruff`/`mypy`/`pydocstyle`/`flake8` clean.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue: #1257 (recovery-latency aspect)
- Follow-up to #1286 / #1287 / #1288.
