### PR TITLE
ci: group all HA-ecosystem deps into homeassistant dependabot group

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -23,10 +23,28 @@ updates:
       - "dependencies"
       - "python"
     groups:
+      # HA pins these exactly (directly or via integration manifests), so they
+      # must move in lockstep with the homeassistant version under test.
       homeassistant:
         patterns:
           - "homeassistant"
           - "pytest-homeassistant-custom-component"
+          - "aioesphomeapi"
+          - "aiofiles"
+          - "aiousbwatcher"
+          - "colorlog"
+          - "debugpy"
+          - "ha-silabs-firmware-client"
+          - "matter-python-client"
+          - "pyserial"
+          - "pyudev"
+          - "universal-silabs-flasher"
+          - "usb-devices"
+          - "zeroconf"
+          - "zha"
+          - "zha-quirks"
+          - "zigpy"
+          - "zwave-js-server-python"
   - package-ecosystem: npm
     directory: "/" # Location of package manifests
     schedule:


### PR DESCRIPTION
## Proposed change

Expand the `homeassistant` dependabot group to cover every HA-ecosystem package in `requirements_dev.txt`. Home Assistant pins these exactly (directly or via integration manifests), so bumping them individually can produce unsolvable or inconsistent dependency sets — e.g. #1375 (`zigpy>=2.1.0`) conflicted with `zha==2.0.1`, which HA 2026.7.4 requires, and #1377 (`zha==2.1.0`) failed pytest because it targets HA 2026.8. Grouping them means one PR moves the whole set in lockstep when HA moves.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- Dependabot will supersede the open individual PRs (#1375, #1377) with a grouped PR on its next run.

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)