### PR TITLE
fix(ci): derive release tag from the release payload, not github.ref

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,11 @@ jobs:
         uses: actions/checkout@v7
       - name: Get Version
         id: get_version
-        run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> "$GITHUB_OUTPUT"
+        # github.ref is unreliable for release events (it can resolve to the
+        # target branch, not the tag); the release payload's tag_name always is.
+        env:
+          VERSION: ${{ github.event.release.tag_name }}
+        run: echo "VERSION=${VERSION}" >> "$GITHUB_OUTPUT"
       - name: Update versions
         env:
           VERSION: ${{ steps.get_version.outputs.VERSION }}
@@ -38,5 +42,5 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: ${{ github.workspace }}/custom_components/lock_code_manager/lock_code_manager.zip
           asset_name: lock_code_manager.zip
-          tag: ${{ github.ref }}
+          tag: ${{ github.event.release.tag_name }}
           overwrite: true


### PR DESCRIPTION
## Proposed change

The Release workflow derived the tag from `github.ref`, which is **unreliable for `release` events** — it can resolve to the target branch instead of the tag. When that happened (run [27973036902](https://github.com/raman325/lock_code_manager/actions/runs/27973036902) for 4.1.4, triggered with ref `main`), the upload step's `tag: ${{ github.ref }}` came through empty and `svenstaro/upload-release-action` failed with `Input required and not supplied: tag`.

The same condition is a latent second bug: the `Get Version` step's `${GITHUB_REF/refs\/tags\//}` substitution would have stamped `refs/heads/main` as the version into `const.py`/`manifest.json` — the upload failing is the only reason a garbage-versioned asset wasn't produced. Every successful release run was triggered with the ref pointing at the tag; only the run where it pointed at `main` failed.

This switches both the version stamp and the upload tag to `github.event.release.tag_name`, which is always the published release's tag regardless of the triggering ref. The `Get Version` step reads it via an `env:` var rather than interpolating into the `run:` script, per workflow-injection hardening.

To recover the missing 4.1.4 asset, re-run that release's job after this merges.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- Fixes the intermittent Release-workflow failure seen on the 4.1.4 release run.
