### PR TITLE
refactor: address credentials by CredentialAddress in coordinator and sync

### DIFF
--- a/custom_components/lock_code_manager/binary_sensor.py
+++ b/custom_components/lock_code_manager/binary_sensor.py
@@ -13,6 +13,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import ATTR_ACTIVE, ATTR_IN_SYNC, ATTR_SYNC_STATUS
 from .domain.coordinator import LockUsercodeUpdateCoordinator
+from .domain.credentials import pin_address
 from .domain.models import LockCodeManagerConfigEntry
 from .domain.sync import SlotSyncManager
 from .entity import BaseLockCodeManagerCodeSlotPerLockEntity, BaseLockCodeManagerEntity
@@ -146,7 +147,7 @@ class LockCodeManagerCodeSlotInSyncEntity(
             config_entry,
             coordinator,
             lock,
-            slot_num,
+            pin_address(slot_num),
             state_writer=_sync_and_write_state,
         )
 

--- a/custom_components/lock_code_manager/domain/coordinator.py
+++ b/custom_components/lock_code_manager/domain/coordinator.py
@@ -28,6 +28,7 @@ from ..const import (
     DOMAIN,
     POLL_FAILURE_ALERT_THRESHOLD,
 )
+from .credentials import CredentialAddress, CredentialType
 from .exceptions import LockCodeManagerError
 from .models import SlotCredential
 from .queries import get_entry_config
@@ -38,6 +39,23 @@ if TYPE_CHECKING:
     from ..providers import BaseLock
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _user_ref_of(address: CredentialAddress) -> int:
+    """
+    Unpack an address to the slot-keyed storage key.
+
+    The coordinator stores credentials slot-keyed and manages Personal
+    Identification Number credentials only, so a non-PIN address cannot be
+    served and is a programming error rather than a missing entry. Failing
+    here keeps a future second credential type from silently reading and
+    writing the PIN's storage.
+    """
+    if address.credential_type is not CredentialType.PIN:
+        raise ValueError(
+            f"Only PIN credentials are addressable today, got {address.credential_type}"
+        )
+    return address.user_ref
 
 
 class LockUsercodeUpdateCoordinator(DataUpdateCoordinator[dict[int, SlotCredential]]):
@@ -106,15 +124,15 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator[dict[int, SlotCredenti
         """Return the lock."""
         return self._lock
 
-    def desired_credential(self, slot_num: int) -> SlotCredential:
+    def desired_credential(self, address: CredentialAddress) -> SlotCredential:
         """
-        Return the credential LCM wants on a slot.
+        Return the credential LCM wants at an address.
 
         Disabled slots and enabled-but-blank slots map to
         ``SlotCredential.empty()``; an enabled slot with a configured PIN
         maps to ``SlotCredential.known(pin)``.
         """
-        slot_data = get_entry_config(self._config_entry).slot(slot_num)
+        slot_data = get_entry_config(self._config_entry).slot(_user_ref_of(address))
         if not slot_data.get(CONF_ENABLED):
             return SlotCredential.empty()
         pin = slot_data.get(CONF_PIN)
@@ -169,25 +187,25 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator[dict[int, SlotCredenti
         self._unverified &= out.keys()
         return out
 
-    def is_verified(self, slot: int) -> bool:
+    def is_verified(self, address: CredentialAddress) -> bool:
         """
-        Return whether the slot's credential is a confirmed observation.
+        Return whether the address's credential is a confirmed observation.
 
-        Unlisted slots are verified: a slot is only unverified while an
-        optimistic write awaits confirmation (push event or hard refresh).
+        Unlisted addresses are verified: an address is only unverified while
+        an optimistic write awaits confirmation (push event or hard refresh).
         """
-        return slot not in self._unverified
+        return _user_ref_of(address) not in self._unverified
 
     @callback
-    def mark_verified(self, slot: int) -> None:
+    def mark_verified(self, address: CredentialAddress) -> None:
         """
-        Drop a slot from the unverified set.
+        Drop an address from the unverified set.
 
         Called when a write is confirmed by the lock (an authoritative
-        ``WriteResult.CONFIRMED``), so a slot left unverified by a prior
-        optimistic write on the same slot cannot strand it.
+        ``WriteResult.CONFIRMED``), so an address left unverified by a prior
+        optimistic write on the same address cannot strand it.
         """
-        self._unverified.discard(slot)
+        self._unverified.discard(_user_ref_of(address))
 
     async def async_confirm_pending_writes(self) -> None:
         """

--- a/custom_components/lock_code_manager/domain/coordinator.py
+++ b/custom_components/lock_code_manager/domain/coordinator.py
@@ -51,11 +51,16 @@ def _user_ref_of(address: CredentialAddress) -> int:
     here keeps a future second credential type from silently reading and
     writing the PIN's storage.
     """
-    if address.credential_type is not CredentialType.PIN:
+    if address.credential_type != CredentialType.PIN:
         raise ValueError(
             f"Only PIN credentials are addressable today, got {address.credential_type}"
         )
-    return address.user_ref
+    # Coerce for the same reason ``_normalize_keys`` does: ``data`` and
+    # ``_unverified`` are int-keyed, and a slot number reaches entities as
+    # either ``int`` or ``str`` (see ``EntryConfig.has_slot``). An
+    # uncoerced ``"1"`` would miss every int key -- ``is_verified`` would
+    # report True for a slot whose optimistic write is still unconfirmed.
+    return int(address.user_ref)
 
 
 class LockUsercodeUpdateCoordinator(DataUpdateCoordinator[dict[int, SlotCredential]]):

--- a/custom_components/lock_code_manager/domain/credentials.py
+++ b/custom_components/lock_code_manager/domain/credentials.py
@@ -132,6 +132,38 @@ class CredentialRef(NamedTuple):
     slot: int
 
 
+class CredentialAddress(NamedTuple):
+    """
+    Address of one credential in Lock Code Manager's own keyspace.
+
+    Distinct from ``CredentialRef``, which addresses a credential on the
+    *device* using the identifiers the lock allocated. ``CredentialAddress``
+    is the integration-side handle the coordinator and the sync engine key
+    on: which managed user, and which kind of credential.
+
+    ``user_ref`` is deliberately loose. Today it is the managed slot number,
+    because the slot number is still the only user handle the configuration
+    has. Once the configuration migrates to named users it becomes the
+    user's name. Keeping both stages behind this one alias is what makes
+    that a one-place type change rather than a second re-key.
+    """
+
+    user_ref: int
+    credential_type: CredentialType
+
+
+def pin_address(user_ref: int) -> CredentialAddress:
+    """
+    Build the Personal Identification Number address for a managed user.
+
+    Every address in the integration is a PIN address today. This exists so
+    the call sites that assume that say so explicitly, and so adding a
+    second credential type surfaces each one as a place that needs a
+    decision rather than silently continuing to mean PIN.
+    """
+    return CredentialAddress(user_ref, CredentialType.PIN)
+
+
 @dataclass(slots=True)
 class User:
     """

--- a/custom_components/lock_code_manager/domain/sync.py
+++ b/custom_components/lock_code_manager/domain/sync.py
@@ -75,10 +75,17 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
-# Which entity holds the desired value for each credential type. Only the
-# value-writable types appear: a learn-at-device credential (fingerprint,
-# face) has no value entity because there is no value Lock Code Manager can
-# author for it.
+# Which entity holds the desired value for each credential type.
+#
+# Only Personal Identification Number is mapped because it is the only type
+# with a value entity today -- not because the other value-writable types
+# (password, Radio Frequency Identification, Near Field Communication) are
+# excluded by category. Adding one here is NOT sufficient on its own: the
+# matching text entity has to exist first, or ``SlotSyncManager.__init__``
+# raises out of entity platform setup.
+#
+# Learn-at-device credentials (fingerprint, face) are the one category that
+# can never appear, because there is no value Lock Code Manager can author.
 _VALUE_ENTITY_KEYS: Mapping[CredentialType, str] = MappingProxyType(
     {CredentialType.PIN: CONF_PIN}
 )

--- a/custom_components/lock_code_manager/domain/sync.py
+++ b/custom_components/lock_code_manager/domain/sync.py
@@ -54,6 +54,7 @@ from ..const import (
     TICK_INTERVAL,
 )
 from .config import build_slot_unique_id
+from .credentials import pin_address
 from .exceptions import (
     CodeRejectedError,
     LockDisconnected,
@@ -74,22 +75,28 @@ _LOGGER = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
-class SlotState:
+class CredentialSyncState:
     """
-    Snapshot of entity states for a slot on a specific lock.
+    Snapshot of entity states for one credential on a specific lock.
 
     Used by SlotSyncManager to compare desired (entity) vs actual
     (coordinator) state. Includes raw HA state strings (rather than
     parsed values) because sync logic needs to distinguish between
     "off" and "unavailable" — both look like the same parsed bool but
     mean different things for retry decisions.
+
+    ``credential_state`` is the desired value read off the entity that holds
+    it, and ``coordinator_credential`` is what the lock actually reports.
+    Both are named for the credential rather than the Personal
+    Identification Number because a second credential type stored in a field
+    called ``pin_state`` would be actively misleading.
     """
 
     active_state: str
-    pin_state: str
+    credential_state: str
     name_state: str | None
     code_state: str
-    coordinator_code: SlotCredential | None
+    coordinator_credential: SlotCredential | None
 
 
 class SlotSyncManager:
@@ -194,7 +201,7 @@ class SlotSyncManager:
         )
         self._breaker_reset_requested: bool = False
 
-        # The desired target (active_state, pin_state) captured when the slot
+        # The desired target (active_state, credential_state) captured when the slot
         # is suspended for a non-converging code or an unexpected error. While
         # set, the slot stays suspended until that target changes (user edits
         # the PIN or toggles the slot) or it returns to sync -- it does NOT
@@ -353,7 +360,7 @@ class SlotSyncManager:
 
         return True
 
-    def _resolve_slot_state(self) -> SlotState | None:
+    def _resolve_credential_snapshot(self) -> CredentialSyncState | None:
         """
         Resolve slot state from current entity and coordinator data.
 
@@ -377,25 +384,25 @@ class SlotSyncManager:
         # entity is optional). No awaits run between that check and these reads,
         # so the states cannot change underneath us on the single-threaded loop.
         active_state = self._get_entity_state(ATTR_ACTIVE)
-        pin_state = self._get_entity_state(CONF_PIN)
+        credential_state = self._get_entity_state(CONF_PIN)
         name_state = self._get_entity_state(CONF_NAME)
         code_state = self._get_entity_state(ATTR_CODE)
         assert active_state is not None
-        assert pin_state is not None
+        assert credential_state is not None
         assert code_state is not None
 
-        coordinator_code = self._coordinator.data.get(self._slot_num)
-        return SlotState(
+        coordinator_credential = self._coordinator.data.get(self._slot_num)
+        return CredentialSyncState(
             active_state=active_state,
-            pin_state=pin_state,
+            credential_state=credential_state,
             name_state=name_state,
             code_state=code_state,
-            coordinator_code=coordinator_code,
+            coordinator_credential=coordinator_credential,
         )
 
     # -- Sync calculation ----------------------------------------------------
 
-    def calculate_in_sync(self, slot_state: SlotState) -> bool:
+    def calculate_in_sync(self, snapshot: CredentialSyncState) -> bool:
         """
         Calculate whether slot should be in sync.
 
@@ -415,10 +422,10 @@ class SlotSyncManager:
         than declare success. Slots with no recorded flag read as verified, so
         this is a no-op for providers that never write optimistically.
         """
-        if not self._coordinator.is_verified(self._slot_num):
+        if not self._coordinator.is_verified(pin_address(self._slot_num)):
             return False
-        credential = slot_state.coordinator_code
-        if slot_state.active_state == STATE_ON:
+        credential = snapshot.coordinator_credential
+        if snapshot.active_state == STATE_ON:
             if credential is not None:
                 if credential.is_empty:
                     # If we recently set a PIN on this slot and it matches the
@@ -427,22 +434,22 @@ class SlotSyncManager:
                     # cloud API).
                     return (
                         self._last_set_pin is not None
-                        and slot_state.pin_state == self._last_set_pin
+                        and snapshot.credential_state == self._last_set_pin
                     )
                 if not credential.is_readable:
-                    return slot_state.pin_state == self._last_set_pin
-                return credential.matches(slot_state.pin_state)
+                    return snapshot.credential_state == self._last_set_pin
+                return credential.matches(snapshot.credential_state)
             # No coordinator data — fall back to the code sensor entity state.
-            return slot_state.pin_state == slot_state.code_state
+            return snapshot.credential_state == snapshot.code_state
         # active_state == STATE_OFF: slot should be cleared
         if credential is not None:
             return credential.is_empty
         # Code sensor entity returns "" for empty credential.
-        return slot_state.code_state == ""
+        return snapshot.code_state == ""
 
     # -- Sync execution ------------------------------------------------------
 
-    async def _perform_sync(self, slot_state: SlotState) -> bool:
+    async def _perform_sync(self, snapshot: CredentialSyncState) -> bool:
         """
         Execute sync operation (set or clear usercode).
 
@@ -452,14 +459,14 @@ class SlotSyncManager:
         propagates any other exception. Error handling and breaker accounting
         live in the caller (``_async_tick_impl``).
         """
-        if slot_state.active_state == STATE_ON:
+        if snapshot.active_state == STATE_ON:
             await self._lock.async_internal_set_usercode(
                 self._slot_num,
-                slot_state.pin_state,
-                slot_state.name_state,
+                snapshot.credential_state,
+                snapshot.name_state,
                 source="sync",
             )
-            self._last_set_pin = slot_state.pin_state
+            self._last_set_pin = snapshot.credential_state
             _LOGGER.debug("%s: Set usercode", self._log_prefix)
             return True
         await self._lock.async_internal_clear_usercode(self._slot_num, source="sync")
@@ -502,7 +509,7 @@ class SlotSyncManager:
         finally:
             self._breaker_reset_requested = True
 
-    def _suspend_slot(self, slot_state: SlotState, reason: str) -> None:
+    def _suspend_slot(self, snapshot: CredentialSyncState, reason: str) -> None:
         """
         Suspend this lock and slot and create a per-slot repair issue.
 
@@ -511,7 +518,7 @@ class SlotSyncManager:
         unrelated coordinator updates.
         """
         self._state = SyncState.SUSPENDED
-        self._code_suspend_target = (slot_state.active_state, slot_state.pin_state)
+        self._code_suspend_target = (snapshot.active_state, snapshot.credential_state)
         self._breaker_reset_requested = True
         self._write_state()
 
@@ -535,7 +542,7 @@ class SlotSyncManager:
             },
         )
 
-    def _clear_resolved_issues(self, slot_state: SlotState) -> None:
+    def _clear_resolved_issues(self, snapshot: CredentialSyncState) -> None:
         """
         Clear repair issues that no longer apply now that the slot is in sync.
 
@@ -545,7 +552,7 @@ class SlotSyncManager:
         issue is cleared regardless of active state.
         """
         entry_id = self._config_entry.entry_id
-        if slot_state.active_state == STATE_ON:
+        if snapshot.active_state == STATE_ON:
             async_delete_issue(
                 self._hass,
                 DOMAIN,
@@ -583,8 +590,8 @@ class SlotSyncManager:
         ``_breaker_reset_requested`` and the next tick consumes it.
         """
         if self._state is SyncState.IN_SYNC:
-            slot_state = self._resolve_slot_state()
-            if slot_state is not None and not self.calculate_in_sync(slot_state):
+            snapshot = self._resolve_credential_snapshot()
+            if snapshot is not None and not self.calculate_in_sync(snapshot):
                 self._state = SyncState.OUT_OF_SYNC
                 self._breaker_reset_requested = True
                 self._write_state()
@@ -595,11 +602,11 @@ class SlotSyncManager:
                 # edits the PIN or toggles the slot) or the slot returns to
                 # sync on its own -- otherwise stay suspended so we don't
                 # hammer the lock with a code it keeps rejecting.
-                slot_state = self._resolve_slot_state()
-                if slot_state is not None and (
-                    (slot_state.active_state, slot_state.pin_state)
+                snapshot = self._resolve_credential_snapshot()
+                if snapshot is not None and (
+                    (snapshot.active_state, snapshot.credential_state)
                     != self._code_suspend_target
-                    or self.calculate_in_sync(slot_state)
+                    or self.calculate_in_sync(snapshot)
                 ):
                     self._breaker_reset_requested = True
                     self._code_suspend_target = None
@@ -675,22 +682,22 @@ class SlotSyncManager:
             self._breaker_reset_requested = False
             self._slot_breaker.reset()
 
-        slot_state = self._resolve_slot_state()
-        if slot_state is None:
+        snapshot = self._resolve_credential_snapshot()
+        if snapshot is None:
             # State resolution failed — stay in current state and retry.
             return
 
-        expected_in_sync = self.calculate_in_sync(slot_state)
+        expected_in_sync = self.calculate_in_sync(snapshot)
 
         # -- LOADING: detect initial sync state without performing operations --
         if self._state is SyncState.LOADING:
-            if slot_state.active_state not in (STATE_ON, STATE_OFF):
+            if snapshot.active_state not in (STATE_ON, STATE_OFF):
                 if not self._logged_invalid_state:
                     _LOGGER.debug(
                         "%s: Active entity has invalid state '%s', waiting "
                         "for valid state (ON/OFF)",
                         self._log_prefix,
-                        slot_state.active_state,
+                        snapshot.active_state,
                     )
                     self._logged_invalid_state = True
                 return
@@ -731,8 +738,8 @@ class SlotSyncManager:
             # reconcile the new target instead of holding PENDING_CONFIRMATION
             # (and re-syncing the old value) until the deadline.
             still_wanted = (
-                slot_state.active_state == STATE_ON
-                and slot_state.pin_state == believed_pin
+                snapshot.active_state == STATE_ON
+                and snapshot.credential_state == believed_pin
             )
             if still_wanted and time.monotonic() < deadline:
                 if self._state is not SyncState.PENDING_CONFIRMATION:
@@ -775,7 +782,7 @@ class SlotSyncManager:
             self._state = SyncState.IN_SYNC
             self._slot_breaker.reset()
             self._write_state()
-            self._clear_resolved_issues(slot_state)
+            self._clear_resolved_issues(snapshot)
             return
 
         # Circuit breaker check: too many failed sync attempts (a set that
@@ -793,7 +800,7 @@ class SlotSyncManager:
             # the reader can settle it at a glance (issue #1397).
             link_health = self._lock.describe_link_health()
             self._suspend_slot(
-                slot_state,
+                snapshot,
                 f"Lock **{self._lock.lock.entity_id}**: slot "
                 f"**{self._slot_num}** failed to sync after "
                 f"{self._slot_breaker.failure_count} consecutive attempts. "
@@ -811,7 +818,7 @@ class SlotSyncManager:
         self._write_state()
         was_set = False
         try:
-            was_set = await self._perform_sync(slot_state)
+            was_set = await self._perform_sync(snapshot)
         except CodeRejectedError as err:
             _LOGGER.error("%s: Code rejected: %s", self._log_prefix, err)
             await self._disable_slot(
@@ -829,7 +836,7 @@ class SlotSyncManager:
             _LOGGER.info(
                 "%s: Lock unreachable during %s usercode: %s. Will retry on next tick.",
                 self._log_prefix,
-                "set" if slot_state.active_state == STATE_ON else "clear",
+                "set" if snapshot.active_state == STATE_ON else "clear",
                 err,
             )
             # Connectivity failure: feed the lock breaker so repeated failures
@@ -848,11 +855,11 @@ class SlotSyncManager:
                 "%s: Lock cannot %s this slot: %s. Suspending sync until the "
                 "configuration changes.",
                 self._log_prefix,
-                "set" if slot_state.active_state == STATE_ON else "clear",
+                "set" if snapshot.active_state == STATE_ON else "clear",
                 err,
             )
             self._suspend_slot(
-                slot_state,
+                snapshot,
                 f"Lock **{self._lock.lock.entity_id}**: slot "
                 f"**{self._slot_num}** cannot be synced because the lock will "
                 f"not accept it.\n\n{err}",
@@ -862,7 +869,7 @@ class SlotSyncManager:
             _LOGGER.info(
                 "%s: Operation failed during %s usercode: %s. Will retry on next tick.",
                 self._log_prefix,
-                "set" if slot_state.active_state == STATE_ON else "clear",
+                "set" if snapshot.active_state == STATE_ON else "clear",
                 err,
             )
             # The lock is reachable but the operation failed. Count toward the
@@ -878,12 +885,12 @@ class SlotSyncManager:
                 "Sync suspended for this lock to prevent infinite retry loop. "
                 "Error: %s: %s",
                 self._log_prefix,
-                "set" if slot_state.active_state == STATE_ON else "clear",
+                "set" if snapshot.active_state == STATE_ON else "clear",
                 type(err).__name__,
                 err,
             )
             self._suspend_slot(
-                slot_state,
+                snapshot,
                 f"Lock **{self._lock.lock.entity_id}**: slot **{self._slot_num}** "
                 f"encountered an unexpected error during sync. This may indicate a bug "
                 f"in the lock code manager integration. Check logs for details and "
@@ -924,12 +931,12 @@ class SlotSyncManager:
             return
 
         # Check if sync actually worked.
-        slot_state = self._resolve_slot_state()
-        if slot_state is not None and self.calculate_in_sync(slot_state):
+        snapshot = self._resolve_credential_snapshot()
+        if snapshot is not None and self.calculate_in_sync(snapshot):
             self._state = SyncState.IN_SYNC
             self._slot_breaker.reset()
             self._write_state()
-            self._clear_resolved_issues(slot_state)
+            self._clear_resolved_issues(snapshot)
         else:
             # Count only unverified sets so eventually-consistent providers
             # don't accumulate spurious failures when the readback lags.

--- a/custom_components/lock_code_manager/domain/sync.py
+++ b/custom_components/lock_code_manager/domain/sync.py
@@ -13,11 +13,12 @@ Circuit breaker: 3 attempts within 5 minutes (MAX_SYNC_ATTEMPTS, SYNC_ATTEMPT_WI
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from datetime import datetime
 import logging
 import time
+from types import MappingProxyType
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
@@ -54,7 +55,7 @@ from ..const import (
     TICK_INTERVAL,
 )
 from .config import build_slot_unique_id
-from .credentials import pin_address
+from .credentials import CredentialAddress, CredentialType
 from .exceptions import (
     CodeRejectedError,
     LockDisconnected,
@@ -72,6 +73,29 @@ if TYPE_CHECKING:
 
 
 _LOGGER = logging.getLogger(__name__)
+
+
+# Which entity holds the desired value for each credential type. Only the
+# value-writable types appear: a learn-at-device credential (fingerprint,
+# face) has no value entity because there is no value Lock Code Manager can
+# author for it.
+_VALUE_ENTITY_KEYS: Mapping[CredentialType, str] = MappingProxyType(
+    {CredentialType.PIN: CONF_PIN}
+)
+
+
+def value_entity_key(credential_type: CredentialType) -> str:
+    """
+    Return the entity key holding the desired value for a credential type.
+
+    Raises rather than defaulting, so a credential type wired up without its
+    value entity fails at construction instead of silently converging against
+    the Personal Identification Number's entity.
+    """
+    try:
+        return _VALUE_ENTITY_KEYS[credential_type]
+    except KeyError:
+        raise ValueError(f"{credential_type} has no value entity key") from None
 
 
 @dataclass(frozen=True)
@@ -138,7 +162,7 @@ class SlotSyncManager:
         config_entry: LockCodeManagerConfigEntry,
         coordinator: LockUsercodeUpdateCoordinator,
         lock: BaseLock,
-        slot_num: int,
+        address: CredentialAddress,
         state_writer: Callable[[bool | None], None],
     ) -> None:
         """Initialize the sync manager."""
@@ -147,19 +171,29 @@ class SlotSyncManager:
         self._config_entry = config_entry
         self._coordinator = coordinator
         self._lock = lock
-        self._slot_num = int(slot_num)
+        self._address = address
+        # The slot number still addresses the device and identifies the
+        # entities. While the configuration is slot-keyed the user reference
+        # IS the slot number; the lease lookup replaces this once users are
+        # named.
+        self._slot_num = slot_num = int(address.user_ref)
         self._state_writer = state_writer
 
         self._log_prefix = (
             f"{config_entry.entry_id} ({config_entry.title}): "
-            f"{lock.lock.entity_id} slot {slot_num}"
+            f"{lock.lock.entity_id} slot {slot_num} "
+            f"{address.credential_type.value}"
         )
 
         # Unique ID components for entity discovery
         entry_id = config_entry.entry_id
         lock_entity_id = lock.lock.entity_id
+        self._value_key = value_entity_key(address.credential_type)
         self._unique_ids: dict[str, tuple[str, str]] = {
-            CONF_PIN: (TEXT_DOMAIN, build_slot_unique_id(entry_id, slot_num, CONF_PIN)),
+            self._value_key: (
+                TEXT_DOMAIN,
+                build_slot_unique_id(entry_id, slot_num, self._value_key),
+            ),
             CONF_NAME: (
                 TEXT_DOMAIN,
                 build_slot_unique_id(entry_id, slot_num, CONF_NAME),
@@ -336,7 +370,7 @@ class SlotSyncManager:
         """
         # Collect all states in a single pass
         states: dict[str, str | None] = {}
-        for key in (CONF_PIN, CONF_NAME, ATTR_ACTIVE, ATTR_CODE):
+        for key in (self._value_key, CONF_NAME, ATTR_ACTIVE, ATTR_CODE):
             if key not in self._entity_id_map:
                 return False
             state = self._get_entity_state(key)
@@ -353,7 +387,7 @@ class SlotSyncManager:
         # Name is always optional (STATE_UNKNOWN = no name configured)
         # PIN and code sensor can be unknown when the slot is inactive
         slot_inactive = states[ATTR_ACTIVE] == STATE_OFF
-        for key in (CONF_PIN, ATTR_CODE):
+        for key in (self._value_key, ATTR_CODE):
             if states[key] == STATE_UNKNOWN and not slot_inactive:
                 _LOGGER.debug("%s: Waiting for %s state", self._log_prefix, key)
                 return False
@@ -384,7 +418,7 @@ class SlotSyncManager:
         # entity is optional). No awaits run between that check and these reads,
         # so the states cannot change underneath us on the single-threaded loop.
         active_state = self._get_entity_state(ATTR_ACTIVE)
-        credential_state = self._get_entity_state(CONF_PIN)
+        credential_state = self._get_entity_state(self._value_key)
         name_state = self._get_entity_state(CONF_NAME)
         code_state = self._get_entity_state(ATTR_CODE)
         assert active_state is not None
@@ -422,7 +456,7 @@ class SlotSyncManager:
         than declare success. Slots with no recorded flag read as verified, so
         this is a no-op for providers that never write optimistically.
         """
-        if not self._coordinator.is_verified(pin_address(self._slot_num)):
+        if not self._coordinator.is_verified(self._address):
             return False
         credential = snapshot.coordinator_credential
         if snapshot.active_state == STATE_ON:

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -54,6 +54,7 @@ from ..domain.credentials import (
     User,
     WriteResult,
     credential_from_slot,
+    pin_address,
     user_from_slot,
 )
 from ..domain.exceptions import (
@@ -1205,7 +1206,7 @@ class BaseLock:
             # optimistic write, so it can converge instead of churning to a suspend.
             self._pending_writes.pop(code_slot, None)
             if self.coordinator is not None:
-                self.coordinator.mark_verified(code_slot)
+                self.coordinator.mark_verified(pin_address(code_slot))
         # Skip coordinator refresh for push providers — they update optimistically
         # via push_update(), and refreshing from cache could overwrite with stale
         # data when the driver defers cache updates until device confirmation.

--- a/custom_components/lock_code_manager/providers/zigbee2mqtt.py
+++ b/custom_components/lock_code_manager/providers/zigbee2mqtt.py
@@ -637,7 +637,7 @@ class Zigbee2MQTTLock(BaseLock):
         # Query one slot at a time so Zigbee2MQTT / firmware can answer each GET before
         # the next. Parallel gather + per-slot timeouts can fail the entire refresh and
         # leave coordinator.data empty -- sync then skips every slot (see
-        # SlotSyncManager._resolve_slot_state).
+        # SlotSyncManager._resolve_credential_snapshot).
         # Transient publish/timeout/read failures use the unreadable credential so sync
         # does not treat the slot as confirmed-empty and storm reprogramming after MQTT
         # recovery.

--- a/custom_components/lock_code_manager/providers/zwave_js.py
+++ b/custom_components/lock_code_manager/providers/zwave_js.py
@@ -59,6 +59,7 @@ from ..domain.credentials import (
     SetUserResult,
     User,
     WriteResult,
+    pin_address,
 )
 from ..domain.exceptions import (
     CodeRejectedError,
@@ -885,7 +886,7 @@ class ZWaveJSLock(BaseLock):
         # set, which would cause infinite sync loops.
         if (
             self.coordinator is not None
-            and self.coordinator.desired_credential(code_slot).is_present
+            and self.coordinator.desired_credential(pin_address(code_slot)).is_present
         ):
             _LOGGER.debug(
                 "Lock %s: ignoring userIdStatus=AVAILABLE for slot %s "

--- a/custom_components/lock_code_manager/sensor.py
+++ b/custom_components/lock_code_manager/sensor.py
@@ -11,6 +11,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import ATTR_CODE
 from .domain.coordinator import LockUsercodeUpdateCoordinator
+from .domain.credentials import pin_address
 from .domain.models import LockCodeManagerConfigEntry
 from .entity import BaseLockCodeManagerCodeSlotPerLockEntity
 from .providers import BaseLock
@@ -84,7 +85,9 @@ class LockCodeManagerCodeSlotSensorEntity(
             return credential.readable_pin
         # Unreadable code: fall back to the configured PIN so the sensor still
         # exposes the slot's intended value to consumers like the sync layer.
-        return self.coordinator.desired_credential(int(self.slot_num)).readable_pin
+        return self.coordinator.desired_credential(
+            pin_address(int(self.slot_num))
+        ).readable_pin
 
     @property
     def available(self) -> bool:

--- a/tests/properties/test_in_sync.py
+++ b/tests/properties/test_in_sync.py
@@ -9,7 +9,10 @@ from hypothesis import given, strategies as st
 from homeassistant.const import STATE_OFF, STATE_ON
 
 from custom_components.lock_code_manager.domain.models import SlotCredential
-from custom_components.lock_code_manager.domain.sync import SlotState, SlotSyncManager
+from custom_components.lock_code_manager.domain.sync import (
+    CredentialSyncState,
+    SlotSyncManager,
+)
 
 PINS = st.text(alphabet="0123456789", min_size=4, max_size=8)
 LAST_SET = st.one_of(st.none(), PINS)
@@ -20,12 +23,12 @@ CREDENTIALS = st.one_of(
     PINS.map(SlotCredential.known),
 )
 SLOT_STATES = st.builds(
-    SlotState,
+    CredentialSyncState,
     active_state=st.sampled_from([STATE_ON, STATE_OFF]),
-    pin_state=PINS,
+    credential_state=PINS,
     name_state=st.one_of(st.none(), st.text(max_size=20)),
     code_state=st.one_of(st.just(""), PINS),
-    coordinator_code=CREDENTIALS,
+    coordinator_credential=CREDENTIALS,
 )
 
 
@@ -39,13 +42,13 @@ def _manager(*, verified: bool, last_set_pin: str | None) -> SlotSyncManager:
     return manager
 
 
-@given(slot_state=SLOT_STATES, last_set_pin=LAST_SET)
+@given(snapshot=SLOT_STATES, last_set_pin=LAST_SET)
 def test_unverified_slot_is_never_in_sync(
-    slot_state: SlotState, last_set_pin: str | None
+    snapshot: CredentialSyncState, last_set_pin: str | None
 ) -> None:
     """An optimistic write awaiting confirmation can never read as in sync."""
     manager = _manager(verified=False, last_set_pin=last_set_pin)
-    assert manager.calculate_in_sync(slot_state) is False
+    assert manager.calculate_in_sync(snapshot) is False
 
 
 @given(pin=PINS, credential_pin=PINS, last_set_pin=LAST_SET)
@@ -54,7 +57,9 @@ def test_active_readable_credential_syncs_iff_pin_matches(
 ) -> None:
     """Active slot with a readable code: in sync exactly when PINs match."""
     manager = _manager(verified=True, last_set_pin=last_set_pin)
-    state = SlotState(STATE_ON, pin, None, "", SlotCredential.known(credential_pin))
+    state = CredentialSyncState(
+        STATE_ON, pin, None, "", SlotCredential.known(credential_pin)
+    )
     assert manager.calculate_in_sync(state) is (pin == credential_pin)
 
 
@@ -64,7 +69,7 @@ def test_active_empty_credential_trusts_recent_set_only(
 ) -> None:
     """Active + lock reports empty: in sync only if we just set this exact PIN."""
     manager = _manager(verified=True, last_set_pin=last_set_pin)
-    state = SlotState(STATE_ON, pin, None, "", SlotCredential.empty())
+    state = CredentialSyncState(STATE_ON, pin, None, "", SlotCredential.empty())
     assert manager.calculate_in_sync(state) is (
         last_set_pin is not None and pin == last_set_pin
     )
@@ -76,7 +81,7 @@ def test_active_unreadable_credential_compares_last_set(
 ) -> None:
     """Active + write-only code: in sync iff configured PIN equals last set."""
     manager = _manager(verified=True, last_set_pin=last_set_pin)
-    state = SlotState(STATE_ON, pin, None, "", SlotCredential.unreadable())
+    state = CredentialSyncState(STATE_ON, pin, None, "", SlotCredential.unreadable())
     assert manager.calculate_in_sync(state) is (pin == last_set_pin)
 
 
@@ -86,23 +91,23 @@ def test_active_without_coordinator_data_falls_back_to_code_sensor(
 ) -> None:
     """No coordinator data: the code sensor entity is the comparison source."""
     manager = _manager(verified=True, last_set_pin=last_set_pin)
-    state = SlotState(STATE_ON, pin, None, code, None)
+    state = CredentialSyncState(STATE_ON, pin, None, code, None)
     assert manager.calculate_in_sync(state) is (pin == code)
 
 
-@given(slot_state=SLOT_STATES, last_set_pin=LAST_SET)
+@given(snapshot=SLOT_STATES, last_set_pin=LAST_SET)
 def test_inactive_slot_syncs_iff_lock_side_empty(
-    slot_state: SlotState, last_set_pin: str | None
+    snapshot: CredentialSyncState, last_set_pin: str | None
 ) -> None:
     """Inactive slot: in sync exactly when the lock side shows no code."""
     manager = _manager(verified=True, last_set_pin=last_set_pin)
-    state = SlotState(
+    state = CredentialSyncState(
         STATE_OFF,
-        slot_state.pin_state,
-        slot_state.name_state,
-        slot_state.code_state,
-        slot_state.coordinator_code,
+        snapshot.credential_state,
+        snapshot.name_state,
+        snapshot.code_state,
+        snapshot.coordinator_credential,
     )
-    credential = state.coordinator_code
+    credential = state.coordinator_credential
     expected = credential.is_empty if credential is not None else state.code_state == ""
     assert manager.calculate_in_sync(state) is expected

--- a/tests/properties/test_in_sync.py
+++ b/tests/properties/test_in_sync.py
@@ -8,6 +8,7 @@ from hypothesis import given, strategies as st
 
 from homeassistant.const import STATE_OFF, STATE_ON
 
+from custom_components.lock_code_manager.domain.credentials import pin_address
 from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.domain.sync import (
     CredentialSyncState,
@@ -34,10 +35,11 @@ SLOT_STATES = st.builds(
 
 def _manager(*, verified: bool, last_set_pin: str | None) -> SlotSyncManager:
     # __new__ skips the heavyweight __init__ (hass, registries, entities);
-    # calculate_in_sync only touches these three attributes.
+    # calculate_in_sync only touches these four attributes.
     manager = SlotSyncManager.__new__(SlotSyncManager)
     manager._slot_num = 1
-    manager._coordinator = SimpleNamespace(is_verified=lambda slot_num: verified)
+    manager._address = pin_address(1)
+    manager._coordinator = SimpleNamespace(is_verified=lambda address: verified)
     manager._last_set_pin = last_set_pin
     return manager
 

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -1985,14 +1985,14 @@ async def test_slot_disabled_during_sync_resolves_correctly(
 
     # Ensure coordinator data reflects the cleared slot. The mock lock
     # removes the key on clear, but the coordinator needs it present
-    # (as empty/SlotCredential.empty()) for _resolve_slot_state to work.
+    # (as empty/SlotCredential.empty()) for _resolve_credential_snapshot to work.
     # Refresh coordinator to pick up the current state.
     await coordinator.async_refresh()
     await hass.async_block_till_done()
 
     # After clearing, slot 1 may not be in coordinator data (provider-dependent).
     # If present with empty value, the next tick resolves to IN_SYNC.
-    # If absent, _resolve_slot_state returns None and the tick is a no-op.
+    # If absent, _resolve_credential_snapshot returns None and the tick is a no-op.
     # Either way, the important thing is that clear was called, not set.
     if mgr._slot_num in coordinator.data:
         await async_trigger_sync_tick(hass, SLOT_1_IN_SYNC_ENTITY, set_dirty=False)

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -26,6 +26,11 @@ from custom_components.lock_code_manager.const import (
 from custom_components.lock_code_manager.domain.coordinator import (
     LockUsercodeUpdateCoordinator,
 )
+from custom_components.lock_code_manager.domain.credentials import (
+    CredentialAddress,
+    CredentialType,
+    pin_address,
+)
 from custom_components.lock_code_manager.domain.exceptions import LockDisconnected
 from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers.virtual import VirtualLock
@@ -207,7 +212,7 @@ async def test_is_verified_defaults_true_for_absent_slot(
     push_coordinator: LockUsercodeUpdateCoordinator,
 ):
     """A slot with no recorded verified flag reads as verified."""
-    assert push_coordinator.is_verified(7) is True
+    assert push_coordinator.is_verified(pin_address(7)) is True
 
 
 async def test_push_update_default_marks_verified(
@@ -215,7 +220,7 @@ async def test_push_update_default_marks_verified(
 ):
     """The default (optimistic=False) push marks the slot verified."""
     push_coordinator.push_update({1: SlotCredential.known("9999")})
-    assert push_coordinator.is_verified(1) is True
+    assert push_coordinator.is_verified(pin_address(1)) is True
 
 
 async def test_push_update_optimistic_marks_unverified(
@@ -224,7 +229,7 @@ async def test_push_update_optimistic_marks_unverified(
     """An optimistic push marks the slot unverified."""
     push_coordinator.push_update({1: SlotCredential.known("9999")}, optimistic=True)
     assert push_coordinator.data[1] == SlotCredential.known("9999")
-    assert push_coordinator.is_verified(1) is False
+    assert push_coordinator.is_verified(pin_address(1)) is False
 
 
 async def test_push_update_verified_push_clears_unverified(
@@ -232,10 +237,10 @@ async def test_push_update_verified_push_clears_unverified(
 ):
     """A later verified push of a new value re-verifies the slot."""
     push_coordinator.push_update({1: SlotCredential.known("9999")}, optimistic=True)
-    assert push_coordinator.is_verified(1) is False
+    assert push_coordinator.is_verified(pin_address(1)) is False
 
     push_coordinator.push_update({1: SlotCredential.unreadable()})
-    assert push_coordinator.is_verified(1) is True
+    assert push_coordinator.is_verified(pin_address(1)) is True
 
 
 async def test_push_update_optimistic_same_value_flips_flag_without_notifying(
@@ -246,7 +251,7 @@ async def test_push_update_optimistic_same_value_flips_flag_without_notifying(
     with patch.object(push_coordinator, "async_set_updated_data") as mock_set_updated:
         push_coordinator.push_update({1: SlotCredential.known("9999")}, optimistic=True)
         mock_set_updated.assert_not_called()
-    assert push_coordinator.is_verified(1) is False
+    assert push_coordinator.is_verified(pin_address(1)) is False
 
 
 async def test_verified_map_pruned_with_data(
@@ -1040,7 +1045,7 @@ async def test_confirm_pending_writes_confirms_present_masked(
     """
     push_lock._pending_writes[1] = ("9999", time.monotonic() + 60.0)
     push_coordinator.push_update({1: SlotCredential.known("9999")}, optimistic=True)
-    assert push_coordinator.is_verified(1) is False
+    assert push_coordinator.is_verified(pin_address(1)) is False
 
     with patch.object(
         push_lock,
@@ -1050,7 +1055,7 @@ async def test_confirm_pending_writes_confirms_present_masked(
         await push_coordinator.async_confirm_pending_writes()
 
     assert 1 not in push_lock._pending_writes
-    assert push_coordinator.is_verified(1) is True
+    assert push_coordinator.is_verified(pin_address(1)) is True
     assert push_coordinator.data[1] == SlotCredential.known("9999")
 
 
@@ -1070,7 +1075,7 @@ async def test_confirm_pending_writes_keeps_absent_slot_pending(
         await push_coordinator.async_confirm_pending_writes()
 
     assert 1 in push_lock._pending_writes
-    assert push_coordinator.is_verified(1) is False
+    assert push_coordinator.is_verified(pin_address(1)) is False
 
 
 async def test_confirm_pending_writes_tolerates_read_failure(
@@ -1089,7 +1094,7 @@ async def test_confirm_pending_writes_tolerates_read_failure(
         await push_coordinator.async_confirm_pending_writes()
 
     assert 1 in push_lock._pending_writes
-    assert push_coordinator.is_verified(1) is False
+    assert push_coordinator.is_verified(pin_address(1)) is False
 
 
 async def test_confirm_pending_writes_noop_without_pending(
@@ -1121,7 +1126,7 @@ async def test_confirm_pending_writes_swallows_unexpected_error(
         await push_coordinator.async_confirm_pending_writes()
 
     assert 1 in push_lock._pending_writes
-    assert push_coordinator.is_verified(1) is False
+    assert push_coordinator.is_verified(pin_address(1)) is False
 
 
 async def test_desired_credential_disabled_slot_is_empty(
@@ -1137,7 +1142,7 @@ async def test_desired_credential_disabled_slot_is_empty(
             CONF_SLOTS: {1: {CONF_NAME: "x", CONF_PIN: "1234", CONF_ENABLED: False}},
         },
     )
-    assert poll_coordinator.desired_credential(1) == SlotCredential.empty()
+    assert poll_coordinator.desired_credential(pin_address(1)) == SlotCredential.empty()
 
 
 async def test_desired_credential_enabled_blank_pin_is_empty(
@@ -1153,7 +1158,7 @@ async def test_desired_credential_enabled_blank_pin_is_empty(
             CONF_SLOTS: {1: {CONF_NAME: "x", CONF_PIN: "", CONF_ENABLED: True}},
         },
     )
-    assert poll_coordinator.desired_credential(1) == SlotCredential.empty()
+    assert poll_coordinator.desired_credential(pin_address(1)) == SlotCredential.empty()
 
 
 async def test_desired_credential_enabled_with_pin_is_known(
@@ -1169,7 +1174,9 @@ async def test_desired_credential_enabled_with_pin_is_known(
             CONF_SLOTS: {1: {CONF_NAME: "x", CONF_PIN: "4242", CONF_ENABLED: True}},
         },
     )
-    assert poll_coordinator.desired_credential(1) == SlotCredential.known("4242")
+    assert poll_coordinator.desired_credential(pin_address(1)) == SlotCredential.known(
+        "4242"
+    )
 
 
 async def test_connection_check_swallows_lock_code_manager_error(
@@ -1202,4 +1209,27 @@ async def test_apply_read_takes_differing_readable_external_change(
 
     assert out[1] == SlotCredential.known("9999")
     assert 1 not in push_lock._pending_writes
-    assert push_coordinator.is_verified(1) is True
+    assert push_coordinator.is_verified(pin_address(1)) is True
+
+
+async def test_accessors_are_addressed_not_slot_numbered(push_coordinator) -> None:
+    """The credential accessors round-trip through a CredentialAddress."""
+    address = pin_address(1)
+    push_coordinator.push_update({1: SlotCredential.known("1234")}, optimistic=True)
+    assert push_coordinator.is_verified(address) is False
+    push_coordinator.mark_verified(address)
+    assert push_coordinator.is_verified(address) is True
+
+
+@pytest.mark.parametrize(
+    "accessor", ["is_verified", "mark_verified", "desired_credential"]
+)
+async def test_non_pin_address_is_rejected(push_coordinator, accessor) -> None:
+    """A non-PIN address is a programming error, not a missing entry.
+
+    Storage is still slot-keyed and PIN-only, so serving another credential
+    type would silently read and write the PIN's storage.
+    """
+    address = CredentialAddress(1, CredentialType.RFID)
+    with pytest.raises(ValueError, match="Only PIN credentials are addressable"):
+        getattr(push_coordinator, accessor)(address)

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1233,3 +1233,17 @@ async def test_non_pin_address_is_rejected(push_coordinator, accessor) -> None:
     address = CredentialAddress(1, CredentialType.RFID)
     with pytest.raises(ValueError, match="Only PIN credentials are addressable"):
         getattr(push_coordinator, accessor)(address)
+
+
+async def test_string_slot_number_still_resolves(push_coordinator) -> None:
+    """A str user_ref indexes the int-keyed storage.
+
+    Slot numbers reach entities as either int or str, which is why the
+    integration is littered with int(self.slot_num). Without coercion here,
+    is_verified would miss every int key and report True for a slot whose
+    optimistic write is still unconfirmed.
+    """
+    push_coordinator.push_update({1: SlotCredential.known("1234")}, optimistic=True)
+    assert push_coordinator.is_verified(pin_address("1")) is False
+    push_coordinator.mark_verified(pin_address("1"))
+    assert push_coordinator.is_verified(pin_address(1)) is True

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -4,6 +4,7 @@ import pytest
 
 from custom_components.lock_code_manager.domain.credentials import (
     Credential,
+    CredentialAddress,
     CredentialRef,
     CredentialRule,
     CredentialState,
@@ -15,6 +16,7 @@ from custom_components.lock_code_manager.domain.credentials import (
     UserType,
     WriteResult,
     credential_from_slot,
+    pin_address,
     slot_credential_of,
     user_from_slot,
 )
@@ -478,3 +480,22 @@ def test_max_user_name_length_defaults_to_zero() -> None:
         supports_user_management=True, max_users=30, credential_types={}
     )
     assert caps.max_user_name_length == 0
+
+
+def test_credential_address_is_hashable_and_destructures() -> None:
+    """CredentialAddress works as a dict key and unpacks positionally."""
+    address = CredentialAddress(3, CredentialType.PIN)
+    user_ref, credential_type = address
+    assert user_ref == 3
+    assert credential_type is CredentialType.PIN
+    assert {address: "x"}[CredentialAddress(3, CredentialType.PIN)] == "x"
+
+
+def test_pin_address_builds_a_pin_credential_address() -> None:
+    """pin_address is the sub-project A shorthand for the PIN-only world."""
+    assert pin_address(5) == CredentialAddress(5, CredentialType.PIN)
+
+
+def test_credential_address_distinguishes_types_at_the_same_user_ref() -> None:
+    """Two credential types on one user are different addresses."""
+    assert pin_address(1) != CredentialAddress(1, CredentialType.RFID)

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -23,6 +23,7 @@ from custom_components.lock_code_manager.const import (
     MAX_SYNC_ATTEMPTS,
 )
 from custom_components.lock_code_manager.domain.credentials import (
+    CredentialType,
     WriteResult,
     pin_address,
 )
@@ -36,6 +37,7 @@ from custom_components.lock_code_manager.domain.models import SlotCredential, Sy
 from custom_components.lock_code_manager.domain.sync import (
     CredentialSyncState,
     SlotSyncManager,
+    value_entity_key,
 )
 
 from .common import (
@@ -75,6 +77,7 @@ def _manager(
     mgr = MagicMock(spec=SlotSyncManager)
     mgr._last_set_pin = last_set_pin
     mgr._slot_num = slot_num
+    mgr._address = pin_address(slot_num)
     mgr._coordinator = MagicMock()
     mgr._coordinator.is_verified.return_value = verified
     mgr.calculate_in_sync = SlotSyncManager.calculate_in_sync.__get__(mgr)
@@ -2111,3 +2114,27 @@ class TestEntityStateHelpers:
         manager._entity_id_map.pop(CONF_PIN, None)
 
         assert manager._ensure_entities_ready() is False
+
+
+class TestValueEntityKey:
+    """Tests for the credential-type to value-entity-key mapping."""
+
+    def test_pin_maps_to_the_pin_entity(self) -> None:
+        """The Personal Identification Number's desired value lives on the pin entity."""
+        assert value_entity_key(CredentialType.PIN) == CONF_PIN
+
+    @pytest.mark.parametrize(
+        "credential_type",
+        [CredentialType.FACE, CredentialType.FINGERPRINT, CredentialType.RFID],
+    )
+    def test_unmapped_type_raises_rather_than_defaulting(
+        self, credential_type: CredentialType
+    ) -> None:
+        """An unmapped type fails loud instead of converging against the PIN entity.
+
+        Defaulting would make a credential type wired up without its value
+        entity silently read and write the Personal Identification Number's
+        state.
+        """
+        with pytest.raises(ValueError, match="has no value entity key"):
+            value_entity_key(credential_type)

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -22,7 +22,10 @@ from custom_components.lock_code_manager.const import (
     DOMAIN,
     MAX_SYNC_ATTEMPTS,
 )
-from custom_components.lock_code_manager.domain.credentials import WriteResult
+from custom_components.lock_code_manager.domain.credentials import (
+    WriteResult,
+    pin_address,
+)
 from custom_components.lock_code_manager.domain.exceptions import (
     CodeRejectedError,
     LockDisconnected,
@@ -30,7 +33,10 @@ from custom_components.lock_code_manager.domain.exceptions import (
     LockOperationUnsupported,
 )
 from custom_components.lock_code_manager.domain.models import SlotCredential, SyncState
-from custom_components.lock_code_manager.domain.sync import SlotState, SlotSyncManager
+from custom_components.lock_code_manager.domain.sync import (
+    CredentialSyncState,
+    SlotSyncManager,
+)
 
 from .common import (
     LOCK_1_ENTITY_ID,
@@ -48,17 +54,17 @@ def _slot(
     pin: str = "1234",
     name: str | None = "Test",
     code: str = "",
-    coordinator_code: str | SlotCredential | None = None,
-) -> SlotState:
-    """Build a SlotState for testing; raw strings are wrapped as known credentials."""
-    if isinstance(coordinator_code, str):
-        coordinator_code = SlotCredential.known(coordinator_code)
-    return SlotState(
+    coordinator_credential: str | SlotCredential | None = None,
+) -> CredentialSyncState:
+    """Build a CredentialSyncState for testing; raw strings are wrapped as known credentials."""
+    if isinstance(coordinator_credential, str):
+        coordinator_credential = SlotCredential.known(coordinator_credential)
+    return CredentialSyncState(
         active_state=active,
-        pin_state=pin,
+        credential_state=pin,
         name_state=name,
         code_state=code,
-        coordinator_code=coordinator_code,
+        coordinator_credential=coordinator_credential,
     )
 
 
@@ -84,13 +90,13 @@ class TestCalculateInSync:
             # -- Active (ON) + various lock codes --
             pytest.param(
                 None,
-                {"active": STATE_ON, "pin": "1234", "coordinator_code": "1234"},
+                {"active": STATE_ON, "pin": "1234", "coordinator_credential": "1234"},
                 True,
                 id="active-matching-pin",
             ),
             pytest.param(
                 None,
-                {"active": STATE_ON, "pin": "1234", "coordinator_code": "5678"},
+                {"active": STATE_ON, "pin": "1234", "coordinator_credential": "5678"},
                 False,
                 id="active-mismatched-pin",
             ),
@@ -99,7 +105,7 @@ class TestCalculateInSync:
                 {
                     "active": STATE_ON,
                     "pin": "1234",
-                    "coordinator_code": SlotCredential.unreadable(),
+                    "coordinator_credential": SlotCredential.unreadable(),
                 },
                 True,
                 id="active-unknown-code-matching-last-set",
@@ -109,7 +115,7 @@ class TestCalculateInSync:
                 {
                     "active": STATE_ON,
                     "pin": "5678",
-                    "coordinator_code": SlotCredential.unreadable(),
+                    "coordinator_credential": SlotCredential.unreadable(),
                 },
                 False,
                 id="active-unknown-code-pin-changed",
@@ -119,7 +125,7 @@ class TestCalculateInSync:
                 {
                     "active": STATE_ON,
                     "pin": "1234",
-                    "coordinator_code": SlotCredential.unreadable(),
+                    "coordinator_credential": SlotCredential.unreadable(),
                 },
                 False,
                 id="active-unknown-code-never-set",
@@ -129,7 +135,7 @@ class TestCalculateInSync:
                 {
                     "active": STATE_ON,
                     "pin": "1234",
-                    "coordinator_code": SlotCredential.empty(),
+                    "coordinator_credential": SlotCredential.empty(),
                 },
                 False,
                 id="active-empty-code",
@@ -139,7 +145,7 @@ class TestCalculateInSync:
                 {
                     "active": STATE_ON,
                     "pin": "1234",
-                    "coordinator_code": SlotCredential.empty(),
+                    "coordinator_credential": SlotCredential.empty(),
                 },
                 True,
                 id="active-empty-code-matching-last-set",
@@ -149,7 +155,7 @@ class TestCalculateInSync:
                 {
                     "active": STATE_ON,
                     "pin": "1234",
-                    "coordinator_code": SlotCredential.empty(),
+                    "coordinator_credential": SlotCredential.empty(),
                 },
                 False,
                 id="active-empty-code-mismatched-last-set",
@@ -159,7 +165,7 @@ class TestCalculateInSync:
                 {
                     "active": STATE_ON,
                     "pin": "1234",
-                    "coordinator_code": None,
+                    "coordinator_credential": None,
                     "code": "1234",
                 },
                 True,
@@ -170,7 +176,7 @@ class TestCalculateInSync:
                 {
                     "active": STATE_ON,
                     "pin": "1234",
-                    "coordinator_code": None,
+                    "coordinator_credential": None,
                     "code": "5678",
                 },
                 False,
@@ -179,31 +185,34 @@ class TestCalculateInSync:
             # -- Inactive (OFF) + various lock codes --
             pytest.param(
                 None,
-                {"active": STATE_OFF, "coordinator_code": SlotCredential.empty()},
+                {"active": STATE_OFF, "coordinator_credential": SlotCredential.empty()},
                 True,
                 id="inactive-empty-code",
             ),
             pytest.param(
                 None,
-                {"active": STATE_OFF, "coordinator_code": SlotCredential.unreadable()},
+                {
+                    "active": STATE_OFF,
+                    "coordinator_credential": SlotCredential.unreadable(),
+                },
                 False,
                 id="inactive-unknown-code",
             ),
             pytest.param(
                 None,
-                {"active": STATE_OFF, "coordinator_code": "1234"},
+                {"active": STATE_OFF, "coordinator_credential": "1234"},
                 False,
                 id="inactive-has-pin",
             ),
             pytest.param(
                 None,
-                {"active": STATE_OFF, "coordinator_code": None, "code": ""},
+                {"active": STATE_OFF, "coordinator_credential": None, "code": ""},
                 True,
                 id="inactive-empty-string-fallback",
             ),
             pytest.param(
                 None,
-                {"active": STATE_OFF, "coordinator_code": None, "code": "1234"},
+                {"active": STATE_OFF, "coordinator_credential": None, "code": "1234"},
                 False,
                 id="inactive-nonempty-string-fallback",
             ),
@@ -228,7 +237,7 @@ class TestCalculateInSync:
         value in the coordinator, but the lock has not confirmed it, so the
         tick must keep watching / re-sync rather than declare success.
         """
-        slot = _slot(active=STATE_ON, pin="1234", coordinator_code="1234")
+        slot = _slot(active=STATE_ON, pin="1234", coordinator_credential="1234")
         assert (
             _manager(last_set_pin="1234", verified=True).calculate_in_sync(slot) is True
         )
@@ -887,7 +896,7 @@ class TestSyncStateMachine:
         # marked verified, pending cleared.
         manager._lock._confirm_slot(1, SlotCredential.unreadable())
         assert 1 not in manager._lock._pending_writes
-        assert manager._coordinator.is_verified(1) is True
+        assert manager._coordinator.is_verified(pin_address(1)) is True
 
         manager.request_sync_check()
         await async_trigger_sync_tick(hass, SLOT_1_IN_SYNC_ENTITY, set_dirty=False)
@@ -949,7 +958,7 @@ class TestSyncStateMachine:
         # changed it while the write was outstanding. The stale entry must not
         # hold the slot in PENDING_CONFIRMATION (re-syncing the old value) until
         # the deadline; it is dropped and the new target re-syncs.
-        desired = manager._resolve_slot_state().pin_state
+        desired = manager._resolve_credential_snapshot().credential_state
         stale_pin = f"{desired}9"
         manager._lock._pending_writes[1] = (stale_pin, time.monotonic() + 60.0)
         manager._coordinator.push_update(
@@ -1731,14 +1740,14 @@ class TestBreakerTickSoleMutatorInvariant:
             manager._slot_breaker.record_failure()
         seeded_count = manager._slot_breaker.failure_count
 
-        slot_state = SlotState(
+        snapshot = CredentialSyncState(
             active_state=STATE_ON,
-            pin_state="1234",
+            credential_state="1234",
             name_state="Test",
             code_state="",
-            coordinator_code=SlotCredential.empty(),
+            coordinator_credential=SlotCredential.empty(),
         )
-        manager._suspend_slot(slot_state, "test reason")
+        manager._suspend_slot(snapshot, "test reason")
 
         # Synchronous: counter is unchanged, flag is set.
         assert manager._slot_breaker.failure_count == seeded_count
@@ -1995,7 +2004,7 @@ class TestOptimisticSetPendingConfirmation:
 
         assert manager._state is SyncState.PENDING_CONFIRMATION
         assert 1 in manager._lock._pending_writes
-        assert manager._coordinator.is_verified(1) is False
+        assert manager._coordinator.is_verified(pin_address(1)) is False
 
 
 class TestAsyncTickDefensiveGuards:


### PR DESCRIPTION
## Proposed change

Introduces `CredentialAddress` — a `(user_ref, credential_type)` handle — and routes the coordinator's credential accessors and `SlotSyncManager` through it instead of a bare slot number.

This is the first step of moving Lock Code Manager's organizing unit from the *slot* to the *user*. The provider layer already reached that shape (`domain/credentials.py` has `User`/`Credential`/`CredentialRef`, and `BaseLock` orchestrates user-first); everything above the provider seam is still slot-keyed. This PR lifts the addressing seam without changing any behavior.

**What changed**

- **`CredentialAddress` + `pin_address()`** in `domain/credentials.py`. Distinct from `CredentialRef`, which addresses a credential on the *device* by lock-allocated identifiers; `CredentialAddress` is the integration-side handle.
- **`desired_credential` / `is_verified` / `mark_verified`** take an address. A non-PIN address raises rather than falling through, so a future second credential type cannot silently read and write the PIN's storage.
- **`SlotState` → `CredentialSyncState`** with credential-generic field names (`pin_state` → `credential_state`, `coordinator_code` → `coordinator_credential`). A second credential type stored in a field called `pin_state` would be actively misleading, so the rename happens now while it is inert.
- **`SlotSyncManager`** takes an address and derives its desired-value entity key from the credential type via `value_entity_key`, rather than hardcoding `CONF_PIN`. Adding a credential type later becomes a mapping entry instead of an edit to the sync manager. `value_entity_key` raises on an unmapped type rather than defaulting.

**What deliberately did NOT change**

`coordinator.data` stays `dict[int, SlotCredential]`. It is read directly by `websocket.py`, `diagnostics.py`, and `providers/_base.py` (whose `_pending_writes` is slot-keyed and indexed by `_apply_read`), so re-keying the storage here would ripple through the websocket API, diagnostics, every provider, and several hundred test assertions — which would destroy the property that makes this PR reviewable. The storage flip lands later, alongside the config schema migration it has to move with anyway.

Also untouched, because they are different things that merely share a name: the providers' `_pin_state` (a raw-value decoder) and the `coordinator_code` key in the diagnostics payload.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

**Zero behavior change, and it is verifiable.** Every address constructed in this PR is `(slot_num, CredentialType.PIN)`, so every code path resolves exactly as before.

The test diff is entirely mechanical — wrapping ints in `pin_address(...)`, field renames, and new tests. No assertion outcome changed. I verified this by normalizing the `pin_address(N)` wraps out of both sides of the diff and comparing; the single non-matching line was `ruff format` line-wrapping, not a changed assertion.

- Full suite: **1491 passed, 3 skipped** (baseline before this work was 1480 passed, 3 skipped; +11 new tests)
- Coverage: **100.00%**, unchanged
- `ruff check`, `ruff format`, `pydocstyle`, `flake8`, `mypy`: all pass

New tests cover the `CredentialAddress` value type, the non-PIN rejection on all three accessors, and `value_entity_key`'s mapped and unmapped branches.

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

🤖 Generated with [Claude Code](https://claude.com/claude-code)
