### PR TITLE
fix: log expected cold-start conditions at info, not warning

### DIFF
--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -657,7 +657,10 @@ class BaseLock:
         try:
             try:
                 if not await self.async_is_integration_connected():
-                    LOGGER.warning(
+                    # Expected during a cold start (the provider integration
+                    # simply hasn't finished loading); recovery is automatic,
+                    # so this is informational, not a warning.
+                    LOGGER.info(
                         "Provider integration for %s is not ready yet. "
                         "Provider setup is deferred until it finishes "
                         "loading; entities will be created but unavailable "
@@ -695,7 +698,9 @@ class BaseLock:
                     try:
                         await self.coordinator.async_config_entry_first_refresh()
                     except (ConfigEntryNotReady, UpdateFailed) as err:
-                        LOGGER.warning(
+                        # Expected while the lock/integration is still coming
+                        # up; the entities already surface the unavailability.
+                        LOGGER.info(
                             "Failed to fetch initial data for lock %s: %s. "
                             "Entities will be created but unavailable until lock is ready.",
                             lock_entity_id,
@@ -704,7 +709,7 @@ class BaseLock:
                 else:
                     await self.coordinator.async_refresh()
                     if not self.coordinator.last_update_success:
-                        LOGGER.warning(
+                        LOGGER.info(
                             "Failed to fetch initial data for lock %s: %s. "
                             "Entities will be created but unavailable until lock is ready.",
                             lock_entity_id,


### PR DESCRIPTION
## Proposed change

Follow-up to #1322. During a normal slow boot, the deferred-setup notice ("Provider integration for <lock> is not ready yet") and the two "Failed to fetch initial data" messages fire for every lock whose provider integration hasn't finished loading. These describe expected startup ordering: the entities already surface the unavailability, and recovery is automatic on the integration's LOADED transition, so there is nothing actionable to warn about. All three now log at info.

The "Provider setup failed for <lock>" message stays at warning: it fires on an actual failed I/O attempt while the integration claims to be connected, which can indicate a real fault rather than startup ordering.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue:
- This PR is related to issue: #1321

🤖 Generated with [Claude Code](https://claude.com/claude-code)