### PR TITLE
fix: link per-lock entities to lock device without merging config entry (HA 2026.8)

### DIFF
--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -1040,11 +1040,10 @@ async def async_update_listener(
     for lock_entity_id in locks_to_remove:
         callbacks.invoke_lock_removed_handlers(lock_entity_id)
         lock: BaseLock = runtime_data.locks[lock_entity_id]
-        if lock.device_entry:
-            dev_reg = dr.async_get(hass)
-            dev_reg.async_update_device(
-                lock.device_entry.id, remove_config_entry_id=entry_id
-            )
+        # LCM no longer adds its config entry to the lock's device (its
+        # per-lock entities link to the device via ``device_entry``), so
+        # there is no config-entry association to unmerge here; the per-lock
+        # entities are torn down by ``async_unload_lock`` below.
         await async_unload_lock(
             hass, config_entry, lock_entity_id=lock_entity_id, remove_permanently=True
         )

--- a/custom_components/lock_code_manager/entity.py
+++ b/custom_components/lock_code_manager/entity.py
@@ -333,10 +333,17 @@ class BaseLockCodeManagerCodeSlotPerLockEntity(BaseLockCodeManagerEntity):
         )
         self.lock = lock
         if lock.device_entry:
-            self._attr_device_info = DeviceInfo(
-                connections=lock.device_entry.connections,
-                identifiers=lock.device_entry.identifiers,
-            )
+            # Link this entity to the lock's own device. Since HA 2026.8 a
+            # device belongs to a single config entry, so a helper
+            # integration must not reuse another integration's device
+            # identifiers/connections in ``device_info`` (which added LCM's
+            # config entry to that device and now forks a duplicate device
+            # instead). Setting ``device_entry`` links the entity to the
+            # existing device without claiming ownership of it; the entity
+            # platform honors a pre-set ``device_entry`` when ``device_info``
+            # is not provided.
+            self._attr_device_info = None
+            self.device_entry = lock.device_entry
 
         self._attr_unique_id = build_slot_unique_id(
             self.base_unique_id, slot_num, self.key, lock.lock.entity_id

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -97,7 +97,20 @@ async def test_entry_setup_and_unload(
     for entity_id in (LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID):
         device = dev_reg.async_get_device({(DOMAIN, entity_id)})
         assert device
-        assert device.config_entries == {mock_lock_entry_id, lcm_entry_id}
+        # LCM links its per-lock entities to the lock's own device but no
+        # longer adds its config entry to it -- a device belongs to a single
+        # config entry as of HA 2026.8.
+        assert device.config_entries == {mock_lock_entry_id}
+        lcm_device_entities = {
+            entry.unique_id
+            for entry in er.async_entries_for_device(ent_reg, device.id)
+            if entry.config_entry_id == lcm_entry_id
+        }
+        assert lcm_device_entities == {
+            f"{lcm_entry_id}|{slot}|{key}|{entity_id}"
+            for slot in range(1, 3)
+            for key in (ATTR_CODE, ATTR_IN_SYNC)
+        }
 
     unique_ids = set()
     for slot in range(1, 3):
@@ -199,11 +212,18 @@ async def test_entry_setup_and_unload(
     )
     await hass.async_block_till_done()
 
-    # Validate that the config entry is removed from the device associated with the
-    # lock that was removed from the config entry
+    # LOCK_2 was removed from the LCM config entry; its device keeps its own
+    # config entry and no longer has any LCM entities linked to it.
     device = dev_reg.async_get_device({(DOMAIN, LOCK_2_ENTITY_ID)})
     assert device
     assert device.config_entries == {mock_lock_entry_id}
+    assert not [
+        entry
+        for entry in er.async_entries_for_device(
+            ent_reg, device.id, include_disabled_entities=True
+        )
+        if entry.config_entry_id == lcm_entry_id
+    ]
 
     unique_ids = set()
     for slot in range(1, 3):


### PR DESCRIPTION
## Proposed change

Home Assistant 2026.8 restricts a device to a **single config entry** and stops merging devices across integrations ([developer blog](https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/), core [PR #175785](https://github.com/home-assistant/core/pull/175785)).

LCM's per-lock entities (`code`, `in_sync`) were attached to the physical lock's device by reusing the lock's `identifiers`/`connections` in `DeviceInfo`:

```python
self._attr_device_info = DeviceInfo(
    connections=lock.device_entry.connections,
    identifiers=lock.device_entry.identifiers,
)
```

This is the "helper adds its config entry to another integration's device" pattern that **stops working in 2026.8** — it no longer merges and instead silently forks a duplicate device.

This PR links the per-lock entities to the lock's existing device via `Entity.device_entry` instead, which associates the entity with the device without claiming ownership of it:

```python
self._attr_device_info = None
self.device_entry = lock.device_entry
```

The entity platform honors a pre-set `device_entry` when `device_info` is absent. This mechanism, and the fallback path, exist in **both 2026.7 (the current minimum, per `hacs.json`) and 2026.8**, so **no new-in-2026.8 API is used** and the fix can ship now without waiting for 2026.8 to release.

It also drops the now-obsolete `async_update_device(..., remove_config_entry_id=entry_id)` cleanup on lock removal, since LCM no longer adds its config entry to the lock device (and that parameter is itself deprecated in 2026.8).

### Not included (deliberately deferred)

These are deprecated-with-shim until HA **2027.8** and are **not** broken in 2026.8. Their replacements (`via_device_id`, `async_get_device_by_identifier`) are new in 2026.8, so switching now would break the repo's 2026.7 support. Left for a later change once the minimum HA version moves to 2026.8:

- `entity.py` — `via_device=(DOMAIN, self.entry_id)` on LCM's own per-slot device (intra-integration link → `via_device_id`).
- `diagnostics.py` — `dev_reg.async_get_device(identifiers=...)` → `async_get_device_by_identifier`.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- Updated `test_entry_setup_and_unload` to assert the per-lock entities are linked to the lock device via `device_id` rather than via a config-entry merge, and that removing a lock unlinks them.
- Note: the HA test suite could not be run in this environment (HA 2026.7 requires Python ≥3.14; the sandbox has 3.11). `ruff check` and `ruff format --check` pass on the changed files; CI will run the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018riVfzP1mwJegAtZ72eCyH

---
_Generated by [Claude Code](https://claude.ai/code/session_018riVfzP1mwJegAtZ72eCyH)_