### PR TITLE
fix: surface out-of-range slot errors instead of retrying forever

### DIFF
--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -158,16 +158,13 @@ async def _async_check_slot_capacity(
             )
             continue
 
-        pin_capability = capabilities.capability_for(CredentialType.PIN)
-        # num_slots of 0 means "capacity unknown", not "no slots".
-        if pin_capability is None or pin_capability.num_slots <= 0:
+        num_slots = capabilities.bounded_slot_count(CredentialType.PIN)
+        if num_slots is None:
             continue
-        if out_of_range := [
-            slot for slot in slots if not 1 <= slot <= pin_capability.num_slots
-        ]:
+        if out_of_range := [slot for slot in slots if not 1 <= slot <= num_slots]:
             return {"base": "slot_out_of_range"}, {
                 "lock": lock_entity_id,
-                "num_slots": str(pin_capability.num_slots),
+                "num_slots": str(num_slots),
                 "out_of_range_slots": ", ".join(str(slot) for slot in out_of_range),
             }
     return {}, {}

--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -34,6 +34,7 @@ from .const import (
     EXCLUDED_CONDITION_PLATFORMS,
 )
 from .domain.config import EntryConfig
+from .domain.credentials import CredentialType
 from .domain.exceptions import LockCodeManagerError
 from .domain.models import SlotCredential
 from .domain.queries import get_entry_config
@@ -110,7 +111,69 @@ def _check_common_slots(
         }
 
 
-def _validate_slots_yaml(
+async def _async_check_slot_capacity(
+    hass: HomeAssistant,
+    locks: Iterable[str],
+    slots_list: Iterable[int | str],
+) -> tuple[dict, dict]:
+    """
+    Reject slot numbers no lock in the set could ever hold.
+
+    Only locks whose credential index IS the slot number are checked (see
+    ``BaseLock.credential_index_follows_slot``) -- Matter allocates its own
+    index, so a slot number above its credential count is perfectly legal
+    there. Catching this at configuration time is what issue #1398 asked
+    for: the write would otherwise fail forever on the device with nothing
+    but a connectivity warning to show for it.
+
+    A lock that cannot be queried is skipped rather than blocking the flow.
+    Capabilities need the lock awake, and a battery lock that happens to be
+    asleep must not make the config flow unusable; the same check runs again
+    at write time, where it can suspend the affected slot precisely.
+    """
+    dev_reg = dr.async_get(hass)
+    ent_reg = er.async_get(hass)
+    slots = sorted({int(slot) for slot in slots_list})
+    for lock_entity_id in locks:
+        try:
+            lock_instance = _async_build_lock_instance(
+                hass, dev_reg, ent_reg, lock_entity_id
+            )
+            if not lock_instance.credential_index_follows_slot:
+                continue
+            capabilities = await lock_instance.async_get_capabilities()
+        except _LockQuerySkipped:
+            continue
+        except LockCodeManagerError as err:
+            _LOGGER.debug(
+                "Skipping slot capacity check for %s: %s", lock_entity_id, err
+            )
+            continue
+        except Exception:
+            _LOGGER.warning(
+                "Skipping slot capacity check for %s; its slot count could not "
+                "be determined",
+                lock_entity_id,
+                exc_info=True,
+            )
+            continue
+
+        pin_capability = capabilities.capability_for(CredentialType.PIN)
+        # num_slots of 0 means "capacity unknown", not "no slots".
+        if pin_capability is None or pin_capability.num_slots <= 0:
+            continue
+        if out_of_range := [
+            slot for slot in slots if not 1 <= slot <= pin_capability.num_slots
+        ]:
+            return {"base": "slot_out_of_range"}, {
+                "lock": lock_entity_id,
+                "num_slots": str(pin_capability.num_slots),
+                "out_of_range_slots": ", ".join(str(slot) for slot in out_of_range),
+            }
+    return {}, {}
+
+
+async def _async_validate_slots_yaml(
     hass: HomeAssistant,
     raw_slots: dict[Any, Any],
     locks: Iterable[str],
@@ -120,9 +183,10 @@ def _validate_slots_yaml(
     Validate a slots-YAML submission for the config and options flows.
 
     Runs ``CODE_SLOTS_SCHEMA`` over ``raw_slots`` and, when it parses cleanly,
-    checks for slots already configured on the same locks by another entry.
-    Returns the parsed slots (or ``None`` if validation failed) along with the
-    accumulated error and description-placeholder dicts.
+    checks for slots already configured on the same locks by another entry and
+    for slot numbers beyond what the locks can hold. Returns the parsed slots
+    (or ``None`` if validation failed) along with the accumulated error and
+    description-placeholder dicts.
     """
     try:
         parsed_slots = CODE_SLOTS_SCHEMA(raw_slots)
@@ -131,6 +195,10 @@ def _validate_slots_yaml(
         return None, {"base": "invalid_config"}, {}
 
     errors, placeholders = _check_common_slots(hass, locks, parsed_slots, config_entry)
+    if not errors:
+        errors, placeholders = await _async_check_slot_capacity(
+            hass, locks, parsed_slots
+        )
     return parsed_slots, errors, placeholders
 
 
@@ -372,13 +440,21 @@ class LockCodeManagerFlowHandler(
         if user_input is not None:
             start = user_input[CONF_START_SLOT]
             num_slots = user_input[CONF_NUM_SLOTS]
+            requested_slots = list(range(start, start + num_slots))
             additional_errors, additional_placeholders = _check_common_slots(
-                self.hass, self.data[CONF_LOCKS], list(range(start, start + num_slots))
+                self.hass, self.data[CONF_LOCKS], requested_slots
             )
+            if not additional_errors:
+                (
+                    additional_errors,
+                    additional_placeholders,
+                ) = await _async_check_slot_capacity(
+                    self.hass, self.data[CONF_LOCKS], requested_slots
+                )
             errors.update(additional_errors)
             description_placeholders.update(additional_placeholders)
             if not errors:
-                self.slots_to_configure = list(range(start, start + num_slots))
+                self.slots_to_configure = requested_slots
                 self._occupied_lock_slots = self._find_occupied_lock_slots(
                     self.slots_to_configure
                 )
@@ -453,7 +529,11 @@ class LockCodeManagerFlowHandler(
         if not user_input:
             user_input = {}
         if user_input:
-            slots, validation_errors, validation_placeholders = _validate_slots_yaml(
+            (
+                slots,
+                validation_errors,
+                validation_placeholders,
+            ) = await _async_validate_slots_yaml(
                 self.hass, user_input[CONF_SLOTS], self.data[CONF_LOCKS]
             )
             errors.update(validation_errors)
@@ -503,12 +583,22 @@ class LockCodeManagerFlowHandler(
             # form; seed the lock selector from the entry's current config.
             user_input = {CONF_LOCKS: list(get_entry_config(config_entry).locks)}
         elif CONF_SLOTS not in user_input:
+            existing_slots = get_entry_config(config_entry).slots.keys()
             additional_errors, additional_placeholders = _check_common_slots(
                 self.hass,
                 user_input[CONF_LOCKS],
-                get_entry_config(config_entry).slots.keys(),
+                existing_slots,
                 config_entry,
             )
+            if not additional_errors:
+                # Reauth is where a lock gets swapped, so it is also where an
+                # already-valid slot set can become too large for the new lock.
+                (
+                    additional_errors,
+                    additional_placeholders,
+                ) = await _async_check_slot_capacity(
+                    self.hass, user_input[CONF_LOCKS], existing_slots
+                )
             errors.update(additional_errors)
             description_placeholders.update(additional_placeholders)
             if not errors:
@@ -571,13 +661,15 @@ class LockCodeManagerOptionsFlow(_ExistingCodesFlowMixin, config_entries.Options
             user_input = {}
 
         if user_input:
-            parsed_slots, validation_errors, validation_placeholders = (
-                _validate_slots_yaml(
-                    self.hass,
-                    user_input[CONF_SLOTS],
-                    user_input[CONF_LOCKS],
-                    self.config_entry,
-                )
+            (
+                parsed_slots,
+                validation_errors,
+                validation_placeholders,
+            ) = await _async_validate_slots_yaml(
+                self.hass,
+                user_input[CONF_SLOTS],
+                user_input[CONF_LOCKS],
+                self.config_entry,
             )
             errors.update(validation_errors)
             description_placeholders.update(validation_placeholders)

--- a/custom_components/lock_code_manager/domain/credentials.py
+++ b/custom_components/lock_code_manager/domain/credentials.py
@@ -287,6 +287,26 @@ class LockCapabilities:
         """Return True when the lock advertises ``credential_type``."""
         return credential_type in self.credential_types
 
+    def bounded_slot_count(self, credential_type: CredentialType) -> int | None:
+        """
+        Return the slot count to bound against, or ``None`` when unknown.
+
+        ``None`` covers both an unadvertised credential type and a
+        ``num_slots`` of 0, which means "capacity unknown" rather than "no
+        slots": Matter reports 0 for a capacity field the lock did not
+        supply, and a lock that cannot answer must never be treated as
+        having nowhere to write. Callers use ``None`` to skip a bounds
+        check rather than to reject.
+
+        This lives here so the 0-means-unknown convention is stated once.
+        Every caller that re-derived it would be one place for a lock with
+        an unreadable capacity to start failing writes it should accept.
+        """
+        capability = self.capability_for(credential_type)
+        if capability is None or capability.num_slots <= 0:
+            return None
+        return capability.num_slots
+
 
 def credential_from_slot(slot: int, state: SlotCredential) -> Credential:
     """

--- a/custom_components/lock_code_manager/domain/exceptions.py
+++ b/custom_components/lock_code_manager/domain/exceptions.py
@@ -84,6 +84,20 @@ class LockOperationFailed(LockCodeManagerProviderError):
     """
 
 
+class LockOperationUnsupported(LockOperationFailed):
+    """
+    Raised when the lock can never complete the operation as specified.
+
+    The distinction from its parent is retryability, and that is the whole
+    point of the type: ``LockOperationFailed`` is a transient lock-side
+    refusal worth retrying, while this says the request itself is invalid
+    for this lock and every retry will fail identically. Configuration has
+    to change first — a slot number beyond the lock's capacity, a
+    credential type the node rejects outright. Callers that don't
+    distinguish keep the retrying behavior, since this is a subclass.
+    """
+
+
 class ProviderNotImplementedError(LockCodeManagerProviderError, NotImplementedError):
     """Raised when a provider method that subclasses must override is called."""
 

--- a/custom_components/lock_code_manager/domain/sync.py
+++ b/custom_components/lock_code_manager/domain/sync.py
@@ -54,7 +54,12 @@ from ..const import (
     TICK_INTERVAL,
 )
 from .config import build_slot_unique_id
-from .exceptions import CodeRejectedError, LockDisconnected, LockOperationFailed
+from .exceptions import (
+    CodeRejectedError,
+    LockDisconnected,
+    LockOperationFailed,
+    LockOperationUnsupported,
+)
 from .models import SlotCredential, SyncState
 from .resilience import CircuitBreaker
 from .util import async_disable_slot
@@ -826,6 +831,26 @@ class SlotSyncManager:
             # successful poll/push).
             self._coordinator.note_connectivity_failure()
             self._state = SyncState.OUT_OF_SYNC
+            return
+        except LockOperationUnsupported as err:
+            # Permanent: the lock can never accept this request as configured,
+            # so charging the slot breaker would just burn three ticks before
+            # suspending with a vaguer message. Suspend now and put the real
+            # reason in the repair. Handled ahead of LockOperationFailed
+            # because it is a subclass of it.
+            _LOGGER.error(
+                "%s: Lock cannot %s this slot: %s. Suspending sync until the "
+                "configuration changes.",
+                self._log_prefix,
+                "set" if slot_state.active_state == STATE_ON else "clear",
+                err,
+            )
+            self._suspend_slot(
+                slot_state,
+                f"Lock **{self._lock.lock.entity_id}**: slot "
+                f"**{self._slot_num}** cannot be synced because the lock will "
+                f"not accept it.\n\n{err}",
+            )
             return
         except LockOperationFailed as err:
             _LOGGER.info(

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -1454,11 +1454,15 @@ class BaseLock:
         misclassification is what made an out-of-range slot look like an
         unreachable lock (issue #1398).
 
-        A capabilities read that fails or reports ``num_slots == 0`` skips
-        the check rather than blocking the write: 0 means "unknown capacity"
-        for Matter, and a lock that cannot answer must not be assumed to
-        have no slots. Letting the write through preserves the previous
-        behavior for those cases instead of inventing a new failure.
+        A capabilities read that fails, or one whose slot count is unknown
+        (see ``LockCapabilities.bounded_slot_count``), skips the check
+        rather than blocking the write, preserving the previous behavior
+        for those cases instead of inventing a new failure.
+
+        The advertised count is the lock's own claim and is not always
+        right -- a Z-Wave node hitting the User Credential CC dispatch
+        defect can report the wrong command class's slot count -- so the
+        error names the stale-interview remedy alongside the renumber one.
         """
         if not self.credential_index_follows_slot:
             return
@@ -1468,16 +1472,16 @@ class BaseLock:
             # Covers the unreachable lock, the failed probe, and the provider
             # that never implemented the read (ProviderNotImplementedError).
             return
-        pin_caps = caps.capability_for(CredentialType.PIN)
-        if pin_caps is None or pin_caps.num_slots <= 0:
+        num_slots = caps.bounded_slot_count(CredentialType.PIN)
+        if num_slots is None or 1 <= code_slot <= num_slots:
             return
-        if not 1 <= code_slot <= pin_caps.num_slots:
-            raise LockOperationUnsupported(
-                f"Lock {self.lock.entity_id} has {pin_caps.num_slots} PIN code "
-                f"slots, so slot {code_slot} does not exist on it. Renumber the "
-                f"slot to a value between 1 and {pin_caps.num_slots}, or remove "
-                f"this lock from the slot's configuration."
-            )
+        raise LockOperationUnsupported(
+            f"Lock {self.lock.entity_id} reports {num_slots} PIN code slots, so "
+            f"slot {code_slot} is out of range. Either renumber the slot to fall "
+            f"within 1-{num_slots} (or drop this lock from the slot), or, if the "
+            f"lock really does have more slots than that, re-interview it -- a "
+            f"stale or incomplete interview makes it under-report its capacity."
+        )
 
     async def _assert_credential_ref_supported(self, ref: CredentialRef) -> None:
         """

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -63,6 +63,7 @@ from ..domain.exceptions import (
     LockCodeManagerProviderError,
     LockDisconnected,
     LockOperationFailed,
+    LockOperationUnsupported,
     ProviderNotImplementedError,
 )
 from ..domain.models import SlotCredential
@@ -561,6 +562,27 @@ class BaseLock:
         legacy one-Personal-Identification-Number-per-slot model.
         """
         return False
+
+    @property
+    def credential_index_follows_slot(self) -> bool:
+        """
+        Return whether the Lock Code Manager slot number IS the lock's credential index.
+
+        True (the default) for providers that address a credential by the
+        slot number verbatim: the Z-Wave unified access control surface
+        passes it as ``credential_slot``, and every slot-only provider
+        keys its single code by slot. On those locks a slot number above
+        the advertised slot count can never be written, so
+        ``_assert_slot_within_capacity`` rejects it before the write.
+
+        False for providers that let the lock allocate the index (Matter
+        picks the next free credential index). There the slot number is a
+        Lock Code Manager-side label with no device-side bound, so slot
+        50 is legal on a 30-credential lock as long as no more than 30
+        slots are configured. Capacity on those locks is a limit on the
+        NUMBER of slots, which this check does not police.
+        """
+        return True
 
     @property
     def supports_code_slot_events(self) -> bool:
@@ -1121,6 +1143,8 @@ class BaseLock:
             source,
         )
 
+        await self._assert_slot_within_capacity(code_slot)
+
         def _pre_execute_checks() -> None:
             """Check for duplicate PINs and firmware-rejected codes, atomically inside the lock."""
             # Clear the firmware-rejection flag first so it doesn't persist
@@ -1417,6 +1441,42 @@ class BaseLock:
                 code_slot=credential.slot,
                 lock_entity_id=self.lock.entity_id,
                 reason=f"unsupported credential type: {credential.type}",
+            )
+
+    async def _assert_slot_within_capacity(self, code_slot: int) -> None:
+        """
+        Raise ``LockOperationUnsupported`` if the slot exceeds the lock's capacity.
+
+        Only meaningful when ``credential_index_follows_slot`` is True; see
+        that property for why Matter is exempt. Without this the write goes
+        out and the lock rejects it deterministically, which providers have
+        no reliable way to tell apart from a transport failure — that
+        misclassification is what made an out-of-range slot look like an
+        unreachable lock (issue #1398).
+
+        A capabilities read that fails or reports ``num_slots == 0`` skips
+        the check rather than blocking the write: 0 means "unknown capacity"
+        for Matter, and a lock that cannot answer must not be assumed to
+        have no slots. Letting the write through preserves the previous
+        behavior for those cases instead of inventing a new failure.
+        """
+        if not self.credential_index_follows_slot:
+            return
+        try:
+            caps = await self._get_cached_capabilities()
+        except LockCodeManagerError:
+            # Covers the unreachable lock, the failed probe, and the provider
+            # that never implemented the read (ProviderNotImplementedError).
+            return
+        pin_caps = caps.capability_for(CredentialType.PIN)
+        if pin_caps is None or pin_caps.num_slots <= 0:
+            return
+        if not 1 <= code_slot <= pin_caps.num_slots:
+            raise LockOperationUnsupported(
+                f"Lock {self.lock.entity_id} has {pin_caps.num_slots} PIN code "
+                f"slots, so slot {code_slot} does not exist on it. Renumber the "
+                f"slot to a value between 1 and {pin_caps.num_slots}, or remove "
+                f"this lock from the slot's configuration."
             )
 
     async def _assert_credential_ref_supported(self, ref: CredentialRef) -> None:

--- a/custom_components/lock_code_manager/providers/matter.py
+++ b/custom_components/lock_code_manager/providers/matter.py
@@ -208,6 +208,19 @@ class MatterLock(BaseLock):
         """
         return True
 
+    @property
+    def credential_index_follows_slot(self) -> bool:
+        """
+        Return False — Matter allocates its own credential index.
+
+        ``async_set_credential`` lets the lock pick the next free credential
+        index rather than pinning it to the slot number, so the slot number
+        carries no device-side bound and must not be range-checked against
+        ``num_slots``. What Matter does bound is how MANY slots can be
+        configured, which the base check deliberately does not police.
+        """
+        return False
+
     def _fresh_device_entry(self) -> Any | None:
         """
         Re-resolve the lock's device entry from the registry on every call.

--- a/custom_components/lock_code_manager/providers/zwave_js.py
+++ b/custom_components/lock_code_manager/providers/zwave_js.py
@@ -104,7 +104,7 @@ _PERMANENT_ZWAVE_ERROR_CODES: frozenset[int] = frozenset(
 
 def _mapped_zwave_error(
     err: BaseZwaveJSServerError, context: str
-) -> LockOperationFailed:
+) -> LockCodeManagerProviderError:
     """
     Classify a zwave-js-server error as permanent or transient.
 
@@ -590,8 +590,9 @@ class ZWaveJSLock(BaseLock):
                 credential_slot=credential.slot,
             )
         except BaseZwaveJSServerError as err:
-            # Transient Z-Wave command failure (e.g. a sleeping/battery lock):
-            # route to retry rather than slot suspension.
+            # Retry a transient command failure (e.g. a sleeping/battery lock);
+            # suspend only on a code the node can never accept. _mapped_zwave_error
+            # decides which, since the two are indistinguishable from here.
             raise _mapped_zwave_error(
                 err, f"set credential slot {credential.slot} failed"
             ) from err

--- a/custom_components/lock_code_manager/providers/zwave_js.py
+++ b/custom_components/lock_code_manager/providers/zwave_js.py
@@ -65,12 +65,60 @@ from ..domain.exceptions import (
     LockCodeManagerProviderError,
     LockDisconnected,
     LockOperationFailed,
+    LockOperationUnsupported,
 )
 from ..domain.models import SlotCredential
 from ._base import BaseLock
 from ._util import parse_tag
 
 _LOGGER = logging.getLogger(__name__)
+
+# Numeric ``ZWaveErrorCodes`` values from node-zwave-js. zwave-js-server-python
+# surfaces the code as a bare int on ``FailedZWaveCommand.zwave_error_code``
+# and ships no enum for it, so the names live here. The driver also appends the
+# padded form to its message ("... (ZW0322)").
+_ZWAVE_ERROR_CC_NOT_SUPPORTED = 302
+_ZWAVE_ERROR_CC_NOT_IMPLEMENTED = 303
+_ZWAVE_ERROR_CC_NO_API = 304
+_ZWAVE_ERROR_ARGUMENT_INVALID = 322
+
+# Codes that mean the request is invalid for this node, so no retry can ever
+# succeed: the caller passed an out-of-range slot or user identifier, or asked
+# for a command class the node does not implement. Every Argument_Invalid the
+# access control API raises is a bounds or shape check on our own arguments
+# (slot range, user range, credential type), never a transport symptom.
+#
+# This is deliberately a list of PERMANENT codes rather than a list of
+# transient ones: an unrecognized code -- including any node-zwave-js adds
+# later -- falls through to the retry path it has today, so the worst case of
+# an incomplete table is the old behavior rather than a wrongly suspended slot.
+_PERMANENT_ZWAVE_ERROR_CODES: frozenset[int] = frozenset(
+    {
+        _ZWAVE_ERROR_CC_NOT_SUPPORTED,
+        _ZWAVE_ERROR_CC_NOT_IMPLEMENTED,
+        _ZWAVE_ERROR_CC_NO_API,
+        _ZWAVE_ERROR_ARGUMENT_INVALID,
+    }
+)
+
+
+def _mapped_zwave_error(
+    err: BaseZwaveJSServerError, context: str
+) -> LockOperationFailed:
+    """
+    Classify a zwave-js-server error as permanent or transient.
+
+    Treating every server-side error as transient is what let an
+    out-of-range slot present as an unreachable lock: the write failed
+    deterministically, the retry path fed the lock circuit breaker, and the
+    only thing the user saw was "Update failed 3 consecutive times" while
+    reads kept succeeding and resetting the breaker (issue #1398).
+    """
+    code = getattr(err, "zwave_error_code", None)
+    if code in _PERMANENT_ZWAVE_ERROR_CODES:
+        return LockOperationUnsupported(f"{context}: {err}")
+    return LockDisconnected(f"{context}: {err}")
+
 
 _PIN_TYPE_STR = lock_helpers.CREDENTIAL_TYPE_MAP[UserCredentialType.PIN_CODE]
 
@@ -234,7 +282,7 @@ class ZWaveJSLock(BaseLock):
             users = await self.node.access_control.get_users_cached()
             credentials = await self.node.access_control.get_all_credentials_cached()
         except BaseZwaveJSServerError as err:
-            raise LockDisconnected(f"get users failed: {err}") from err
+            raise _mapped_zwave_error(err, "get users failed") from err
         except HomeAssistantError as err:
             raise LockOperationFailed(f"get users failed: {err}") from err
         users_by_id: dict[int, User] = {
@@ -344,7 +392,7 @@ class ZWaveJSLock(BaseLock):
         try:
             return await lock_helpers.async_get_credential_capabilities(self.node)
         except BaseZwaveJSServerError as err:
-            raise LockDisconnected(f"get capabilities failed: {err}") from err
+            raise _mapped_zwave_error(err, "get capabilities failed") from err
         except HomeAssistantError as err:
             raise LockOperationFailed(f"get capabilities failed: {err}") from err
 
@@ -426,7 +474,7 @@ class ZWaveJSLock(BaseLock):
                 active=user.active,
             )
         except BaseZwaveJSServerError as err:
-            raise LockDisconnected(f"set user for slot {slot} failed: {err}") from err
+            raise _mapped_zwave_error(err, f"set user for slot {slot} failed") from err
         except HomeAssistantError as err:
             raise LockOperationFailed(
                 f"set user for slot {slot} failed: {err}"
@@ -500,7 +548,7 @@ class ZWaveJSLock(BaseLock):
         try:
             await lock_helpers.async_delete_user(self.node, user_id)
         except BaseZwaveJSServerError as err:
-            raise LockDisconnected(f"delete user {user_id} failed: {err}") from err
+            raise _mapped_zwave_error(err, f"delete user {user_id} failed") from err
         except HomeAssistantError as err:
             raise LockOperationFailed(f"delete user {user_id} failed: {err}") from err
 
@@ -544,8 +592,8 @@ class ZWaveJSLock(BaseLock):
         except BaseZwaveJSServerError as err:
             # Transient Z-Wave command failure (e.g. a sleeping/battery lock):
             # route to retry rather than slot suspension.
-            raise LockDisconnected(
-                f"set credential slot {credential.slot} failed: {err}"
+            raise _mapped_zwave_error(
+                err, f"set credential slot {credential.slot} failed"
             ) from err
         except HomeAssistantError as err:
             key = getattr(err, "translation_key", None)
@@ -595,8 +643,8 @@ class ZWaveJSLock(BaseLock):
                 self.node, ref.user_id, UserCredentialType.PIN_CODE, ref.slot
             )
         except BaseZwaveJSServerError as err:
-            raise LockDisconnected(
-                f"delete credential slot {ref.slot} failed: {err}"
+            raise _mapped_zwave_error(
+                err, f"delete credential slot {ref.slot} failed"
             ) from err
         except HomeAssistantError as err:
             # Same supervised-failure staleness as the set path (see
@@ -968,7 +1016,7 @@ class ZWaveJSLock(BaseLock):
             await self.node.access_control.get_users()
             await self.node.access_control.get_all_credentials()
         except BaseZwaveJSServerError as err:
-            raise LockDisconnected(f"hard refresh failed: {err}") from err
+            raise _mapped_zwave_error(err, "hard refresh failed") from err
         except HomeAssistantError as err:
             raise LockOperationFailed(f"hard refresh failed: {err}") from err
         return await self.async_get_usercodes()

--- a/custom_components/lock_code_manager/strings.json
+++ b/custom_components/lock_code_manager/strings.json
@@ -10,7 +10,7 @@
       "excluded_platform": "Entities from the `{integration}` integration are not supported as condition entities. See the [wiki]({docs_url}) for details.",
       "invalid_config": "Slots configuration is invalid. For more information, check the logs and the docs.",
       "missing_pin_if_enabled": "PIN must be set if slot is enabled.",
-      "slot_out_of_range": "Lock {lock} has only {num_slots} PIN code slots, so these slot numbers cannot be used with it: {out_of_range_slots}. Renumber them to fall within 1-{num_slots}, or manage that lock from a separate configuration.",
+      "slot_out_of_range": "Lock {lock} reports only {num_slots} PIN code slots, so these slot numbers are out of range for it: {out_of_range_slots}. Renumber them to fall within 1-{num_slots}, or manage that lock from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity.",
       "slots_already_configured": "The following slots for lock {lock} are already managed by another config entry ({entry_title}) and can't be added to this configuration without being removed from the other one: {common_slots}"
     },
     "step": {
@@ -129,7 +129,7 @@
     "error": {
       "invalid_config": "Slots configuration is invalid. For more information, check the logs and the docs.",
       "locks_already_configured": "The following lock(s) are already managed by another config entry: {locks}.",
-      "slot_out_of_range": "Lock {lock} has only {num_slots} PIN code slots, so these slot numbers cannot be used with it: {out_of_range_slots}. Renumber them to fall within 1-{num_slots}, or manage that lock from a separate configuration."
+      "slot_out_of_range": "Lock {lock} reports only {num_slots} PIN code slots, so these slot numbers are out of range for it: {out_of_range_slots}. Renumber them to fall within 1-{num_slots}, or manage that lock from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity."
     },
     "step": {
       "init": {

--- a/custom_components/lock_code_manager/strings.json
+++ b/custom_components/lock_code_manager/strings.json
@@ -10,6 +10,7 @@
       "excluded_platform": "Entities from the `{integration}` integration are not supported as condition entities. See the [wiki]({docs_url}) for details.",
       "invalid_config": "Slots configuration is invalid. For more information, check the logs and the docs.",
       "missing_pin_if_enabled": "PIN must be set if slot is enabled.",
+      "slot_out_of_range": "Lock {lock} has only {num_slots} PIN code slots, so these slot numbers cannot be used with it: {out_of_range_slots}. Renumber them to fall within 1-{num_slots}, or manage that lock from a separate configuration.",
       "slots_already_configured": "The following slots for lock {lock} are already managed by another config entry ({entry_title}) and can't be added to this configuration without being removed from the other one: {common_slots}"
     },
     "step": {
@@ -127,7 +128,8 @@
     },
     "error": {
       "invalid_config": "Slots configuration is invalid. For more information, check the logs and the docs.",
-      "locks_already_configured": "The following lock(s) are already managed by another config entry: {locks}."
+      "locks_already_configured": "The following lock(s) are already managed by another config entry: {locks}.",
+      "slot_out_of_range": "Lock {lock} has only {num_slots} PIN code slots, so these slot numbers cannot be used with it: {out_of_range_slots}. Renumber them to fall within 1-{num_slots}, or manage that lock from a separate configuration."
     },
     "step": {
       "init": {

--- a/custom_components/lock_code_manager/translations/en.json
+++ b/custom_components/lock_code_manager/translations/en.json
@@ -10,7 +10,7 @@
       "excluded_platform": "Entities from the `{integration}` integration are not supported as condition entities. See the [wiki]({docs_url}) for details.",
       "invalid_config": "Slots configuration is invalid. For more information, check the logs and the docs.",
       "missing_pin_if_enabled": "PIN must be set if slot is enabled.",
-      "slot_out_of_range": "Lock {lock} has only {num_slots} PIN code slots, so these slot numbers cannot be used with it: {out_of_range_slots}. Renumber them to fall within 1-{num_slots}, or manage that lock from a separate configuration.",
+      "slot_out_of_range": "Lock {lock} reports only {num_slots} PIN code slots, so these slot numbers are out of range for it: {out_of_range_slots}. Renumber them to fall within 1-{num_slots}, or manage that lock from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity.",
       "slots_already_configured": "The following slots for lock {lock} are already managed by another config entry ({entry_title}) and can't be added to this configuration without being removed from the other one: {common_slots}"
     },
     "step": {
@@ -129,7 +129,7 @@
     "error": {
       "invalid_config": "Slots configuration is invalid. For more information, check the logs and the docs.",
       "locks_already_configured": "The following lock(s) are already managed by another config entry: {locks}.",
-      "slot_out_of_range": "Lock {lock} has only {num_slots} PIN code slots, so these slot numbers cannot be used with it: {out_of_range_slots}. Renumber them to fall within 1-{num_slots}, or manage that lock from a separate configuration."
+      "slot_out_of_range": "Lock {lock} reports only {num_slots} PIN code slots, so these slot numbers are out of range for it: {out_of_range_slots}. Renumber them to fall within 1-{num_slots}, or manage that lock from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity."
     },
     "step": {
       "init": {

--- a/custom_components/lock_code_manager/translations/en.json
+++ b/custom_components/lock_code_manager/translations/en.json
@@ -10,6 +10,7 @@
       "excluded_platform": "Entities from the `{integration}` integration are not supported as condition entities. See the [wiki]({docs_url}) for details.",
       "invalid_config": "Slots configuration is invalid. For more information, check the logs and the docs.",
       "missing_pin_if_enabled": "PIN must be set if slot is enabled.",
+      "slot_out_of_range": "Lock {lock} has only {num_slots} PIN code slots, so these slot numbers cannot be used with it: {out_of_range_slots}. Renumber them to fall within 1-{num_slots}, or manage that lock from a separate configuration.",
       "slots_already_configured": "The following slots for lock {lock} are already managed by another config entry ({entry_title}) and can't be added to this configuration without being removed from the other one: {common_slots}"
     },
     "step": {
@@ -127,7 +128,8 @@
     },
     "error": {
       "invalid_config": "Slots configuration is invalid. For more information, check the logs and the docs.",
-      "locks_already_configured": "The following lock(s) are already managed by another config entry: {locks}."
+      "locks_already_configured": "The following lock(s) are already managed by another config entry: {locks}.",
+      "slot_out_of_range": "Lock {lock} has only {num_slots} PIN code slots, so these slot numbers cannot be used with it: {out_of_range_slots}. Renumber them to fall within 1-{num_slots}, or manage that lock from a separate configuration."
     },
     "step": {
       "init": {

--- a/tests/providers/matter/test_provider.py
+++ b/tests/providers/matter/test_provider.py
@@ -1734,6 +1734,17 @@ async def test_supports_native_users(matter_lock: MatterLock) -> None:
     assert matter_lock.supports_native_users is True
 
 
+async def test_credential_index_does_not_follow_slot(matter_lock: MatterLock) -> None:
+    """
+    Matter opts out of the slot capacity check (issue #1398).
+
+    ``async_set_credential`` lets the lock allocate the credential index, so a
+    slot number above the lock's credential count is legal here and must not be
+    range-checked the way the Z-Wave path is.
+    """
+    assert matter_lock.credential_index_follows_slot is False
+
+
 # =============================================================================
 # async_get_users tests
 # =============================================================================

--- a/tests/providers/test_seam.py
+++ b/tests/providers/test_seam.py
@@ -29,6 +29,7 @@ from custom_components.lock_code_manager.domain.exceptions import (
     CodeRejectedError,
     LockDisconnected,
     LockOperationFailed,
+    LockOperationUnsupported,
     ProviderNotImplementedError,
 )
 from custom_components.lock_code_manager.domain.models import SlotCredential
@@ -1177,3 +1178,94 @@ async def test_confirm_slot_keeps_belief_when_readable_matches(
 
     assert pushed == [({4: SlotCredential.known("1234")}, False)]
     assert 4 not in lock._pending_writes
+
+
+# Slot capacity pre-flight (issue #1398)
+
+
+class _AutoIndexStubLock(_NativeStubLock):
+    """Native provider whose lock allocates the credential index (Matter-shaped)."""
+
+    @property
+    def credential_index_follows_slot(self) -> bool:
+        return False
+
+
+class _UnknownCapacityStubLock(_NativeStubLock):
+    """Native provider that advertises PIN support without a slot count."""
+
+    async def async_get_capabilities(self) -> LockCapabilities:
+        return LockCapabilities(
+            supports_user_management=True,
+            max_users=0,
+            credential_types={
+                CredentialType.PIN: CredentialTypeCapability(
+                    num_slots=0,
+                    min_length=4,
+                    max_length=8,
+                    supports_learn=False,
+                ),
+            },
+            max_user_name_length=16,
+        )
+
+
+async def test_set_usercode_rejects_slot_beyond_capacity(hass: HomeAssistant) -> None:
+    """
+    A slot above the lock's advertised count fails before any device write.
+
+    Issue #1398: the write would otherwise be rejected deterministically by the
+    driver and misread as a transport failure, retrying forever.
+    """
+    lock = _make_lock(hass, _NativeStubLock, "seam_capacity_reject")
+    lock._min_operation_delay = 0.0
+    with (
+        patch.object(BaseLock, "async_is_integration_connected", return_value=True),
+        pytest.raises(LockOperationUnsupported, match="30 PIN code slots"),
+    ):
+        await lock.async_internal_set_usercode(50, "4321", "guest")
+    assert lock.calls == []
+
+
+async def test_set_usercode_accepts_slot_at_capacity_boundary(
+    hass: HomeAssistant,
+) -> None:
+    """The highest advertised slot is usable; the bound is inclusive."""
+    lock = _make_lock(hass, _NativeStubLock, "seam_capacity_boundary")
+    lock._min_operation_delay = 0.0
+    with patch.object(BaseLock, "async_is_integration_connected", return_value=True):
+        await lock.async_internal_set_usercode(30, "4321", "guest")
+    assert ("set_credential", 30, 30) in lock.calls
+
+
+async def test_set_usercode_skips_capacity_check_when_lock_allocates_index(
+    hass: HomeAssistant,
+) -> None:
+    """A high slot number is legal when the lock picks its own credential index."""
+    lock = _make_lock(hass, _AutoIndexStubLock, "seam_capacity_auto_index")
+    lock._min_operation_delay = 0.0
+    with patch.object(BaseLock, "async_is_integration_connected", return_value=True):
+        await lock.async_internal_set_usercode(50, "4321", "guest")
+    assert ("set_credential", 50, 50) in lock.calls
+
+
+async def test_set_usercode_skips_capacity_check_when_capacity_unknown(
+    hass: HomeAssistant,
+) -> None:
+    """``num_slots`` of 0 means unknown capacity, so it must not block the write."""
+    lock = _make_lock(hass, _UnknownCapacityStubLock, "seam_capacity_unknown")
+    lock._min_operation_delay = 0.0
+    with patch.object(BaseLock, "async_is_integration_connected", return_value=True):
+        await lock.async_internal_set_usercode(50, "4321", "guest")
+    assert ("set_credential", 50, 50) in lock.calls
+
+
+async def test_set_usercode_skips_capacity_check_when_capabilities_unavailable(
+    hass: HomeAssistant,
+) -> None:
+    """A provider with no capabilities read keeps writing as it did before."""
+    lock = _make_lock(hass, _DegenerateStubLock, "seam_capacity_no_caps")
+    lock._min_operation_delay = 0.0
+    with patch.object(BaseLock, "async_is_integration_connected", return_value=True):
+        await lock.async_internal_set_usercode(50, "4321", "guest")
+    assert ("set_credential", 50, 50) in lock.calls

--- a/tests/providers/zwave_js/test_provider.py
+++ b/tests/providers/zwave_js/test_provider.py
@@ -42,6 +42,7 @@ from custom_components.lock_code_manager.domain.exceptions import (
     LockCodeManagerProviderError,
     LockDisconnected,
     LockOperationFailed,
+    LockOperationUnsupported,
 )
 from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers.zwave_js import ZWaveJSLock
@@ -1182,6 +1183,90 @@ async def test_async_delete_credential_maps_failed_command_to_lock_disconnected(
     with pytest.raises(LockDisconnected):
         await zwave_js_lock.async_delete_credential(
             CredentialRef(user_id=4, type=CredentialType.PIN, slot=4)
+        )
+
+
+@pytest.mark.parametrize(
+    "zwave_error_code",
+    [
+        302,  # CC_NotSupported
+        303,  # CC_NotImplemented
+        304,  # CC_NoAPI
+        322,  # Argument_Invalid -- the out-of-range slot from issue #1398
+    ],
+)
+async def test_async_set_credential_maps_permanent_codes_to_unsupported(
+    zwave_js_lock: ZWaveJSLock,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
+    zwave_error_code: int,
+) -> None:
+    """
+    A deterministic driver rejection must not look like a transport failure.
+
+    These codes mean the request itself is invalid for the node, so the retry
+    path would loop forever while the lock circuit breaker logged nothing but
+    "Update failed N consecutive times" (issue #1398).
+    """
+    mock_lock_helpers["async_set_credential"].side_effect = FailedZWaveCommand(
+        "cmd", zwave_error_code, "Credential slot 50 is out of range"
+    )
+    credential = Credential(
+        type=CredentialType.PIN, slot=50, state=SlotCredential.known("2222")
+    )
+    with pytest.raises(LockOperationUnsupported, match="out of range"):
+        await zwave_js_lock.async_set_credential(
+            user_id=1,
+            credential=credential,
+            pin="2222",
+            name=None,
+            source="sync",
+        )
+
+
+async def test_async_set_credential_unknown_code_stays_retryable(
+    zwave_js_lock: ZWaveJSLock,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
+) -> None:
+    """
+    An unlisted error code keeps the retry classification it has today.
+
+    The permanent-code table is a deny-list, so a code node-zwave-js adds
+    later degrades to the old behavior rather than wrongly suspending a slot.
+    """
+    mock_lock_helpers["async_set_credential"].side_effect = FailedZWaveCommand(
+        "cmd", 9999, "something new"
+    )
+    credential = Credential(
+        type=CredentialType.PIN, slot=4, state=SlotCredential.known("2222")
+    )
+    # LockDisconnected and LockOperationUnsupported are siblings, so this
+    # raises-check also asserts the code did not land in the permanent bucket.
+    with pytest.raises(LockDisconnected):
+        await zwave_js_lock.async_set_credential(
+            user_id=1,
+            credential=credential,
+            pin="2222",
+            name=None,
+            source="sync",
+        )
+
+
+async def test_async_set_user_maps_permanent_code_to_unsupported(
+    zwave_js_lock: ZWaveJSLock,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
+) -> None:
+    """The user write path classifies the same way as the credential write."""
+    mock_access_control.get_users.return_value = []
+    mock_access_control.get_all_credentials.return_value = []
+    mock_lock_helpers["async_set_user"].side_effect = FailedZWaveCommand(
+        "cmd", 322, "User ID 50 is out of range"
+    )
+    with pytest.raises(LockOperationUnsupported, match="out of range"):
+        await zwave_js_lock.async_set_user(
+            User(user_id=50, name="lcm:50:Guest", active=True)
         )
 
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -21,13 +21,18 @@ from custom_components.lock_code_manager.const import (
     CONF_START_SLOT,
     DOMAIN,
 )
+from custom_components.lock_code_manager.domain.credentials import (
+    CredentialType,
+    CredentialTypeCapability,
+    LockCapabilities,
+)
 from custom_components.lock_code_manager.domain.exceptions import (
     LockCodeManagerError,
     LockDisconnected,
 )
 from custom_components.lock_code_manager.domain.models import SlotCredential
 
-from .common import BASE_CONFIG, LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID
+from .common import BASE_CONFIG, LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID, MockLCMLock
 
 GET_ALL_CODES_PATCH = (
     "custom_components.lock_code_manager.config_flow._async_get_all_codes"
@@ -1090,3 +1095,149 @@ async def test_options_flow_invalid_yaml_shows_error(hass: HomeAssistant):
     assert result["type"] == "form"
     assert result["errors"] == {"base": "invalid_config"}
     mock_get_codes.assert_not_called()
+
+
+# Slot capacity validation (issue #1398)
+
+
+def _capacity_probe(**capabilities_mock_kwargs):
+    """
+    Make the config flow able to probe the test lock's capacity.
+
+    The autouse ``auto_setup_mock_lock`` fixture only registers MockLCMLock in
+    the ``domain.locks`` provider map; the config flow builds its throwaway
+    provider instance from its own map, so the test platform has to be
+    registered there too or every capacity check silently skips.
+    """
+    return (
+        patch.dict(
+            "custom_components.lock_code_manager.config_flow.INTEGRATIONS_CLASS_MAP",
+            {"test": MockLCMLock},
+        ),
+        patch.object(
+            MockLCMLock,
+            "async_get_capabilities",
+            new_callable=AsyncMock,
+            **capabilities_mock_kwargs,
+        ),
+    )
+
+
+def _capabilities_with_slots(num_slots: int) -> LockCapabilities:
+    """Build PIN-capable capabilities advertising ``num_slots`` slots."""
+    return LockCapabilities(
+        supports_user_management=False,
+        max_users=num_slots,
+        credential_types={
+            CredentialType.PIN: CredentialTypeCapability(
+                num_slots=num_slots,
+                min_length=4,
+                max_length=8,
+                supports_learn=False,
+            )
+        },
+    )
+
+
+async def test_config_flow_yaml_rejects_slot_beyond_lock_capacity(
+    hass: HomeAssistant, mock_lock_config_entry
+):
+    """A slot number the lock cannot hold is caught before the entry is created."""
+    flow_id = await _start_yaml_config_flow(hass)
+
+    probe_registered, probe_capabilities = _capacity_probe(
+        return_value=_capabilities_with_slots(30)
+    )
+    with probe_registered, probe_capabilities:
+        result = await hass.config_entries.flow.async_configure(
+            flow_id,
+            {CONF_SLOTS: {50: {CONF_ENABLED: True, CONF_PIN: "2222"}}},
+        )
+
+    assert result["type"] == "form"
+    assert result["errors"] == {"base": "slot_out_of_range"}
+    assert result["description_placeholders"]["out_of_range_slots"] == "50"
+    assert result["description_placeholders"]["num_slots"] == "30"
+
+
+async def test_config_flow_yaml_accepts_slot_within_capacity(
+    hass: HomeAssistant, mock_lock_config_entry
+):
+    """A slot inside the advertised range still creates the entry."""
+    flow_id = await _start_yaml_config_flow(hass)
+
+    probe_registered, probe_capabilities = _capacity_probe(
+        return_value=_capabilities_with_slots(30)
+    )
+    with probe_registered, probe_capabilities:
+        result = await hass.config_entries.flow.async_configure(
+            flow_id,
+            {CONF_SLOTS: {30: {CONF_ENABLED: True, CONF_PIN: "2222"}}},
+        )
+
+    assert result["type"] == "create_entry"
+
+
+async def test_config_flow_ui_rejects_slot_range_beyond_lock_capacity(
+    hass: HomeAssistant, mock_lock_config_entry
+):
+    """The UI path bounds start+count against the lock the same way YAML does."""
+    flow_id = await _start_config_flow(hass)
+    result = await hass.config_entries.flow.async_configure(
+        flow_id, {"next_step_id": "ui"}
+    )
+    assert result["step_id"] == "ui"
+
+    probe_registered, probe_capabilities = _capacity_probe(
+        return_value=_capabilities_with_slots(10)
+    )
+    with probe_registered, probe_capabilities:
+        result = await hass.config_entries.flow.async_configure(
+            flow_id, {CONF_START_SLOT: 8, CONF_NUM_SLOTS: 5}
+        )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "ui"
+    assert result["errors"] == {"base": "slot_out_of_range"}
+    assert result["description_placeholders"]["out_of_range_slots"] == "11, 12"
+
+
+async def test_config_flow_capacity_check_skipped_when_lock_unreachable(
+    hass: HomeAssistant, mock_lock_config_entry
+):
+    """
+    An unreachable lock must not block configuration.
+
+    Capabilities need the lock awake, so a sleeping battery lock would
+    otherwise make the flow unusable. The write-time check still covers it.
+    """
+    flow_id = await _start_yaml_config_flow(hass)
+
+    probe_registered, probe_capabilities = _capacity_probe(
+        side_effect=LockDisconnected("lock asleep")
+    )
+    with probe_registered, probe_capabilities:
+        result = await hass.config_entries.flow.async_configure(
+            flow_id,
+            {CONF_SLOTS: {50: {CONF_ENABLED: True, CONF_PIN: "2222"}}},
+        )
+
+    assert result["type"] == "create_entry"
+
+
+async def test_config_flow_capacity_check_skipped_when_capacity_unknown(
+    hass: HomeAssistant, mock_lock_config_entry
+):
+    """``num_slots`` of 0 is "unknown", not "no slots", so it cannot reject."""
+    flow_id = await _start_yaml_config_flow(hass)
+
+    probe_registered, probe_capabilities = _capacity_probe(
+        return_value=_capabilities_with_slots(0)
+    )
+    with probe_registered, probe_capabilities:
+        result = await hass.config_entries.flow.async_configure(
+            flow_id,
+            {CONF_SLOTS: {50: {CONF_ENABLED: True, CONF_PIN: "2222"}}},
+        )
+
+    assert result["type"] == "create_entry"

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,6 +1,6 @@
 """Config flow tests."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -1241,3 +1241,62 @@ async def test_config_flow_capacity_check_skipped_when_capacity_unknown(
         )
 
     assert result["type"] == "create_entry"
+
+
+async def test_config_flow_capacity_check_skipped_when_lock_allocates_index(
+    hass: HomeAssistant, mock_lock_config_entry
+):
+    """
+    A provider that allocates its own credential index is not slot-bounded.
+
+    Matter picks the next free index, so a high slot number is legal there and
+    the flow must not query capabilities or reject it.
+    """
+    flow_id = await _start_yaml_config_flow(hass)
+
+    capabilities = AsyncMock(return_value=_capabilities_with_slots(30))
+    with (
+        patch.dict(
+            "custom_components.lock_code_manager.config_flow.INTEGRATIONS_CLASS_MAP",
+            {"test": MockLCMLock},
+        ),
+        patch.object(
+            MockLCMLock,
+            "credential_index_follows_slot",
+            new_callable=PropertyMock,
+            return_value=False,
+        ),
+        patch.object(MockLCMLock, "async_get_capabilities", capabilities),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            flow_id,
+            {CONF_SLOTS: {50: {CONF_ENABLED: True, CONF_PIN: "2222"}}},
+        )
+
+    assert result["type"] == "create_entry"
+    # Bailing before the read is the point: the answer would be irrelevant.
+    capabilities.assert_not_called()
+
+
+async def test_config_flow_capacity_check_survives_unexpected_error(
+    hass: HomeAssistant, mock_lock_config_entry, caplog: pytest.LogCaptureFixture
+):
+    """
+    An unexpected provider error must not take the config flow down with it.
+
+    Validation is advisory; a provider raising something outside the Lock Code
+    Manager hierarchy should degrade to "not checked", not a broken flow.
+    """
+    flow_id = await _start_yaml_config_flow(hass)
+
+    probe_registered, probe_capabilities = _capacity_probe(
+        side_effect=RuntimeError("provider blew up")
+    )
+    with probe_registered, probe_capabilities:
+        result = await hass.config_entries.flow.async_configure(
+            flow_id,
+            {CONF_SLOTS: {50: {CONF_ENABLED: True, CONF_PIN: "2222"}}},
+        )
+
+    assert result["type"] == "create_entry"
+    assert "provider blew up" in caplog.text

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -27,6 +27,7 @@ from custom_components.lock_code_manager.domain.exceptions import (
     CodeRejectedError,
     LockDisconnected,
     LockOperationFailed,
+    LockOperationUnsupported,
 )
 from custom_components.lock_code_manager.domain.models import SlotCredential, SyncState
 from custom_components.lock_code_manager.domain.sync import SlotState, SlotSyncManager
@@ -544,6 +545,74 @@ class TestLockOperationFailedRetry:
         await hass.async_block_till_done()
         assert manager._state is SyncState.SUSPENDED
         assert manager._coordinator.unreachable is False
+
+
+class TestLockOperationUnsupportedSuspend:
+    """A permanently-invalid request suspends immediately (issue #1398)."""
+
+    async def test_unsupported_operation_suspends_on_first_failure(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """
+        No retries: the lock can never accept this request, so waiting out the
+        breaker would only delay a vaguer message by three ticks.
+        """
+        entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
+        manager = entity_obj._sync_manager
+        manager._state = SyncState.OUT_OF_SYNC
+        manager._coordinator.data[1] = SlotCredential.empty()
+
+        with patch.object(
+            manager,
+            "_perform_sync",
+            new_callable=AsyncMock,
+            side_effect=LockOperationUnsupported(
+                "Lock lock.test_1 has 30 PIN code slots, so slot 50 does not "
+                "exist on it."
+            ),
+        ):
+            await manager._async_tick()
+            await hass.async_block_till_done()
+
+        assert manager._state is SyncState.SUSPENDED
+        # The retry budget is untouched -- the suspend did not come from it.
+        assert manager._slot_breaker.failure_count == 0
+        # A permanent request error is not evidence the lock is unreachable.
+        assert manager._coordinator.unreachable is False
+
+    async def test_unsupported_operation_surfaces_reason_in_repair(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """The driver's own explanation reaches the repair, not a generic one."""
+        entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
+        manager = entity_obj._sync_manager
+        manager._state = SyncState.OUT_OF_SYNC
+        manager._coordinator.data[1] = SlotCredential.empty()
+        lock_entity_id = manager._lock.lock.entity_id
+        entry_id = manager._config_entry.entry_id
+
+        with patch.object(
+            manager,
+            "_perform_sync",
+            new_callable=AsyncMock,
+            side_effect=LockOperationUnsupported(
+                "set credential slot 50 failed: zwave_error: Z-Wave error 322"
+            ),
+        ):
+            await manager._async_tick()
+            await hass.async_block_till_done()
+
+        issue = async_get_issue_registry(hass).async_get_issue(
+            DOMAIN, f"slot_suspended_{entry_id}_{lock_entity_id}_1"
+        )
+        assert issue is not None
+        assert "Z-Wave error 322" in issue.translation_placeholders["reason"]
 
 
 class TestSyncStateMachine:


### PR DESCRIPTION
## Proposed change

A slot number above the lock's PIN slot count was written to the device, deterministically rejected by node-zwave-js, and then classified as a *transport* failure — so it was retried forever and never explained.

The trace:

1. `providers/zwave_js.py` passes the Lock Code Manager slot number through as the lock's credential slot (`credential_slot=credential.slot`).
2. node-zwave-js bounds-checks it against `numberOfCredentialSlots` and throws `ZWaveError(..., Argument_Invalid)` (`AccessControl.ts` `#assertValidSlot`).
3. zwave-js-server-python surfaces it as `FailedZWaveCommand(zwave_error_code=322)`, a `BaseZwaveJSServerError`.
4. The provider mapped **every** `BaseZwaveJSServerError` to `LockDisconnected` ("transient Z-Wave command failure").
5. `domain/sync.py` logged that at INFO and called `note_connectivity_failure()`, tripping the *lock* circuit breaker — the only WARNING the reporter ever saw:
   `Update failed 3 consecutive times for lock.front_door, polling every 60s until it recovers`
6. Recovery polling then *succeeded*, because reads work fine — only the write is invalid — which reset the breaker so the next tick could fail all over again.

Net effect: an infinite oscillation, no repair issue, and no sign of the actual reason. Nothing anywhere validated slot numbers against `CredentialTypeCapability.num_slots`, which Lock Code Manager already reads but only used for the "zero slots" degenerate check.

Three layers now cover it:

**1. A retryability distinction in the exception hierarchy.** `LockOperationUnsupported` subclasses `LockOperationFailed` and means "this request can never succeed as specified." The sync tick handles it ahead of its parent and suspends the affected lock+slot immediately, with the underlying error text in the `slot_suspended` repair — rather than burning the retry budget first and then suspending with a vaguer message. Suspension is per-(lock, slot), so an entry spanning locks of differing capacity only loses the slot on the lock that cannot hold it.

**2. Z-Wave error-code classification.** Instead of assuming every server-side error is transient, `FailedZWaveCommand` is classified by `zwave_error_code`. The table lists **permanent** codes only — `CC_NotSupported` (302), `CC_NotImplemented` (303), `CC_NoAPI` (304), `Argument_Invalid` (322) — so an unrecognized or newly added code keeps today's retry behavior. The worst case of an incomplete table is the old behavior, never a wrongly suspended slot. Every `Argument_Invalid` the access control API raises is a bounds or shape check on our own arguments (slot range, user range, credential type), never a transport symptom.

**3. Pre-flight capacity validation, at both ends.** `BaseLock._assert_slot_within_capacity` rejects out-of-capacity slots before the write, and the config flow (YAML, UI, and reauth paths) rejects them before the entry is ever stored.

Both checks are gated on a new `BaseLock.credential_index_follows_slot` property. Z-Wave and the slot-only providers address a credential *by* the slot number, so the bound applies. **Matter does not** — `async_set_credential` lets the lock allocate the next free credential index, so Lock Code Manager slot 50 is perfectly legal on a 30-credential Matter lock as long as no more than 30 slots are configured. Matter overrides the property to `False`. Capacity on those locks is a limit on the *number* of slots, which this check deliberately does not police.

Both checks skip rather than block when capabilities are unavailable or report `num_slots == 0` ("unknown capacity", not "no slots"). A sleeping battery lock must not make the config flow unusable, and a provider that never implemented the capabilities read keeps writing exactly as it did before.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #1398
- This PR is related to issue:

19 new tests: Z-Wave code classification (permanent vs. unrecognized, set-credential and set-user paths), the seam capacity check (reject, inclusive boundary, and each of the three skip conditions), the sync tick's immediate suspend (breaker untouched, lock not marked unreachable, driver message reaching the repair), Matter's opt-out, and config-flow validation across the YAML and UI paths.

Full suite passes (1264 passed). The 43 errors in `tests/providers/zha/test_provider.py` are pre-existing on `main` in my local environment — a ZHA fixture that creates no lock entity — and are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)