### PR TITLE
fix: handle None user_input when rendering the reauth form

### DIFF
--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -486,19 +486,23 @@ class LockCodeManagerFlowHandler(
             last_step=True,
         )
 
-    async def async_step_reauth(self, user_input: dict[str, Any]):
-        """Handle import flow step."""
+    async def async_step_reauth(self, user_input: dict[str, Any] | None = None):
+        """Handle reauth flow step."""
         config_entry = self.hass.config_entries.async_get_entry(
             self.context["entry_id"]
         )
+        assert config_entry
         errors = {}
         description_placeholders = {
             **self.context["title_placeholders"],
             "lock": self.context["lock_entity_id"],
         }
 
-        if CONF_SLOTS not in user_input:
-            assert config_entry
+        if user_input is None:
+            # The frontend re-invokes the step with no input to render the
+            # form; seed the lock selector from the entry's current config.
+            user_input = {CONF_LOCKS: list(get_entry_config(config_entry).locks)}
+        elif CONF_SLOTS not in user_input:
             additional_errors, additional_placeholders = _check_common_slots(
                 self.hass,
                 user_input[CONF_LOCKS],

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -270,6 +270,33 @@ async def test_config_flow_reauth(
     assert result["reason"] == "locks_updated"
 
 
+async def test_config_flow_reauth_form_refetch(
+    hass: HomeAssistant, mock_lock_config_entry, lock_code_manager_config_entry
+):
+    """The reauth form renders when re-fetched with no user input.
+
+    The frontend re-invokes the current step with ``user_input=None`` to
+    render the form when the user opens the flow, so the step must handle
+    ``None`` and seed defaults from the entry's configured locks.
+    """
+    lock_code_manager_config_entry.async_start_reauth(
+        hass, context={"lock_entity_id": LOCK_1_ENTITY_ID}
+    )
+    await hass.async_block_till_done()
+    [flow] = lock_code_manager_config_entry.async_get_active_flows(
+        hass, {SOURCE_REAUTH}
+    )
+
+    result = await hass.config_entries.flow.async_configure(flow["flow_id"], None)
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "reauth"
+    assert result["data_schema"]({})[CONF_LOCKS] == [
+        LOCK_1_ENTITY_ID,
+        LOCK_2_ENTITY_ID,
+    ]
+
+
 async def test_reauth_wins_over_stale_options(
     hass: HomeAssistant, mock_lock_config_entry, lock_code_manager_config_entry
 ):


### PR DESCRIPTION
## Proposed change

When a configured lock entity is missing, setup fails and a reauth flow is started. Home Assistant's frontend re-invokes the current flow step with `user_input=None` to render the form when the user opens the reauth dialog, but `async_step_reauth` assumed a dict and crashed with `TypeError: argument of type 'NoneType' is not a container or iterable`, leaving the reauth flow unusable — the only recourse was hand-editing `core.config_entries`.

This handles the `None` case by seeding the lock selector with the entry's current lock list and routing straight to showing the form (submission processing is unchanged). Existing tests never caught this because they always submitted input directly instead of first fetching the form like the UI does; the new test re-fetches the form with no input.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #1348
- This PR is related to issue:

🤖 Generated with [Claude Code](https://claude.com/claude-code)