### PR TITLE
fix: suspend sync for unvalidated locks; make reauth writes win over stale options

### DIFF
--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -508,8 +508,20 @@ class LockCodeManagerFlowHandler(
             errors.update(additional_errors)
             description_placeholders.update(additional_placeholders)
             if not errors:
+                # Consume any options-flow save that sat unprocessed while
+                # the entry was failed (no update listener registered in
+                # that state) and clear it: the data→options migration
+                # merges options-preferred, so leaving stale options in
+                # place would silently override this reauth fix on the
+                # next load.
                 self.hass.config_entries.async_update_entry(
-                    config_entry, data={**config_entry.data, **user_input}
+                    config_entry,
+                    data={
+                        **config_entry.data,
+                        **config_entry.options,
+                        **user_input,
+                    },
+                    options={},
                 )
                 self.hass.async_create_task(
                     self.hass.config_entries.async_reload(config_entry.entry_id),

--- a/custom_components/lock_code_manager/domain/sync.py
+++ b/custom_components/lock_code_manager/domain/sync.py
@@ -600,9 +600,12 @@ class SlotSyncManager:
                     self._code_suspend_target = None
                     self._state = SyncState.OUT_OF_SYNC
                     self._write_state()
-            elif not self._coordinator.unreachable:
-                # Suspended because the lock was unreachable; it is reachable
-                # again, so resume.
+            elif (
+                not self._coordinator.unreachable
+                and self._lock.provider_setup_succeeded
+            ):
+                # Suspended because the lock was unreachable or its provider
+                # setup had not validated; both have cleared, so resume.
                 self._breaker_reset_requested = True
                 self._state = SyncState.OUT_OF_SYNC
                 self._write_state()
@@ -751,8 +754,13 @@ class SlotSyncManager:
             self._write_state()
             return
 
-        # -- OUT_OF_SYNC: check lock reachability, then attempt sync --
-        if self._coordinator.unreachable:
+        # -- OUT_OF_SYNC: check lock readiness, then attempt sync --
+        # An unvalidated provider setup (deferred or structurally failed)
+        # suspends alongside unreachability: any write would only fail on
+        # the capability probe, landing in the generic error handler with a
+        # misleading "report this bug" suspension — and, for Z-Wave, re-fire
+        # the slot-count recovery device query on every attempt.
+        if self._coordinator.unreachable or not self._lock.provider_setup_succeeded:
             self._state = SyncState.SUSPENDED
             self._write_state()
             return

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -524,6 +524,21 @@ class BaseLock:
         """
         return False
 
+    @final
+    @property
+    def provider_setup_succeeded(self) -> bool:
+        """
+        Return whether provider setup (including capability validation) succeeded.
+
+        False both while setup is deferred (provider integration still
+        loading) and after a structural validation failure (e.g. the lock
+        reports zero usable PIN slots). Sync managers gate write attempts
+        on this so a degraded lock is not hammered with operations that
+        fail on the capability probe; the LOADED-transition revalidation
+        flips it back and reconciliation resumes.
+        """
+        return self._setup_succeeded
+
     @property
     def supports_native_users(self) -> bool:
         """
@@ -800,6 +815,10 @@ class BaseLock:
                 self.lock.entity_id,
                 err,
             )
+            # A previously-validated lock can fail revalidation (e.g. a
+            # re-interview zeroed its slot count); reset the flag so sync
+            # stays gated and the eventual recovery is observable.
+            self._setup_succeeded = False
         else:
             if not self._setup_succeeded:
                 LOGGER.info(

--- a/custom_components/lock_code_manager/providers/zwave_js.py
+++ b/custom_components/lock_code_manager/providers/zwave_js.py
@@ -372,10 +372,14 @@ class ZWaveJSLock(BaseLock):
             "users count once before concluding the lock is unusable",
             self.lock.entity_id,
         )
+        # .get() rather than subscription: a KeyError from a node model
+        # missing its root endpoint would escape past every typed handler
+        # and get the lock dropped instead of degraded.
+        endpoint = self.node.endpoints.get(0)
+        if endpoint is None:
+            return False
         try:
-            await self.node.endpoints[0].async_invoke_cc_api(
-                CommandClass.USER_CODE, "getUsersCount"
-            )
+            await endpoint.async_invoke_cc_api(CommandClass.USER_CODE, "getUsersCount")
         except BaseZwaveJSServerError as err:
             _LOGGER.debug(
                 "Lock %s: users count recovery query failed: %s",

--- a/tests/providers/zwave_js/test_provider.py
+++ b/tests/providers/zwave_js/test_provider.py
@@ -720,8 +720,15 @@ async def test_async_get_capabilities_maps_lock_helpers_response(
     )
 
 
-def _zero_slot_caps() -> dict:
-    """Return a degenerate capabilities response: PIN type advertised, 0 slots."""
+def _user_code_caps(num_slots: int) -> dict:
+    """
+    Return a User Code CC capabilities response with the given slot count.
+
+    ``num_slots=0`` is the degenerate interview-incomplete shape from issue
+    #1298; a positive count is the recovered/healthy shape. Everything else
+    matches what the driver reports for a User Code CC dispatch (no user
+    management, spec-default 4-10 code length).
+    """
     pin_type_str = lock_helpers.CREDENTIAL_TYPE_MAP[UserCredentialType.PIN_CODE]
     return {
         "supports_user_management": False,
@@ -731,27 +738,7 @@ def _zero_slot_caps() -> dict:
         "supported_credential_rules": [],
         "supported_credential_types": {
             pin_type_str: {
-                "num_slots": 0,
-                "min_length": 4,
-                "max_length": 10,
-                "supports_learn": False,
-            }
-        },
-    }
-
-
-def _healthy_caps() -> dict:
-    """Return a healthy capabilities response with 30 PIN slots."""
-    pin_type_str = lock_helpers.CREDENTIAL_TYPE_MAP[UserCredentialType.PIN_CODE]
-    return {
-        "supports_user_management": False,
-        "max_users": 0,
-        "supported_user_types": [],
-        "max_user_name_length": 0,
-        "supported_credential_rules": [],
-        "supported_credential_types": {
-            pin_type_str: {
-                "num_slots": 30,
+                "num_slots": num_slots,
                 "min_length": 4,
                 "max_length": 10,
                 "supports_learn": False,
@@ -777,8 +764,8 @@ async def test_async_get_capabilities_zero_slots_recovers_via_users_count_query(
     concluding the lock is unusable (issue #1298 follow-up).
     """
     mock_lock_helpers["async_get_credential_capabilities"].side_effect = [
-        _zero_slot_caps(),
-        _healthy_caps(),
+        _user_code_caps(num_slots=0),
+        _user_code_caps(num_slots=30),
     ]
     invoke = AsyncMock()
     with patch.object(zwave_js_lock.node.endpoints[0], "async_invoke_cc_api", invoke):
@@ -807,7 +794,7 @@ async def test_async_get_capabilities_zero_slots_raises_actionable_error(
     """
     mock_lock_helpers[
         "async_get_credential_capabilities"
-    ].return_value = _zero_slot_caps()
+    ].return_value = _user_code_caps(num_slots=0)
     invoke = AsyncMock()
     with patch.object(zwave_js_lock.node.endpoints[0], "async_invoke_cc_api", invoke):
         with pytest.raises(LockCodeManagerProviderError, match="no usable PIN slots"):
@@ -831,7 +818,7 @@ async def test_async_get_capabilities_zero_slots_recovery_query_failure_still_ra
     """
     mock_lock_helpers[
         "async_get_credential_capabilities"
-    ].return_value = _zero_slot_caps()
+    ].return_value = _user_code_caps(num_slots=0)
     invoke = AsyncMock(side_effect=FailedZWaveCommand("cmd", 1, "node asleep"))
     with patch.object(zwave_js_lock.node.endpoints[0], "async_invoke_cc_api", invoke):
         with pytest.raises(LockCodeManagerProviderError, match="no usable PIN slots"):

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -270,6 +270,40 @@ async def test_config_flow_reauth(
     assert result["reason"] == "locks_updated"
 
 
+async def test_reauth_wins_over_stale_options(
+    hass: HomeAssistant, mock_lock_config_entry, lock_code_manager_config_entry
+):
+    """A reauth fix is not reverted by stale options saved while the entry was failed.
+
+    While an entry is failed (e.g. a configured lock entity vanished after a
+    Z-Wave exclusion) no update listener is registered, so an options-flow
+    save just sits in ``options``. The data→options migration merges
+    options-preferred, so a reauth that only wrote into ``data`` would lose
+    to the stale options on the next load. The reauth write must therefore
+    consume the pending options (options-preferred, its own input winning)
+    and clear them.
+    """
+    entry = lock_code_manager_config_entry
+    entry.async_start_reauth(hass, context={"lock_entity_id": LOCK_1_ENTITY_ID})
+    await hass.async_block_till_done()
+
+    # An options-flow save the failed entry could never process.
+    stale_options = {**BASE_CONFIG, CONF_LOCKS: [LOCK_2_ENTITY_ID]}
+    hass.config_entries.async_update_entry(entry, options=stale_options)
+
+    [flow] = entry.async_get_active_flows(hass, {SOURCE_REAUTH})
+    result = await hass.config_entries.flow.async_configure(
+        flow["flow_id"], {CONF_LOCKS: [LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID]}
+    )
+    assert result["reason"] == "locks_updated"
+    await hass.async_block_till_done()
+
+    # The reauth's lock list won and the stale options were consumed, so the
+    # next data→options migration has nothing stale to prefer.
+    assert entry.data[CONF_LOCKS] == [LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID]
+    assert not entry.options
+
+
 async def test_config_flow_slots_already_configured(
     hass: HomeAssistant, mock_lock_config_entry, lock_code_manager_config_entry
 ):

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -854,6 +854,63 @@ class TestSyncStateMachine:
 
         assert manager._state is SyncState.OUT_OF_SYNC
 
+    async def test_tick_suspends_while_provider_setup_not_validated(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """A lock whose provider setup has not validated suspends sync quietly.
+
+        A structurally-degraded lock (e.g. zero usable PIN slots after a
+        re-inclusion) is kept in runtime data with entities, but attempting
+        writes against it would fail on the capability probe and land in the
+        generic error handler — raising a misleading "report this bug"
+        suspension repair on top of the accurate lock_setup_failed one, and
+        re-firing the recovery device query on every attempt. The tick must
+        suspend without calling _perform_sync, and resume via
+        request_sync_check once validation succeeds.
+        """
+        entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
+        manager = entity_obj._sync_manager
+
+        manager._state = SyncState.OUT_OF_SYNC
+        manager._coordinator.data[1] = SlotCredential.empty()
+        manager._lock._setup_succeeded = False
+
+        with patch.object(
+            manager, "_perform_sync", new_callable=AsyncMock
+        ) as perform_sync:
+            await manager._async_tick()
+            await hass.async_block_till_done()
+
+        perform_sync.assert_not_called()
+        assert manager._state is SyncState.SUSPENDED
+
+        # Validation succeeds later (re-interview + integration reload); the
+        # next sync-check request resumes reconciliation.
+        manager._lock._setup_succeeded = True
+        manager.request_sync_check()
+        assert manager._state is SyncState.OUT_OF_SYNC
+
+    async def test_suspended_does_not_resume_while_setup_not_validated(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """request_sync_check keeps an unvalidated lock suspended even when reachable."""
+        entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
+        manager = entity_obj._sync_manager
+
+        manager._state = SyncState.SUSPENDED
+        manager._code_suspend_target = None
+        manager._lock._setup_succeeded = False
+        assert manager._coordinator.unreachable is False
+
+        manager.request_sync_check()
+        assert manager._state is SyncState.SUSPENDED
+
     async def test_syncing_to_suspended_on_unexpected_error(
         self,
         hass: HomeAssistant,


### PR DESCRIPTION
## Proposed change

Follow-ups from the review of #1344/#1345:

1. **Sync managers now suspend while a lock's provider setup has not validated** (deferred or structurally failed), resuming via `request_sync_check` once the LOADED-transition revalidation succeeds. Without this gate, every tick against a degraded lock attempted a write that could only fail on the capability probe — landing in the generic error handler with a misleading "may indicate a bug … report this issue" suspension repair (or, on matter, a `CodeRejectedError` → slot disabled + active switch off) stacked on top of the accurate `lock_setup_failed` repair, and re-firing the Z-Wave slot-count recovery device query (radio traffic against a battery lock) on every attempt. This also makes the `lock_setup_failed` repair text in #1345 ("code synchronization is paused for this lock") true. Backed by a new public `BaseLock.provider_setup_succeeded` property.

2. **`_setup_succeeded` resets when revalidation fails on the reconnect path**, so a previously-healthy lock that degrades (e.g. a re-interview zeroed its slot count) re-gates sync instead of keeping stale success state.

3. **Reauth writes now consume pending options and clear them** (options-preferred merge with the reauth input winning). An options-flow save made while the entry was failed sits unprocessed in `options`; since the data→options migration merges options-preferred, it would silently override the newer reauth fix on the next load.

4. **The Z-Wave recovery's root-endpoint lookup uses `.get(0)`** so a `KeyError` cannot escape past the typed handlers and drop the lock.

5. Tests: the duplicated zero-slot/healthy capability dict builders collapse into one `_user_code_caps(num_slots)` factory.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue: follow-up to #1344 and #1345

🤖 Generated with [Claude Code](https://claude.com/claude-code)