### PR TITLE
perf(entity): scope availability subscription to the lock entities

### DIFF
--- a/custom_components/lock_code_manager/entity.py
+++ b/custom_components/lock_code_manager/entity.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, final
+from typing import TYPE_CHECKING, Any, final
 
 from homeassistant.components.lock import LockState
 from homeassistant.config_entries import ConfigEntry
@@ -30,6 +30,9 @@ from .domain.models import LockCodeManagerConfigEntry
 from .domain.queries import get_entry_config
 from .domain.slot_coordinator import SlotEntityCoordinator
 from .providers import BaseLock
+
+if TYPE_CHECKING:
+    from homeassistant.helpers.event import _TrackStateChangeFiltered
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -82,6 +85,12 @@ class BaseLockCodeManagerEntity(Entity):
         # bound to the new coordinator. See ``SlotEntityCoordinator``.
         self._slot_coordinator: SlotEntityCoordinator | None = None
 
+        # Availability is driven by a state-change subscription scoped to just
+        # the lock entities (re-scoped when locks are added/removed), rather
+        # than every state in the instance. Created in ``async_added_to_hass``;
+        # ``None`` until then.
+        self._available_state_tracker: _TrackStateChangeFiltered | None = None
+
     @final
     @property
     def _state(self) -> Any:
@@ -132,6 +141,7 @@ class BaseLockCodeManagerEntity(Entity):
         self.locks = [
             lock for lock in self.locks if lock.lock.entity_id != lock_entity_id
         ]
+        self._async_handle_locks_updated()
 
     @callback
     def _handle_add_locks(self, locks: list[BaseLock]) -> None:
@@ -141,6 +151,26 @@ class BaseLockCodeManagerEntity(Entity):
         Can be overwritten by platforms.
         """
         self.locks.extend(locks)
+        self._async_handle_locks_updated()
+
+    @callback
+    def _async_handle_locks_updated(self) -> None:
+        """
+        Re-scope the availability subscription after the lock set changes.
+
+        ``self.locks`` is mutated at runtime by ``_handle_add_locks`` and
+        ``_handle_remove_lock``. The availability subscription tracks only the
+        lock entities (not every state change in the instance), so it is
+        re-scoped to the new set here. Availability is recomputed immediately
+        because the added/removed lock's own state change will not otherwise
+        trigger an update.
+        """
+        if (tracker := self._available_state_tracker) is None:
+            return
+        tracker.async_update_listeners(
+            TrackStates(False, {lock.lock.entity_id for lock in self.locks}, set())
+        )
+        self._handle_available_state_update()
 
     def _get_removal_uid(self) -> str:
         """
@@ -240,13 +270,12 @@ class BaseLockCodeManagerEntity(Entity):
             )
 
         self._register_callbacks()
-        self.async_on_remove(
-            async_track_state_change_filtered(
-                self.hass,
-                TrackStates(True, set(), set()),
-                self._handle_available_state_update,
-            ).async_remove
+        self._available_state_tracker = async_track_state_change_filtered(
+            self.hass,
+            TrackStates(False, {lock.lock.entity_id for lock in self.locks}, set()),
+            self._handle_available_state_update,
         )
+        self.async_on_remove(self._available_state_tracker.async_remove)
         self._handle_available_state_update()
 
         _LOGGER.debug(

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -2050,3 +2050,35 @@ async def test_rapid_coordinator_updates_coalesce(
     assert set_calls[0] == (1, "1234", "test1"), (
         "Sync should restore the configured PIN"
     )
+
+
+async def test_availability_subscription_scoped_to_locks(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """Availability subscription is scoped to the lock entities, and re-scopes on lock changes.
+
+    Regression guard for the previous ``TrackStates(True, ...)`` all-states
+    subscription, which fired the availability handler on every state change in
+    the entire instance. The subscription must track only the lock entities and
+    be re-scoped when locks are added/removed at runtime.
+    """
+    entity = get_in_sync_entity_obj(hass, SLOT_1_ACTIVE_ENTITY)
+    tracker = entity._available_state_tracker
+    assert tracker is not None
+
+    # Scoped to the configured locks, NOT every state in the instance.
+    assert tracker._last_track_states.all_states is False
+    assert tracker._last_track_states.entities == {LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID}
+
+    # Removing a lock re-scopes the subscription to the remaining locks.
+    entity._handle_remove_lock(LOCK_1_ENTITY_ID)
+    assert tracker._last_track_states.all_states is False
+    assert tracker._last_track_states.entities == {LOCK_2_ENTITY_ID}
+
+    # Re-adding the lock re-scopes the subscription to include it again.
+    re_added_lock = lock_code_manager_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
+    entity._handle_add_locks([re_added_lock])
+    assert tracker._last_track_states.all_states is False
+    assert tracker._last_track_states.entities == {LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID}


### PR DESCRIPTION
## Proposed change

The availability `binary_sensor` registers its state-change handler with `all_states=True`:

```python
async_track_state_change_filtered(
    self.hass, TrackStates(True, set(), set()), self._handle_available_state_update
)
```

`TrackStates(True, ...)` subscribes to **every state change in the entire Home Assistant instance**. `_handle_available_state_update` then filters in Python and early-returns for any entity that isn't one of the slot's locks.

On a production instance with ~6–7 of these entities, `cProfile` measured the handler running **~86,580 times / 30s (~2,900/sec)** and its inner generator **~640,100 times / 30s** — the single largest application-level CPU consumer, doing no useful work.

### Fix

Scope the subscription to just the lock entities:

```python
TrackStates(False, {lock.lock.entity_id for lock in self.locks}, set())
```

`self.locks` is mutated at runtime (`_handle_add_locks` / `_handle_remove_lock`), so the tracked set is re-scoped via `async_update_listeners()` whenever locks change, and availability is recomputed at that point — previously the all-states firehose recomputed it implicitly, so this preserves behavior for the dynamic add/remove-lock case. The initial availability computation and the `async_on_remove` cleanup are unchanged.

Pure performance fix; **no behavior change**. Verified: the full `test_binary_sensor.py`, `test_event.py`, and `test_callbacks.py` suites pass (48 tests), and a new regression test asserts the subscription is scoped to the locks and re-scopes on lock add/remove.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- Performance regression measured via `cProfile` on a production HA instance running 4.2.0.
- No existing issue; filing this PR directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)