### PR TITLE
ci: ignore PLR0917 to match existing PLR0913 lint policy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ lint.ignore = [
     "PLR0912", # Too many branches
     "PLR0913", # Too many arguments
     "PLR0915", # Too many statements
+    "PLR0917", # Too many positional arguments
     "PLR2004", # Magic value used in comparison
 ]
 exclude = [


### PR DESCRIPTION
## Proposed change

The ruff pre-commit autoupdate to **v0.16.0** promoted `PLR0917` (too many positional arguments) out of preview, so the **Ruff** CI job now fails on **nine pre-existing function signatures** across the codebase (`__init__.py`, `binary_sensor.py`, `sensor.py`, `text.py`, `diagnostics.py`, `domain/sync.py`, `entity.py`, `providers/_base.py`, `providers/matter.py`).

Because the Ruff job checks the whole tree, this is currently red on `main` and blocks **every open PR**.

The repo already ignores the sibling rule `PLR0913` (too many arguments) along with the other `PLR` complexity rules (`PLR0911`, `PLR0912`, `PLR0915`). `PLR0917` is the same family — HA-style constructors that take `hass`, `config_entry`, etc. positionally trip it — so ignoring it is consistent with the existing lint policy. This adds one line to `lint.ignore`.

Verified `ruff check` (v0.16.0) passes on the whole tree after the change.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- Once this merges, rebasing open PRs (e.g. #1379) onto `main` will clear their Ruff failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018riVfzP1mwJegAtZ72eCyH

---
_Generated by [Claude Code](https://claude.ai/code/session_018riVfzP1mwJegAtZ72eCyH)_