### PR TITLE
test: bring the integration to 100% line coverage

### DIFF
--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -344,7 +344,9 @@ async def async_setup(hass: HomeAssistant, config: Config) -> bool:
         )
         errors = [err for err in results if isinstance(err, Exception)]
         if errors:
-            errors_str = "\n".join(str(errors))
+            # Join the individual messages, not str(list): the latter iterates
+            # the repr's characters and puts a newline between each one.
+            errors_str = "\n".join(str(err) for err in errors)
             raise HomeAssistantError(
                 "The following errors occurred while processing this service "
                 f"request:\n{errors_str}"

--- a/custom_components/lock_code_manager/entity.py
+++ b/custom_components/lock_code_manager/entity.py
@@ -61,8 +61,6 @@ class BaseLockCodeManagerEntity(Entity):
         self.key = key
         self.ent_reg = ent_reg
 
-        self._uid_cache: dict[str, str] = {}
-
         self._attr_translation_key = key
         self._attr_translation_placeholders = {"slot_num": slot_num}
 
@@ -98,15 +96,6 @@ class BaseLockCodeManagerEntity(Entity):
     def _state(self) -> Any:
         """Return state of entity."""
         return get_entry_config(self.config_entry).slot(self.slot_num).get(self.key)
-
-    @final
-    def _get_uid(self, key: str) -> str:
-        """Get and cache unique id for a given key."""
-        if key not in self._uid_cache:
-            self._uid_cache[key] = build_slot_unique_id(
-                self.base_unique_id, self.slot_num, key
-            )
-        return self._uid_cache[key]
 
     async def _internal_async_remove(self) -> None:
         """

--- a/tests/providers/akuvox/test_provider.py
+++ b/tests/providers/akuvox/test_provider.py
@@ -445,6 +445,46 @@ class TestSetCredential:
         # Friendly portion preserved verbatim; only the format changed.
         assert modify_calls[0]["name"] == "lcm:1:Guest"
 
+    async def test_set_credential_ignores_cloud_user_tagged_for_slot(
+        self, hass: HomeAssistant, akuvox_lock: AkuvoxLock
+    ) -> None:
+        """A cloud user tagged for the target slot is ignored; a new local user is added."""
+        list_response = {
+            LOCK_ENTITY_ID: {
+                "users": [
+                    make_user("300", "lcm:1:Cloud Guest", "1111", source_type="2"),
+                ],
+            },
+        }
+        register_mock_service(
+            hass, AKUVOX_DOMAIN, "list_users", AsyncMock(return_value=list_response)
+        )
+
+        add_calls: list[dict[str, Any]] = []
+
+        async def _capture_add(call):
+            add_calls.append(dict(call.data))
+
+        register_mock_service(
+            hass, AKUVOX_DOMAIN, "add_user", AsyncMock(side_effect=_capture_add)
+        )
+        modify_handler = AsyncMock(return_value=None)
+        register_mock_service(hass, AKUVOX_DOMAIN, "modify_user", modify_handler)
+
+        result = await akuvox_lock.async_set_credential(
+            1,
+            _pin_cred(1, "9999"),
+            "9999",
+            name="New Guest",
+            source="direct",
+        )
+
+        assert result is WriteResult.CONFIRMED
+        # The cloud user is not modified; a brand new local user is added.
+        modify_handler.assert_not_called()
+        assert len(add_calls) == 1
+        assert add_calls[0]["name"] == "lcm:1:New Guest"
+
     async def test_set_credential_service_failure(
         self, hass: HomeAssistant, akuvox_lock: AkuvoxLock
     ) -> None:
@@ -489,6 +529,28 @@ class TestDeleteCredential:
 
         result = await akuvox_lock.async_delete_credential(_cred_ref(1))
         assert result is False
+
+    async def test_delete_credential_ignores_cloud_user_tagged_for_slot(
+        self, hass: HomeAssistant, akuvox_lock: AkuvoxLock
+    ) -> None:
+        """A cloud user tagged for the target slot is ignored, so deletion reports no change."""
+        list_response = {
+            LOCK_ENTITY_ID: {
+                "users": [
+                    make_user("300", "lcm:1:Cloud Guest", "1111", source_type="2"),
+                ],
+            },
+        }
+        register_mock_service(
+            hass, AKUVOX_DOMAIN, "list_users", AsyncMock(return_value=list_response)
+        )
+        delete_handler = AsyncMock(return_value=None)
+        register_mock_service(hass, AKUVOX_DOMAIN, "delete_user", delete_handler)
+
+        result = await akuvox_lock.async_delete_credential(_cred_ref(1))
+
+        assert result is False
+        delete_handler.assert_not_called()
 
     async def test_delete_credential_service_failure(
         self, hass: HomeAssistant, akuvox_lock: AkuvoxLock
@@ -584,6 +646,31 @@ class TestListUsersErrors:
         ):
             await akuvox_lock.async_get_users()
 
+    async def test_list_users_top_level_non_dict_response(
+        self,
+        hass: HomeAssistant,
+        akuvox_lock: AkuvoxLock,
+        lcm_config_entry: MockConfigEntry,
+    ) -> None:
+        """
+        Test that a non-dict top-level response raises LockCodeManagerError.
+
+        Home Assistant's service layer normally guarantees a dict when
+        return_response=True (a non-dict return is rejected before it ever
+        reaches provider code), so the transport seam is patched directly
+        here to exercise the provider's own defensive guard in case that
+        contract is ever violated by a future transport change.
+        """
+        with patch.object(
+            akuvox_lock,
+            "async_call_service",
+            AsyncMock(return_value=["not", "a", "dict"]),
+        ):
+            with pytest.raises(
+                LockCodeManagerError, match="Malformed list_users response from"
+            ):
+                await akuvox_lock._async_list_users()
+
 
 # ---------------------------------------------------------------------------
 # Auto-tagging
@@ -663,6 +750,71 @@ class TestAutoTagging:
         assert len(modify_calls) == 1
         assert modify_calls[0]["id"] == "201"
         assert modify_calls[0]["name"] == "lcm:1:Visitor B"
+
+    async def test_tag_pass_skips_cloud_users_and_reuses_free_slot(
+        self,
+        hass: HomeAssistant,
+        akuvox_lock: AkuvoxLock,
+        lcm_config_entry: MockConfigEntry,
+    ) -> None:
+        """Cloud users are ignored, and an already-tagged local user reserves its slot."""
+        mock_response = {
+            LOCK_ENTITY_ID: {
+                "users": [
+                    make_user("50", "Cloud Visitor", "0000", source_type="2"),
+                    make_user("100", "lcm:1:Guest", "1111"),
+                    make_user("200", "New Local", "3333"),
+                ],
+            },
+        }
+        register_mock_service(
+            hass, AKUVOX_DOMAIN, "list_users", AsyncMock(return_value=mock_response)
+        )
+
+        modify_calls: list[dict[str, Any]] = []
+
+        async def _capture_modify(call):
+            modify_calls.append(dict(call.data))
+
+        register_mock_service(
+            hass, AKUVOX_DOMAIN, "modify_user", AsyncMock(side_effect=_capture_modify)
+        )
+
+        await akuvox_lock._async_tag_unmanaged_users()
+
+        # Only the untagged local user is touched; slot 1 is already reserved
+        # by the tagged local user, and the cloud user is ignored entirely.
+        assert len(modify_calls) == 1
+        assert modify_calls[0]["id"] == "200"
+        assert modify_calls[0]["name"] == "lcm:2:New Local"
+
+    async def test_tag_pass_no_available_slot_leaves_untouched(
+        self,
+        hass: HomeAssistant,
+        akuvox_lock: AkuvoxLock,
+        lcm_config_entry: MockConfigEntry,
+    ) -> None:
+        """Untagged local users are left untouched once all managed slots are assigned."""
+        mock_response = {
+            LOCK_ENTITY_ID: {
+                "users": [
+                    make_user("100", "lcm:1:Guest", "1111"),
+                    make_user("101", "lcm:2:Family", "2222"),
+                    make_user("200", "Visitor", "9999"),
+                ],
+            },
+        }
+        register_mock_service(
+            hass, AKUVOX_DOMAIN, "list_users", AsyncMock(return_value=mock_response)
+        )
+        modify_handler = AsyncMock(return_value=None)
+        register_mock_service(hass, AKUVOX_DOMAIN, "modify_user", modify_handler)
+
+        await akuvox_lock._async_tag_unmanaged_users()
+
+        # Both managed slots are already assigned, so the untagged visitor
+        # cannot be tagged; no modify_user call should be made for them.
+        modify_handler.assert_not_called()
 
     async def test_no_managed_slots_is_noop(
         self,

--- a/tests/providers/matter/test_provider.py
+++ b/tests/providers/matter/test_provider.py
@@ -511,6 +511,73 @@ async def test_require_client_and_node_no_node(
         matter_lock._require_client_and_node()
 
 
+def test_match_node_returns_none_without_matching_device_identifier(
+    matter_lock: MatterLock, matter_client: MagicMock
+) -> None:
+    """_match_node returns None when the device has no Matter deviceid_ identifier.
+
+    ``_resolve`` calls this for every device it looks up; a device whose
+    identifiers don't include a ``deviceid_``-prefixed Matter identifier
+    (e.g. a stale or foreign device) must resolve to "no node" rather than
+    raising, so the caller reports it via the ordinary node-not-found path.
+    """
+    device = MagicMock()
+    device.identifiers = {("not_matter", "some_other_id")}
+
+    assert matter_lock._match_node(matter_client, device) is None
+
+
+async def test_log_node_resolution_failure_handles_get_nodes_exception(
+    hass: HomeAssistant,
+    matter_lock: MatterLock,
+    matter_client: MagicMock,
+) -> None:
+    """The node-count diagnostic degrades to -1 when get_nodes() itself fails.
+
+    ``_require_client_and_node`` resolves once via ``_resolve`` (which
+    succeeds with an empty node list here) and then calls ``get_nodes()``
+    again purely for the failure-diagnostic log. If the client's node list
+    becomes unavailable between those two calls (e.g. a disconnect mid
+    resolution), the diagnostic log must still complete -- with node_count
+    reported as -1 -- rather than letting the logging failure mask the
+    real "node not found" error.
+    """
+    matter_client.get_nodes.side_effect = [[], RuntimeError("nodes unavailable")]
+
+    with pytest.raises(LockDisconnected, match="Matter node not found"):
+        matter_lock._require_client_and_node()
+
+
+async def test_log_node_resolution_failure_falls_back_when_diagnostics_raise(
+    hass: HomeAssistant,
+    matter_lock: MatterLock,
+    matter_client: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Diagnostic logging itself is best-effort and never escapes the caller.
+
+    ``_log_node_resolution_failure`` is purely informational (issue #1268
+    triage data). If collecting that diagnostic data raises for any reason
+    (e.g. the config entries API failing), the fallback debug log fires
+    instead of the exception propagating -- the caller still surfaces the
+    ordinary "node not found" LockDisconnected.
+    """
+    matter_client.get_nodes.return_value = []
+    caplog.set_level(logging.DEBUG, logger=_PROVIDER_MODULE)
+
+    with (
+        patch.object(
+            hass.config_entries,
+            "async_loaded_entries",
+            side_effect=RuntimeError("registry unavailable"),
+        ),
+        pytest.raises(LockDisconnected, match="Matter node not found"),
+    ):
+        matter_lock._require_client_and_node()
+
+    assert "diagnostics unavailable" in caplog.text
+
+
 # =============================================================================
 # Tag resolver helpers (pure functions over the raw user list)
 # =============================================================================

--- a/tests/providers/schlage/test_provider.py
+++ b/tests/providers/schlage/test_provider.py
@@ -355,6 +355,134 @@ async def test_tag_unmanaged_codes_rollback_on_delete_failure(
     assert delete_handler.call_count == 2
 
 
+async def test_tag_unmanaged_codes_skips_already_assigned_slot(
+    hass: HomeAssistant,
+    schlage_lock: SchlageLock,
+    simple_lcm_config_entry: MockConfigEntry,
+) -> None:
+    """An already-tagged code reserves its slot so a new untagged code gets the next one."""
+    get_response = {
+        LOCK_ENTITY_ID: {
+            "code0": {"name": "lcm:1:Existing", "code": "****"},
+            "code1": {"name": "Guest", "code": "1234"},
+        },
+    }
+    register_mock_service(
+        hass, SCHLAGE_DOMAIN, "get_codes", AsyncMock(return_value=get_response)
+    )
+    add_handler = AsyncMock(return_value=None)
+    register_mock_service(hass, SCHLAGE_DOMAIN, "add_code", add_handler)
+    register_mock_service(
+        hass, SCHLAGE_DOMAIN, "delete_code", AsyncMock(return_value=None)
+    )
+
+    await schlage_lock._async_tag_unmanaged_codes()
+
+    # Slot 1 is already reserved by the tagged code, so the untagged Guest
+    # code must be tagged into slot 2 instead.
+    assert add_handler.call_count == 1
+    add_call = add_handler.call_args[0][0]
+    assert add_call.data["name"] == "lcm:2:Guest"
+
+
+async def test_tag_unmanaged_codes_skips_empty_name(
+    hass: HomeAssistant,
+    schlage_lock: SchlageLock,
+    simple_lcm_config_entry: MockConfigEntry,
+) -> None:
+    """Untagged codes with an empty or whitespace-only name cannot be tagged and are skipped."""
+    get_response = {
+        LOCK_ENTITY_ID: {
+            "code1": {"name": "   ", "code": "1234"},
+        },
+    }
+    register_mock_service(
+        hass, SCHLAGE_DOMAIN, "get_codes", AsyncMock(return_value=get_response)
+    )
+    add_handler = AsyncMock(return_value=None)
+    register_mock_service(hass, SCHLAGE_DOMAIN, "add_code", add_handler)
+
+    await schlage_lock._async_tag_unmanaged_codes()
+
+    assert add_handler.call_count == 0
+
+
+async def test_tag_unmanaged_codes_no_slot_for_extra_code(
+    hass: HomeAssistant,
+    schlage_lock: SchlageLock,
+    simple_lcm_config_entry: MockConfigEntry,
+) -> None:
+    """Once the two managed slots are exhausted, a third untagged code is left untouched."""
+    get_response = {
+        LOCK_ENTITY_ID: {
+            "code1": {"name": "Guest A", "code": "1111"},
+            "code2": {"name": "Guest B", "code": "2222"},
+            "code3": {"name": "Guest C", "code": "3333"},
+        },
+    }
+    register_mock_service(
+        hass, SCHLAGE_DOMAIN, "get_codes", AsyncMock(return_value=get_response)
+    )
+
+    add_calls: list[str] = []
+
+    async def _capture_add(call):
+        add_calls.append(call.data["name"])
+
+    register_mock_service(
+        hass, SCHLAGE_DOMAIN, "add_code", AsyncMock(side_effect=_capture_add)
+    )
+    register_mock_service(
+        hass, SCHLAGE_DOMAIN, "delete_code", AsyncMock(return_value=None)
+    )
+
+    await schlage_lock._async_tag_unmanaged_codes()
+
+    # Only 2 managed slots exist (simple_lcm_config_entry), so exactly the
+    # first two codes get tagged and the third is left untouched.
+    assert len(add_calls) == 2
+    assert "lcm:1:Guest A" in add_calls
+    assert "lcm:2:Guest B" in add_calls
+
+
+async def test_tag_unmanaged_codes_rollback_disconnect_sets_first_disconnect(
+    hass: HomeAssistant,
+    schlage_lock: SchlageLock,
+    simple_lcm_config_entry: MockConfigEntry,
+) -> None:
+    """
+    A LockDisconnected during rollback still surfaces after a non-disconnect delete failure.
+
+    The original-delete failure is a plain LockOperationFailed (which does
+    not set first_disconnect), so the subsequent rollback failure is the
+    first LockDisconnected seen and must be the one that gets raised.
+    """
+    get_response = {
+        LOCK_ENTITY_ID: {
+            "code1": {"name": "Guest", "code": "1234"},
+        },
+    }
+    register_mock_service(
+        hass, SCHLAGE_DOMAIN, "get_codes", AsyncMock(return_value=get_response)
+    )
+    register_mock_service(
+        hass, SCHLAGE_DOMAIN, "add_code", AsyncMock(return_value=None)
+    )
+
+    with patch.object(
+        schlage_lock,
+        "_async_delete_code",
+        AsyncMock(
+            side_effect=[
+                LockOperationFailed("delete failed"),
+                LockDisconnected("rollback failed"),
+            ]
+        ),
+    ):
+        with pytest.raises(LockDisconnected, match="disconnect during tag pass"):
+            await schlage_lock._async_tag_unmanaged_codes()
+
+
 async def test_tag_unmanaged_codes_no_managed_slots(
     hass: HomeAssistant,
     schlage_lock: SchlageLock,
@@ -845,6 +973,27 @@ async def test_get_codes_malformed_entity_response(
 
     with pytest.raises(LockCodeManagerError, match="malformed entity response"):
         await schlage_lock.async_get_users()
+
+
+async def test_get_codes_top_level_non_dict_response(
+    hass: HomeAssistant,
+    schlage_lock: SchlageLock,
+    simple_lcm_config_entry: MockConfigEntry,
+) -> None:
+    """
+    Test that a non-dict top-level response raises LockCodeManagerError.
+
+    Home Assistant's service layer normally guarantees a dict when
+    return_response=True (a non-dict return is rejected before it ever
+    reaches provider code), so the transport seam is patched directly here
+    to exercise the provider's own defensive guard in case that contract is
+    ever violated by a future transport change.
+    """
+    with patch.object(
+        schlage_lock, "async_call_service", AsyncMock(return_value="not a dict")
+    ):
+        with pytest.raises(LockCodeManagerError, match="malformed response"):
+            await schlage_lock._async_get_codes()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/providers/test_base.py
+++ b/tests/providers/test_base.py
@@ -11,7 +11,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant, State, callback
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
 from homeassistant.helpers import (
     device_registry as dr,
     entity_registry as er,
@@ -23,6 +23,9 @@ from custom_components.lock_code_manager.const import (
     ATTR_NOTIFICATION_SOURCE,
     DOMAIN,
     EVENT_LOCK_STATE_CHANGED,
+)
+from custom_components.lock_code_manager.domain.coordinator import (
+    LockUsercodeUpdateCoordinator,
 )
 from custom_components.lock_code_manager.domain.credentials import (
     CredentialType,
@@ -151,6 +154,89 @@ async def test_unsubscribe_push_updates_suppresses_not_implemented(
 
     # The public wrapper must not propagate it
     lock.unsubscribe_push_updates()  # must not raise
+
+
+class _PushSetupRaisesLock(MockLCMLock):
+    """Mock lock whose setup_push_subscription raises a configurable error."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        """Initialize mock lock."""
+        super().__init__(*args, **kwargs)
+        self.push_setup_error: Exception | None = None
+
+    @property
+    def supports_push(self) -> bool:
+        """Return whether this lock supports push-based updates."""
+        return True
+
+    def setup_push_subscription(self) -> None:
+        """Subscribe to push-based value updates, raising if configured to."""
+        if self.push_setup_error is not None:
+            raise self.push_setup_error
+
+
+async def test_subscribe_push_updates_reraises_provider_not_implemented(
+    hass: HomeAssistant,
+) -> None:
+    """subscribe_push_updates re-raises ProviderNotImplementedError, not swallowing it.
+
+    Every other setup_push_subscription failure is logged and absorbed (the
+    reconnect paths retry later), but ProviderNotImplementedError signals a
+    programming error -- a provider claiming supports_push without
+    overriding setup_push_subscription -- and must surface loudly instead
+    of silently disabling push updates.
+    """
+    entity_reg = er.async_get(hass)
+    config_entry = MockConfigEntry(domain=DOMAIN)
+    config_entry.add_to_hass(hass)
+    lock_entity = entity_reg.async_get_or_create(
+        "lock",
+        "test",
+        "test_lock_push_not_implemented",
+        config_entry=config_entry,
+    )
+    lock = _PushSetupRaisesLock(
+        hass, dr.async_get(hass), entity_reg, config_entry, lock_entity
+    )
+    lock.push_setup_error = ProviderNotImplementedError(lock, "setup_push_subscription")
+
+    with pytest.raises(ProviderNotImplementedError):
+        lock.subscribe_push_updates()
+
+
+async def test_subscribe_push_updates_logs_warning_on_unexpected_error(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """subscribe_push_updates logs and swallows an unexpected setup exception.
+
+    Unlike LockDisconnected (expected, debug-logged, retried automatically)
+    or ProviderNotImplementedError (re-raised), an unanticipated exception
+    from setup_push_subscription must not crash the caller -- it is logged
+    at warning level and the existing reconnect paths retry later.
+    """
+    entity_reg = er.async_get(hass)
+    config_entry = MockConfigEntry(domain=DOMAIN)
+    config_entry.add_to_hass(hass)
+    lock_entity = entity_reg.async_get_or_create(
+        "lock",
+        "test",
+        "test_lock_push_unexpected_error",
+        config_entry=config_entry,
+    )
+    lock = _PushSetupRaisesLock(
+        hass, dr.async_get(hass), entity_reg, config_entry, lock_entity
+    )
+    lock.push_setup_error = RuntimeError("unexpected driver failure")
+
+    with caplog.at_level(logging.WARNING):
+        lock.subscribe_push_updates()  # must not raise
+
+    assert any(
+        record.levelname == "WARNING"
+        and "push subscription failed unexpectedly" in record.message
+        for record in caplog.records
+    )
 
 
 async def test_config_entry_state_change_resubscribes(
@@ -588,6 +674,32 @@ async def test_lock_equality_with_non_baselock(hass: HomeAssistant):
     assert lock != {"entity_id": lock_entity.entity_id}
 
 
+async def test_lock_equality_with_same_entity_id(hass: HomeAssistant):
+    """Two BaseLock instances wrapping the same lock entity are equal.
+
+    __hash__ is defined by entity ID alone, so __eq__ must agree: any two
+    BaseLock objects (even different provider classes or instances) that
+    wrap the same lock.entity_id are the same logical lock.
+    """
+    entity_reg = er.async_get(hass)
+    config_entry = MockConfigEntry(domain=DOMAIN)
+    config_entry.add_to_hass(hass)
+
+    lock_entity = entity_reg.async_get_or_create(
+        "lock",
+        "test",
+        "test_lock_eq_same",
+        config_entry=config_entry,
+    )
+
+    lock_a = BaseLock(hass, dr.async_get(hass), entity_reg, config_entry, lock_entity)
+    lock_b = BaseLock(hass, dr.async_get(hass), entity_reg, config_entry, lock_entity)
+
+    assert lock_a is not lock_b
+    assert lock_a == lock_b
+    assert lock_a == lock_a  # noqa: PLR0124 - Intentionally testing reflexive __eq__
+
+
 async def test_fire_code_slot_event_with_state_source(
     hass: HomeAssistant,
     mock_lock_config_entry,
@@ -669,6 +781,85 @@ async def test_fire_code_slot_event_with_dict_source(
     )  # dict doesn't set source type
     extra_data = events[0].data[ATTR_EXTRA_DATA]
     assert extra_data == custom_data
+
+
+async def test_fire_code_slot_event_with_state_source_distinct_timestamps(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """A State whose last_updated differs from last_changed serializes both distinctly.
+
+    The common case (no attribute update since the state changed) collapses
+    last_updated to the same ISO string as last_changed. When a state has
+    been updated (e.g. an attribute-only refresh) without a state change,
+    the two timestamps diverge and must each serialize to their own value.
+    """
+    lock_provider = lock_code_manager_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
+
+    events = []
+
+    @callback
+    def capture_events(event):
+        events.append(event)
+
+    hass.bus.async_listen(EVENT_LOCK_STATE_CHANGED, capture_events)
+
+    changed = datetime.now() - timedelta(minutes=5)
+    updated = datetime.now()
+    state = State(
+        entity_id="lock.test_lock",
+        state="locked",
+        last_changed=changed,
+        last_updated=updated,
+    )
+
+    lock_provider.async_fire_code_slot_event(
+        code_slot=1,
+        to_locked=True,
+        action_text="Keypad lock",
+        source_data=state,
+    )
+    await hass.async_block_till_done()
+
+    assert len(events) == 1
+    extra_data = events[0].data[ATTR_EXTRA_DATA]
+    assert extra_data["last_changed"] == changed.isoformat()
+    assert extra_data["last_updated"] == updated.isoformat()
+    assert extra_data["last_changed"] != extra_data["last_updated"]
+
+
+async def test_fire_code_slot_event_with_no_source_data(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """An event fired without source_data serializes to no source / no extra data.
+
+    Not every caller has an Event, State, or dict to attach (e.g. a purely
+    synthetic notification); source_data defaults to None and must resolve
+    to (None, None) rather than raising or mislabeling the source type.
+    """
+    lock_provider = lock_code_manager_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
+
+    events = []
+
+    @callback
+    def capture_events(event):
+        events.append(event)
+
+    hass.bus.async_listen(EVENT_LOCK_STATE_CHANGED, capture_events)
+
+    lock_provider.async_fire_code_slot_event(
+        code_slot=1,
+        to_locked=True,
+        action_text="Keypad lock",
+    )
+    await hass.async_block_till_done()
+
+    assert len(events) == 1
+    assert events[0].data[ATTR_NOTIFICATION_SOURCE] is None
+    assert events[0].data[ATTR_EXTRA_DATA] is None
 
 
 async def test_setup_defers_push_subscription_when_entry_not_loaded(
@@ -785,6 +976,54 @@ async def test_async_setup_internal_creates_coordinator_when_setup_fails(
     assert lock._setup_succeeded is True
 
 
+async def test_async_setup_internal_setup_in_progress_first_refresh_not_ready(
+    hass: HomeAssistant,
+):
+    """A first-refresh failure during initial setup is absorbed, not propagated.
+
+    When async_setup_internal runs while its own LCM config entry is still
+    SETUP_IN_PROGRESS (the normal case: initial integration load), the new
+    coordinator's first refresh uses
+    async_config_entry_first_refresh(), which raises ConfigEntryNotReady /
+    UpdateFailed instead of returning when the initial fetch fails. That
+    failure is expected during a cold start and must not escape
+    async_setup_internal -- the coordinator is still created and the lock
+    stays degraded until the next successful refresh.
+    """
+    entity_reg = er.async_get(hass)
+    dev_reg = dr.async_get(hass)
+
+    # state=SETUP_IN_PROGRESS mirrors what HA sets on the LCM config entry
+    # while running its own async_setup_entry -- the actual state
+    # async_setup_internal observes on initial (non-hot-added) lock setup.
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, state=ConfigEntryState.SETUP_IN_PROGRESS
+    )
+    config_entry.add_to_hass(hass)
+
+    lock_entity = entity_reg.async_get_or_create(
+        "lock",
+        "test",
+        "test_lock_setup_in_progress_not_ready",
+        config_entry=config_entry,
+    )
+
+    lock = BaseLock(hass, dev_reg, entity_reg, config_entry, lock_entity)
+
+    with patch.object(
+        LockUsercodeUpdateCoordinator,
+        "async_config_entry_first_refresh",
+        side_effect=ConfigEntryNotReady("lock still asleep"),
+    ):
+        # Should not raise even though the first refresh wasn't ready.
+        await lock.async_setup_internal(config_entry)
+
+    assert lock.coordinator is not None
+    assert lock._setup_complete.is_set()
+
+    await lock.async_unload(False)
+
+
 async def test_on_integration_loaded_skips_when_no_config_entry(
     hass: HomeAssistant,
 ):
@@ -807,10 +1046,17 @@ async def test_on_integration_loaded_skips_when_no_config_entry(
     assert lock._setup_succeeded is False
 
 
-async def test_on_integration_loaded_retries_on_disconnect(
+async def test_on_integration_loaded_skips_when_entry_not_loaded(
     hass: HomeAssistant,
 ):
-    """Test that _async_on_integration_loaded retries setup on LockDisconnected."""
+    """
+    A not-yet-loaded provider entry short circuits before setup is attempted.
+
+    The handler fires on any config entry state change, so it has to ignore
+    the transitions that are not "the integration finished loading" -- probing
+    a half-loaded integration would fail on the capability read and churn the
+    degraded-lock machinery for nothing.
+    """
     entity_reg = er.async_get(hass)
     dev_reg = dr.async_get(hass)
 
@@ -823,14 +1069,54 @@ async def test_on_integration_loaded_retries_on_disconnect(
 
     lock = BaseLock(hass, dev_reg, entity_reg, config_entry, lock_entity)
     lock._lcm_config_entry = config_entry
+    assert lock.lock_config_entry.state is not ConfigEntryState.LOADED
 
-    # async_setup raises LockDisconnected — should not propagate
+    with patch.object(lock, "async_setup") as setup:
+        await lock._async_on_integration_loaded()
+
+    # The point of the guard: no provider I/O was attempted at all.
+    setup.assert_not_called()
+    assert lock._setup_succeeded is False
+
+
+async def test_on_integration_loaded_logs_debug_on_transient_reconnect_failure(
+    hass: HomeAssistant,
+) -> None:
+    """A transient LockDisconnected/LockOperationFailed during reconnect setup is quiet.
+
+    Unlike a structural LockCodeManagerProviderError (which reports a repair
+    issue), a transport failure while re-running provider setup on the
+    LOADED transition is expected and logged at debug only -- the next
+    reconnect event tries again automatically. This requires the config
+    entry to actually be in the LOADED state; a not-yet-loaded entry short
+    circuits before the retry logic runs at all.
+    """
+    entity_reg = er.async_get(hass)
+    dev_reg = dr.async_get(hass)
+
+    config_entry = MockConfigEntry(domain=DOMAIN)
+    config_entry.add_to_hass(hass)
+
+    lock_entity = entity_reg.async_get_or_create(
+        "lock", "test", "test_lock_retry_transient", config_entry=config_entry
+    )
+
+    lock = BaseLock(hass, dev_reg, entity_reg, config_entry, lock_entity)
+    lock._lcm_config_entry = config_entry
+
+    loaded_entry = MagicMock()
+    loaded_entry.state = ConfigEntryState.LOADED
+    lock.lock_config_entry = loaded_entry
+
     with patch.object(
-        lock, "async_setup", side_effect=LockDisconnected("still offline")
+        lock, "async_setup", side_effect=LockOperationFailed("transient failure")
     ):
         await lock._async_on_integration_loaded()
 
+    # The transient failure is absorbed: setup did not succeed, but it also
+    # did not escalate to a repair issue or leave _setup_running stuck.
     assert lock._setup_succeeded is False
+    assert lock._setup_running is False
 
 
 class MockNativeUserLock(MockLCMLock):
@@ -1370,6 +1656,34 @@ async def test_check_duplicate_code_no_coordinator(
     lock._check_duplicate_code(1, "1234")
 
 
+async def test_mark_code_rejected_causes_next_set_to_raise_duplicate_then_clears(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """A firmware-rejected slot raises DuplicateCodeError on the next set, then clears.
+
+    mark_code_rejected() records that the lock's own firmware rejected the
+    PIN already written to a slot (e.g. an asynchronous duplicate-code NAK
+    the driver only reports after the write call returned success).
+    async_internal_set_usercode surfaces that as a DuplicateCodeError on the
+    very next set attempt for that slot -- but the flag is single-shot: it
+    is cleared up front, so a retry after the raise proceeds normally
+    instead of wedging the slot as permanently invalid.
+    """
+    lock_provider = lock_code_manager_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
+
+    lock_provider.mark_code_rejected(1)
+    assert 1 in lock_provider._rejected_code_slots
+
+    with pytest.raises(DuplicateCodeError):
+        await lock_provider.async_internal_set_usercode(1, "1111", "Test 1")
+
+    # Single-shot: the flag was cleared by the failed attempt above.
+    assert 1 not in lock_provider._rejected_code_slots
+    await lock_provider.async_internal_set_usercode(1, "1111", "Test 1")
+
+
 async def test_async_unload_cancels_in_flight_reconnect_task(
     hass: HomeAssistant,
     mock_lock_config_entry,
@@ -1394,6 +1708,44 @@ async def test_async_unload_cancels_in_flight_reconnect_task(
     await lock.async_unload(False)
 
     assert lock._reconnect_task is None
+
+
+async def test_async_unload_reraises_cancelled_when_caller_itself_is_cancelled(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """async_unload propagates CancelledError when its own caller is cancelled.
+
+    async_unload cancels its in-flight reconnect task and awaits it, which
+    always raises CancelledError for that reason alone -- that case is
+    expected and absorbed. But if the *caller's own task* is what's being
+    cancelled (e.g. Home Assistant shutting down while a lock is mid
+    unload), the CancelledError must propagate rather than being silently
+    swallowed, or the outer cancellation would never take effect.
+    """
+    lock = lock_code_manager_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
+
+    started = asyncio.Event()
+
+    async def slow_reconnect() -> None:
+        started.set()
+        await asyncio.sleep(60)
+
+    lock._reconnect_task = hass.async_create_task(slow_reconnect())
+    await started.wait()
+
+    unload_task = hass.async_create_task(lock.async_unload(False))
+    # Let unload_task run up to its first await point: it synchronously
+    # cancels the reconnect task, then suspends on `await reconnect_task`.
+    # Cancelling unload_task itself right there means the CancelledError it
+    # receives is attributable to its own cancellation, not just the
+    # reconnect task's.
+    await asyncio.sleep(0)
+    unload_task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await unload_task
 
 
 async def test_handle_state_change_supersedes_prior_reconnect_task(

--- a/tests/providers/test_seam.py
+++ b/tests/providers/test_seam.py
@@ -183,6 +183,8 @@ async def test_primitive_defaults_raise(hass: HomeAssistant) -> None:
         await lock.async_delete_credential(CredentialRef(1, CredentialType.PIN, 1))
     with pytest.raises(ProviderNotImplementedError):
         await lock.async_get_users()
+    with pytest.raises(ProviderNotImplementedError):
+        await lock.async_get_capabilities()
 
 
 async def test_setup_internal_rejects_lock_without_pin_support(

--- a/tests/providers/virtual/test_provider.py
+++ b/tests/providers/virtual/test_provider.py
@@ -2,6 +2,10 @@
 
 import pytest
 
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.storage import Store
+
+from custom_components.lock_code_manager.const import DOMAIN
 from custom_components.lock_code_manager.domain.credentials import (
     Credential,
     CredentialRef,
@@ -105,6 +109,42 @@ async def test_delete_credential_returns_changed_status(virtual_lock: VirtualLoc
     # Clearing again should return False (already cleared)
     changed = await lock.async_delete_credential(_make_ref(1))
     assert changed is False
+
+
+async def test_async_unload_remove_permanently_removes_store(
+    hass: HomeAssistant,
+    virtual_lock_with_slots: VirtualLock,
+):
+    """
+    remove_permanently=True deletes the persisted store instead of saving current state.
+
+    A brand-new Store instance is used to verify the on-disk state rather
+    than reusing ``lock._store``: the HA test harness's in-memory storage
+    mock caches the loaded/saved payload on the Store instance itself once
+    it has been read, so re-reading through the same instance would not
+    reliably reflect a subsequent removal.
+    """
+    lock = virtual_lock_with_slots
+    await lock.async_set_credential(
+        1,
+        credential_from_slot(1, SlotCredential.known("1234")),
+        "1234",
+        name="test",
+        source="direct",
+    )
+
+    def _fresh_store() -> Store:
+        return Store(hass, 1, f"{lock.domain}_{DOMAIN}_{lock.lock.entity_id}")
+
+    # Persist to disk first (remove_permanently=False path) so there is
+    # something on disk to remove.
+    await lock.async_unload(remove_permanently=False)
+    assert await _fresh_store().async_load() == {"1": {"code": "1234", "name": "test"}}
+
+    await lock.async_unload(remove_permanently=True)
+
+    # The store file itself is gone rather than re-saved.
+    assert await _fresh_store().async_load() is None
 
 
 async def test_virtual_lock_does_not_support_code_slot_events(

--- a/tests/providers/zha/test_provider.py
+++ b/tests/providers/zha/test_provider.py
@@ -403,6 +403,63 @@ async def test_get_gateway_handles_exceptions(
         assert zha_lock._get_gateway() is None
 
 
+async def test_get_gateway_handles_value_error(
+    hass: HomeAssistant, zha_lock: ZHALock
+) -> None:
+    """Test _get_gateway logs a warning and returns None on an unexpected ValueError."""
+    with patch(
+        "custom_components.lock_code_manager.providers.zha._get_zha_gateway_proxy",
+        side_effect=ValueError("unexpected"),
+    ):
+        assert zha_lock._get_gateway() is None
+
+
+async def test_get_door_lock_cluster_no_device_proxy(
+    hass: HomeAssistant, zha_lock: ZHALock
+) -> None:
+    """Test cluster lookup returns None when device proxy is missing."""
+    zha_lock._door_lock_cluster = None
+    entity_ref = MagicMock()
+    entity_ref.entity_data.device_proxy = None
+    gateway = MagicMock()
+    gateway.get_entity_reference.return_value = entity_ref
+    with patch.object(zha_lock, "_get_gateway", return_value=gateway):
+        assert zha_lock._get_door_lock_cluster() is None
+
+
+async def test_get_door_lock_cluster_no_zigpy_device(
+    hass: HomeAssistant, zha_lock: ZHALock
+) -> None:
+    """Test cluster lookup returns None when the underlying zigpy device is missing."""
+    zha_lock._door_lock_cluster = None
+    entity_ref = MagicMock()
+    entity_ref.entity_data.device_proxy.device.device = None
+    gateway = MagicMock()
+    gateway.get_entity_reference.return_value = entity_ref
+    with patch.object(zha_lock, "_get_gateway", return_value=gateway):
+        assert zha_lock._get_door_lock_cluster() is None
+
+
+async def test_get_door_lock_cluster_no_matching_endpoint_cluster(
+    hass: HomeAssistant, zha_lock: ZHALock
+) -> None:
+    """Test cluster lookup returns None and warns when no endpoint exposes DoorLock."""
+    zha_lock._door_lock_cluster = None
+    fake_endpoint = MagicMock()
+    fake_endpoint.in_clusters = {}
+    entity_ref = MagicMock()
+    entity_ref.entity_data.device_proxy.device.device.endpoints = {
+        0: MagicMock(),
+        1: fake_endpoint,
+    }
+    gateway = MagicMock()
+    gateway.get_entity_reference.return_value = entity_ref
+    with patch.object(zha_lock, "_get_gateway", return_value=gateway):
+        assert zha_lock._get_door_lock_cluster() is None
+        # Not cached since no cluster was found.
+        assert zha_lock._door_lock_cluster is None
+
+
 # ---------------------------------------------------------------------------
 # Parse PIN response edge cases
 # ---------------------------------------------------------------------------
@@ -695,3 +752,63 @@ async def test_delete_credential_generic_exception(
     ref = CredentialRef(user_id=1, type=CredentialType.PIN, slot=1)
     with pytest.raises(LockDisconnected, match="Failed to clear PIN"):
         await zha_lock.async_delete_credential(ref)
+
+
+async def test_get_users_propagates_lock_disconnected(
+    hass: HomeAssistant,
+    zha_lock: ZHALock,
+    simple_lcm_config_entry: MockConfigEntry,
+) -> None:
+    """Test async_get_users re-raises LockDisconnected instead of marking unreadable.
+
+    Unlike a bare zigpy comms error (which degrades the slot to unreadable),
+    a LockDisconnected raised mid-loop means the connection gate itself
+    tripped, so it must propagate for reconnect handling rather than being
+    swallowed per-slot.
+    """
+    cluster = zha_lock._get_door_lock_cluster()
+    assert cluster is not None
+    cluster.get_pin_code = AsyncMock(side_effect=LockDisconnected("gone"))
+
+    with pytest.raises(LockDisconnected, match="gone"):
+        await zha_lock.async_get_users()
+
+
+async def test_hard_refresh_codes(
+    hass: HomeAssistant,
+    zha_lock: ZHALock,
+    simple_lcm_config_entry: MockConfigEntry,
+) -> None:
+    """Test async_hard_refresh_codes re-reads all managed slots from the lock."""
+    cluster = zha_lock._get_door_lock_cluster()
+    assert cluster is not None
+
+    async def mock_get_pin_code(slot_num):
+        return type(
+            "Response",
+            (),
+            {"user_status": DoorLock.UserStatus.Enabled, "code": "1111"},
+        )()
+
+    cluster.get_pin_code = AsyncMock(side_effect=mock_get_pin_code)
+
+    codes = await zha_lock.async_hard_refresh_codes()
+    assert codes[1] == SlotCredential.known("1111")
+    assert codes[2] == SlotCredential.known("1111")
+
+
+async def test_programming_event_unparseable_with_coordinator_triggers_refresh(
+    hass: HomeAssistant, zha_lock: ZHALock
+) -> None:
+    """Test unparseable programming event still refreshes as a safety net.
+
+    When the args can't be parsed we don't know which slot changed, but we
+    know *something* did — so a coordinator refresh must fire if attached.
+    """
+    zha_lock.coordinator = MagicMock()
+    zha_lock.coordinator.async_request_refresh = AsyncMock()
+
+    zha_lock._handle_programming_event(None)
+    await hass.async_block_till_done()
+
+    zha_lock.coordinator.async_request_refresh.assert_called_once()

--- a/tests/providers/zigbee2mqtt/test_payload.py
+++ b/tests/providers/zigbee2mqtt/test_payload.py
@@ -361,6 +361,47 @@ def test_users_payload_before_coordinator_does_not_poison_delta_gate() -> None:
     )
 
 
+def test_users_non_dict_user_info_skipped() -> None:
+    """A users entry whose value is not a dict (malformed payload) is skipped.
+
+    The valid entry alongside it still updates normally, proving the
+    malformed entry didn't abort the whole payload.
+    """
+    lock = _minimal_lock()
+    lock.coordinator = MagicMock()
+    lock._process_z2m_device_payload(
+        {
+            "users": {
+                "2": "not_a_dict",
+                "3": {"status": "enabled", "pin_code": "1234"},
+            }
+        }
+    )
+    lock.coordinator.push_update.assert_called_once_with(
+        {3: SlotCredential.known("1234")}
+    )
+
+
+def test_pin_code_payload_without_user_field_ignored() -> None:
+    """A pin_code payload missing the user field is ignored without touching futures."""
+    lock = _minimal_lock()
+    fut = MagicMock(spec=["cancel", "done", "set_result"])
+    fut.done.return_value = False
+    lock._pending_codes[1] = fut  # type: ignore[assignment]
+    lock._process_z2m_device_payload(
+        {"pin_code": {"user_enabled": True, "pin_code": "1234"}}
+    )
+    fut.set_result.assert_not_called()
+    assert 1 in lock._pending_codes
+
+
+def test_maybe_raise_wrong_bridge_disconnect_no_device_entry_returns() -> None:
+    """Without a device entry there is nothing to compare, so this is a no-op."""
+    lock = _minimal_lock()
+    assert lock.device_entry is None
+    lock._maybe_raise_wrong_bridge_disconnect()
+
+
 def test_pin_code_boolean_user_does_not_resolve_slot_one() -> None:
     """A malformed boolean ``user`` must not address slot 1 (int(True) == 1)."""
     lock = _minimal_lock()

--- a/tests/providers/zigbee2mqtt/test_provider.py
+++ b/tests/providers/zigbee2mqtt/test_provider.py
@@ -206,6 +206,83 @@ class TestPushSubscription:
         assert not lock._push_unsubs
         assert fut.cancelled()
 
+    async def test_ensure_device_subscription_idempotent(
+        self,
+        hass: HomeAssistant,
+        zigbee2mqtt_lock_with_device: Zigbee2MQTTLock,
+    ) -> None:
+        """A second call is a no-op once a subscription is already active."""
+        lock = zigbee2mqtt_lock_with_device
+        lock._push_unsubs.append(lambda: None)
+        with patch(
+            "custom_components.lock_code_manager.providers.zigbee2mqtt.async_subscribe",
+            new_callable=AsyncMock,
+        ) as mock_subscribe:
+            await lock._async_ensure_device_subscription()
+
+        mock_subscribe.assert_not_called()
+
+    async def test_ensure_device_subscription_raises_when_mqtt_disabled(
+        self,
+        hass: HomeAssistant,
+        zigbee2mqtt_lock_with_device: Zigbee2MQTTLock,
+    ) -> None:
+        """Subscribing while MQTT is disabled raises LockDisconnected."""
+        lock = zigbee2mqtt_lock_with_device
+        with (
+            patch(
+                "custom_components.lock_code_manager.providers.zigbee2mqtt.mqtt_config_entry_enabled",
+                return_value=False,
+            ),
+            pytest.raises(LockDisconnected, match="MQTT component not available"),
+        ):
+            await lock._async_ensure_device_subscription()
+
+    async def test_ensure_device_subscription_raises_when_no_topic(
+        self,
+        hass: HomeAssistant,
+        zigbee2mqtt_lock_wrong_identifier: Zigbee2MQTTLock,
+    ) -> None:
+        """Subscribing without a resolvable Zigbee2MQTT topic raises LockDisconnected."""
+        lock = zigbee2mqtt_lock_wrong_identifier
+        with (
+            patch(
+                "custom_components.lock_code_manager.providers.zigbee2mqtt.mqtt_config_entry_enabled",
+                return_value=True,
+            ),
+            pytest.raises(LockDisconnected, match="Cannot subscribe for"),
+        ):
+            await lock._async_ensure_device_subscription()
+
+    async def test_setup_push_subscribe_home_assistant_error_wrapped_and_deferred(
+        self,
+        hass: HomeAssistant,
+        zigbee2mqtt_lock_with_device: Zigbee2MQTTLock,
+    ) -> None:
+        """A HomeAssistantError from async_subscribe is wrapped as LockDisconnected.
+
+        This happens inside the background reconnect task scheduled by
+        ``setup_push_subscription``, which must catch the resulting
+        LockDisconnected and defer rather than raise (it runs sync and
+        cannot propagate an exception to a caller).
+        """
+        lock = zigbee2mqtt_lock_with_device
+        lock.coordinator = MagicMock()
+        with (
+            patch(
+                "custom_components.lock_code_manager.providers.zigbee2mqtt.mqtt_config_entry_enabled",
+                return_value=True,
+            ),
+            patch(
+                "custom_components.lock_code_manager.providers.zigbee2mqtt.async_subscribe",
+                new=AsyncMock(side_effect=HomeAssistantError("denied")),
+            ),
+        ):
+            lock.setup_push_subscription()
+            await hass.async_block_till_done()
+
+        assert not lock._push_unsubs
+
 
 class TestAsyncGetUsers:
     """Request/response path for async_get_users via MQTT get + pin_code futures."""

--- a/tests/providers/zwave_js/test_events.py
+++ b/tests/providers/zwave_js/test_events.py
@@ -731,6 +731,43 @@ async def test_uc_shim_zeros_on_available_slot_pushes_empty(
     zwave_js_lock.unsubscribe_push_updates()
 
 
+async def test_uc_shim_zeros_on_unknown_slot_pushes_known(
+    hass: HomeAssistant,
+    zwave_js_lock: ZWaveJSLock,
+    lock_schlage_be469: Node,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
+) -> None:
+    """All-zeros on a slot with no cached userIdStatus value pushes known, not empty.
+
+    ``_uc_slot_in_use`` reads the User Code CC status value from the
+    driver's cache via ``get_usercode``; a slot the value database has
+    never seen (e.g. one outside the fixture's populated range) raises
+    ``NotFoundError`` there, which resolves to an *unknown* (None) in-use
+    state -- distinct from the explicitly-False case that maps zeros to
+    empty. Zeros must not be misread as "cleared" when in_use can't be
+    determined at all.
+    """
+    mock_coordinator = MagicMock()
+    mock_coordinator.data = {}
+    zwave_js_lock.coordinator = mock_coordinator
+
+    zwave_js_lock.subscribe_push_updates()
+
+    # Slot 99 has no userCode/userIdStatus values in the fixture at all, so
+    # get_usercode() raises NotFoundError and in_use resolves to None.
+    lock_schlage_be469.receive_event(
+        _make_uc_value_event(lock_schlage_be469.node_id, "userCode", 99, "0000")
+    )
+    await hass.async_block_till_done()
+
+    mock_coordinator.push_update.assert_called_once_with(
+        {99: SlotCredential.known("0000")}
+    )
+
+    zwave_js_lock.unsubscribe_push_updates()
+
+
 async def test_uc_shim_empty_code_pushes_empty(
     hass: HomeAssistant,
     zwave_js_lock: ZWaveJSLock,

--- a/tests/providers/zwave_js/test_provider.py
+++ b/tests/providers/zwave_js/test_provider.py
@@ -828,6 +828,30 @@ async def test_async_get_capabilities_zero_slots_recovery_query_failure_still_ra
     assert mock_lock_helpers["async_get_credential_capabilities"].await_count == 1
 
 
+async def test_recover_user_code_slot_count_returns_false_without_root_endpoint(
+    zwave_js_lock: ZWaveJSLock,
+    mock_access_control: MagicMock,
+) -> None:
+    """The recovery query is skipped (not attempted) when endpoint 0 is missing.
+
+    ``.get()`` is used instead of a direct index lookup specifically so a
+    node model missing its root endpoint degrades to "recovery
+    unavailable" rather than raising a KeyError that would escape every
+    typed handler and get the lock dropped. No device query should be
+    attempted in that case.
+    """
+    original_endpoint = zwave_js_lock.node.endpoints[0]
+    invoke = AsyncMock()
+    with (
+        patch.object(original_endpoint, "async_invoke_cc_api", invoke),
+        patch.object(zwave_js_lock.node, "endpoints", {}),
+    ):
+        result = await zwave_js_lock._async_recover_user_code_slot_count()
+
+    assert result is False
+    invoke.assert_not_called()
+
+
 async def test_async_get_capabilities_no_pin_type_returns_empty(
     zwave_js_lock: ZWaveJSLock,
     mock_access_control: MagicMock,

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -27,7 +27,8 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNAVAILABLE,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import Event, HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.update_coordinator import UpdateFailed
 from homeassistant.util import dt as dt_util
 
@@ -46,6 +47,7 @@ from custom_components.lock_code_manager.domain.exceptions import (
     DuplicateCodeError,
     LockCodeManagerError,
 )
+from custom_components.lock_code_manager.domain.locks import async_create_lock_instance
 from custom_components.lock_code_manager.domain.models import SlotCredential, SyncState
 
 from .common import (
@@ -2082,3 +2084,143 @@ async def test_availability_subscription_scoped_to_locks(
     entity._handle_add_locks([re_added_lock])
     assert tracker._last_track_states.all_states is False
     assert tracker._last_track_states.entities == {LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID}
+
+
+async def test_handle_locks_updated_noop_before_tracker_exists(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """A lock-added/removed callback firing before the availability tracker exists is a no-op.
+
+    ``_register_callbacks`` (which wires ``_handle_add_locks`` /
+    ``_handle_remove_lock``) runs slightly before
+    ``_available_state_tracker`` is assigned in ``async_added_to_hass``.
+    ``_async_handle_locks_updated`` guards that window by returning early
+    when the tracker is still ``None`` instead of crashing on
+    ``tracker.async_update_listeners``.
+    """
+    entity = get_in_sync_entity_obj(hass, SLOT_1_ACTIVE_ENTITY)
+    assert entity._available_state_tracker is not None
+    entity._available_state_tracker = None
+
+    # Must not raise despite the tracker being unset.
+    entity._handle_remove_lock(LOCK_1_ENTITY_ID)
+
+    # The locks list is still updated even though the re-scope was skipped.
+    assert LOCK_1_ENTITY_ID not in [lock.lock.entity_id for lock in entity.locks]
+
+
+async def test_handle_available_state_update_ignores_unrelated_entity(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """A stray state-changed event for an entity outside the tracked lock set is ignored."""
+    entity = get_in_sync_entity_obj(hass, SLOT_1_ACTIVE_ENTITY)
+    initial_available = entity._attr_available
+
+    stray_event = Event(
+        "state_changed",
+        {"entity_id": "lock.unrelated", "old_state": None, "new_state": None},
+    )
+    entity._handle_available_state_update(stray_event)
+
+    assert entity._attr_available == initial_available
+
+
+async def test_handle_available_state_update_skips_recompute_between_available_states(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """A lock transition between two non-unavailable states skips the availability recompute.
+
+    Both endpoints of the transition are already known-available, so
+    ``_handle_available_state_update`` short-circuits before calling
+    ``_is_available()`` again -- verified here by counting calls rather than
+    by the (unchanged either way) resulting ``available`` value.
+    """
+    entity = get_in_sync_entity_obj(hass, SLOT_1_ACTIVE_ENTITY)
+    assert entity.available
+
+    call_count = [0]
+    original_is_available = entity._is_available
+
+    def _counting_is_available():
+        call_count[0] += 1
+        return original_is_available()
+
+    with patch.object(entity, "_is_available", _counting_is_available):
+        # LOCK_1 starts "unlocked" (MockLockEntity's default) -- moving to
+        # "locked" is a real state change between two non-unavailable states.
+        hass.states.async_set(LOCK_1_ENTITY_ID, "locked")
+        await hass.async_block_till_done()
+
+    assert call_count[0] == 0
+    assert entity.available
+
+
+async def test_add_code_slot_entity_skipped_when_lock_has_no_coordinator(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """A lock whose provider setup has not finished (no coordinator yet) is skipped.
+
+    ``add_code_slot_entities`` is invoked via the lock-slot-adder callback
+    registry once a lock has been set up. This exercises the defensive
+    ``if coordinator is None: return`` for a lock instance that has not
+    completed ``async_setup_internal`` -- the in-sync sensor is simply not
+    created rather than crashing on a ``None`` coordinator.
+    """
+    entry = lock_code_manager_config_entry
+    dev_reg = dr.async_get(hass)
+    ent_reg = er.async_get(hass)
+    fresh_lock = async_create_lock_instance(
+        hass, dev_reg, ent_reg, entry, LOCK_1_ENTITY_ID
+    )
+    assert fresh_lock.coordinator is None
+
+    entities_before = set(hass.states.async_entity_ids("binary_sensor"))
+    entry.runtime_data.callbacks.invoke_lock_slot_adders(fresh_lock, 1, ent_reg)
+    await hass.async_block_till_done()
+
+    assert set(hass.states.async_entity_ids("binary_sensor")) == entities_before
+
+
+async def test_add_standard_entity_for_slot_without_coordinator_logs_warning(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Adding an entity for a slot with no registered SlotEntityCoordinator logs a warning.
+
+    The normal flow (``async_update_listener``) always creates the slot
+    coordinator before adding entities for a new slot -- see the comment
+    above the loop that creates them "BEFORE setting up new locks". This
+    covers the defensive fallback for a slot number added out of band
+    (``invoke_standard_adders`` called directly for a slot the coordinator
+    registry has never seen), verifying entity creation degrades gracefully
+    with a warning rather than raising.
+    """
+    runtime_data = lock_code_manager_config_entry.runtime_data
+    assert 99 not in runtime_data.slot_coordinators
+
+    ent_reg = er.async_get(hass)
+    caplog.set_level(logging.WARNING)
+    runtime_data.callbacks.invoke_standard_adders(99, ent_reg)
+    await hass.async_block_till_done()
+
+    assert "No slot coordinator for slot 99" in caplog.text
+
+    # The active binary sensor entity was still created for the slot.
+    slot_99_entities = [
+        entry
+        for entry in er.async_entries_for_config_entry(
+            ent_reg, lock_code_manager_config_entry.entry_id
+        )
+        if "|99|" in entry.unique_id
+    ]
+    assert slot_99_entities

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from homeassistant.const import CONF_ENABLED, CONF_NAME, CONF_PIN
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.issue_registry import async_get as async_get_issue_registry
@@ -17,6 +18,8 @@ from custom_components.lock_code_manager.const import (
     BACKOFF_FAILURE_THRESHOLD,
     BACKOFF_INITIAL_SECONDS,
     BACKOFF_MAX_SECONDS,
+    CONF_LOCKS,
+    CONF_SLOTS,
     DOMAIN,
     POLL_FAILURE_ALERT_THRESHOLD,
 )
@@ -1119,6 +1122,68 @@ async def test_confirm_pending_writes_swallows_unexpected_error(
 
     assert 1 in push_lock._pending_writes
     assert push_coordinator.is_verified(1) is False
+
+
+async def test_desired_credential_disabled_slot_is_empty(
+    hass: HomeAssistant,
+    poll_coordinator: LockUsercodeUpdateCoordinator,
+    lcm_config_entry: MockConfigEntry,
+) -> None:
+    """A disabled slot's desired credential is empty even with a configured PIN."""
+    hass.config_entries.async_update_entry(
+        lcm_config_entry,
+        data={
+            CONF_LOCKS: [],
+            CONF_SLOTS: {1: {CONF_NAME: "x", CONF_PIN: "1234", CONF_ENABLED: False}},
+        },
+    )
+    assert poll_coordinator.desired_credential(1) == SlotCredential.empty()
+
+
+async def test_desired_credential_enabled_blank_pin_is_empty(
+    hass: HomeAssistant,
+    poll_coordinator: LockUsercodeUpdateCoordinator,
+    lcm_config_entry: MockConfigEntry,
+) -> None:
+    """An enabled slot with no configured PIN has an empty desired credential."""
+    hass.config_entries.async_update_entry(
+        lcm_config_entry,
+        data={
+            CONF_LOCKS: [],
+            CONF_SLOTS: {1: {CONF_NAME: "x", CONF_PIN: "", CONF_ENABLED: True}},
+        },
+    )
+    assert poll_coordinator.desired_credential(1) == SlotCredential.empty()
+
+
+async def test_desired_credential_enabled_with_pin_is_known(
+    hass: HomeAssistant,
+    poll_coordinator: LockUsercodeUpdateCoordinator,
+    lcm_config_entry: MockConfigEntry,
+) -> None:
+    """An enabled slot with a configured PIN yields that PIN as the desired credential."""
+    hass.config_entries.async_update_entry(
+        lcm_config_entry,
+        data={
+            CONF_LOCKS: [],
+            CONF_SLOTS: {1: {CONF_NAME: "x", CONF_PIN: "4242", CONF_ENABLED: True}},
+        },
+    )
+    assert poll_coordinator.desired_credential(1) == SlotCredential.known("4242")
+
+
+async def test_connection_check_swallows_lock_code_manager_error(
+    push_coordinator: LockUsercodeUpdateCoordinator,
+    push_lock: MockLCMPushLock,
+) -> None:
+    """A LockCodeManagerError from the reachability probe is logged and swallowed."""
+    mock_check = AsyncMock(side_effect=LockDisconnected("offline"))
+    with patch.object(push_lock, "async_is_integration_connected", mock_check):
+        # Must not raise: this runs on a periodic timer with no caller to
+        # observe an exception.
+        await push_coordinator._async_connection_check(dt_util.utcnow())
+
+    mock_check.assert_called_once()
 
 
 async def test_apply_read_takes_differing_readable_external_change(

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -2,16 +2,20 @@
 
 from __future__ import annotations
 
+import copy
+
+from homeassistant.const import CONF_ENABLED, CONF_NAME, CONF_PIN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
-from custom_components.lock_code_manager.const import DOMAIN
+from custom_components.lock_code_manager.const import CONF_SLOTS, DOMAIN
 from custom_components.lock_code_manager.diagnostics import (
     async_get_config_entry_diagnostics,
     async_get_device_diagnostics,
 )
+from custom_components.lock_code_manager.domain.models import SlotCredential
 
-from .common import LOCK_1_ENTITY_ID
+from .common import BASE_CONFIG, LOCK_1_ENTITY_ID
 
 # SlotCode sentinel values as they appear after _mask_code
 _SENTINEL_VALUES = {"empty", "unreadable_code", None}
@@ -179,3 +183,50 @@ async def test_sensitive_entities_redacted(
     for entity in redacted:
         assert entity["attributes"] == {}
         assert entity["platform"] == DOMAIN
+
+
+async def test_mask_code_covers_missing_and_edge_case_credentials(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+) -> None:
+    """``_mask_code`` covers three distinct branches of its label-to-string mapping.
+
+    A slot absent from coordinator data, a cleared slot (SlotCode.EMPTY),
+    and a present-but-empty-string PIN (the falsy-label fallback) all
+    surface differently in diagnostics output.
+    """
+    entry = lock_code_manager_config_entry
+    lock_1 = entry.runtime_data.locks[LOCK_1_ENTITY_ID]
+    coordinator = lock_1.coordinator
+    assert coordinator is not None
+
+    # Add slot 3 to config but never write a code for it on lock 1 --
+    # coordinator.data has no entry for slot 3 even though it is non-empty.
+    new_config = copy.deepcopy(BASE_CONFIG)
+    new_config[CONF_SLOTS][3] = {
+        CONF_NAME: "test3",
+        CONF_PIN: "9999",
+        CONF_ENABLED: False,
+    }
+    hass.config_entries.async_update_entry(entry, options=new_config)
+    await hass.async_block_till_done()
+    assert 3 not in coordinator.data
+
+    # Slot 1: cleared on the lock -> SlotCode.EMPTY sentinel.
+    coordinator.push_update({1: SlotCredential.empty()})
+    # Slot 2: present but with an empty-string PIN -- the falsy-label
+    # fallback distinct from the SlotCode.EMPTY sentinel above.
+    coordinator.push_update({2: SlotCredential.known("")})
+    await hass.async_block_till_done()
+
+    result = await async_get_config_entry_diagnostics(hass, entry)
+
+    lock_1_data = result["locks"][LOCK_1_ENTITY_ID]["coordinator"]["data"]
+    assert lock_1_data["1"] == "empty"
+    assert lock_1_data["2"] == "empty"
+
+    # Slot 3's per-lock entry is built via _slot_diagnostic's .get() lookup,
+    # which returns None for a slot the coordinator has never seen.
+    slot_3_lock_1 = result["slots"]["3"]["locks"][LOCK_1_ENTITY_ID]
+    assert slot_3_lock_1["coordinator_code"] is None

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -3,7 +3,7 @@
 import asyncio
 import copy
 import logging
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -23,6 +23,7 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import CoreState, HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import (
     device_registry as dr,
     entity_registry as er,
@@ -33,18 +34,24 @@ from custom_components.lock_code_manager import (
     _setup_entry_after_start,
     async_remove_config_entry_device,
     async_remove_entry,
+    async_unload_lock,
 )
 from custom_components.lock_code_manager.const import (
     ATTR_ACTIVE,
     ATTR_IN_SYNC,
+    ATTR_TEXT,
     BACKOFF_FAILURE_THRESHOLD,
     CONF_CALENDAR,
     CONF_LOCKS,
     CONF_SLOTS,
     DOMAIN,
     EVENT_PIN_USED,
+    SERVICE_DEOBFUSCATE_LOG,
     SERVICE_HARD_REFRESH_USERCODES,
     STRATEGY_PATH,
+)
+from custom_components.lock_code_manager.domain.exceptions import (
+    LockDisconnected,
 )
 from custom_components.lock_code_manager.domain.models import SlotCredential, SyncState
 from custom_components.lock_code_manager.repairs import (
@@ -546,6 +553,16 @@ async def test_migration_v1_to_v2_calendar_to_entity_id(
                 CONF_ENABLED: True,
                 CONF_CALENDAR: "calendar.test_1",
             },
+            3: {
+                CONF_NAME: "test3",
+                CONF_PIN: "9012",
+                CONF_ENABLED: True,
+                # Both fields already set (e.g. a partially-migrated config) --
+                # the migration must drop the stale calendar key and leave the
+                # already-set entity_id alone rather than overwriting it.
+                CONF_CALENDAR: "calendar.stale",
+                CONF_ENTITY_ID: "calendar.test_2",
+            },
         },
     }
 
@@ -574,6 +591,11 @@ async def test_migration_v1_to_v2_calendar_to_entity_id(
     # Slot 2 should have CONF_ENTITY_ID instead of CONF_CALENDAR
     assert CONF_CALENDAR not in migrated_data[CONF_SLOTS][2]
     assert migrated_data[CONF_SLOTS][2][CONF_ENTITY_ID] == "calendar.test_1"
+
+    # Slot 3 already had both fields set -- calendar is dropped and the
+    # pre-existing entity_id value is preserved untouched.
+    assert CONF_CALENDAR not in migrated_data[CONF_SLOTS][3]
+    assert migrated_data[CONF_SLOTS][3][CONF_ENTITY_ID] == "calendar.test_2"
 
     await hass.config_entries.async_unload(config_entry.entry_id)
     await hass.config_entries.async_remove(config_entry.entry_id)
@@ -1611,3 +1633,255 @@ async def test_remove_config_entry_device_allows_only_unconfigured_slots(
             )
             is True
         ), f"slot {stale_slot} device should be deletable"
+
+
+async def test_hard_refresh_usercodes_service_raises_on_lock_error(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """The hard_refresh_usercodes service surfaces per-lock failures as one error.
+
+    ``asyncio.gather(..., return_exceptions=True)`` isolates a failing lock
+    from its siblings; the service handler collects any exceptions and
+    re-raises a single ``HomeAssistantError`` summarizing them, rather than
+    letting one bad lock silently swallow the whole request.
+    """
+    locks = lock_code_manager_config_entry.runtime_data.locks
+    lock_2 = locks[LOCK_2_ENTITY_ID]
+
+    with patch.object(
+        lock_2,
+        "async_hard_refresh_codes",
+        AsyncMock(side_effect=Exception("simulated refresh failure")),
+    ):
+        with pytest.raises(HomeAssistantError) as exc_info:
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_HARD_REFRESH_USERCODES,
+                {ATTR_ENTITY_ID: [LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID]},
+                blocking=True,
+            )
+
+    # One line per failing lock, readable as-is.
+    assert str(exc_info.value).endswith("simulated refresh failure")
+
+    # LOCK_1's refresh still completed despite LOCK_2 raising.
+    assert locks[LOCK_1_ENTITY_ID].service_calls["hard_refresh_codes"]
+
+
+async def test_deobfuscate_log_service_errors_when_not_fully_set_up(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """The deobfuscate_log service refuses to run without a usable instance_id.
+
+    ``instance_id`` is populated once during ``async_setup`` and never
+    cleared in normal operation. This simulates a call landing before that
+    completes (or after it was wiped) to verify the service degrades to an
+    explicit, actionable error instead of building a broken deobfuscation
+    table.
+    """
+    original_instance_id = hass.data[DOMAIN]["instance_id"]
+    hass.data[DOMAIN]["instance_id"] = ""
+    try:
+        with pytest.raises(HomeAssistantError, match="not fully set up yet"):
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_DEOBFUSCATE_LOG,
+                {ATTR_TEXT: "some log text"},
+                blocking=True,
+                return_response=True,
+            )
+    finally:
+        hass.data[DOMAIN]["instance_id"] = original_instance_id
+
+
+async def test_setup_entry_with_empty_data_uses_initial_listener_task(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+):
+    """An entry persisted with empty ``data`` and full ``options`` still sets up.
+
+    Every entry created through the config flow starts with populated
+    ``data``, so the normal first-setup path always takes the "move data to
+    options" branch in ``_setup_entry_after_start``. A config entry can also
+    legitimately hold its config entirely under ``options`` with empty
+    ``data`` (nothing currently produces this via the flow, but restored/
+    hand-edited storage could) -- that takes the other branch, scheduling
+    ``async_update_listener`` directly as a background task instead.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={},
+        options=BASE_CONFIG,
+        unique_id="Empty Data Entry",
+        title="Empty Data Entry",
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert set(entry.runtime_data.locks) == {LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID}
+    # The listener consolidates options back into data, as normal.
+    assert entry.data[CONF_SLOTS]
+    assert not entry.options
+
+    await hass.config_entries.async_unload(entry.entry_id)
+
+
+async def test_async_unload_lock_skips_untracked_lock_entity_id(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """async_unload_lock is a no-op for a lock_entity_id no longer tracked.
+
+    Guards the defensive ``if lock is None: continue`` in the per-lock loop
+    -- calling it for an entity_id that was never (or is no longer) part of
+    ``runtime_data.locks`` must not raise, and must leave the entry's real
+    locks untouched.
+    """
+    entry = lock_code_manager_config_entry
+    runtime_data = entry.runtime_data
+    assert set(runtime_data.locks) == {LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID}
+
+    await async_unload_lock(hass, entry, lock_entity_id="lock.untracked")
+
+    assert set(runtime_data.locks) == {LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID}
+
+
+async def test_new_lock_setup_failure_logged_and_lock_excluded(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    caplog: pytest.LogCaptureFixture,
+):
+    """An unexpected exception during a new lock's setup is logged, not fatal.
+
+    Structural/transport failures are caught inside ``async_setup_internal``
+    and leave the lock degraded but present. An exception of any other type
+    is a genuine bug; ``_async_setup_new_locks`` must still log it and drop
+    just that lock, without blocking sibling locks in the same batch.
+    """
+    config = copy.deepcopy(BASE_CONFIG)
+    config[CONF_LOCKS] = [LOCK_1_ENTITY_ID]
+    entry = MockConfigEntry(
+        domain=DOMAIN, data=config, unique_id="Partial Locks", title="Partial Locks"
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    original_setup_internal = MockLCMLock.async_setup_internal
+
+    async def _maybe_fail(self: MockLCMLock, config_entry) -> None:
+        if self.lock.entity_id == LOCK_2_ENTITY_ID:
+            raise RuntimeError("simulated unexpected setup failure")
+        await original_setup_internal(self, config_entry)
+
+    new_config = copy.deepcopy(config)
+    new_config[CONF_LOCKS] = [LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID]
+
+    caplog.set_level(logging.ERROR)
+    with patch.object(MockLCMLock, "async_setup_internal", _maybe_fail):
+        hass.config_entries.async_update_entry(entry, options=new_config)
+        await hass.async_block_till_done()
+
+    assert "Failed to set up lock" in caplog.text
+    assert LOCK_2_ENTITY_ID not in entry.runtime_data.locks
+    assert LOCK_1_ENTITY_ID in entry.runtime_data.locks
+
+    await hass.config_entries.async_unload(entry.entry_id)
+
+
+async def test_update_listener_slot_removal_handles_missing_and_failing_coordinators(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+    caplog: pytest.LogCaptureFixture,
+):
+    """Slot removal tolerates a coordinator already gone or one that raises on stop.
+
+    Covers two defensive branches in the ``slots_to_remove`` loop of
+    ``async_update_listener``: a slot whose coordinator was already
+    discarded is skipped cleanly, and a coordinator whose ``async_stop``
+    raises is logged but does not block removal of the other slot.
+    """
+    caplog.set_level(logging.ERROR)
+    runtime_data = lock_code_manager_config_entry.runtime_data
+    assert 1 in runtime_data.slot_coordinators
+    assert 2 in runtime_data.slot_coordinators
+
+    # Simulate slot 1's coordinator already having been discarded.
+    runtime_data.slot_coordinators.pop(1)
+
+    # Slot 2's coordinator raises when stopped.
+    boom = RuntimeError("simulated coordinator stop failure")
+    slot_2_coordinator = runtime_data.slot_coordinators[2]
+    with patch.object(slot_2_coordinator, "async_stop", side_effect=boom):
+        new_config = copy.deepcopy(BASE_CONFIG)
+        new_config[CONF_SLOTS] = {}
+        hass.config_entries.async_update_entry(
+            lock_code_manager_config_entry, options=new_config
+        )
+        await hass.async_block_till_done()
+
+    # Both slots were removed from the registry despite the failure.
+    assert 1 not in runtime_data.slot_coordinators
+    assert 2 not in runtime_data.slot_coordinators
+    assert not hass.states.async_entity_ids(Platform.TEXT)
+    assert "slot 2 coordinator stop raised" in caplog.text
+
+
+async def test_pairs_removed_skips_untracked_lock_and_logs_release_failure(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    caplog: pytest.LogCaptureFixture,
+):
+    """Slot removal releases lock-side state per (lock, slot) pair, tolerating failures.
+
+    Covers two edge cases in the ``pairs_removed`` loop of
+    ``async_update_listener``: a lock still listed in config but absent
+    from ``runtime_data.locks`` (e.g. it failed setup) is skipped rather
+    than raising, and a ``LockDisconnected``/``LockOperationFailed`` from a
+    present lock's ``async_release_managed_slot`` is logged as a warning
+    without blocking the rest of the teardown.
+    """
+    config = copy.deepcopy(BASE_CONFIG)
+    entry = MockConfigEntry(
+        domain=DOMAIN, data=config, unique_id="Release Test", title="Release Test"
+    )
+    entry.add_to_hass(hass)
+
+    original_setup_internal = MockLCMLock.async_setup_internal
+
+    async def _fail_lock_2(self: MockLCMLock, config_entry) -> None:
+        if self.lock.entity_id == LOCK_2_ENTITY_ID:
+            raise RuntimeError("simulated unexpected setup failure")
+        await original_setup_internal(self, config_entry)
+
+    with patch.object(MockLCMLock, "async_setup_internal", _fail_lock_2):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    # LOCK_2 failed setup and was popped, but remains listed in config.
+    assert LOCK_2_ENTITY_ID not in entry.runtime_data.locks
+    assert LOCK_1_ENTITY_ID in entry.runtime_data.locks
+
+    lock_1 = entry.runtime_data.locks[LOCK_1_ENTITY_ID]
+    with patch.object(
+        lock_1,
+        "async_release_managed_slot",
+        AsyncMock(side_effect=LockDisconnected("simulated disconnect")),
+    ):
+        new_config = copy.deepcopy(config)
+        new_config[CONF_SLOTS].pop(1)
+        caplog.set_level(logging.WARNING)
+        hass.config_entries.async_update_entry(entry, options=new_config)
+        await hass.async_block_till_done()
+
+    assert "could not release slot 1" in caplog.text
+    assert LOCK_1_ENTITY_ID in caplog.text
+
+    await hass.config_entries.async_unload(entry.entry_id)

--- a/tests/test_pin_generator.py
+++ b/tests/test_pin_generator.py
@@ -1,7 +1,10 @@
 """Tests for the PIN generator."""
 
+from unittest.mock import patch
+
 import pytest
 
+from custom_components.lock_code_manager.domain import pin_generator
 from custom_components.lock_code_manager.domain.pin_generator import (
     COMMON_WEAK_PINS_4,
     DEFAULT_PIN_LENGTH,
@@ -79,3 +82,9 @@ class TestGeneratePin:
         """Statistical check: the generator should not be returning a fixed value."""
         pins = {generate_pin() for _ in range(50)}
         assert len(pins) > 30
+
+    def test_gives_up_after_100_failed_attempts(self) -> None:
+        """A filter that rejects every candidate raises RuntimeError, not an infinite loop."""
+        with patch.object(pin_generator, "is_unsafe_pin", return_value=True):
+            with pytest.raises(RuntimeError, match="after 100 attempts"):
+                generate_pin()

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -2,11 +2,14 @@
 
 import pytest
 
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_AREA_ID, ATTR_DEVICE_ID, ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import area_registry as ar, entity_registry as er
 
 from custom_components.lock_code_manager.domain.locks import get_locks_from_targets
+from custom_components.lock_code_manager.domain.queries import get_loaded_config_entry
 
 from .common import LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID
 
@@ -129,3 +132,22 @@ async def test_get_locks_from_targets_deduplicates(
     )
 
     assert len(locks) == 1
+
+
+async def test_get_loaded_config_entry_raises_when_not_loaded(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+) -> None:
+    """get_loaded_config_entry raises ServiceValidationError for an unloaded entry.
+
+    Covers the loaded-vs-not-loaded branch distinct from the "no such
+    entry"/"wrong domain" cases already covered via the services tests.
+    """
+    entry = lock_code_manager_config_entry
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+    assert entry.state is not ConfigEntryState.LOADED
+
+    with pytest.raises(ServiceValidationError, match="not loaded"):
+        get_loaded_config_entry(hass, entry.entry_id)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -3,7 +3,9 @@
 import logging
 
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
+from custom_components.lock_code_manager.domain.locks import async_create_lock_instance
 from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers import BaseLock
 
@@ -57,3 +59,31 @@ async def test_sensor_native_value_with_slot_code(
     state = hass.states.get("sensor.test_1_code_slot_1")
     assert state is not None
     assert state.state == "5678"
+
+
+async def test_add_code_slot_entity_skipped_when_lock_has_no_coordinator(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+) -> None:
+    """A lock whose provider setup has not finished (no coordinator yet) is skipped.
+
+    ``add_code_slot_entities`` is invoked via the lock-slot-adder callback
+    registry once a lock has been set up. This exercises the defensive
+    ``if coordinator is None: return`` for a lock instance that has not
+    completed ``async_setup_internal`` -- the code sensor is simply not
+    created rather than crashing on a ``None`` coordinator.
+    """
+    entry = lock_code_manager_config_entry
+    dev_reg = dr.async_get(hass)
+    ent_reg = er.async_get(hass)
+    fresh_lock = async_create_lock_instance(
+        hass, dev_reg, ent_reg, entry, LOCK_1_ENTITY_ID
+    )
+    assert fresh_lock.coordinator is None
+
+    entities_before = set(hass.states.async_entity_ids("sensor"))
+    entry.runtime_data.callbacks.invoke_lock_slot_adders(fresh_lock, 1, ent_reg)
+    await hass.async_block_till_done()
+
+    assert set(hass.states.async_entity_ids("sensor")) == entities_before

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -27,6 +27,7 @@ from custom_components.lock_code_manager.const import (
     SERVICE_SET_USERCODE,
 )
 from custom_components.lock_code_manager.domain.pin_generator import is_unsafe_pin
+from custom_components.lock_code_manager.domain.services import async_set_usercode
 from custom_components.lock_code_manager.domain.util import mask_pin
 
 from .common import LOCK_1_ENTITY_ID
@@ -293,6 +294,23 @@ async def test_set_usercode_service_empty_usercode(
                 },
                 blocking=True,
             )
+
+
+async def test_async_set_usercode_domain_function_rejects_empty_usercode(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+) -> None:
+    """The domain-layer function itself rejects a blank usercode.
+
+    The HA service schema for ``set_usercode`` already strips and enforces
+    a minimum length, so a whitespace-only usercode never reaches
+    ``async_set_usercode`` through that path. The websocket API's schema is
+    looser (a bare ``str``), so the domain function's own guard is the last
+    line of defense and must be exercised directly.
+    """
+    with pytest.raises(ServiceValidationError, match="must not be empty"):
+        await async_set_usercode(hass, LOCK_1_ENTITY_ID, 3, "   ")
 
 
 async def test_get_loaded_config_entry_wrong_domain(

--- a/tests/test_slot_coordinator.py
+++ b/tests/test_slot_coordinator.py
@@ -830,6 +830,165 @@ async def test_text_set_value_raises_when_slot_coordinator_missing(
         await text_entity.async_set_value("9999")
 
 
+async def test_inactive_because_of_returns_defensive_copy(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """inactive_because_of returns a fresh list, not the internal state list."""
+    coordinator = lock_code_manager_config_entry.runtime_data.slot_coordinators[2]
+    # Slot 2 has a calendar condition entity that starts inactive.
+    assert coordinator.is_active is False
+
+    result = coordinator.inactive_because_of
+    assert result == coordinator._inactive_because_of
+    assert result is not coordinator._inactive_because_of
+
+    result.append("mutated")
+    assert "mutated" not in coordinator._inactive_because_of
+
+
+async def test_async_request_name_update_writes_name_field(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """async_request_name_update writes the CONF_NAME field for the slot."""
+    coordinator = lock_code_manager_config_entry.runtime_data.slot_coordinators[1]
+
+    await coordinator.async_request_name_update("Bob")
+    await hass.async_block_till_done()
+
+    config = get_entry_config(lock_code_manager_config_entry).slot(1)
+    assert config.get(CONF_NAME) == "Bob"
+
+
+async def test_async_start_is_idempotent(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """A second async_start call is a no-op; it does not re-subscribe or recompute."""
+    coordinator = lock_code_manager_config_entry.runtime_data.slot_coordinators[1]
+    assert coordinator._started is True
+
+    with patch.object(coordinator, "_recompute_active") as recompute:
+        coordinator.async_start()
+
+    recompute.assert_not_called()
+
+
+async def test_notify_config_changed_noop_once_stopped(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """notify_config_changed is a no-op once the coordinator has been stopped."""
+    coordinator = lock_code_manager_config_entry.runtime_data.slot_coordinators[1]
+    coordinator.async_stop()
+    assert coordinator._started is False
+
+    with patch.object(coordinator, "_recompute_active") as recompute:
+        coordinator.notify_config_changed()
+
+    recompute.assert_not_called()
+
+
+async def test_notify_state_subscribers_isolates_individual_failures(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+    caplog: pytest.LogCaptureFixture,
+):
+    """One raising state subscriber does not prevent the others from being notified."""
+    coordinator = lock_code_manager_config_entry.runtime_data.slot_coordinators[1]
+    boom = RuntimeError("simulated subscriber failure")
+    healthy_called = {"value": False}
+
+    def failing() -> None:
+        raise boom
+
+    def healthy() -> None:
+        healthy_called["value"] = True
+
+    unsub_failing = coordinator.register_state_subscriber(failing)
+    unsub_healthy = coordinator.register_state_subscriber(healthy)
+    try:
+        with caplog.at_level(logging.ERROR):
+            coordinator._notify_state_subscribers()
+    finally:
+        unsub_failing()
+        unsub_healthy()
+
+    assert healthy_called["value"] is True
+    assert any(
+        record.exc_info is not None and record.exc_info[1] is boom
+        for record in caplog.records
+        if record.levelname == "ERROR"
+    )
+
+
+async def test_recompute_active_missing_condition_entity_is_inactive(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+):
+    """A configured condition entity with no state (not created) reads as inactive.
+
+    ``hass.states.get`` returns None for a nonexistent entity, which must be
+    treated the same as "unknown" (neither definitely on nor off) rather
+    than crashing or defaulting to active.
+    """
+    config = {
+        CONF_LOCKS: [LOCK_1_ENTITY_ID],
+        CONF_SLOTS: {
+            1: {
+                CONF_NAME: "alice",
+                CONF_PIN: "1234",
+                CONF_ENABLED: True,
+                CONF_ENTITY_ID: "input_boolean.does_not_exist",
+            },
+        },
+    }
+    entry = MockConfigEntry(domain=DOMAIN, data=config, unique_id="Test Missing Cond")
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    coordinator = entry.runtime_data.slot_coordinators[1]
+    assert coordinator.is_active is False
+    assert CONF_ENTITY_ID in coordinator.inactive_because_of
+
+    await hass.config_entries.async_unload(entry.entry_id)
+
+
+async def test_pin_required_issue_creation_failure_is_swallowed(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+    caplog: pytest.LogCaptureFixture,
+):
+    """A failure creating the pin_required repair issue does not swallow the raise."""
+    coordinator = lock_code_manager_config_entry.runtime_data.slot_coordinators[1]
+    await coordinator.async_request_pin_update("")
+    await hass.async_block_till_done()
+    assert coordinator.pin_value is None
+
+    boom = RuntimeError("issue registry boom")
+    with patch(
+        "custom_components.lock_code_manager.domain.slot_coordinator.async_create_issue",
+        side_effect=boom,
+    ):
+        with caplog.at_level(logging.ERROR):
+            with pytest.raises(PinRequiredError):
+                await coordinator.async_request_active_toggle(True)
+
+    assert any(
+        record.exc_info is not None and record.exc_info[1] is boom
+        for record in caplog.records
+        if record.levelname == "ERROR"
+    )
+
+
 async def test_unload_clears_registry_when_coordinator_stop_raises_before_cleanup(
     hass: HomeAssistant,
     mock_lock_config_entry,

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNKNOWN
+from homeassistant.const import CONF_PIN, STATE_OFF, STATE_ON, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.issue_registry import (
     IssueSeverity,
@@ -1369,6 +1369,30 @@ class TestSyncStatusAttribute:
         assert state is not None
         assert state.attributes.get("sync_status") == "suspended"
 
+    async def test_sync_status_and_state_unknown_while_loading(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """The entity renders unknown with no sync_status attribute while LOADING.
+
+        ``in_sync``/``sync_status`` read None until the manager's initial
+        tick determines a real state; that lets the in-sync binary sensor
+        show "unknown" rather than a stale guess before the first tick.
+        """
+        entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
+        manager = entity_obj._sync_manager
+
+        manager._state = SyncState.LOADING
+        manager._write_state()
+        await hass.async_block_till_done()
+
+        state = hass.states.get(SLOT_1_IN_SYNC_ENTITY)
+        assert state is not None
+        assert state.state == STATE_UNKNOWN
+        assert "sync_status" not in state.attributes
+
 
 class TestAsyncStopAwaitsInFlightTick:
     """Tests that SlotSyncManager.async_stop blocks until the in-flight tick completes."""
@@ -1847,3 +1871,163 @@ class TestBreakerTickSoleMutatorInvariant:
 
         assert manager._state is SyncState.OUT_OF_SYNC
         assert manager._slot_breaker.failure_count == starting_count
+
+
+class TestOptimisticSetPendingConfirmation:
+    """Tests for the post-sync pending-write check in ``_async_tick_impl``."""
+
+    async def test_optimistic_set_transitions_to_pending_confirmation(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """A successful but ambiguous (OPTIMISTIC) set parks the slot in PENDING_CONFIRMATION.
+
+        Mirrors a masked lock whose post-write verification is ambiguous: the
+        provider returns ``WriteResult.OPTIMISTIC``, the seam records a
+        pending write, and when the immediate confirmation read can't observe
+        the slot (simulated here by removing it from the mock lock's
+        readable codes), the pending write survives into the tick's post-sync
+        check, which must not declare success or failure -- it waits.
+        """
+        entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
+        manager = entity_obj._sync_manager
+        await async_trigger_sync_tick(hass, SLOT_1_IN_SYNC_ENTITY, set_dirty=False)
+        assert manager._state is SyncState.IN_SYNC
+
+        manager._coordinator.data[1] = SlotCredential.empty()
+        manager.request_sync_check()
+        assert manager._state is SyncState.OUT_OF_SYNC
+
+        async def optimistic_set_usercode(
+            code_slot: int,
+            usercode: str,
+            name: str | None = None,
+            source: str = "direct",
+        ) -> WriteResult:
+            return WriteResult.OPTIMISTIC
+
+        async def absent_read() -> dict[int, SlotCredential]:
+            # Every read (the immediate confirmation read AND the tick's own
+            # post-sync poll refresh) observes slot 1 as still empty -- e.g.
+            # a masked lock whose write hasn't propagated to readback yet --
+            # so the pending write survives both.
+            return {1: SlotCredential.empty(), 2: SlotCredential.known("5678")}
+
+        with (
+            patch.object(manager._lock, "async_set_usercode", optimistic_set_usercode),
+            patch.object(manager._lock, "async_hard_refresh_codes", absent_read),
+            patch.object(manager._lock, "async_get_usercodes", absent_read),
+        ):
+            await manager._async_tick()
+
+        assert manager._state is SyncState.PENDING_CONFIRMATION
+        assert 1 in manager._lock._pending_writes
+        assert manager._coordinator.is_verified(1) is False
+
+
+class TestAsyncTickDefensiveGuards:
+    """Tests for the defensive early-return guards in ``_async_tick``."""
+
+    async def test_tick_noop_when_manager_stopped(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """_async_tick is a no-op if the manager has already been stopped."""
+        entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
+        manager = entity_obj._sync_manager
+        manager._started = False
+        try:
+            with patch.object(
+                manager, "_async_tick_impl", new_callable=AsyncMock
+            ) as tick_impl:
+                await manager._async_tick()
+
+            tick_impl.assert_not_called()
+        finally:
+            # Restore so the fixture's normal entry-unload teardown actually
+            # unsubscribes the tick timer instead of short-circuiting on a
+            # manager that looks already-stopped (which would leak a timer).
+            manager._started = True
+
+    async def test_tick_noop_when_no_current_task(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """_async_tick is a defensive no-op if asyncio.current_task() returns None.
+
+        Guards against registering a task tracker with a None key -- this
+        should never happen in practice (the tick is always awaited from
+        within a task), but the guard exists so ``async_stop`` can safely
+        assume every entry in ``_tick_tasks`` is a real task.
+        """
+        entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
+        manager = entity_obj._sync_manager
+
+        with patch(
+            "custom_components.lock_code_manager.domain.sync.asyncio.current_task",
+            return_value=None,
+        ):
+            await manager._async_tick()
+
+        assert manager._tick_tasks == set()
+
+
+class TestAsyncStartIdempotent:
+    """Tests for the idempotent-start guard in ``SlotSyncManager.async_start``."""
+
+    async def test_async_start_second_call_is_noop(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """A second async_start call does not re-subscribe or re-tick."""
+        entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
+        manager = entity_obj._sync_manager
+        assert manager._started is True
+
+        with (
+            patch.object(manager, "_setup_state_tracking") as setup_tracking,
+            patch.object(manager, "_setup_coordinator_listener") as setup_listener,
+        ):
+            await manager.async_start()
+
+        setup_tracking.assert_not_called()
+        setup_listener.assert_not_called()
+
+
+class TestEntityStateHelpers:
+    """Tests for small entity-state-resolution helpers."""
+
+    async def test_get_entity_state_returns_none_for_undiscovered_role(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """_get_entity_state returns None for a role key with no discovered entity ID."""
+        entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
+        manager = entity_obj._sync_manager
+
+        assert manager._get_entity_state("nonexistent_role") is None
+
+    async def test_ensure_entities_ready_false_when_role_undiscovered(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """_ensure_entities_ready returns False if a required role wasn't discovered."""
+        entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
+        manager = entity_obj._sync_manager
+        # A full setup tick has already populated the map; simulate a role
+        # whose entity was never found (e.g. platform not loaded yet).
+        manager._entity_id_map.pop(CONF_PIN, None)
+
+        assert manager._ensure_entities_ready() is False

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -59,6 +59,29 @@ async def test_text_entities(
     assert state.state == STATE_OFF
 
 
+async def test_set_name_updates_slot_name(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """Setting the name text entity's value updates the slot's configured name."""
+    state = hass.states.get(SLOT_2_NAME_ENTITY)
+    assert state
+    assert state.state == "test2"
+
+    await hass.services.async_call(
+        TEXT_DOMAIN,
+        SERVICE_SET_VALUE,
+        service_data={ATTR_VALUE: "renamed"},
+        target={ATTR_ENTITY_ID: SLOT_2_NAME_ENTITY},
+        blocking=True,
+    )
+
+    state = hass.states.get(SLOT_2_NAME_ENTITY)
+    assert state
+    assert state.state == "renamed"
+
+
 async def test_whitespace_pin_normalized_to_empty(
     hass: HomeAssistant,
     mock_lock_config_entry,

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -3,12 +3,14 @@
 import re
 
 import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from homeassistant.const import CONF_ENABLED, CONF_NAME, CONF_PIN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.issue_registry import async_get as async_get_issue_registry
 
-from custom_components.lock_code_manager.const import DOMAIN
+from custom_components.lock_code_manager.const import CONF_LOCKS, CONF_SLOTS, DOMAIN
 from custom_components.lock_code_manager.domain.util import (
     async_disable_slot,
     build_pin_deobfuscation_map,
@@ -162,6 +164,43 @@ async def test_build_pin_deobfuscation_map_uses_configured_pins(
     assert table[mask_pin("1234", 1, INSTANCE_ID)] == "1234"
     assert table[mask_pin("5678", 2, INSTANCE_ID)] == "5678"
     assert len(table) == 2
+
+
+async def test_build_pin_deobfuscation_map_skips_empty_pin_slots(
+    hass: HomeAssistant,
+):
+    """A slot with no configured PIN contributes no entry to the map.
+
+    ``mask_pin`` returns the sentinel ``<empty>`` for a falsy PIN, which is
+    not a token worth reversing, so the empty slot must be skipped rather
+    than mapped to ``<empty>``.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_LOCKS: [],
+            CONF_SLOTS: {
+                1: {CONF_NAME: "a", CONF_PIN: "1234", CONF_ENABLED: True},
+                2: {CONF_NAME: "b", CONF_PIN: "", CONF_ENABLED: False},
+            },
+        },
+    )
+    entry.add_to_hass(hass)
+
+    table = build_pin_deobfuscation_map([entry], INSTANCE_ID)
+
+    assert table == {mask_pin("1234", 1, INSTANCE_ID): "1234"}
+
+
+async def test_async_disable_slot_returns_false_when_switch_not_found(
+    hass: HomeAssistant,
+):
+    """async_disable_slot returns False when no switch entity exists for the slot."""
+    ent_reg = er.async_get(hass)
+
+    result = await async_disable_slot(hass, ent_reg, "nonexistent_entry", 99)
+
+    assert result is False
 
 
 async def test_async_disable_slot_no_issue_without_reason(

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -21,6 +21,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
 )
 from homeassistant.core import Event, HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import entity_registry as er
 
 from custom_components.lock_code_manager.const import (
@@ -30,6 +31,7 @@ from custom_components.lock_code_manager.const import (
     ATTR_CALENDAR_END_TIME,
     ATTR_CALENDAR_NEXT_START,
     ATTR_CALENDAR_NEXT_SUMMARY,
+    ATTR_CALENDAR_START_TIME,
     ATTR_CALENDAR_SUMMARY,
     ATTR_CODE,
     ATTR_CODE_LENGTH,
@@ -65,7 +67,7 @@ from custom_components.lock_code_manager.const import (
     CONF_SLOTS,
 )
 from custom_components.lock_code_manager.domain.exceptions import DuplicateCodeError
-from custom_components.lock_code_manager.domain.models import SlotCredential
+from custom_components.lock_code_manager.domain.models import SlotCode, SlotCredential
 from custom_components.lock_code_manager.providers import BaseLock
 from custom_components.lock_code_manager.websocket import (
     SlotEntities,
@@ -79,14 +81,17 @@ from custom_components.lock_code_manager.websocket import (
     _get_slot_state_entity_ids,
     _get_text_state,
     _serialize_slot,
+    _slot_code_payload,
 )
 
 from .common import (
     LOCK_1_ENTITY_ID,
     LOCK_2_ENTITY_ID,
     SLOT_1_ENABLED_ENTITY,
+    SLOT_1_IN_SYNC_ENTITY,
     SLOT_1_PIN_ENTITY,
 )
+from .conftest import async_initial_tick, async_trigger_sync_tick
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -187,6 +192,46 @@ async def test_get_config_entry_data(
     )
     msg = await ws_client.receive_json()
     assert not msg["success"]
+
+
+async def test_get_config_entry_data_lock_name_falls_back_to_display_name(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """A lock whose state carries no friendly_name attribute falls back to display_name.
+
+    ``_get_lock_friendly_name`` prefers the state's ``friendly_name``
+    attribute (what HA shows in the UI) and only falls back to the
+    provider's ``display_name`` when that attribute is absent.
+    """
+    ws_client = await hass_ws_client(hass)
+
+    state = hass.states.get(LOCK_1_ENTITY_ID)
+    assert state is not None
+    # Re-set the state with no attributes at all, dropping friendly_name.
+    hass.states.async_set(LOCK_1_ENTITY_ID, state.state, {})
+    await hass.async_block_till_done()
+
+    lock = lock_code_manager_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
+
+    await ws_client.send_json(
+        {
+            "id": 1,
+            "type": "lock_code_manager/get_config_entry_data",
+            ATTR_CONFIG_ENTRY_ID: lock_code_manager_config_entry.entry_id,
+        }
+    )
+    msg = await ws_client.receive_json()
+    assert msg["success"]
+
+    lock_1 = next(
+        lock_data
+        for lock_data in msg["result"][CONF_LOCKS]
+        if lock_data[ATTR_ENTITY_ID] == LOCK_1_ENTITY_ID
+    )
+    assert lock_1[CONF_NAME] == lock.display_name
 
 
 async def test_subscribe_lock_codes(
@@ -406,6 +451,45 @@ async def test_subscribe_code_slot(
     # Config entry title is surfaced so the slot card header can render
     # the "Slot N · {title}" kicker without a separate WS round-trip.
     assert data[ATTR_CONFIG_ENTRY_TITLE] == lock_code_manager_config_entry.title
+
+
+async def test_subscribe_code_slot_includes_sync_status_once_determined(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Once a slot's sync state is determined, subscribe_code_slot surfaces it per-lock.
+
+    Right after entry setup the in-sync sensor may still be at
+    ``SyncState.LOADING`` (no ``sync_status`` attribute yet); the per-lock
+    status only includes ``sync_status`` once the sync manager has ticked
+    into a real state.
+    """
+    await async_initial_tick(hass, SLOT_1_IN_SYNC_ENTITY)
+    await async_trigger_sync_tick(hass, SLOT_1_IN_SYNC_ENTITY)
+
+    ws_client = await hass_ws_client(hass)
+    await ws_client.send_json(
+        {
+            "id": 1,
+            "type": "lock_code_manager/subscribe_code_slot",
+            ATTR_CONFIG_ENTRY_ID: lock_code_manager_config_entry.entry_id,
+            ATTR_SLOT: 1,
+        }
+    )
+    msg = await ws_client.receive_json()
+    assert msg["success"]
+
+    event = await ws_client.receive_json()
+    data = event["event"]
+
+    lock_1_status = next(
+        lock_data
+        for lock_data in data[CONF_LOCKS]
+        if lock_data[ATTR_ENTITY_ID] == LOCK_1_ENTITY_ID
+    )
+    assert lock_1_status[ATTR_SYNC_STATUS] == "in_sync"
 
 
 async def test_subscribe_code_slot_masked(
@@ -1796,6 +1880,7 @@ class TestGetConditionEntityData:
             {
                 "friendly_name": "Test Calendar",
                 "message": "Team Meeting",
+                "start_time": "2024-01-15T09:00:00",
                 "end_time": "2024-01-15T10:00:00",
             },
         )
@@ -1811,6 +1896,7 @@ class TestGetConditionEntityData:
         assert ATTR_CALENDAR in result
         assert result[ATTR_CALENDAR][ATTR_CALENDAR_ACTIVE] is True
         assert result[ATTR_CALENDAR][ATTR_CALENDAR_SUMMARY] == "Team Meeting"
+        assert result[ATTR_CALENDAR][ATTR_CALENDAR_START_TIME] == "2024-01-15T09:00:00"
         assert result[ATTR_CALENDAR][ATTR_CALENDAR_END_TIME] == "2024-01-15T10:00:00"
 
     async def test_calendar_entity_inactive(self, hass: HomeAssistant) -> None:
@@ -1852,6 +1938,32 @@ class TestGetConditionEntityData:
         assert result[ATTR_CONDITION_ENTITY_DOMAIN] == "schedule"
         assert ATTR_SCHEDULE in result
         assert ATTR_SCHEDULE_NEXT_EVENT in result[ATTR_SCHEDULE]
+        assert result[ATTR_SCHEDULE][ATTR_SCHEDULE_NEXT_EVENT] == next_event.isoformat()
+
+    async def test_schedule_entity_with_next_event_as_string(
+        self, hass: HomeAssistant
+    ) -> None:
+        """A next_event attribute that is already a plain string is passed through as-is.
+
+        Not every schedule-like integration necessarily reports
+        ``next_event`` as a ``datetime`` -- the helper falls back to
+        ``str(next_event)`` for anything without an ``isoformat`` method.
+        """
+        hass.states.async_set(
+            SCHEDULE_TEST_ENTITY_ID,
+            STATE_OFF,
+            {
+                "friendly_name": "Test Schedule",
+                "next_event": "2024-01-15T08:00:00",
+            },
+        )
+        await hass.async_block_till_done()
+
+        result = _get_condition_entity_data(hass, SCHEDULE_TEST_ENTITY_ID)
+
+        assert result is not None
+        assert ATTR_SCHEDULE in result
+        assert result[ATTR_SCHEDULE][ATTR_SCHEDULE_NEXT_EVENT] == "2024-01-15T08:00:00"
 
     async def test_schedule_entity_without_next_event(
         self, hass: HomeAssistant
@@ -2355,6 +2467,73 @@ class TestSetSlotCondition:
 
         assert result["success"] is True
 
+    async def test_unrecognized_validation_error_maps_to_unknown_error(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+        hass_ws_client: WebSocketGenerator,
+    ) -> None:
+        """A ServiceValidationError message matching no known pattern maps to unknown_error.
+
+        Neither "not found" nor "not supported" appears in the message, so
+        it falls through to the generic unknown_error code rather than
+        being misclassified.
+        """
+        ws_client = await hass_ws_client(hass)
+
+        with patch(
+            "custom_components.lock_code_manager.websocket.async_set_slot_condition",
+            AsyncMock(side_effect=ServiceValidationError("something went sideways")),
+        ):
+            await ws_client.send_json(
+                {
+                    "id": 1,
+                    "type": "lock_code_manager/set_slot_condition",
+                    ATTR_CONFIG_ENTRY_ID: lock_code_manager_config_entry.entry_id,
+                    "slot": 1,
+                    "entity_id": BINARY_SENSOR_TEST_ENTITY_ID,
+                }
+            )
+            result = await ws_client.receive_json()
+
+        assert result["success"] is False
+        assert result["error"]["code"] == "unknown_error"
+        assert "something went sideways" in result["error"]["message"]
+
+    async def test_unexpected_exception_maps_to_unknown_error(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+        hass_ws_client: WebSocketGenerator,
+    ) -> None:
+        """A non-ServiceValidationError exception is still caught and reported.
+
+        The generic ``except Exception`` fallback reports it as
+        unknown_error instead of crashing the websocket connection.
+        """
+        ws_client = await hass_ws_client(hass)
+
+        with patch(
+            "custom_components.lock_code_manager.websocket.async_set_slot_condition",
+            AsyncMock(side_effect=RuntimeError("boom")),
+        ):
+            await ws_client.send_json(
+                {
+                    "id": 1,
+                    "type": "lock_code_manager/set_slot_condition",
+                    ATTR_CONFIG_ENTRY_ID: lock_code_manager_config_entry.entry_id,
+                    "slot": 1,
+                    "entity_id": BINARY_SENSOR_TEST_ENTITY_ID,
+                }
+            )
+            result = await ws_client.receive_json()
+
+        assert result["success"] is False
+        assert result["error"]["code"] == "unknown_error"
+        assert "boom" in result["error"]["message"]
+
 
 class TestClearSlotCondition:
     """Tests for clear_slot_condition websocket command."""
@@ -2854,6 +3033,26 @@ async def test_subscribe_code_slot_unsub_all_with_empty_state_ref(
 # =============================================================================
 # _serialize_slot SlotCode tests
 # =============================================================================
+
+
+class TestSlotCodePayloadWithBareSlotCode:
+    """A bare SlotCode reaching the payload builder serializes as its label."""
+
+    @pytest.mark.parametrize("sentinel", [SlotCode.EMPTY, SlotCode.UNREADABLE_CODE])
+    @pytest.mark.parametrize("reveal", [True, False])
+    def test_bare_slot_code_serializes_as_label(
+        self, sentinel: SlotCode, reveal: bool
+    ) -> None:
+        """
+        The sentinel is a label, never a secret, so reveal must not change it.
+
+        SlotCode is a StrEnum, so a value annotated ``str`` can legitimately be
+        one of these members. Masking it would emit a "code length" for a slot
+        that holds no code.
+        """
+        result = _slot_code_payload(sentinel, reveal=reveal)
+        assert result == {ATTR_CODE: str(sentinel)}
+        assert ATTR_CODE_LENGTH not in result
 
 
 class TestSerializeSlotWithSlotCode:


### PR DESCRIPTION
## Proposed change

Takes the Python integration from 95% to **100% line coverage** (5109 statements, 0 missed). 1378 tests, still ~59s for the full suite.

Earned rather than gamed — verifiable from the diff:
- No `# pragma: no cover` anywhere in the repo
- No `[tool.coverage]` `omit`/`exclude_lines` config added
- No existing test weakened or deleted (the one removed test function is a rename, see below)
- Every new test asserts an observable outcome — a return value, a raised exception, a service call made or not made, a state written. None merely execute a line

Most of the gap was error handling and defensive branches: provider transport failures, capability probes returning degenerate data, payload shapes a device can send but the happy path never produces, and the guards that stop one failing lock from taking its siblings down. Those are exactly the paths that matter when something breaks in the field, and the least likely to be exercised by hand.

### Three things that were not just missing tests

**1. A real formatting bug in the multi-lock error summary.** `__init__.py` built its aggregated error with `"\n".join(str(errors))` — joining over the *list repr's characters*, producing one character per line:

```
CURRENT: "[\nV\na\nl\nu\ne\nE\nr\nr\no\nr\n(\n'\nl\no\nc\nk\n \nA\n..."
FIXED:   "lock A failed\nlock B failed"
```

Fixed to join the messages. The `hard_refresh_usercodes` service is the caller.

**2. Dead code removed instead of tested into permanence.** `entity.py`'s `_get_uid` and the `_uid_cache` that existed solely for it had zero callers anywhere in production or test code. Deleting was the honest route to covering those lines.

**3. A test that asserted nothing.** `test_on_integration_loaded_retries_on_disconnect` built a `MockConfigEntry` that was never loaded, so `_async_on_integration_loaded` short-circuited on its `state != LOADED` guard and the patched `async_setup` was never called — leaving `assert lock._setup_succeeded is False` trivially true against its default. Repurposed to test that short circuit explicitly (now asserting `setup.assert_not_called()`), and the retry path it originally claimed has a genuine test alongside it.

### Two lines worth calling out

Both were initially reported to me as unreachable; I checked and neither was:

- `websocket.py` `_slot_code_payload`'s `isinstance(code, SlotCode)` branch. The parameter is annotated `str | SlotCredential | None`, which looks like it excludes `SlotCode` — but `SlotCode` is a `StrEnum`, so a `str`-annotated value can legitimately be one. Covered with a direct parametrized test asserting the sentinel serializes as its label under both `reveal=True` and `reveal=False` (masking it would emit a code length for a slot holding no code).
- `providers/_base.py`'s LOADED-transition retry, which is what surfaced finding 3 above.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue:
- This PR is related to issue:

Production changes are limited to the two items above (4 lines added, 12 removed). Everything else is tests.

Note for anyone running the suite locally: `requirements_dev.txt` pins `zha==2.1.0`, and a stale `zha==2.0.0` in a local venv makes 43 ZHA tests error at fixture setup with `AttributeError: 'dict' object has no attribute 'unique_id'` (HA 2026.8 expects `entity.state` to be an object). CI installs the pinned version and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)