### PR TITLE
feat: surface link health in the slot suspension repair

### DIFF
--- a/custom_components/lock_code_manager/domain/sync.py
+++ b/custom_components/lock_code_manager/domain/sync.py
@@ -787,6 +787,11 @@ class SlotSyncManager:
                 self._slot_breaker.failure_count,
                 SYNC_ATTEMPT_WINDOW,
             )
+            # The sentence below can only guess between a silently rejected
+            # code and a lock whose replies never arrive. Whatever the
+            # provider can measure about its transport goes in verbatim so
+            # the reader can settle it at a glance (issue #1397).
+            link_health = self._lock.describe_link_health()
             self._suspend_slot(
                 slot_state,
                 f"Lock **{self._lock.lock.entity_id}**: slot "
@@ -796,7 +801,8 @@ class SlotSyncManager:
                 f"experiencing communication issues. "
                 f"Sync has been suspended for this slot. It will resume "
                 f"automatically once the lock accepts the code or you change "
-                f"the PIN for this slot.",
+                f"the PIN for this slot."
+                + (f"\n\n{link_health}" if link_health else ""),
             )
             return
 

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -530,6 +530,26 @@ class BaseLock:
         """
         return False
 
+    def describe_link_health(self) -> str | None:
+        """
+        Describe how reliably the integration is reaching this lock, if it can.
+
+        Purely descriptive: the returned sentence is appended to the repair
+        raised when a slot suspends, and nothing reads it to make a decision.
+        A provider that cannot measure its transport returns None and the
+        repair keeps its generic wording.
+
+        The point is to state measurements, not conclusions. "Failed to sync"
+        cannot distinguish a lock that refuses a code from a lock whose
+        replies never arrive, and the integration has no reliable way to tell
+        those apart -- but a transport that reports how much traffic it is
+        losing lets the person reading the repair tell instantly. So report
+        counters and leave the diagnosis to the reader (issue #1397, where a
+        lock dropping roughly half its responses looked identical to a lock
+        rejecting the code).
+        """
+        return None
+
     @final
     @property
     def provider_setup_succeeded(self) -> bool:

--- a/custom_components/lock_code_manager/providers/matter.py
+++ b/custom_components/lock_code_manager/providers/matter.py
@@ -61,6 +61,15 @@ from .const import LOGGER
 # DoorLock cluster ID (0x0101 = 257)
 _DOOR_LOCK_CLUSTER_ID = 257
 
+# Thread Network Diagnostics cluster (0x0035 = 53) on the root endpoint, and
+# the three counters describe_link_health quotes. Every one is optional --
+# the cluster gates them behind feature bits -- so each is read on its own and
+# dropped when absent rather than probing the feature map.
+_THREAD_DIAGNOSTICS_CLUSTER_ID = 53
+_THREAD_DETACHED_ROLE_COUNT = 14
+_THREAD_TX_ACK_REQUESTED_COUNT = 25
+_THREAD_TX_ACKED_COUNT = 26
+
 # DoorLock cluster event IDs
 _LOCK_OPERATION_EVENT_ID = 2
 _LOCK_USER_CHANGE_EVENT_ID = 4
@@ -1085,6 +1094,75 @@ class MatterLock(BaseLock):
         return state is not None and state.state not in (
             STATE_UNAVAILABLE,
             STATE_UNKNOWN,
+        )
+
+    def describe_link_health(self) -> str | None:
+        """
+        Report the lock's own Thread radio counters.
+
+        Two numbers, both read straight from Thread Network Diagnostics:
+        acknowledged transmissions out of those that asked to be
+        acknowledged, and how many times the lock has dropped off the Thread
+        network. The first pair is safe to state as a proportion because
+        both counters are drawn from the same population -- unlike most
+        counter pairs in this cluster, where the numerator and denominator
+        count different traffic and a ratio would quietly mislead.
+
+        Every counter here is optional (the cluster gates them behind
+        feature bits), so each is read independently and simply omitted when
+        the lock does not keep it. That avoids having to model which feature
+        bit governs which attribute, and a lock keeping neither produces no
+        description at all rather than a sentence full of blanks.
+
+        The wording is explicit that these are the lock's own view of its
+        radio, not the hub's view of reaching the lock, and that they are
+        cumulative since the lock last restarted. Both caveats matter:
+        counters that survived a healthy month look alarming next to a
+        problem that started an hour ago.
+
+        Thread only. A Wi-Fi or Ethernet Matter lock exposes a different
+        diagnostics cluster whose semantics have not been verified against
+        real hardware, and guessing at them is exactly how a reassuring
+        sentence ends up pointing at the wrong cause.
+        """
+        _client, node, _device = self._resolve()
+        if node is None:
+            return None
+        try:
+            acked = node.get_attribute_value(
+                0, _THREAD_DIAGNOSTICS_CLUSTER_ID, _THREAD_TX_ACKED_COUNT
+            )
+            ack_requested = node.get_attribute_value(
+                0, _THREAD_DIAGNOSTICS_CLUSTER_ID, _THREAD_TX_ACK_REQUESTED_COUNT
+            )
+            detached = node.get_attribute_value(
+                0, _THREAD_DIAGNOSTICS_CLUSTER_ID, _THREAD_DETACHED_ROLE_COUNT
+            )
+        except (KeyError, AttributeError, MatterError, HomeAssistantError) as err:
+            LOGGER.debug(
+                "Lock %s: failed to read Thread diagnostics: %s",
+                self.lock.entity_id,
+                err,
+            )
+            return None
+        parts = []
+        if acked is not None and ack_requested:
+            parts.append(
+                f"{acked} of {ack_requested} transmissions that asked to be "
+                f"acknowledged were acknowledged"
+            )
+        if detached:
+            parts.append(
+                f"the lock has dropped off the Thread network {detached} times"
+            )
+        if not parts:
+            return None
+        return (
+            f"Thread link, from the lock's own radio counters since it last "
+            f"restarted: {', and '.join(parts)}. These are the lock's view of its "
+            f"own radio rather than the hub's view of reaching it; repeated drops "
+            f"or unacknowledged transmissions point to a Thread range or mesh "
+            f"problem rather than the lock refusing the code."
         )
 
     # -- Event subscription via push framework --------------------------------

--- a/custom_components/lock_code_manager/providers/zha.py
+++ b/custom_components/lock_code_manager/providers/zha.py
@@ -23,6 +23,7 @@ from homeassistant.components.zha.helpers import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import callback
+from homeassistant.util import dt as dt_util
 
 from ..domain.credentials import (
     Credential,
@@ -174,6 +175,48 @@ class ZHALock(BaseLock):
 
         _LOGGER.warning("Could not find DoorLock cluster for %s", self.lock.entity_id)
         return None
+
+    def describe_link_health(self) -> str | None:
+        """
+        Report what the coordinator last heard from this lock.
+
+        Zigbee offers nothing equivalent to Z-Wave's per-node failure
+        counters -- zigpy tracks counters on the radio application, not per
+        device -- so this reports the other honest signal: the quality of
+        the most recent frame received *from* the lock, and how long ago
+        that was. The wording says "last frame" rather than "signal
+        strength" because that is literally what zigpy stores: ``lqi`` and
+        ``rssi`` are overwritten from each received packet, so they describe
+        one moment rather than an average.
+
+        Staleness carries most of the weight here. A lock that has not been
+        heard from in hours while Lock Code Manager is actively writing to
+        it is the Zigbee equivalent of the unanswered-command count, and it
+        stays meaningful even when the radio reports no signal metrics.
+
+        Descriptive only: an unresolvable device yields no description
+        rather than an error, because this runs while a slot is already
+        suspending and the repair matters more than the detail.
+        """
+        cluster = self._get_door_lock_cluster()
+        if cluster is None:
+            return None
+        device = cluster.endpoint.device
+        parts = []
+        if (lqi := device.lqi) is not None:
+            parts.append(f"signal quality {lqi} of 255")
+        if (rssi := device.rssi) is not None:
+            parts.append(f"{rssi} dBm")
+        if (last_seen := device.last_seen) is not None:
+            age = dt_util.get_age(dt_util.utc_from_timestamp(last_seen))
+            parts.append(f"last heard from {age} ago")
+        if not parts:
+            return None
+        return (
+            f"Zigbee link, from the last frame this lock sent: {', '.join(parts)}. "
+            f"A weak signal, or a lock not heard from recently, points to a Zigbee "
+            f"range or mesh problem rather than the lock refusing the code."
+        )
 
     async def _get_connected_cluster(self) -> DoorLock:
         """Return a connected DoorLock cluster or raise LockDisconnected."""

--- a/custom_components/lock_code_manager/providers/zwave_js.py
+++ b/custom_components/lock_code_manager/providers/zwave_js.py
@@ -1068,30 +1068,57 @@ class ZWaveJSLock(BaseLock):
 
     def describe_link_health(self) -> str | None:
         """
-        Report how much of the traffic aimed at this node goes unanswered.
+        Report how much of the traffic aimed at this node fails to complete.
 
-        The counters are cumulative since Z-Wave JS last started, which the
-        wording says outright: a node that was unreachable last week and is
-        healthy now still reads badly, and a reader who assumed the numbers
-        were recent would draw the wrong conclusion from them.
+        Reports three counters side by side rather than a single ratio,
+        because each answers a different question and node-zwave-js counts
+        them over different populations. ``commandsTX`` counts only commands
+        that were *successfully sent*, so a lock that has drifted out of
+        range increments ``commandsDroppedTX`` instead and would otherwise
+        report a flawless link at the very moment it is unreachable.
+        ``timeoutResponse`` counts only Get-type commands whose reply never
+        arrived, so dividing it by every command sent -- Sets included --
+        would understate the failure rate on a lock that is mostly written
+        to. Quoting the raw numbers sidesteps both distortions.
 
-        They also count every command sent to the node, not only Lock Code
-        Manager's, so this describes the link rather than any one write --
-        which is exactly the question the suspension repair cannot answer on
-        its own.
+        The wording states the window ("since Z-Wave JS started or the
+        statistics were last reset") because the counters are cumulative and
+        resettable: a node that was unreachable last week and is healthy now
+        still reads badly, and a reader who assumed the numbers were recent
+        would draw the wrong conclusion. Round-trip time is reported as an
+        average for the same reason -- node-zwave-js keeps it as an
+        exponential moving average, so one old outlier holds it up long
+        after the link recovers.
+
+        Descriptive only, so an unresolvable node yields no description
+        rather than an error: this runs while a slot is already suspending,
+        and the repair matters more than the detail.
         """
-        statistics = self.node.statistics
-        if not (sent := statistics.commands_tx):
+        try:
+            statistics = self.node.statistics
+        except Exception as err:
+            _LOGGER.debug(
+                "Lock %s: failed to read Z-Wave node statistics: %s",
+                self.lock.entity_id,
+                err,
+            )
+            return None
+        sent = statistics.commands_tx
+        unsendable = statistics.commands_dropped_tx
+        if not (sent or unsendable):
             return None
         summary = (
-            f"Z-Wave link: {statistics.timeout_response} of {sent} commands sent "
-            f"to this lock went unanswered since Z-Wave JS last started"
+            f"Z-Wave link, counted since Z-Wave JS started or the statistics were "
+            f"last reset: {sent} commands reached this lock, {unsendable} could "
+            f"not be sent at all, and {statistics.timeout_response} read requests "
+            f"went unanswered"
         )
         if (round_trip := statistics.rtt) is not None:
-            summary += f", and the last round trip took {round_trip:.0f} ms"
+            summary += f"; recent round trips averaged {round_trip:.0f} ms"
         return (
-            f"{summary}. A large proportion of unanswered commands points to a "
-            f"Z-Wave range or mesh problem rather than the lock refusing the code."
+            f"{summary}. Commands that cannot be sent, or that go unanswered, "
+            f"point to a Z-Wave range or mesh problem rather than the lock "
+            f"refusing the code."
         )
 
     async def async_hard_refresh_codes(self) -> dict[int, SlotCredential]:

--- a/custom_components/lock_code_manager/providers/zwave_js.py
+++ b/custom_components/lock_code_manager/providers/zwave_js.py
@@ -1066,6 +1066,34 @@ class ZWaveJSLock(BaseLock):
             )
             return False
 
+    def describe_link_health(self) -> str | None:
+        """
+        Report how much of the traffic aimed at this node goes unanswered.
+
+        The counters are cumulative since Z-Wave JS last started, which the
+        wording says outright: a node that was unreachable last week and is
+        healthy now still reads badly, and a reader who assumed the numbers
+        were recent would draw the wrong conclusion from them.
+
+        They also count every command sent to the node, not only Lock Code
+        Manager's, so this describes the link rather than any one write --
+        which is exactly the question the suspension repair cannot answer on
+        its own.
+        """
+        statistics = self.node.statistics
+        if not (sent := statistics.commands_tx):
+            return None
+        summary = (
+            f"Z-Wave link: {statistics.timeout_response} of {sent} commands sent "
+            f"to this lock went unanswered since Z-Wave JS last started"
+        )
+        if (round_trip := statistics.rtt) is not None:
+            summary += f", and the last round trip took {round_trip:.0f} ms"
+        return (
+            f"{summary}. A large proportion of unanswered commands points to a "
+            f"Z-Wave range or mesh problem rather than the lock refusing the code."
+        )
+
     async def async_hard_refresh_codes(self) -> dict[int, SlotCredential]:
         """Re-read users AND credentials fresh from the device, then project to slots."""
         try:

--- a/tests/providers/matter/test_provider.py
+++ b/tests/providers/matter/test_provider.py
@@ -147,6 +147,77 @@ class TestNativeTransportContract(ProviderNativeTransportContractTests):
         )
 
 
+class TestLinkHealth:
+    """Thread diagnostics quoted into the slot suspension repair (issue #1397)."""
+
+    @staticmethod
+    def _resolve(lock: MatterLock, values: dict[int, Any] | None):
+        """Patch node resolution to a node serving the given Thread counters."""
+        if values is None:
+            return patch.object(lock, "_resolve", return_value=(None, None, None))
+        node = MagicMock()
+        node.get_attribute_value.side_effect = lambda _endpoint, _cluster, attribute: (
+            values.get(attribute)
+        )
+        return patch.object(lock, "_resolve", return_value=(MagicMock(), node, None))
+
+    async def test_reports_acknowledgements_and_drops(
+        self, matter_lock_simple: MatterLock
+    ) -> None:
+        """Counters taken from a real Aqara U300 on Thread."""
+        with self._resolve(matter_lock_simple, {25: 3611401, 26: 3608185, 14: 228}):
+            description = matter_lock_simple.describe_link_health()
+
+        assert description is not None
+        assert "3608185 of 3611401 transmissions" in description
+        assert "dropped off the Thread network 228 times" in description
+
+    async def test_omits_counters_the_lock_does_not_keep(
+        self, matter_lock_simple: MatterLock
+    ) -> None:
+        """
+        Every Thread counter is optional, so a lock keeping only some of them
+        still describes those rather than reporting blanks.
+        """
+        with self._resolve(matter_lock_simple, {25: None, 26: None, 14: 228}):
+            description = matter_lock_simple.describe_link_health()
+
+        assert description is not None
+        assert "dropped off the Thread network 228 times" in description
+        assert "transmissions that asked to be" not in description
+
+    async def test_none_when_no_counters_kept(
+        self, matter_lock_simple: MatterLock
+    ) -> None:
+        """A Wi-Fi lock, or one without the counter features, describes nothing."""
+        with self._resolve(matter_lock_simple, {25: None, 26: None, 14: None}):
+            assert matter_lock_simple.describe_link_health() is None
+
+    async def test_none_when_node_unresolved(
+        self, matter_lock_simple: MatterLock
+    ) -> None:
+        """An unresolved node must not abort the suspension it is describing."""
+        with self._resolve(matter_lock_simple, None):
+            assert matter_lock_simple.describe_link_health() is None
+
+    @pytest.mark.parametrize(
+        "error", [UnknownError("boom"), KeyError(0), HomeAssistantError("boom")]
+    )
+    async def test_none_when_reading_counters_fails(
+        self, matter_lock_simple: MatterLock, error: Exception
+    ) -> None:
+        """
+        A failed diagnostics read must not cost the caller its repair: this runs
+        ahead of _suspend_slot, outside the tick's own error handling.
+        """
+        node = MagicMock()
+        node.get_attribute_value.side_effect = error
+        with patch.object(
+            matter_lock_simple, "_resolve", return_value=(MagicMock(), node, None)
+        ):
+            assert matter_lock_simple.describe_link_health() is None
+
+
 class TestDeviceAvailability:
     """Device availability tests for Matter provider."""
 

--- a/tests/providers/test_base.py
+++ b/tests/providers/test_base.py
@@ -156,6 +156,22 @@ async def test_unsubscribe_push_updates_suppresses_not_implemented(
     lock.unsubscribe_push_updates()  # must not raise
 
 
+async def test_describe_link_health_defaults_to_none(hass: HomeAssistant) -> None:
+    """A provider that cannot measure its transport describes nothing."""
+    entity_reg = er.async_get(hass)
+    config_entry = MockConfigEntry(domain=DOMAIN)
+    config_entry.add_to_hass(hass)
+    lock_entity = entity_reg.async_get_or_create(
+        "lock",
+        "test",
+        "test_lock_link_health",
+        config_entry=config_entry,
+    )
+    lock = BaseLock(hass, dr.async_get(hass), entity_reg, config_entry, lock_entity)
+
+    assert lock.describe_link_health() is None
+
+
 class _PushSetupRaisesLock(MockLCMLock):
     """Mock lock whose setup_push_subscription raises a configurable error."""
 

--- a/tests/providers/zha/test_provider.py
+++ b/tests/providers/zha/test_provider.py
@@ -11,6 +11,7 @@ from zigpy.zcl.clusters.closures import DoorLock
 
 from homeassistant.components.zha.const import DOMAIN as ZHA_DOMAIN
 from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
 
 from custom_components.lock_code_manager.domain.credentials import (
     CredentialRef,
@@ -104,6 +105,69 @@ async def test_get_door_lock_cluster_caches_result(
     cluster1 = zha_lock._get_door_lock_cluster()
     cluster2 = zha_lock._get_door_lock_cluster()
     assert cluster1 is cluster2
+
+
+async def test_describe_link_health_reports_last_frame(
+    hass: HomeAssistant, zha_lock: ZHALock
+) -> None:
+    """Signal metrics and staleness describe the most recent frame received."""
+    cluster = zha_lock._get_door_lock_cluster()
+    assert cluster is not None
+    device = cluster.endpoint.device
+    device.lqi = 12
+    device.rssi = -89
+    device.last_seen = dt_util.utcnow() - timedelta(hours=3)
+
+    description = zha_lock.describe_link_health()
+
+    assert description is not None
+    assert "signal quality 12 of 255" in description
+    assert "-89 dBm" in description
+    assert "last heard from 3 hours ago" in description
+
+
+async def test_describe_link_health_reports_staleness_without_signal(
+    hass: HomeAssistant, zha_lock: ZHALock
+) -> None:
+    """
+    A radio that reports no signal metrics still says when the lock was last
+    heard from -- the part that carries the diagnosis.
+    """
+    cluster = zha_lock._get_door_lock_cluster()
+    assert cluster is not None
+    device = cluster.endpoint.device
+    device.lqi = None
+    device.rssi = None
+    device.last_seen = dt_util.utcnow() - timedelta(minutes=45)
+
+    description = zha_lock.describe_link_health()
+
+    assert description is not None
+    assert "45 minutes ago" in description
+    assert "signal quality" not in description
+    assert "dBm" not in description
+
+
+async def test_describe_link_health_none_without_any_metrics(
+    hass: HomeAssistant, zha_lock: ZHALock
+) -> None:
+    """Nothing measured means nothing truthful to report."""
+    cluster = zha_lock._get_door_lock_cluster()
+    assert cluster is not None
+    device = cluster.endpoint.device
+    device.lqi = None
+    device.rssi = None
+    device.last_seen = None
+
+    assert zha_lock.describe_link_health() is None
+
+
+async def test_describe_link_health_none_when_cluster_unresolvable(
+    hass: HomeAssistant, zha_lock: ZHALock
+) -> None:
+    """An unresolvable device must not abort the suspension it is describing."""
+    with patch.object(zha_lock, "_get_door_lock_cluster", return_value=None):
+        assert zha_lock.describe_link_health() is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/providers/zwave_js/test_provider.py
+++ b/tests/providers/zwave_js/test_provider.py
@@ -11,6 +11,7 @@ from zwave_js_server.const.command_class.access_control import (
     UserCredentialType,
     UserCredentialUserType,
 )
+from zwave_js_server.event import Event
 from zwave_js_server.exceptions import FailedZWaveCommand
 from zwave_js_server.model.access_control import CredentialData, UserData
 from zwave_js_server.model.node import Node
@@ -101,6 +102,69 @@ async def test_connection_check_interval_is_none(zwave_js_lock: ZWaveJSLock) -> 
 async def test_supports_native_users(zwave_js_lock: ZWaveJSLock) -> None:
     """Test that Z-Wave JS lock reports supports_native_users=True."""
     assert zwave_js_lock.supports_native_users is True
+
+
+def _set_node_statistics(node: Node, **statistics: object) -> None:
+    """Push a statistics update through the node's normal event handler."""
+    node.handle_statistics_updated(
+        Event(
+            "statistics updated",
+            {
+                "source": "node",
+                "event": "statistics updated",
+                "nodeId": node.node_id,
+                "statistics": {
+                    "commandsTX": 0,
+                    "commandsRX": 0,
+                    "commandsDroppedTX": 0,
+                    "commandsDroppedRX": 0,
+                    "timeoutResponse": 0,
+                    **statistics,
+                },
+            },
+        )
+    )
+
+
+async def test_describe_link_health_reports_unanswered_commands(
+    zwave_js_lock: ZWaveJSLock,
+    lock_schlage_be469: Node,
+) -> None:
+    """The description quotes the raw counters rather than a verdict."""
+    _set_node_statistics(
+        lock_schlage_be469, commandsTX=256, timeoutResponse=126, rtt=1072.1
+    )
+
+    description = zwave_js_lock.describe_link_health()
+
+    assert description is not None
+    assert "126 of 256 commands" in description
+    # Rounded, not raw: a fractional millisecond reads as false precision.
+    assert "1072 ms" in description
+
+
+async def test_describe_link_health_omits_round_trip_when_unknown(
+    zwave_js_lock: ZWaveJSLock,
+    lock_schlage_be469: Node,
+) -> None:
+    """A node that has not reported a round trip still describes its counters."""
+    _set_node_statistics(lock_schlage_be469, commandsTX=10, timeoutResponse=1)
+
+    description = zwave_js_lock.describe_link_health()
+
+    assert description is not None
+    assert "1 of 10 commands" in description
+    assert "round trip" not in description
+
+
+async def test_describe_link_health_none_without_traffic(
+    zwave_js_lock: ZWaveJSLock,
+    lock_schlage_be469: Node,
+) -> None:
+    """No commands sent yet means there is nothing truthful to report."""
+    _set_node_statistics(lock_schlage_be469, commandsTX=0, timeoutResponse=0)
+
+    assert zwave_js_lock.describe_link_health() is None
 
 
 async def test_node_property(

--- a/tests/providers/zwave_js/test_provider.py
+++ b/tests/providers/zwave_js/test_provider.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -126,21 +126,43 @@ def _set_node_statistics(node: Node, **statistics: object) -> None:
     )
 
 
-async def test_describe_link_health_reports_unanswered_commands(
+async def test_describe_link_health_reports_each_counter(
     zwave_js_lock: ZWaveJSLock,
     lock_schlage_be469: Node,
 ) -> None:
-    """The description quotes the raw counters rather than a verdict."""
+    """Each counter is quoted on its own rather than folded into a ratio."""
     _set_node_statistics(
-        lock_schlage_be469, commandsTX=256, timeoutResponse=126, rtt=1072.1
+        lock_schlage_be469,
+        commandsTX=256,
+        commandsDroppedTX=4,
+        timeoutResponse=126,
+        rtt=1072.1,
     )
 
     description = zwave_js_lock.describe_link_health()
 
     assert description is not None
-    assert "126 of 256 commands" in description
-    # Rounded, not raw: a fractional millisecond reads as false precision.
-    assert "1072 ms" in description
+    assert "256 commands reached this lock" in description
+    assert "4 could not be sent at all" in description
+    assert "126 read requests went unanswered" in description
+    # An exponential moving average, so it must not read as a single sample.
+    assert "recent round trips averaged 1072 ms" in description
+
+
+async def test_describe_link_health_reports_unsendable_commands_alone(
+    zwave_js_lock: ZWaveJSLock,
+    lock_schlage_be469: Node,
+) -> None:
+    """
+    A lock that is out of range never increments commandsTX, so keying off it
+    alone would stay silent exactly when the link is worst.
+    """
+    _set_node_statistics(lock_schlage_be469, commandsTX=0, commandsDroppedTX=20)
+
+    description = zwave_js_lock.describe_link_health()
+
+    assert description is not None
+    assert "20 could not be sent at all" in description
 
 
 async def test_describe_link_health_omits_round_trip_when_unknown(
@@ -153,18 +175,34 @@ async def test_describe_link_health_omits_round_trip_when_unknown(
     description = zwave_js_lock.describe_link_health()
 
     assert description is not None
-    assert "1 of 10 commands" in description
-    assert "round trip" not in description
+    assert "10 commands reached this lock" in description
+    assert "round trips" not in description
 
 
 async def test_describe_link_health_none_without_traffic(
     zwave_js_lock: ZWaveJSLock,
     lock_schlage_be469: Node,
 ) -> None:
-    """No commands sent yet means there is nothing truthful to report."""
-    _set_node_statistics(lock_schlage_be469, commandsTX=0, timeoutResponse=0)
+    """No traffic either way means there is nothing truthful to report."""
+    _set_node_statistics(lock_schlage_be469, commandsTX=0, commandsDroppedTX=0)
 
     assert zwave_js_lock.describe_link_health() is None
+
+
+async def test_describe_link_health_none_when_node_unresolvable(
+    zwave_js_lock: ZWaveJSLock,
+) -> None:
+    """
+    An unresolvable node must not abort the suspension it is describing: this
+    runs before _suspend_slot, outside the tick's own error handling.
+    """
+    with patch.object(
+        type(zwave_js_lock),
+        "node",
+        new_callable=PropertyMock,
+        side_effect=LockDisconnected("zwave_js entry reloading"),
+    ):
+        assert zwave_js_lock.describe_link_health() is None
 
 
 async def test_node_property(

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -547,6 +547,77 @@ class TestLockOperationFailedRetry:
         assert manager._coordinator.unreachable is False
 
 
+class TestSuspensionRepairLinkHealth:
+    """The suspension repair carries whatever the provider can measure (#1397)."""
+
+    async def _suspend_via_breaker(self, hass: HomeAssistant, manager) -> None:
+        """Fail the slot until the breaker trips, then tick once more to suspend."""
+        manager._coordinator.data[1] = SlotCredential.empty()
+        with patch.object(
+            manager,
+            "_perform_sync",
+            new_callable=AsyncMock,
+            side_effect=LockOperationFailed("operation failed"),
+        ):
+            for _ in range(MAX_SYNC_ATTEMPTS):
+                manager._state = SyncState.OUT_OF_SYNC
+                await manager._async_tick()
+                await hass.async_block_till_done()
+        manager._state = SyncState.OUT_OF_SYNC
+        await manager._async_tick()
+        await hass.async_block_till_done()
+
+    def _suspension_reason(self, hass: HomeAssistant, manager, entry_id: str) -> str:
+        """Return the reason text of the slot's suspension repair."""
+        issue = async_get_issue_registry(hass).async_get_issue(
+            DOMAIN,
+            f"slot_suspended_{entry_id}_{manager._lock.lock.entity_id}"
+            f"_{manager._slot_num}",
+        )
+        assert issue is not None
+        return issue.translation_placeholders["reason"]
+
+    async def test_reason_appends_provider_link_health(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """A provider that can measure its transport gets quoted verbatim."""
+        manager = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)._sync_manager
+
+        with patch.object(
+            manager._lock,
+            "describe_link_health",
+            return_value="Radio link: 126 of 256 commands went unanswered.",
+        ):
+            await self._suspend_via_breaker(hass, manager)
+
+        reason = self._suspension_reason(
+            hass, manager, lock_code_manager_config_entry.entry_id
+        )
+        assert "126 of 256 commands went unanswered" in reason
+        # The generic wording still leads; the measurement is added, not swapped in.
+        assert "failed to sync after" in reason
+
+    async def test_reason_unchanged_when_provider_cannot_measure(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """Providers with no transport insight keep the original wording."""
+        manager = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)._sync_manager
+
+        with patch.object(manager._lock, "describe_link_health", return_value=None):
+            await self._suspend_via_breaker(hass, manager)
+
+        reason = self._suspension_reason(
+            hass, manager, lock_code_manager_config_entry.entry_id
+        )
+        assert reason.endswith("the PIN for this slot.")
+
+
 class TestLockOperationUnsupportedSuspend:
     """A permanently-invalid request suspends immediately (issue #1398)."""
 


### PR DESCRIPTION
## Proposed change

The slot suspension repair currently guesses between two very different causes:

> The lock may be rejecting the code silently **or** experiencing communication issues.

Lock Code Manager has no reliable way to tell those apart from the lock's behaviour alone — both present identically from the slot: a code that was written and never reads back.

Providers that can measure their own transport do know. This adds an optional `describe_link_health()` hook on `BaseLock` (default `None`) whose sentence is appended to that repair.

**Descriptive only** — nothing reads it to make a decision, no new state, no thresholds, no control-flow change. A provider that cannot measure anything returns `None` and the repair keeps its wording verbatim. Every implementation reports *measurements*, never a verdict, states the semantics of what it reports, and never lets a failed read cost the caller its repair.

### Z-Wave JS

> Z-Wave link, counted since Z-Wave JS started or the statistics were last reset: 256 commands reached this lock, 4 could not be sent at all, and 126 read requests went unanswered; recent round trips averaged 1072 ms.

Three counters side by side rather than one ratio, because node-zwave-js counts them over different populations (verified against `NodeStatistics.ts`): `commandsTX` counts only commands *successfully sent* (`:47`) — an out-of-range lock increments `commandsDroppedTX` (`:54`) instead — while `timeoutResponse` counts only Get-type commands (`:55`). Any ratio built from these distorts in the exact case the feature exists for. `rtt` is an exponential moving average (`:59-61`), so it is reported as an average, and the window wording covers resets as well as restarts (`:44`).

### ZHA

> Zigbee link, from the last frame this lock sent: signal quality 12 of 255, -89 dBm, last heard from 3 hours ago.

Zigbee has no per-node failure counters — zigpy keeps counters on the radio application, not per device — so ZHA reports the other honest signal. Staleness carries most of the weight: a lock unheard-from for hours while LCM is actively writing to it is the Zigbee equivalent of an unanswered-command count, and it stays meaningful on radios reporting no signal metrics. `lqi`/`rssi` are overwritten from each received packet, so the wording says "the last frame this lock sent" rather than implying an average.

### Matter (Thread)

> Thread link, from the lock's own radio counters since it last restarted: 3608185 of 3611401 transmissions that asked to be acknowledged were acknowledged, and the lock has dropped off the Thread network 228 times.

Validated against real hardware (an Aqara Smart Lock U300 on Thread) after the mock fixture showed every Thread Network Diagnostics counter as zero, leaving it unclear whether they are ever populated. They are — that lock reports a feature map of 15, all four counter features present.

The acknowledgement pair is safe to state as a proportion because both counters are drawn from the same population, unlike most pairs in this cluster. Every counter is optional, so each is read independently and omitted when absent, which avoids modelling which feature bit governs which attribute. The wording is explicit that these are the lock's own view of its radio rather than the hub's view of reaching it.

Thread only: a Wi-Fi or Ethernet Matter lock exposes a different diagnostics cluster whose semantics are unverified against hardware.

### Providers with nothing to report

- **zigbee2mqtt** — publishes `linkquality`, but the provider does not retain it; capturing it would mean new per-lock state for a point-in-time value with no staleness signal.
- **Schlage / Akuvox** — cloud APIs with no radio telemetry.
- **virtual** — nothing to measure.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue: #1397

Motivated by #1397, where the reporter's lock left ~49% of the commands sent to it unanswered (126 of 256 cumulative; 19 of 39 during a controlled test). The write reached the lock — the PIN works on the keypad — but the driver's post-write verification read timed out, so the value database kept serving a stale `userIdStatus = Available` and the slot could never confirm. It looked exactly like a silently rejected code.

This does **not** close #1397: the reporter's underlying problem is their Z-Wave mesh, not integration logic. It makes the next report of this shape self-diagnosing.

Coverage remains at 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)