### PR TITLE
fix: recover zero-slot Z-Wave locks, keep failed locks visible, stop clobbering saved options

### DIFF
--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -529,9 +529,16 @@ def _setup_entry_after_start(
         config_entry.async_on_unload(_clear_listener_registered)
 
     if config_entry.data:
-        # Move data from data to options so update listener can work
+        # Move data from data to options so update listener can work.
+        # Merge options-preferred (matching EntryConfig.from_entry): a
+        # non-empty options here holds an options-flow save the entry
+        # could not process (no listener was registered while it was
+        # failed) — overwriting it with data would silently discard the
+        # user's fix.
         hass.config_entries.async_update_entry(
-            config_entry, data={}, options={**config_entry.data}
+            config_entry,
+            data={},
+            options={**config_entry.data, **config_entry.options},
         )
     else:
         hass.async_create_task(
@@ -857,6 +864,10 @@ async def _async_setup_new_locks(
     added_locks: list[BaseLock] = []
     for lock_entity_id, result in zip(locks_to_add, setup_results, strict=True):
         if isinstance(result, BaseException):
+            # Only unexpected exceptions land here: transport failures
+            # degrade inside async_setup_internal and structural
+            # validation failures are logged there and kept degraded, so
+            # a popped lock indicates a genuine bug, not a lock state.
             _LOGGER.error(
                 "%s (%s): Failed to set up lock %s: %s",
                 entry_id,

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -632,7 +632,12 @@ class BaseLock:
 
         Validates the lock advertises PIN credential support for
         native-user providers; structural failures
-        (``LockCodeManagerProviderError``) propagate and prevent setup.
+        (``LockCodeManagerProviderError``) are logged and the lock is
+        kept degraded — the same outcome as the reconnect path — so the
+        LOADED transition can revalidate once the underlying condition is
+        fixed (e.g. a re-interview repopulating a Z-Wave lock's slot
+        count). Dropping the lock here would leave it invisible with no
+        retry path until a full reload.
         ``supports_user_management`` is deliberately NOT required: a
         native-user provider can serve a slot-only lock (e.g. a Z-Wave
         User Code CC fallback), in which case the seam's
@@ -676,6 +681,14 @@ class BaseLock:
                     "created but data will be unavailable until the lock "
                     "comes online. Setup will be retried when the lock "
                     "integration reconnects.",
+                    self.lock.entity_id,
+                    err,
+                )
+            except LockCodeManagerProviderError as err:
+                LOGGER.error(
+                    "Provider setup failed validation for %s: %s. Entities "
+                    "will be created but unavailable; validation is retried "
+                    "when the lock's integration reloads or reconnects.",
                     self.lock.entity_id,
                     err,
                 )
@@ -741,6 +754,10 @@ class BaseLock:
         if self.supports_native_users:
             caps = await self._get_cached_capabilities()
             if CredentialType.PIN not in caps.credential_types:
+                # A degenerate-but-successful probe was just cached;
+                # invalidate it so the reconnect-path revalidation
+                # re-probes instead of serving the failed read forever.
+                self._capabilities_cache = None
                 raise LockCodeManagerProviderError(
                     f"{self.lock.entity_id}: lock does not advertise PIN credential support"
                 )

--- a/custom_components/lock_code_manager/providers/zwave_js.py
+++ b/custom_components/lock_code_manager/providers/zwave_js.py
@@ -281,15 +281,22 @@ class ZWaveJSLock(BaseLock):
 
         ``num_slots == 0`` while a PIN type is advertised is no longer a
         routing branch -- it means the node interview is incomplete or the
-        driver is too old, so we raise an actionable error (issue #1298).
+        driver is too old. Before concluding that, a one-shot recovery
+        query re-reads the users count from the device (see
+        ``_async_recover_user_code_slot_count``); only when the re-read is
+        still degenerate do we raise an actionable error (issue #1298).
         """
-        try:
-            caps = await lock_helpers.async_get_credential_capabilities(self.node)
-        except BaseZwaveJSServerError as err:
-            raise LockDisconnected(f"get capabilities failed: {err}") from err
-        except HomeAssistantError as err:
-            raise LockOperationFailed(f"get capabilities failed: {err}") from err
+        caps = await self._async_read_credential_capabilities()
         pin = caps["supported_credential_types"].get(_PIN_TYPE_STR)
+
+        if (
+            pin is not None
+            and pin["num_slots"] == 0
+            and self._node_advertises_user_code_cc()
+            and await self._async_recover_user_code_slot_count()
+        ):
+            caps = await self._async_read_credential_capabilities()
+            pin = caps["supported_credential_types"].get(_PIN_TYPE_STR)
 
         if pin and pin["num_slots"] > 0:
             return LockCapabilities(
@@ -331,6 +338,52 @@ class ZWaveJSLock(BaseLock):
             credential_types={},
             max_user_name_length=0,
         )
+
+    async def _async_read_credential_capabilities(self) -> dict[str, Any]:
+        """Read raw credential capabilities, mapping transport errors."""
+        try:
+            return await lock_helpers.async_get_credential_capabilities(self.node)
+        except BaseZwaveJSServerError as err:
+            raise LockDisconnected(f"get capabilities failed: {err}") from err
+        except HomeAssistantError as err:
+            raise LockOperationFailed(f"get capabilities failed: {err}") from err
+
+    async def _async_recover_user_code_slot_count(self) -> bool:
+        """
+        Re-query the User Code CC users count so the driver caches it.
+
+        The driver derives a User Code CC lock's PIN slot count from the
+        cached ``supportedUsers`` value and reports 0 when it is missing
+        from the value database -- the state a battery lock lands in when
+        its interview completes while asleep (common right after a
+        factory-reset re-inclusion, issue #1298). ``refreshValues`` on the
+        CC reads that same cached value rather than re-querying it, so the
+        only primitive that repopulates it is the CC API ``getUsersCount``
+        device query: the solicited UsersNumberReport persists
+        ``supportedUsers``, after which the cached capability read serves
+        real numbers.
+
+        Returns True when the query completed and a capability re-read is
+        worthwhile; False when it failed (the caller falls through to the
+        actionable structural error).
+        """
+        _LOGGER.info(
+            "Lock %s reports zero PIN slots; re-querying the User Code CC "
+            "users count once before concluding the lock is unusable",
+            self.lock.entity_id,
+        )
+        try:
+            await self.node.endpoints[0].async_invoke_cc_api(
+                CommandClass.USER_CODE, "getUsersCount"
+            )
+        except BaseZwaveJSServerError as err:
+            _LOGGER.debug(
+                "Lock %s: users count recovery query failed: %s",
+                self.lock.entity_id,
+                err,
+            )
+            return False
+        return True
 
     async def async_set_user(self, user: User) -> SetUserResult:
         """

--- a/tests/providers/matter/test_provider.py
+++ b/tests/providers/matter/test_provider.py
@@ -31,7 +31,6 @@ from custom_components.lock_code_manager.domain.credentials import (
 from custom_components.lock_code_manager.domain.exceptions import (
     CodeRejectedError,
     DuplicateCodeError,
-    LockCodeManagerError,
     LockDisconnected,
     LockOperationFailed,
 )
@@ -205,20 +204,25 @@ async def test_setup_internal_unsupported_lock(
     matter_lock: MatterLock,
     simple_lcm_config_entry: MockConfigEntry,
 ) -> None:
-    """Base setup raises when the lock advertises no PIN credential support.
+    """Base setup degrades when the lock advertises no PIN credential support.
 
     ``supports_user_management`` alone no longer fails setup (slot-only
     locks are served via the seam's credential-primitive routing); the
     structural requirement is PIN support, which this lock also lacks.
+    The failure keeps the lock degraded (coordinator created, setup not
+    marked successful) rather than raising, so it stays visible and
+    revalidates when the provider integration reloads.
     """
     mock_get_lock_info = AsyncMock(return_value={"supports_user_management": False})
-    with (
-        patch(f"{_PROVIDER_MODULE}.get_lock_info", mock_get_lock_info),
-        pytest.raises(
-            LockCodeManagerError, match="does not advertise PIN credential support"
-        ),
-    ):
+    with patch(f"{_PROVIDER_MODULE}.get_lock_info", mock_get_lock_info):
         await matter_lock.async_setup_internal(simple_lcm_config_entry)
+
+    assert matter_lock._setup_succeeded is False
+    assert matter_lock.coordinator is not None
+    assert matter_lock._setup_complete.is_set()
+
+    await matter_lock.coordinator.async_shutdown()
+    await matter_lock.async_unload(False)
 
 
 async def test_setup_internal_no_pin_support(
@@ -226,18 +230,21 @@ async def test_setup_internal_no_pin_support(
     matter_lock: MatterLock,
     simple_lcm_config_entry: MockConfigEntry,
 ) -> None:
-    """Base setup raises when the lock supports users but not PIN credentials."""
+    """Base setup degrades when the lock supports users but not PIN credentials."""
     mock_get_lock_info = AsyncMock(
         return_value={
             "supports_user_management": True,
             "supported_credential_types": ["rfid"],
         }
     )
-    with (
-        patch(f"{_PROVIDER_MODULE}.get_lock_info", mock_get_lock_info),
-        pytest.raises(LockCodeManagerError, match="PIN credential"),
-    ):
+    with patch(f"{_PROVIDER_MODULE}.get_lock_info", mock_get_lock_info):
         await matter_lock.async_setup_internal(simple_lcm_config_entry)
+
+    assert matter_lock._setup_succeeded is False
+    assert matter_lock.coordinator is not None
+
+    await matter_lock.coordinator.async_shutdown()
+    await matter_lock.async_unload(False)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/providers/test_base.py
+++ b/tests/providers/test_base.py
@@ -945,6 +945,55 @@ async def test_on_integration_loaded_runs_deferred_capability_validation(
     await lock.async_unload(False)
 
 
+async def test_setup_internal_structural_failure_degrades_and_recovers_on_reload(
+    hass: HomeAssistant,
+):
+    """Initial-setup validation failure degrades the lock instead of dropping it.
+
+    A structural failure (no PIN support / zero usable slots) during initial
+    setup used to propagate, making ``_async_setup_new_locks`` pop the lock
+    from runtime data with no retry path and no UI surface — a re-included
+    Z-Wave lock whose interview completed asleep stayed invisible until a
+    full reload. Initial setup now matches the reconnect path: the failure is
+    logged, the coordinator and recovery listener are still created, and the
+    LOADED transition re-runs validation so the lock recovers once the
+    underlying condition is fixed (e.g. after a re-interview).
+    """
+    lock = _make_base_test_lock(
+        hass, "test_lock_structural_degraded", MockNativeUserLock
+    )
+
+    no_pin_caps = LockCapabilities(
+        supports_user_management=True, max_users=10, credential_types={}
+    )
+    caps_mock = AsyncMock(return_value=no_pin_caps)
+    with patch.object(lock, "async_get_capabilities", caps_mock):
+        await lock.async_setup_internal(lock.lock_config_entry)
+
+        caps_mock.assert_awaited_once()
+        assert lock._setup_succeeded is False
+        # Degraded, not dropped: coordinator and recovery listener exist.
+        assert lock.coordinator is not None
+        assert lock._config_entry_state_unsub is not None
+        assert lock._setup_complete.is_set()
+
+        # The lock's condition is fixed (e.g. re-interview repopulated the
+        # slot count); the next LOADED transition revalidates and recovers.
+        caps_mock.return_value = _pin_capabilities()
+        # Validation failure must invalidate the capability cache; a
+        # degenerate-but-successful read would otherwise be served to every
+        # revalidation, making recovery impossible.
+        loaded_entry = MagicMock()
+        loaded_entry.state = ConfigEntryState.LOADED
+        lock.lock_config_entry = loaded_entry
+        await lock._async_on_integration_loaded()
+
+    assert lock._setup_succeeded is True
+
+    await lock.coordinator.async_shutdown()
+    await lock.async_unload(False)
+
+
 async def test_on_integration_loaded_rejects_lock_without_pin_support(
     hass: HomeAssistant,
 ):

--- a/tests/providers/test_seam.py
+++ b/tests/providers/test_seam.py
@@ -27,7 +27,6 @@ from custom_components.lock_code_manager.domain.credentials import (
 )
 from custom_components.lock_code_manager.domain.exceptions import (
     CodeRejectedError,
-    LockCodeManagerProviderError,
     LockDisconnected,
     LockOperationFailed,
     ProviderNotImplementedError,
@@ -188,7 +187,12 @@ async def test_primitive_defaults_raise(hass: HomeAssistant) -> None:
 async def test_setup_internal_rejects_lock_without_pin_support(
     hass: HomeAssistant,
 ) -> None:
-    """A native-user lock missing PIN support fails setup with a typed error."""
+    """A native-user lock missing PIN support degrades instead of setting up.
+
+    The structural failure is logged and the lock kept degraded (setup not
+    marked successful, coordinator created) so it stays visible and
+    revalidates when the provider integration reloads.
+    """
 
     class _NoPinLock(_NativeStubLock):
         async def async_get_capabilities(self) -> LockCapabilities:
@@ -204,11 +208,14 @@ async def test_setup_internal_rejects_lock_without_pin_support(
     config_entry.add_to_hass(hass)
     # The stub's config entry never loads; force the connected signal so
     # setup runs the capability validation instead of deferring it.
-    with (
-        patch.object(lock, "async_is_integration_connected", return_value=True),
-        pytest.raises(LockCodeManagerProviderError, match="PIN credential"),
-    ):
+    with patch.object(lock, "async_is_integration_connected", return_value=True):
         await lock.async_setup_internal(config_entry)
+
+    assert lock._setup_succeeded is False
+    assert lock.coordinator is not None
+
+    await lock.coordinator.async_shutdown()
+    await lock.async_unload(False)
 
 
 async def test_setup_internal_accepts_slot_only_capabilities(

--- a/tests/providers/zwave_js/test_provider.py
+++ b/tests/providers/zwave_js/test_provider.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
-from zwave_js_server.const import NodeStatus
+from zwave_js_server.const import CommandClass, NodeStatus
 from zwave_js_server.const.command_class.access_control import (
     UserCredentialType,
     UserCredentialUserType,
@@ -720,23 +720,10 @@ async def test_async_get_capabilities_maps_lock_helpers_response(
     )
 
 
-async def test_async_get_capabilities_zero_slots_raises_actionable_error(
-    zwave_js_lock: ZWaveJSLock,
-    mock_access_control: MagicMock,
-    mock_lock_helpers: dict,
-) -> None:
-    """
-    A degenerate ``num_slots == 0`` capability probe fails with an actionable error.
-
-    The unified API reports a PIN credential type but zero usable slots when the
-    node's interview is incomplete (values missing from the DB) or the connected
-    Z-Wave JS driver predates the spec-compliant capability fix (15.24.3). Rather
-    than the misleading "does not advertise PIN credential support", the provider
-    surfaces a structural ``LockCodeManagerProviderError`` that points at the
-    actual remedies: re-interview the lock and update Z-Wave JS (see issue #1298).
-    """
+def _zero_slot_caps() -> dict:
+    """Return a degenerate capabilities response: PIN type advertised, 0 slots."""
     pin_type_str = lock_helpers.CREDENTIAL_TYPE_MAP[UserCredentialType.PIN_CODE]
-    mock_lock_helpers["async_get_credential_capabilities"].return_value = {
+    return {
         "supports_user_management": False,
         "max_users": 0,
         "supported_user_types": [],
@@ -752,8 +739,105 @@ async def test_async_get_capabilities_zero_slots_raises_actionable_error(
         },
     }
 
-    with pytest.raises(LockCodeManagerProviderError, match="no usable PIN slots"):
-        await zwave_js_lock.async_get_capabilities()
+
+def _healthy_caps() -> dict:
+    """Return a healthy capabilities response with 30 PIN slots."""
+    pin_type_str = lock_helpers.CREDENTIAL_TYPE_MAP[UserCredentialType.PIN_CODE]
+    return {
+        "supports_user_management": False,
+        "max_users": 0,
+        "supported_user_types": [],
+        "max_user_name_length": 0,
+        "supported_credential_rules": [],
+        "supported_credential_types": {
+            pin_type_str: {
+                "num_slots": 30,
+                "min_length": 4,
+                "max_length": 10,
+                "supports_learn": False,
+            }
+        },
+    }
+
+
+async def test_async_get_capabilities_zero_slots_recovers_via_users_count_query(
+    zwave_js_lock: ZWaveJSLock,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
+) -> None:
+    """
+    A degenerate ``num_slots == 0`` probe recovers by re-querying the users count.
+
+    The driver derives a User Code CC lock's slot count from the cached
+    ``supportedUsers`` value, defaulting to 0 when it is missing from the value
+    DB (e.g. the interview completed while the lock was asleep after a
+    re-inclusion). ``UserCodeCC.refreshValues`` reads that same cached value, so
+    the only primitive that repopulates it is the CC API ``getUsersCount``
+    device query. The provider invokes it once and re-reads capabilities before
+    concluding the lock is unusable (issue #1298 follow-up).
+    """
+    mock_lock_helpers["async_get_credential_capabilities"].side_effect = [
+        _zero_slot_caps(),
+        _healthy_caps(),
+    ]
+    invoke = AsyncMock()
+    with patch.object(zwave_js_lock.node.endpoints[0], "async_invoke_cc_api", invoke):
+        caps = await zwave_js_lock.async_get_capabilities()
+
+    invoke.assert_awaited_once_with(CommandClass.USER_CODE, "getUsersCount")
+    assert caps.credential_types[CredentialType.PIN].num_slots == 30
+    assert mock_lock_helpers["async_get_credential_capabilities"].await_count == 2
+
+
+async def test_async_get_capabilities_zero_slots_raises_actionable_error(
+    zwave_js_lock: ZWaveJSLock,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
+) -> None:
+    """
+    A degenerate ``num_slots == 0`` capability probe fails with an actionable error.
+
+    The unified API reports a PIN credential type but zero usable slots when the
+    node's interview is incomplete (values missing from the DB) or the connected
+    Z-Wave JS driver predates the spec-compliant capability fix (15.24.3). The
+    one-shot ``getUsersCount`` recovery query runs first; when the re-read is
+    still degenerate, the provider surfaces a structural
+    ``LockCodeManagerProviderError`` that points at the actual remedies:
+    re-interview the lock and update Z-Wave JS (see issue #1298).
+    """
+    mock_lock_helpers[
+        "async_get_credential_capabilities"
+    ].return_value = _zero_slot_caps()
+    invoke = AsyncMock()
+    with patch.object(zwave_js_lock.node.endpoints[0], "async_invoke_cc_api", invoke):
+        with pytest.raises(LockCodeManagerProviderError, match="no usable PIN slots"):
+            await zwave_js_lock.async_get_capabilities()
+
+    invoke.assert_awaited_once_with(CommandClass.USER_CODE, "getUsersCount")
+    assert mock_lock_helpers["async_get_credential_capabilities"].await_count == 2
+
+
+async def test_async_get_capabilities_zero_slots_recovery_query_failure_still_raises(
+    zwave_js_lock: ZWaveJSLock,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
+) -> None:
+    """
+    A failed recovery query falls through to the actionable structural error.
+
+    The ``getUsersCount`` device query is best-effort: when it fails (node
+    unreachable, command error), the provider raises the same actionable error
+    without re-reading capabilities.
+    """
+    mock_lock_helpers[
+        "async_get_credential_capabilities"
+    ].return_value = _zero_slot_caps()
+    invoke = AsyncMock(side_effect=FailedZWaveCommand("cmd", 1, "node asleep"))
+    with patch.object(zwave_js_lock.node.endpoints[0], "async_invoke_cc_api", invoke):
+        with pytest.raises(LockCodeManagerProviderError, match="no usable PIN slots"):
+            await zwave_js_lock.async_get_capabilities()
+
+    assert mock_lock_helpers["async_get_credential_capabilities"].await_count == 1
 
 
 async def test_async_get_capabilities_no_pin_type_returns_empty(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1311,6 +1311,45 @@ async def test_setup_entry_after_start_does_not_stack_update_listeners(
     assert runtime_data.update_listener_registered is False
 
 
+async def test_options_saved_while_entry_down_survive_data_migration(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+):
+    """Options written while the entry could not process them survive setup.
+
+    When an entry fails setup (e.g. a configured lock entity vanished after a
+    Z-Wave exclusion), no update listener is registered, so an options-flow
+    save just sits in ``options``. The data→options migration in
+    ``_setup_entry_after_start`` used to overwrite ``options`` wholesale with
+    the stale ``data``, silently discarding the user's fix on the next
+    successful setup. The migration must merge options-preferred instead —
+    the same precedence ``EntryConfig.from_entry`` uses.
+    """
+    old_config = copy.deepcopy(BASE_CONFIG)
+    # The user's fix, saved via the options flow while the entry was down:
+    # LOCK_2 removed from the entry.
+    new_config = copy.deepcopy(BASE_CONFIG)
+    new_config[CONF_LOCKS] = [LOCK_1_ENTITY_ID]
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=old_config,
+        options=new_config,
+        unique_id="Mock Title Options Survive",
+    )
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # The saved options won: LOCK_2 is not managed and the persisted config
+    # (migrated back to data by the update listener) reflects the fix.
+    assert set(config_entry.runtime_data.locks) == {LOCK_1_ENTITY_ID}
+    assert config_entry.data[CONF_LOCKS] == [LOCK_1_ENTITY_ID]
+    assert not config_entry.options
+
+    await hass.config_entries.async_unload(config_entry.entry_id)
+
+
 async def test_unload_stops_sync_managers_before_callbacks_and_platforms(
     hass: HomeAssistant,
     mock_lock_config_entry,


### PR DESCRIPTION
## Proposed change

Three fixes for the re-included-lock failure mode reported on the [community forum](https://community.home-assistant.io/t/695681/86) (a factory-reset BE469ZP that LCM "wouldn't accept," which also "dropped" a sibling lock):

1. **zwave_js: one-shot recovery before concluding zero PIN slots.** The driver derives a User Code CC lock's slot count from the cached `supportedUsers` value, defaulting to 0 when it is missing from the value DB — the state a battery lock lands in when its interview completes while asleep (common right after a factory-reset re-inclusion, #1298). `UserCodeCC.refreshValues` reads that same cached value rather than re-querying it, so the only primitive that repopulates it is the CC API `getUsersCount` device query: its solicited UsersNumberReport persists `supportedUsers`. The provider now invokes it once and re-reads capabilities before raising the actionable structural error.

2. **providers: structural validation failures degrade instead of dropping.** A `LockCodeManagerProviderError` during initial setup used to propagate, making `_async_setup_new_locks` pop the lock from runtime data — invisible in the UI, no repair issue, and no retry path until a full reload (the config-entry state listener was never registered). Initial setup now matches the reconnect path: the failure is logged, the coordinator/entities/recovery listener are still created, and the LOADED transition revalidates. The capability cache is invalidated on validation failure so revalidation re-probes instead of serving the degenerate read forever.

3. **init: the data→options migration merges options-preferred instead of clobbering.** An options-flow save made while the entry was failed (e.g. right after a Z-Wave exclusion removed a configured lock entity — no update listener registered in that state) sat unprocessed in `options`, and the next successful setup overwrote it wholesale with stale `data`, silently discarding the user's fix. The migration now merges with options winning, matching `EntryConfig.from_entry` precedence.

A follow-up PR adds a repair issue so structural setup failures are visible in the UI.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue: #1298

🤖 Generated with [Claude Code](https://claude.com/claude-code)