### PR TITLE
fix: remove per-slot devices when the slot is removed

### DIFF
--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 import logging
 from pathlib import Path
 from typing import Any
@@ -80,7 +80,11 @@ from .const import (
     STRATEGY_PATH,
     Platform,
 )
-from .domain.config import EntryConfig
+from .domain.config import (
+    EntryConfig,
+    build_slot_device_identifier,
+    parse_slot_device_identifier,
+)
 from .domain.exceptions import LockDisconnected, LockOperationFailed
 from .domain.locks import async_create_lock_instance, get_locks_from_targets
 from .domain.models import (
@@ -587,6 +591,7 @@ async def async_setup_entry(
         name=config_entry.title,
         serial_number=entry_id,
     )
+    _async_prune_orphaned_slot_devices(hass, config_entry)
 
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
 
@@ -811,6 +816,96 @@ async def async_remove_entry(
             )
 
 
+@callback
+def _async_remove_slot_devices(
+    hass: HomeAssistant,
+    config_entry: LockCodeManagerConfigEntry,
+    slot_nums: Iterable[int],
+) -> None:
+    """
+    Remove the per-slot devices for slots that are no longer configured.
+
+    Removing a slot's entities is not enough to retire its device: Home
+    Assistant's own registry cleanup only reaps devices referenced by
+    neither an entity nor a live config entry, and a slot device stays
+    attached to this entry forever. Left alone it lingers in the UI with
+    no way to delete it short of removing the whole entry (issue #1399).
+    """
+    dev_reg = dr.async_get(hass)
+    for slot_num in slot_nums:
+        identifier = build_slot_device_identifier(config_entry.entry_id, slot_num)
+        if device := dev_reg.async_get_device(identifiers={(DOMAIN, identifier)}):
+            _LOGGER.debug(
+                "%s (%s): Removing device for slot %s",
+                config_entry.entry_id,
+                config_entry.title,
+                slot_num,
+            )
+            dev_reg.async_remove_device(device.id)
+
+
+@callback
+def _async_prune_orphaned_slot_devices(
+    hass: HomeAssistant, config_entry: LockCodeManagerConfigEntry
+) -> None:
+    """
+    Drop slot devices left behind by a slot that is no longer in config.
+
+    Runs at setup so registries already polluted by the pre-fix behavior get
+    cleaned up on the next reload, rather than only newly-removed slots
+    benefiting. Sweeps by identifier rather than by diffing against a
+    previous config, so it also catches slots removed while the entry was
+    unloaded.
+    """
+    dev_reg = dr.async_get(hass)
+    entry_id = config_entry.entry_id
+    configured = get_entry_config(config_entry).slots
+    orphaned = {
+        slot_num
+        for device in dr.async_entries_for_config_entry(dev_reg, entry_id)
+        for domain, identifier in device.identifiers
+        if domain == DOMAIN
+        and (slot_num := parse_slot_device_identifier(entry_id, identifier)) is not None
+        and slot_num not in configured
+    }
+    if orphaned:
+        _LOGGER.debug(
+            "%s (%s): Pruning devices for unconfigured slots %s",
+            entry_id,
+            config_entry.title,
+            sorted(orphaned),
+        )
+        _async_remove_slot_devices(hass, config_entry, orphaned)
+
+
+async def async_remove_config_entry_device(
+    hass: HomeAssistant,
+    config_entry: LockCodeManagerConfigEntry,
+    device_entry: dr.DeviceEntry,
+) -> bool:
+    """
+    Allow deleting a slot device from the UI, but only once it is unused.
+
+    Home Assistant renders the device's Delete button only when this hook
+    exists, which is why there was previously no way to clear a stale slot
+    device (issue #1399). A device whose slot is still configured must stay:
+    deleting it would strand the slot's entities, and the next reload would
+    recreate it anyway.
+    """
+    entry_id = config_entry.entry_id
+    slot_nums = {
+        slot_num
+        for domain, identifier in device_entry.identifiers
+        if domain == DOMAIN
+        and (slot_num := parse_slot_device_identifier(entry_id, identifier)) is not None
+    }
+    # No slot identifier means this is the entry's own device, which has to
+    # outlive every slot -- it is what the slot devices hang off of.
+    if not slot_nums:
+        return False
+    return slot_nums.isdisjoint(get_entry_config(config_entry).slots)
+
+
 async def _async_setup_new_locks(
     hass: HomeAssistant,
     config_entry: LockCodeManagerConfigEntry,
@@ -994,6 +1089,9 @@ async def async_update_listener(
                 for slot_num in slots_to_remove
             )
         )
+        # After the entity removers have run, so the registry teardown order
+        # matches a normal removal (entities first, then their device).
+        _async_remove_slot_devices(hass, config_entry, slots_to_remove)
         for slot_num in slots_to_remove:
             coordinator = runtime_data.slot_coordinators.pop(slot_num, None)
             if coordinator is None:

--- a/custom_components/lock_code_manager/diagnostics.py
+++ b/custom_components/lock_code_manager/diagnostics.py
@@ -9,6 +9,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .const import DOMAIN
+from .domain.config import build_slot_device_identifier
 from .domain.models import SlotCode, SlotCredential
 from .domain.queries import get_entry_config
 from .domain.util import mask_pin
@@ -162,7 +163,10 @@ def _slot_diagnostic(
     }
 
     # Find the slot device and its entities
-    slot_identifier = (DOMAIN, f"{config_entry.entry_id}|{slot_num}")
+    slot_identifier = (
+        DOMAIN,
+        build_slot_device_identifier(config_entry.entry_id, slot_num),
+    )
     device = dev_reg.async_get_device(identifiers={slot_identifier})
     if device:
         result["entities"] = _entity_states_for_device(hass, ent_reg, device.id)

--- a/custom_components/lock_code_manager/domain/config.py
+++ b/custom_components/lock_code_manager/domain/config.py
@@ -329,9 +329,22 @@ def parse_slot_device_identifier(entry_id: str, identifier: str) -> int | None:
     device apart from the entry's own device when sweeping the registry.
     ``None`` covers both the entry device (bare entry_id, no separator) and
     anything that does not belong to this entry.
+
+    Accepts exactly what the builder emits, verified by round-tripping the
+    parsed number back to a string. Anything looser breaks the pairing in one
+    direction or the other: ``str.isdigit()`` rejects the negative slot the
+    builder will happily encode (the slots YAML schema does not bound the key),
+    while a bare ``int()`` accepts ``+1`` and ``1_0`` as aliases the builder
+    would never produce. Either way the device becomes invisible to the sweep
+    AND to the removal hook -- the exact stuck, undeletable device this pairing
+    exists to clean up.
     """
     prefix = f"{entry_id}|"
     if not identifier.startswith(prefix):
         return None
     suffix = identifier.removeprefix(prefix)
-    return int(suffix) if suffix.isdigit() else None
+    try:
+        slot_num = int(suffix)
+    except ValueError:
+        return None
+    return slot_num if str(slot_num) == suffix else None

--- a/custom_components/lock_code_manager/domain/config.py
+++ b/custom_components/lock_code_manager/domain/config.py
@@ -309,3 +309,29 @@ def build_slot_unique_id(
     if lock_entity_id:
         uid = f"{uid}|{lock_entity_id}"
     return uid
+
+
+def build_slot_device_identifier(entry_id: str, slot_num: int) -> str:
+    """
+    Build the device registry identifier for a slot's device.
+
+    Format: {entry_id}|{slot_num}. Deliberately distinct from the entry's
+    own device identifier, which is the bare entry_id.
+    """
+    return f"{entry_id}|{slot_num}"
+
+
+def parse_slot_device_identifier(entry_id: str, identifier: str) -> int | None:
+    """
+    Recover the slot number from a slot device identifier, else ``None``.
+
+    The inverse of :func:`build_slot_device_identifier`, used to tell a slot
+    device apart from the entry's own device when sweeping the registry.
+    ``None`` covers both the entry device (bare entry_id, no separator) and
+    anything that does not belong to this entry.
+    """
+    prefix = f"{entry_id}|"
+    if not identifier.startswith(prefix):
+        return None
+    suffix = identifier.removeprefix(prefix)
+    return int(suffix) if suffix.isdigit() else None

--- a/custom_components/lock_code_manager/entity.py
+++ b/custom_components/lock_code_manager/entity.py
@@ -25,7 +25,7 @@ from .const import (
     ATTR_TO,
     DOMAIN,
 )
-from .domain.config import build_slot_unique_id
+from .domain.config import build_slot_device_identifier, build_slot_unique_id
 from .domain.models import LockCodeManagerConfigEntry
 from .domain.queries import get_entry_config
 from .domain.slot_coordinator import SlotEntityCoordinator
@@ -67,7 +67,9 @@ class BaseLockCodeManagerEntity(Entity):
         self._attr_translation_placeholders = {"slot_num": slot_num}
 
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, f"{self.entry_id}|{slot_num}")},
+            identifiers={
+                (DOMAIN, build_slot_device_identifier(self.entry_id, slot_num))
+            },
             name=f"{config_entry.title} Code slot {slot_num}",
             manufacturer="Lock Code Manager",
             model="Code Slot",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,6 +14,8 @@ from custom_components.lock_code_manager.const import (
 from custom_components.lock_code_manager.domain.config import (
     EntryConfig,
     EntryConfigDiff,
+    build_slot_device_identifier,
+    parse_slot_device_identifier,
 )
 from custom_components.lock_code_manager.domain.queries import get_entry_config
 
@@ -523,3 +525,42 @@ def test_to_dict_produces_plain_mutable_dicts() -> None:
     # Original EntryConfig is untouched by that mutation
     assert config.slots[1]["pin"] == "1234"
     assert config.locks == ("lock.a",)
+
+
+# Slot device identifier round-trip (issue #1399)
+
+
+@pytest.mark.parametrize("slot_num", [1, 2, 0, 30, 255, -1, -42])
+def test_slot_device_identifier_round_trips(slot_num: int) -> None:
+    """
+    Every identifier the builder emits must parse back to the same slot.
+
+    A slot the builder encodes but the parser rejects is invisible to both the
+    orphan sweep and the removal hook, which is the stuck undeletable device
+    issue #1399 is about. Negative slots are included because the slots YAML
+    schema does not bound the key.
+    """
+    identifier = build_slot_device_identifier("abc123", slot_num)
+    assert parse_slot_device_identifier("abc123", identifier) == slot_num
+
+
+def test_parse_slot_device_identifier_rejects_non_slot_identifiers() -> None:
+    """The entry's own device and other entries' devices are not slot devices."""
+    # The entry device carries the bare entry_id, with no slot suffix.
+    assert parse_slot_device_identifier("abc123", "abc123") is None
+    # A different entry's slot device.
+    assert parse_slot_device_identifier("abc123", "def456|1") is None
+    # Not a slot number at all.
+    assert parse_slot_device_identifier("abc123", "abc123|name") is None
+    assert parse_slot_device_identifier("abc123", "abc123|") is None
+
+
+@pytest.mark.parametrize("suffix", ["+1", "1_0", " 1", "01"])
+def test_parse_slot_device_identifier_rejects_builder_aliases(suffix: str) -> None:
+    """
+    Reject int-parseable spellings the builder would never emit.
+
+    ``int()`` accepts all of these, but treating them as slot numbers would map
+    two distinct identifiers onto one slot.
+    """
+    assert parse_slot_device_identifier("abc123", f"abc123|{suffix}") is None

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1530,16 +1530,20 @@ async def test_removing_slot_removes_its_device(
     assert dev_reg.async_get_device({(DOMAIN, entry_id)}) is not None
 
 
+@pytest.mark.parametrize("stale_slot", [99, 0, -1])
 async def test_setup_prunes_devices_for_unconfigured_slots(
     hass: HomeAssistant,
     mock_lock_config_entry,
     lock_code_manager_config_entry,
+    stale_slot: int,
 ):
     """
     A device left behind by the pre-fix behavior is swept up on reload.
 
     Without this, everyone who already hit the bug would have to delete each
-    stale device by hand.
+    stale device by hand. Negative and zero slots are covered because the
+    slots YAML schema does not bound the key, and a slot the identifier
+    parser cannot recover would be skipped by the sweep forever.
     """
     entry_id = lock_code_manager_config_entry.entry_id
     dev_reg = dr.async_get(hass)
@@ -1547,9 +1551,9 @@ async def test_setup_prunes_devices_for_unconfigured_slots(
     # that is not in the entry's config.
     stale = dev_reg.async_get_or_create(
         config_entry_id=entry_id,
-        identifiers={(DOMAIN, f"{entry_id}|99")},
+        identifiers={(DOMAIN, f"{entry_id}|{stale_slot}")},
         manufacturer="Lock Code Manager",
-        name="Mock Title Code slot 99",
+        name=f"Mock Title Code slot {stale_slot}",
         model="Code Slot",
     )
     assert dev_reg.async_get(stale.id) is not None
@@ -1557,7 +1561,7 @@ async def test_setup_prunes_devices_for_unconfigured_slots(
     await hass.config_entries.async_reload(entry_id)
     await hass.async_block_till_done()
 
-    assert dev_reg.async_get_device({(DOMAIN, f"{entry_id}|99")}) is None
+    assert dev_reg.async_get_device({(DOMAIN, f"{entry_id}|{stale_slot}")}) is None
     assert dev_reg.async_get_device({(DOMAIN, f"{entry_id}|1")}) is not None
 
 
@@ -1593,16 +1597,17 @@ async def test_remove_config_entry_device_allows_only_unconfigured_slots(
         is False
     )
 
-    stale = dev_reg.async_get_or_create(
-        config_entry_id=entry_id,
-        identifiers={(DOMAIN, f"{entry_id}|99")},
-        manufacturer="Lock Code Manager",
-        name="Mock Title Code slot 99",
-        model="Code Slot",
-    )
-    assert (
-        await async_remove_config_entry_device(
-            hass, lock_code_manager_config_entry, stale
+    for stale_slot in (99, -1):
+        stale = dev_reg.async_get_or_create(
+            config_entry_id=entry_id,
+            identifiers={(DOMAIN, f"{entry_id}|{stale_slot}")},
+            manufacturer="Lock Code Manager",
+            name=f"Mock Title Code slot {stale_slot}",
+            model="Code Slot",
         )
-        is True
-    )
+        assert (
+            await async_remove_config_entry_device(
+                hass, lock_code_manager_config_entry, stale
+            )
+            is True
+        ), f"slot {stale_slot} device should be deletable"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -31,6 +31,7 @@ from homeassistant.helpers import (
 
 from custom_components.lock_code_manager import (
     _setup_entry_after_start,
+    async_remove_config_entry_device,
     async_remove_entry,
 )
 from custom_components.lock_code_manager.const import (
@@ -1495,3 +1496,113 @@ async def test_unload_logs_sync_manager_stop_exceptions(
     # Sibling managers must still have been stopped even though one raised.
     for mgr in other_mgrs:
         assert not mgr._started
+
+
+# Slot device lifecycle (issue #1399)
+
+
+async def test_removing_slot_removes_its_device(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """
+    Dropping a slot from config retires its device, not just its entities.
+
+    Home Assistant's registry cleanup never reaps these: the device stays
+    attached to the LCM entry, so it outlived the slot indefinitely.
+    """
+    entry_id = lock_code_manager_config_entry.entry_id
+    dev_reg = dr.async_get(hass)
+    slot_2_identifiers = {(DOMAIN, f"{entry_id}|2")}
+    assert dev_reg.async_get_device(slot_2_identifiers) is not None
+
+    new_config = copy.deepcopy(dict(lock_code_manager_config_entry.data))
+    new_config[CONF_SLOTS].pop(2)
+    assert hass.config_entries.async_update_entry(
+        lock_code_manager_config_entry, options=new_config
+    )
+    await hass.async_block_till_done()
+
+    assert dev_reg.async_get_device(slot_2_identifiers) is None
+    # The surviving slot and the entry's own device are untouched.
+    assert dev_reg.async_get_device({(DOMAIN, f"{entry_id}|1")}) is not None
+    assert dev_reg.async_get_device({(DOMAIN, entry_id)}) is not None
+
+
+async def test_setup_prunes_devices_for_unconfigured_slots(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """
+    A device left behind by the pre-fix behavior is swept up on reload.
+
+    Without this, everyone who already hit the bug would have to delete each
+    stale device by hand.
+    """
+    entry_id = lock_code_manager_config_entry.entry_id
+    dev_reg = dr.async_get(hass)
+    # Stand in for a slot removed by an older version: a device for a slot
+    # that is not in the entry's config.
+    stale = dev_reg.async_get_or_create(
+        config_entry_id=entry_id,
+        identifiers={(DOMAIN, f"{entry_id}|99")},
+        manufacturer="Lock Code Manager",
+        name="Mock Title Code slot 99",
+        model="Code Slot",
+    )
+    assert dev_reg.async_get(stale.id) is not None
+
+    await hass.config_entries.async_reload(entry_id)
+    await hass.async_block_till_done()
+
+    assert dev_reg.async_get_device({(DOMAIN, f"{entry_id}|99")}) is None
+    assert dev_reg.async_get_device({(DOMAIN, f"{entry_id}|1")}) is not None
+
+
+async def test_remove_config_entry_device_allows_only_unconfigured_slots(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """
+    The Delete button appears for stale slot devices but not live ones.
+
+    Deleting a configured slot's device would strand its entities, and the
+    next reload would recreate it regardless.
+    """
+    entry_id = lock_code_manager_config_entry.entry_id
+    dev_reg = dr.async_get(hass)
+
+    configured = dev_reg.async_get_device({(DOMAIN, f"{entry_id}|1")})
+    assert configured is not None
+    assert (
+        await async_remove_config_entry_device(
+            hass, lock_code_manager_config_entry, configured
+        )
+        is False
+    )
+
+    entry_device = dev_reg.async_get_device({(DOMAIN, entry_id)})
+    assert entry_device is not None
+    assert (
+        await async_remove_config_entry_device(
+            hass, lock_code_manager_config_entry, entry_device
+        )
+        is False
+    )
+
+    stale = dev_reg.async_get_or_create(
+        config_entry_id=entry_id,
+        identifiers={(DOMAIN, f"{entry_id}|99")},
+        manufacturer="Lock Code Manager",
+        name="Mock Title Code slot 99",
+        model="Code Slot",
+    )
+    assert (
+        await async_remove_config_entry_device(
+            hass, lock_code_manager_config_entry, stale
+        )
+        is True
+    )


### PR DESCRIPTION
## Proposed change

Each slot gets its own device (`entity.py`, `identifiers={(DOMAIN, f"{entry_id}|{slot_num}")}`), but removing a slot from config only tore down its entities — `async_update_listener`'s `slots_to_remove` branch never touched the device registry.

Home Assistant does not clean these up either. `device_registry.async_cleanup` reaps a device only when it is referenced by **neither** an entity **nor** a live config entry; a slot device stays attached to the Lock Code Manager entry, so it is permanently exempt. And with no `async_remove_config_entry_device` hook, Home Assistant rendered no Delete button — matching the report's "no way to delete it besides completely removing the config entry."

Three changes:

- **Slot removal now removes the slot's device**, after the entity removers have run, so registry teardown order matches a normal removal (entities first, then their device).
- **Setup sweeps devices whose slot is no longer configured.** Registries already polluted by this bug clean up on the next reload rather than needing manual deletion. It sweeps by identifier rather than diffing against a previous config, so it also catches slots removed while the entry was unloaded.
- **`async_remove_config_entry_device` exposes the Delete button**, and allows it only for slot devices that are not currently configured. Deleting a live slot's device would strand its entities and be undone on the next reload; the entry's own device (bare `entry_id`, no slot suffix) has to outlive the slots that hang off it, so it is refused too.

The device identifier format moves into `build_slot_device_identifier` / `parse_slot_device_identifier` next to the existing `build_slot_unique_id`. The sweep has to parse identifiers back into slot numbers, so the format can no longer live inline at the three call sites that were each rebuilding it by hand.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #1399
- This PR is related to issue:

Three new tests, one per change: removing a slot retires its device while the surviving slot's and the entry's own devices are untouched; a stale slot device is pruned on reload; and the removal hook refuses a configured slot's device and the entry device but permits an unconfigured one. All three were confirmed to fail with the production changes reverted.

Full suite passes (1248 passed). The 43 errors in `tests/providers/zha/test_provider.py` are pre-existing on `main` in my local environment and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)