### PR TITLE
fix: don't drop locks when provider integration is still loading

### DIFF
--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -643,29 +643,40 @@ class BaseLock:
         capability probe OR the provider's own ``async_setup`` are logged
         and the coordinator is created anyway so the integration retries
         once the lock comes online.
+
+        When the provider integration is not connected yet (e.g. zwave_js
+        still loading during a slow Home Assistant boot, issue #1321), no
+        provider I/O is attempted at all: the capability probe and
+        ``async_setup`` are deferred to the integration's LOADED
+        transition, which re-runs them via
+        ``_async_on_integration_loaded``. This keeps an untranslated
+        provider exception during startup from dropping the lock
+        entirely.
         """
         self._lcm_config_entry = config_entry
         try:
-            if self.supports_native_users:
-                caps = await self._get_cached_capabilities()
-                if CredentialType.PIN not in caps.credential_types:
-                    raise LockCodeManagerProviderError(
-                        f"{self.lock.entity_id}: lock does not advertise PIN credential support"
+            try:
+                if not await self.async_is_integration_connected():
+                    LOGGER.warning(
+                        "Provider integration for %s is not ready yet. "
+                        "Provider setup is deferred until it finishes "
+                        "loading; entities will be created but unavailable "
+                        "until then.",
+                        self.lock.entity_id,
                     )
-            await self.async_setup(config_entry)
-        except (LockDisconnected, LockOperationFailed) as err:
-            LOGGER.warning(
-                "Provider setup failed for %s: %s. Coordinator will be "
-                "created but data will be unavailable until the lock "
-                "comes online. Setup will be retried when the lock "
-                "integration reconnects.",
-                self.lock.entity_id,
-                err,
-            )
-        else:
-            self._setup_succeeded = True
+                else:
+                    await self._async_run_provider_setup(config_entry)
+                    self._setup_succeeded = True
+            except (LockDisconnected, LockOperationFailed) as err:
+                LOGGER.warning(
+                    "Provider setup failed for %s: %s. Coordinator will be "
+                    "created but data will be unavailable until the lock "
+                    "comes online. Setup will be retried when the lock "
+                    "integration reconnects.",
+                    self.lock.entity_id,
+                    err,
+                )
 
-        try:
             lock_entity_id = self.lock.entity_id
             # Track the provider's config entry (e.g., zwave_js) so we can resubscribe
             # when that integration reloads or reconnects.
@@ -714,13 +725,32 @@ class BaseLock:
         finally:
             self._setup_complete.set()
 
+    async def _async_run_provider_setup(self, config_entry: ConfigEntry) -> None:
+        """
+        Validate lock capabilities and run provider-specific setup.
+
+        Shared by initial setup and the integration-reconnect path so a
+        lock whose integration was still loading at boot gets the same
+        PIN-support validation once the integration comes up.
+        """
+        if self.supports_native_users:
+            caps = await self._get_cached_capabilities()
+            if CredentialType.PIN not in caps.credential_types:
+                raise LockCodeManagerProviderError(
+                    f"{self.lock.entity_id}: lock does not advertise PIN credential support"
+                )
+        await self.async_setup(config_entry)
+
     async def _async_on_integration_loaded(self) -> None:
         """
         Handle provider integration LOADED transition.
 
-        Re-runs ``async_setup`` to re-initialize provider state (e.g.
-        re-register event listeners after an integration reload), then
-        refreshes the coordinator and subscribes to push updates.
+        Re-runs the capability validation and ``async_setup`` to
+        re-initialize provider state (e.g. re-register event listeners
+        after an integration reload), then refreshes the coordinator and
+        subscribes to push updates. The validation matters for locks
+        whose initial setup was deferred because the integration was
+        still loading (issue #1321) -- this is the first time it can run.
 
         Operations are chained sequentially so setup completes before
         the coordinator refresh or push subscription begins.
@@ -735,12 +765,18 @@ class BaseLock:
 
         self._setup_running = True
         try:
-            await self.async_setup(self._lcm_config_entry)
+            await self._async_run_provider_setup(self._lcm_config_entry)
         except LockDisconnected, LockOperationFailed:
             LOGGER.debug(
                 "Provider setup failed for %s, will retry on next reconnect",
                 self.lock.entity_id,
                 exc_info=True,
+            )
+        except LockCodeManagerProviderError as err:
+            LOGGER.error(
+                "Provider setup failed validation for %s: %s",
+                self.lock.entity_id,
+                err,
             )
         else:
             if not self._setup_succeeded:

--- a/custom_components/lock_code_manager/providers/zwave_js.py
+++ b/custom_components/lock_code_manager/providers/zwave_js.py
@@ -129,10 +129,20 @@ class ZWaveJSLock(BaseLock):
 
     @property
     def node(self) -> Node:
-        """Return ZWave JS node."""
-        return async_get_node_from_entity_id(
-            self.hass, self.lock.entity_id, self.ent_reg
-        )
+        """
+        Return ZWave JS node.
+
+        Home Assistant's helper raises a bare ``ValueError`` while the
+        zwave_js config entry is still loading (issue #1321); translate it
+        to ``LockDisconnected`` so callers route it to the degraded/retry
+        path instead of treating it as an unexpected crash.
+        """
+        try:
+            return async_get_node_from_entity_id(
+                self.hass, self.lock.entity_id, self.ent_reg
+            )
+        except ValueError as err:
+            raise LockDisconnected(f"Z-Wave JS node unavailable: {err}") from err
 
     @property
     def supports_push(self) -> bool:

--- a/tests/providers/test_base.py
+++ b/tests/providers/test_base.py
@@ -20,6 +20,11 @@ from custom_components.lock_code_manager.const import (
     DOMAIN,
     EVENT_LOCK_STATE_CHANGED,
 )
+from custom_components.lock_code_manager.domain.credentials import (
+    CredentialType,
+    CredentialTypeCapability,
+    LockCapabilities,
+)
 from custom_components.lock_code_manager.domain.exceptions import (
     DuplicateCodeError,
     LockDisconnected,
@@ -822,6 +827,153 @@ async def test_on_integration_loaded_retries_on_disconnect(
         await lock._async_on_integration_loaded()
 
     assert lock._setup_succeeded is False
+
+
+class MockNativeUserLock(MockLCMLock):
+    """Mock lock that opts into the native-user capability validation."""
+
+    @property
+    def supports_native_users(self) -> bool:
+        """Return True so async_setup_internal runs the capability probe."""
+        return True
+
+
+def _pin_capabilities() -> LockCapabilities:
+    """Return capabilities advertising PIN support."""
+    return LockCapabilities(
+        supports_user_management=True,
+        max_users=10,
+        credential_types={
+            CredentialType.PIN: CredentialTypeCapability(
+                num_slots=10, min_length=4, max_length=8, supports_learn=False
+            )
+        },
+        max_user_name_length=10,
+    )
+
+
+def _make_base_test_lock(
+    hass: HomeAssistant, unique_id: str, lock_cls: type[MockLCMLock] = MockLCMLock
+) -> MockLCMLock:
+    """Create a mock lock wired to a registry entry and config entry."""
+    entity_reg = er.async_get(hass)
+    config_entry = MockConfigEntry(domain=DOMAIN)
+    config_entry.add_to_hass(hass)
+    lock_entity = entity_reg.async_get_or_create(
+        "lock", "test", unique_id, config_entry=config_entry
+    )
+    return lock_cls(hass, dr.async_get(hass), entity_reg, config_entry, lock_entity)
+
+
+async def test_setup_internal_defers_provider_io_when_integration_not_connected(
+    hass: HomeAssistant,
+):
+    """Setup skips the capability probe and async_setup while the integration is down.
+
+    Regression test for issue #1321: the base class must not touch the
+    provider integration before it is connected — a provider whose probe
+    raises an untranslated error (e.g. zwave_js's node lookup ValueError)
+    would otherwise crash setup and permanently drop the lock.
+    """
+    lock = _make_base_test_lock(hass, "test_lock_defer_io", MockNativeUserLock)
+    lock.set_connected(False)
+
+    with (
+        patch.object(lock, "async_get_capabilities") as mock_caps,
+        patch.object(lock, "async_setup") as mock_setup,
+    ):
+        await lock.async_setup_internal(lock.lock_config_entry)
+
+    mock_caps.assert_not_called()
+    mock_setup.assert_not_called()
+    assert lock._setup_succeeded is False
+    # Degraded, not dropped: coordinator and recovery listener exist.
+    assert lock.coordinator is not None
+    assert lock._config_entry_state_unsub is not None
+    assert lock._setup_complete.is_set()
+
+    await lock.coordinator.async_shutdown()
+    await lock.async_unload(False)
+
+
+async def test_setup_complete_set_when_setup_raises_unexpectedly(
+    hass: HomeAssistant,
+):
+    """_setup_complete is set even when setup escapes with an unexpected error.
+
+    Waiters in async_wait_for_setup (shared lock instances across config
+    entries) must not hang forever when setup fails structurally.
+    """
+    lock = _make_base_test_lock(hass, "test_lock_setup_complete")
+
+    with patch.object(lock, "async_setup", side_effect=RuntimeError("boom")):
+        with pytest.raises(RuntimeError):
+            await lock.async_setup_internal(lock.lock_config_entry)
+
+    assert lock._setup_complete.is_set()
+
+
+async def test_on_integration_loaded_runs_deferred_capability_validation(
+    hass: HomeAssistant,
+):
+    """The reconnect path runs the capability validation setup deferred.
+
+    When initial setup ran degraded (integration down), the LOADED
+    transition must run the same probe + PIN validation as initial setup
+    before marking the provider set up.
+    """
+    lock = _make_base_test_lock(hass, "test_lock_deferred_caps", MockNativeUserLock)
+    lock.set_connected(False)
+
+    caps_mock = AsyncMock(return_value=_pin_capabilities())
+    with patch.object(lock, "async_get_capabilities", caps_mock):
+        await lock.async_setup_internal(lock.lock_config_entry)
+        assert lock._setup_succeeded is False
+        caps_mock.assert_not_called()
+
+        # Integration comes up; simulate the LOADED transition callback.
+        lock.set_connected(True)
+        loaded_entry = MagicMock()
+        loaded_entry.state = ConfigEntryState.LOADED
+        lock.lock_config_entry = loaded_entry
+        await lock._async_on_integration_loaded()
+
+    caps_mock.assert_awaited_once()
+    assert lock._setup_succeeded is True
+
+    await lock.coordinator.async_shutdown()
+    await lock.async_unload(False)
+
+
+async def test_on_integration_loaded_rejects_lock_without_pin_support(
+    hass: HomeAssistant,
+):
+    """Deferred validation failing (no PIN support) leaves setup unsuccessful.
+
+    The structural failure must not escape into the reconnect task; the
+    provider simply never reaches the set-up state.
+    """
+    lock = _make_base_test_lock(hass, "test_lock_deferred_no_pin", MockNativeUserLock)
+    lock.set_connected(False)
+
+    no_pin_caps = LockCapabilities(
+        supports_user_management=True, max_users=10, credential_types={}
+    )
+    caps_mock = AsyncMock(return_value=no_pin_caps)
+    with patch.object(lock, "async_get_capabilities", caps_mock):
+        await lock.async_setup_internal(lock.lock_config_entry)
+
+        lock.set_connected(True)
+        loaded_entry = MagicMock()
+        loaded_entry.state = ConfigEntryState.LOADED
+        lock.lock_config_entry = loaded_entry
+        await lock._async_on_integration_loaded()
+
+    caps_mock.assert_awaited_once()
+    assert lock._setup_succeeded is False
+
+    await lock.coordinator.async_shutdown()
+    await lock.async_unload(False)
 
 
 async def test_set_usercode_skips_refresh_for_push_provider(

--- a/tests/providers/test_seam.py
+++ b/tests/providers/test_seam.py
@@ -202,7 +202,12 @@ async def test_setup_internal_rejects_lock_without_pin_support(
     lock = _make_lock(hass, _NoPinLock, "seam_setup_no_pin")
     config_entry = MockConfigEntry(domain=DOMAIN)
     config_entry.add_to_hass(hass)
-    with pytest.raises(LockCodeManagerProviderError, match="PIN credential"):
+    # The stub's config entry never loads; force the connected signal so
+    # setup runs the capability validation instead of deferring it.
+    with (
+        patch.object(lock, "async_is_integration_connected", return_value=True),
+        pytest.raises(LockCodeManagerProviderError, match="PIN credential"),
+    ):
         await lock.async_setup_internal(config_entry)
 
 
@@ -237,7 +242,8 @@ async def test_setup_internal_accepts_slot_only_capabilities(
     lock = _make_lock(hass, _SlotOnlyCapsLock, "seam_setup_slot_only_caps")
     config_entry = MockConfigEntry(domain=DOMAIN)
     config_entry.add_to_hass(hass)
-    await lock.async_setup_internal(config_entry)
+    with patch.object(lock, "async_is_integration_connected", return_value=True):
+        await lock.async_setup_internal(config_entry)
 
     assert lock._setup_succeeded is True
     assert await lock._supports_user_records() is False

--- a/tests/providers/zwave_js/test_e2e.py
+++ b/tests/providers/zwave_js/test_e2e.py
@@ -27,6 +27,7 @@ from custom_components.lock_code_manager.const import (
 from custom_components.lock_code_manager.domain.credentials import WriteResult
 from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers.zwave_js import ZWaveJSLock
+from tests.providers.zwave_js.conftest import ZWAVE_JS_LCM_CONFIG_SLOTS
 
 
 def async_capture_events(
@@ -273,3 +274,53 @@ class TestEvents:
         # Credential events push unreadable (the lock doesn't expose the Personal
         # Identification Number value in the event; a coordinator refresh reads it).
         assert e2e_zwave_lock.coordinator.data.get(1) == SlotCredential.unreadable()
+
+
+class TestColdStartRace:
+    """Regression tests for issue #1321: LCM setup racing zwave_js startup."""
+
+    async def test_lcm_setup_survives_zwave_entry_not_loaded(
+        self,
+        hass: HomeAssistant,
+        zwave_integration: MockConfigEntry,
+        lock_entity: er.RegistryEntry,
+        mock_access_control,
+        mock_lock_helpers: dict,
+    ) -> None:
+        """LCM setup while zwave_js is still loading degrades and recovers.
+
+        Reproduces issue #1321: the zwave_js config entry has not reached
+        LOADED when LCM sets up (slow boot). The lock must not be dropped;
+        it stays registered in a degraded state and recovers automatically
+        when the zwave_js entry finishes loading.
+        """
+        assert await hass.config_entries.async_unload(zwave_integration.entry_id)
+        await hass.async_block_till_done()
+
+        lcm_entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={
+                CONF_LOCKS: [lock_entity.entity_id],
+                CONF_SLOTS: ZWAVE_JS_LCM_CONFIG_SLOTS,
+            },
+            unique_id="test_zwave_js_cold_start",
+        )
+        lcm_entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(lcm_entry.entry_id)
+        await hass.async_block_till_done()
+
+        # The lock survived setup in a degraded state instead of being dropped.
+        lock = lcm_entry.runtime_data.locks.get(lock_entity.entity_id)
+        assert lock is not None
+        assert isinstance(lock, ZWaveJSLock)
+        assert lock.coordinator is not None
+        assert lock._setup_succeeded is False
+
+        # zwave_js finishes loading -> the LOADED transition drives recovery.
+        assert await hass.config_entries.async_setup(zwave_integration.entry_id)
+        await hass.async_block_till_done()
+
+        assert lock._setup_succeeded is True
+        assert lock._push_unsubs
+
+        await hass.config_entries.async_unload(lcm_entry.entry_id)

--- a/tests/providers/zwave_js/test_provider.py
+++ b/tests/providers/zwave_js/test_provider.py
@@ -111,6 +111,25 @@ async def test_node_property(
     assert node.node_id == lock_schlage_be469.node_id
 
 
+async def test_node_raises_lock_disconnected_when_entry_not_loaded(
+    hass: HomeAssistant,
+    zwave_js_lock: ZWaveJSLock,
+    zwave_integration: MockConfigEntry,
+) -> None:
+    """Node resolution while the zwave_js entry is down maps to LockDisconnected.
+
+    Home Assistant's async_get_node_from_entity_id raises a raw ValueError
+    when the zwave_js config entry is not loaded (issue #1321). The provider
+    must translate that into LockDisconnected so the base class routes it to
+    the degraded-setup/retry path instead of dropping the lock.
+    """
+    await hass.config_entries.async_unload(zwave_integration.entry_id)
+    await hass.async_block_till_done()
+
+    with pytest.raises(LockDisconnected):
+        _ = zwave_js_lock.node
+
+
 async def test_setup_is_idempotent(
     hass: HomeAssistant,
     zwave_js_lock: ZWaveJSLock,


### PR DESCRIPTION
## Proposed change

Fixes the cold-start race in #1321: when Home Assistant boots slowly, Lock Code Manager can set up before the zwave_js config entry reaches `LOADED`. The zwave_js node lookup then raises a raw `ValueError` (`Device <id> config entry is not loaded`) that bypassed the base class's degraded-setup machinery entirely — the lock was dropped from runtime data with no recovery listener registered, and every LCM entity stayed unavailable until a manual reload.

The fix has three layers:

1. **zwave_js provider**: node resolution now translates the `ValueError` into `LockDisconnected`, the provider contract's transport failure, so every call site (setup, coordinator refresh, writes) routes it to the existing degraded/retry path instead of treating it as a crash.
2. **Base class enforcement (all providers)**: `async_setup_internal` checks `async_is_integration_connected()` before attempting any provider I/O. If the provider integration isn't up yet, the capability probe and `async_setup` are deferred to the integration's `LOADED` transition — no provider can opt out of this protection by leaking an untranslated exception during startup. `_setup_complete` is also now set unconditionally so shared-lock-instance waiters can't hang when setup fails structurally.
3. **Recovery-path parity**: the `LOADED` transition handler re-runs the same capability validation as initial setup (extracted into `_async_run_provider_setup`), so a lock whose validation was deferred at boot still gets the PIN-support check once its integration comes up. A structural validation failure on reconnect is logged and leaves the provider un-setup rather than escaping into the reconnect task.

New tests cover the exact reported failure (node lookup while the zwave_js entry is unloaded), the end-to-end cold-start scenario (LCM setup with zwave_js unloaded → lock survives degraded → recovers automatically when zwave_js loads), the base-class deferral, the deferred validation on reconnect (both PIN-supported and unsupported), and the `_setup_complete` guarantee. Two existing seam tests that exercised capability validation through a never-loaded stub entry now force the connected signal, preserving their intent under the new contract.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #1321
- This PR is related to issue: #1257, #1268

🤖 Generated with [Claude Code](https://claude.com/claude-code)