### PR TITLE
refactor: key coordinator storage by CredentialAddress

### DIFF
--- a/custom_components/lock_code_manager/binary_sensor.py
+++ b/custom_components/lock_code_manager/binary_sensor.py
@@ -155,7 +155,7 @@ class LockCodeManagerCodeSlotInSyncEntity(
     def available(self) -> bool:
         """Return whether binary sensor is available or not."""
         return BaseLockCodeManagerCodeSlotPerLockEntity._is_available(self) and (
-            int(self.slot_num) in self.coordinator.data
+            self.coordinator.has_credential(pin_address(int(self.slot_num)))
         )
 
     @property

--- a/custom_components/lock_code_manager/diagnostics.py
+++ b/custom_components/lock_code_manager/diagnostics.py
@@ -10,6 +10,7 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .const import DOMAIN
 from .domain.config import build_slot_device_identifier
+from .domain.credentials import pin_address
 from .domain.models import SlotCode, SlotCredential
 from .domain.queries import get_entry_config
 from .domain.util import mask_pin
@@ -97,7 +98,7 @@ def _lock_diagnostic(
     coordinator_data = (
         {
             str(slot): _mask_code(code, slot, instance_id)
-            for slot, code in coordinator.data.items()
+            for slot, code in coordinator.credentials_by_slot().items()
         }
         if coordinator and coordinator.data
         else {}
@@ -152,7 +153,9 @@ def _slot_diagnostic(
         lock_id: (
             {
                 "coordinator_code": _mask_code(
-                    lock.coordinator.data.get(slot_num), slot_num, instance_id
+                    lock.coordinator.credential(pin_address(slot_num)),
+                    slot_num,
+                    instance_id,
                 )
             }
             if lock.coordinator and lock.coordinator.data

--- a/custom_components/lock_code_manager/domain/coordinator.py
+++ b/custom_components/lock_code_manager/domain/coordinator.py
@@ -183,14 +183,10 @@ class LockUsercodeUpdateCoordinator(
         """
         out: dict[CredentialAddress, SlotCredential] = {}
         for address, cred in observed.items():
-            # ``_pending_writes`` is keyed by DEVICE slot, not by address: it
-            # tracks a write aimed at a slot on the lock. Today the two
-            # coincide, which is why ``user_ref`` indexes it directly.
-            slot = address.user_ref
-            pending = self._lock._pending_writes.get(slot)
+            pending = self._lock._pending_writes.get(address)
             if pending is not None and cred.is_present:
                 pin, _deadline = pending
-                del self._lock._pending_writes[slot]
+                del self._lock._pending_writes[address]
                 if cred.is_readable and cred.readable_pin != pin:
                     out[address] = cred
                 else:

--- a/custom_components/lock_code_manager/domain/coordinator.py
+++ b/custom_components/lock_code_manager/domain/coordinator.py
@@ -28,7 +28,7 @@ from ..const import (
     DOMAIN,
     POLL_FAILURE_ALERT_THRESHOLD,
 )
-from .credentials import CredentialAddress, CredentialType
+from .credentials import CredentialAddress, CredentialType, pin_address
 from .exceptions import LockCodeManagerError
 from .models import SlotCredential
 from .queries import get_entry_config
@@ -41,29 +41,31 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
-def _user_ref_of(address: CredentialAddress) -> int:
+def _checked(address: CredentialAddress) -> CredentialAddress:
     """
-    Unpack an address to the slot-keyed storage key.
+    Return ``address`` normalized, rejecting types the coordinator cannot serve.
 
-    The coordinator stores credentials slot-keyed and manages Personal
-    Identification Number credentials only, so a non-PIN address cannot be
-    served and is a programming error rather than a missing entry. Failing
-    here keeps a future second credential type from silently reading and
-    writing the PIN's storage.
+    The coordinator manages Personal Identification Number credentials only,
+    so another type is a programming error rather than a missing entry.
+    Failing here keeps a future second credential type from silently reading
+    and writing the PIN's storage.
+
+    ``user_ref`` is coerced for the same reason ``_normalize_keys`` coerces:
+    a slot number reaches entities as either ``int`` or ``str`` (see
+    ``EntryConfig.has_slot``), and an uncoerced ``"1"`` would miss every
+    ``int``-keyed entry -- ``is_verified`` would report True for a slot whose
+    optimistic write is still unconfirmed.
     """
     if address.credential_type != CredentialType.PIN:
         raise ValueError(
             f"Only PIN credentials are addressable today, got {address.credential_type}"
         )
-    # Coerce for the same reason ``_normalize_keys`` does: ``data`` and
-    # ``_unverified`` are int-keyed, and a slot number reaches entities as
-    # either ``int`` or ``str`` (see ``EntryConfig.has_slot``). An
-    # uncoerced ``"1"`` would miss every int key -- ``is_verified`` would
-    # report True for a slot whose optimistic write is still unconfirmed.
-    return int(address.user_ref)
+    return CredentialAddress(int(address.user_ref), address.credential_type)
 
 
-class LockUsercodeUpdateCoordinator(DataUpdateCoordinator[dict[int, SlotCredential]]):
+class LockUsercodeUpdateCoordinator(
+    DataUpdateCoordinator[dict[CredentialAddress, SlotCredential]]
+):
     """Class to manage usercode updates."""
 
     def __init__(self, hass: HomeAssistant, lock: BaseLock, config_entry: Any) -> None:
@@ -82,7 +84,7 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator[dict[int, SlotCredenti
             update_interval=update_interval,
             config_entry=config_entry,
         )
-        self.data: dict[int, SlotCredential] = {}
+        self.data: dict[CredentialAddress, SlotCredential] = {}
         # Slots awaiting confirmation, kept in lockstep with ``data``. A slot is
         # unverified only while an optimistic (ambiguous-but-treated-as-completed)
         # write awaits confirmation; every other source -- genuine push events,
@@ -93,7 +95,7 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator[dict[int, SlotCredenti
         # ``dict[int, bool]`` admitted a third, redundant value -- an explicit
         # ``True`` that read identically to absence -- and every writer had to
         # remember which of the two to use. See the Phase 2 push-as-commit spec.
-        self._unverified: set[int] = set()
+        self._unverified: set[CredentialAddress] = set()
         self._config_entry = config_entry
         self._lock_breaker = CircuitBreaker(
             BACKOFF_FAILURE_THRESHOLD,
@@ -137,7 +139,9 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator[dict[int, SlotCredenti
         ``SlotCredential.empty()``; an enabled slot with a configured PIN
         maps to ``SlotCredential.known(pin)``.
         """
-        slot_data = get_entry_config(self._config_entry).slot(_user_ref_of(address))
+        slot_data = get_entry_config(self._config_entry).slot(
+            _checked(address).user_ref
+        )
         if not slot_data.get(CONF_ENABLED):
             return SlotCredential.empty()
         pin = slot_data.get(CONF_PIN)
@@ -148,13 +152,19 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator[dict[int, SlotCredenti
     @staticmethod
     def _normalize_keys(
         data: dict[Any, SlotCredential],
-    ) -> dict[int, SlotCredential]:
-        """Coerce slot keys to ``int``. Raises ValueError/TypeError if a key cannot be cast."""
-        return {int(k): v for k, v in data.items()}
+    ) -> dict[CredentialAddress, SlotCredential]:
+        """
+        Lift a provider's slot-keyed read into the address keyspace.
+
+        Providers report what they found on the device, keyed by device slot,
+        and every credential they report today is a Personal Identification
+        Number. Raises ValueError/TypeError if a key cannot be cast to int.
+        """
+        return {pin_address(int(k)): v for k, v in data.items()}
 
     def _apply_read(
-        self, observed: dict[int, SlotCredential]
-    ) -> dict[int, SlotCredential]:
+        self, observed: dict[CredentialAddress, SlotCredential]
+    ) -> dict[CredentialAddress, SlotCredential]:
         """
         Resolve a genuine read (poll or hard refresh) against pending writes.
 
@@ -171,23 +181,27 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator[dict[int, SlotCredenti
         genuine observations and are marked verified. See the Phase 2
         push-as-commit spec.
         """
-        out: dict[int, SlotCredential] = {}
-        for slot, cred in observed.items():
+        out: dict[CredentialAddress, SlotCredential] = {}
+        for address, cred in observed.items():
+            # ``_pending_writes`` is keyed by DEVICE slot, not by address: it
+            # tracks a write aimed at a slot on the lock. Today the two
+            # coincide, which is why ``user_ref`` indexes it directly.
+            slot = address.user_ref
             pending = self._lock._pending_writes.get(slot)
             if pending is not None and cred.is_present:
                 pin, _deadline = pending
                 del self._lock._pending_writes[slot]
                 if cred.is_readable and cred.readable_pin != pin:
-                    out[slot] = cred
+                    out[address] = cred
                 else:
-                    out[slot] = SlotCredential.known(pin)
-                self._unverified.discard(slot)
+                    out[address] = SlotCredential.known(pin)
+                self._unverified.discard(address)
             elif pending is not None:
-                out[slot] = cred
-                self._unverified.add(slot)
+                out[address] = cred
+                self._unverified.add(address)
             else:
-                out[slot] = cred
-                self._unverified.discard(slot)
+                out[address] = cred
+                self._unverified.discard(address)
         # Keep the unverified set in lockstep with the read.
         self._unverified &= out.keys()
         return out
@@ -199,7 +213,7 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator[dict[int, SlotCredenti
         Unlisted addresses are verified: an address is only unverified while
         an optimistic write awaits confirmation (push event or hard refresh).
         """
-        return _user_ref_of(address) not in self._unverified
+        return _checked(address) not in self._unverified
 
     @callback
     def mark_verified(self, address: CredentialAddress) -> None:
@@ -210,7 +224,41 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator[dict[int, SlotCredenti
         ``WriteResult.CONFIRMED``), so an address left unverified by a prior
         optimistic write on the same address cannot strand it.
         """
-        self._unverified.discard(_user_ref_of(address))
+        self._unverified.discard(_checked(address))
+
+    def credential(self, address: CredentialAddress) -> SlotCredential | None:
+        """
+        Return the credential the lock reports at an address, or ``None``.
+
+        ``None`` means the lock has not reported anything for this address --
+        distinct from ``SlotCredential.empty()``, which is a positive
+        observation that the slot holds no code.
+        """
+        return self.data.get(_checked(address))
+
+    def has_credential(self, address: CredentialAddress) -> bool:
+        """Return whether the lock has reported anything at an address."""
+        return _checked(address) in self.data
+
+    def credentials_by_slot(
+        self, credential_type: CredentialType = CredentialType.PIN
+    ) -> dict[int, SlotCredential]:
+        """
+        Project the stored credentials of one type into a slot-keyed view.
+
+        The websocket payload and the diagnostics output are contracts with
+        things outside this integration -- the dashboard card reads one, and
+        people paste the other into issue reports -- so both keep their
+        slot-keyed shape while the storage underneath moves to addresses.
+        Lossless while Personal Identification Number is the only type
+        stored; when a second type arrives, those boundaries choose which
+        type they are projecting instead of silently flattening both.
+        """
+        return {
+            address.user_ref: credential
+            for address, credential in self.data.items()
+            if address.credential_type is credential_type
+        }
 
     async def async_confirm_pending_writes(self) -> None:
         """
@@ -392,7 +440,7 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator[dict[int, SlotCredenti
             per_lock_issue_id("lock_offline", self._lock.lock.entity_id),
         )
 
-    async def async_get_usercodes(self) -> dict[int, SlotCredential]:
+    async def async_get_usercodes(self) -> dict[CredentialAddress, SlotCredential]:
         """Fetch usercodes from the provider, normalize slot keys, and apply backoff handling."""
         try:
             data = await self._lock.async_internal_get_usercodes()

--- a/custom_components/lock_code_manager/domain/sync.py
+++ b/custom_components/lock_code_manager/domain/sync.py
@@ -770,7 +770,7 @@ class SlotSyncManager:
         # (clearing the pending entry). On timeout, count a breaker failure and
         # fall through to re-sync -- so a write the lock never committed ends in
         # a visible suspend, never a silent in-sync.
-        pending = self._lock._pending_writes.get(self._slot_num)
+        pending = self._lock._pending_writes.get(self._address)
         if pending is not None:
             believed_pin, deadline = pending
             # A pending write only gates reconciliation while it still reflects
@@ -791,7 +791,7 @@ class SlotSyncManager:
             # than falling through to _perform_sync this tick) lets a confirming
             # push that lands between ticks resolve the slot first, and avoids
             # double-charging the breaker when the re-sync itself also fails.
-            del self._lock._pending_writes[self._slot_num]
+            del self._lock._pending_writes[self._address]
             if still_wanted:
                 # Genuine timeout: the write we still want never confirmed.
                 self._slot_breaker.record_failure()
@@ -966,7 +966,7 @@ class SlotSyncManager:
         # in PENDING_CONFIRMATION. The breaker is only charged when that wait
         # times out (handled at the top of the tick), so a masked-but-accepted
         # write is not penalised before its confirming event arrives.
-        if self._slot_num in self._lock._pending_writes:
+        if self._address in self._lock._pending_writes:
             self._state = SyncState.PENDING_CONFIRMATION
             self._write_state()
             return

--- a/custom_components/lock_code_manager/domain/sync.py
+++ b/custom_components/lock_code_manager/domain/sync.py
@@ -411,7 +411,7 @@ class SlotSyncManager:
         if not self._build_entity_id_map():
             return None
 
-        if self._slot_num not in self._coordinator.data:
+        if not self._coordinator.has_credential(self._address):
             _LOGGER.debug(
                 "%s: Slot not in coordinator data, skipping",
                 self._log_prefix,
@@ -432,7 +432,7 @@ class SlotSyncManager:
         assert credential_state is not None
         assert code_state is not None
 
-        coordinator_credential = self._coordinator.data.get(self._slot_num)
+        coordinator_credential = self._coordinator.credential(self._address)
         return CredentialSyncState(
             active_state=active_state,
             credential_state=credential_state,

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -477,7 +477,7 @@ class BaseLock:
         try:
             other_code_slot = next(
                 other_code_slot
-                for other_code_slot, other_credential in self.coordinator.data.items()
+                for other_code_slot, other_credential in self.coordinator.credentials_by_slot().items()
                 if other_code_slot != code_slot and other_credential.matches(usercode)
             )
         except StopIteration:

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -47,6 +47,7 @@ from ..domain.config import build_slot_unique_id
 from ..domain.coordinator import LockUsercodeUpdateCoordinator
 from ..domain.credentials import (
     Credential,
+    CredentialAddress,
     CredentialRef,
     CredentialType,
     LockCapabilities,
@@ -230,7 +231,12 @@ class BaseLock:
     # present -- clears the entry and re-pushes the believed value as verified;
     # if none arrives before the deadline, the sync layer re-syncs. See the
     # Phase 2 push-as-commit spec.
-    _pending_writes: dict[int, tuple[str, float]] = field(
+    # Keyed by CredentialAddress, NOT by device slot. One slot can hold a
+    # credential of each type, so a slot-keyed map would let two addresses
+    # sharing a slot collide: the first read processed would consume the
+    # other's pending entry, apply its believed value to the wrong
+    # credential, and leave the second silently marked verified.
+    _pending_writes: dict[CredentialAddress, tuple[str, float]] = field(
         default_factory=dict, init=False
     )
     # Reconnect task spawned by the config-entry state listener when the lock
@@ -430,7 +436,10 @@ class BaseLock:
         a confirmation (push event or hard-refresh presence) via
         ``_confirm_slot``, or re-syncs once the deadline passes.
         """
-        self._pending_writes[code_slot] = (pin, time.monotonic() + PENDING_WRITE_TTL)
+        self._pending_writes[pin_address(code_slot)] = (
+            pin,
+            time.monotonic() + PENDING_WRITE_TTL,
+        )
         self._push_credential_update(
             code_slot, SlotCredential.known(pin), optimistic=True
         )
@@ -450,7 +459,7 @@ class BaseLock:
         observation as the verified state. Either way the pending entry is
         cleared.
         """
-        pending = self._pending_writes.pop(code_slot, None)
+        pending = self._pending_writes.pop(pin_address(code_slot), None)
         if pending is not None and observed.is_present:
             pin, _deadline = pending
             if observed.is_readable and observed.readable_pin != pin:
@@ -1204,7 +1213,7 @@ class BaseLock:
             # The lock acknowledged the write: supersede any pending optimistic
             # state and drop the slot from the unverified set left by a prior
             # optimistic write, so it can converge instead of churning to a suspend.
-            self._pending_writes.pop(code_slot, None)
+            self._pending_writes.pop(pin_address(code_slot), None)
             if self.coordinator is not None:
                 self.coordinator.mark_verified(pin_address(code_slot))
         # Skip coordinator refresh for push providers — they update optimistically
@@ -1299,7 +1308,7 @@ class BaseLock:
         # A clear supersedes any outstanding optimistic set on this slot, so the
         # stale pending entry must not keep gating reconciliation (the sync tick
         # keys PENDING_CONFIRMATION on this dict).
-        self._pending_writes.pop(code_slot, None)
+        self._pending_writes.pop(pin_address(code_slot), None)
         changed = await self._execute_rate_limited(
             "clear", self.async_clear_usercode, code_slot
         )

--- a/custom_components/lock_code_manager/sensor.py
+++ b/custom_components/lock_code_manager/sensor.py
@@ -76,7 +76,7 @@ class LockCodeManagerCodeSlotSensorEntity(
     @property
     def native_value(self) -> str | None:
         """Return native value."""
-        credential = self.coordinator.data.get(int(self.slot_num))
+        credential = self.coordinator.credential(pin_address(int(self.slot_num)))
         if credential is None:
             return None
         if credential.is_empty:
@@ -93,7 +93,7 @@ class LockCodeManagerCodeSlotSensorEntity(
     def available(self) -> bool:
         """Return whether sensor is available or not."""
         return BaseLockCodeManagerCodeSlotPerLockEntity._is_available(self) and (
-            int(self.slot_num) in self.coordinator.data
+            self.coordinator.has_credential(pin_address(int(self.slot_num)))
         )
 
     async def async_added_to_hass(self) -> None:

--- a/custom_components/lock_code_manager/websocket.py
+++ b/custom_components/lock_code_manager/websocket.py
@@ -95,6 +95,7 @@ from .const import (
     DOMAIN,
     EVENT_PIN_USED,
 )
+from .domain.credentials import pin_address
 from .domain.locks import get_managed_locks
 from .domain.models import SlotCode, SlotCredential
 from .domain.queries import get_entry_config, get_managed_slots
@@ -595,7 +596,7 @@ def _serialize_lock_coordinator(
 ) -> dict[str, Any]:
     """Serialize coordinator data for a lock."""
     coordinator = lock.coordinator
-    data = coordinator.data if coordinator is not None else {}
+    data = coordinator.credentials_by_slot() if coordinator is not None else {}
     managed_slots = get_managed_slots(hass, lock.lock.entity_id)
     slot_entity_ids = _get_slot_entity_ids(hass, lock.lock.entity_id)
     slot_metadata = _get_slot_metadata(hass, slot_entity_ids)
@@ -847,9 +848,7 @@ def _build_lock_status(
 
     # Get code from coordinator — SlotCode sentinels pass through as strings
     coordinator = lock.coordinator
-    raw_code = (
-        coordinator.data.get(slot_num) if coordinator and coordinator.data else None
-    )
+    raw_code = coordinator.credential(pin_address(slot_num)) if coordinator else None
 
     lock_status: dict[str, Any] = {
         ATTR_ENTITY_ID: lock_entity_id,

--- a/tests/properties/test_credential_machine.py
+++ b/tests/properties/test_credential_machine.py
@@ -77,7 +77,7 @@ class CredentialMachine(RuleBasedStateMachine):
         # which may lag lock.codes until the next refresh.
         return any(
             other_slot != slot and credential.matches(pin)
-            for other_slot, credential in self.coordinator.data.items()
+            for other_slot, credential in self.coordinator.credentials_by_slot().items()
         )
 
     @rule(slot=SLOTS, pin=PINS)
@@ -138,7 +138,7 @@ class CredentialMachine(RuleBasedStateMachine):
         self._run(self.coordinator.async_refresh())
         observed = {
             slot: credential.readable_pin
-            for slot, credential in self.coordinator.data.items()
+            for slot, credential in self.coordinator.credentials_by_slot().items()
             if credential.is_present
         }
         assert observed == self.expected

--- a/tests/providers/matter/test_e2e.py
+++ b/tests/providers/matter/test_e2e.py
@@ -9,7 +9,10 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from custom_components.lock_code_manager.domain.credentials import WriteResult
+from custom_components.lock_code_manager.domain.credentials import (
+    WriteResult,
+    pin_address,
+)
 from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers.matter import MatterLock
 
@@ -129,7 +132,10 @@ class TestSetAndClearUsercodes:
         ):
             await e2e_matter_lock.async_set_usercode(4, "5678", "Test User")
 
-        assert e2e_matter_lock.coordinator.data.get(4) is SlotCredential.unreadable()
+        assert (
+            e2e_matter_lock.coordinator.data.get(pin_address(4))
+            is SlotCredential.unreadable()
+        )
 
     async def test_clear_usercode_optimistic_update(
         self,
@@ -154,7 +160,10 @@ class TestSetAndClearUsercodes:
         ):
             await e2e_matter_lock.async_clear_usercode(2)
 
-        assert e2e_matter_lock.coordinator.data.get(2) is SlotCredential.empty()
+        assert (
+            e2e_matter_lock.coordinator.data.get(pin_address(2))
+            is SlotCredential.empty()
+        )
 
 
 class TestGetUsercodes:

--- a/tests/providers/matter/test_provider.py
+++ b/tests/providers/matter/test_provider.py
@@ -27,6 +27,7 @@ from custom_components.lock_code_manager.domain.credentials import (
     SetUserResult,
     User,
     WriteResult,
+    pin_address,
 )
 from custom_components.lock_code_manager.domain.exceptions import (
     CodeRejectedError,
@@ -1471,7 +1472,7 @@ class TestLockUserChangeEvent:
         index in dataIndex (which is now Matter-auto-allocated and opaque).
         """
         mock_coordinator = MagicMock()
-        mock_coordinator.data = {3: SlotCredential.empty()}
+        mock_coordinator.data = {pin_address(3): SlotCredential.empty()}
         matter_lock.coordinator = mock_coordinator
 
         with self._patch_users(
@@ -1506,7 +1507,7 @@ class TestLockUserChangeEvent:
     ) -> None:
         """Modifying a PIN credential pushes SlotCredential.unreadable() to the LCM slot."""
         mock_coordinator = MagicMock()
-        mock_coordinator.data = {5: SlotCredential.unreadable()}
+        mock_coordinator.data = {pin_address(5): SlotCredential.unreadable()}
         matter_lock.coordinator = mock_coordinator
 
         with self._patch_users(
@@ -1541,7 +1542,7 @@ class TestLockUserChangeEvent:
     ) -> None:
         """Clearing a PIN credential pushes SlotCredential.empty() to the LCM slot."""
         mock_coordinator = MagicMock()
-        mock_coordinator.data = {2: SlotCredential.unreadable()}
+        mock_coordinator.data = {pin_address(2): SlotCredential.unreadable()}
         matter_lock.coordinator = mock_coordinator
 
         with self._patch_users(
@@ -1648,7 +1649,7 @@ class TestLockUserChangeEvent:
         slot comes from ``userIndex`` -> tag.
         """
         mock_coordinator = MagicMock()
-        mock_coordinator.data = {3: SlotCredential.empty()}
+        mock_coordinator.data = {pin_address(3): SlotCredential.empty()}
         matter_lock.coordinator = mock_coordinator
 
         with self._patch_users(

--- a/tests/providers/schlage/test_e2e.py
+++ b/tests/providers/schlage/test_e2e.py
@@ -14,6 +14,7 @@ from custom_components.lock_code_manager.domain.credentials import (
     CredentialType,
     WriteResult,
     credential_from_slot,
+    pin_address,
 )
 from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers.schlage import (
@@ -146,8 +147,14 @@ class TestSetAndClearCredentials:
 
         await e2e_schlage_lock.coordinator.async_refresh()
 
-        assert e2e_schlage_lock.coordinator.data.get(1) is SlotCredential.unreadable()
-        assert e2e_schlage_lock.coordinator.data.get(2) is SlotCredential.empty()
+        assert (
+            e2e_schlage_lock.coordinator.data.get(pin_address(1))
+            is SlotCredential.unreadable()
+        )
+        assert (
+            e2e_schlage_lock.coordinator.data.get(pin_address(2))
+            is SlotCredential.empty()
+        )
 
     async def test_coordinator_reflects_clear_credential(
         self,
@@ -167,8 +174,14 @@ class TestSetAndClearCredentials:
 
         await e2e_schlage_lock.coordinator.async_refresh()
 
-        assert e2e_schlage_lock.coordinator.data.get(1) is SlotCredential.empty()
-        assert e2e_schlage_lock.coordinator.data.get(2) is SlotCredential.empty()
+        assert (
+            e2e_schlage_lock.coordinator.data.get(pin_address(1))
+            is SlotCredential.empty()
+        )
+        assert (
+            e2e_schlage_lock.coordinator.data.get(pin_address(2))
+            is SlotCredential.empty()
+        )
 
 
 class TestGetUsers:

--- a/tests/providers/test_base.py
+++ b/tests/providers/test_base.py
@@ -31,6 +31,7 @@ from custom_components.lock_code_manager.domain.credentials import (
     CredentialType,
     CredentialTypeCapability,
     LockCapabilities,
+    pin_address,
 )
 from custom_components.lock_code_manager.domain.exceptions import (
     DuplicateCodeError,
@@ -1598,9 +1599,9 @@ async def test_check_duplicate_code_raises_on_match(
 
     coordinator.async_set_updated_data(
         {
-            1: SlotCredential.known("1234"),
-            2: SlotCredential.known("5678"),
-            3: SlotCredential.empty(),
+            pin_address(1): SlotCredential.known("1234"),
+            pin_address(2): SlotCredential.known("5678"),
+            pin_address(3): SlotCredential.empty(),
         }
     )
 
@@ -1622,7 +1623,10 @@ async def test_check_duplicate_code_skips_masked(
     assert coordinator is not None
 
     coordinator.async_set_updated_data(
-        {1: SlotCredential.unreadable(), 3: SlotCredential.empty()}
+        {
+            pin_address(1): SlotCredential.unreadable(),
+            pin_address(3): SlotCredential.empty(),
+        }
     )
 
     lock._check_duplicate_code(3, "1234")
@@ -1638,7 +1642,7 @@ async def test_check_duplicate_code_skips_same_slot(
     coordinator = lock.coordinator
     assert coordinator is not None
 
-    coordinator.async_set_updated_data({1: SlotCredential.known("1234")})
+    coordinator.async_set_updated_data({pin_address(1): SlotCredential.known("1234")})
 
     lock._check_duplicate_code(1, "1234")
 
@@ -1654,7 +1658,7 @@ async def test_check_duplicate_code_no_op_on_empty_usercode(
     assert coordinator is not None
 
     coordinator.async_set_updated_data(
-        {1: SlotCredential.empty(), 2: SlotCredential.empty()}
+        {pin_address(1): SlotCredential.empty(), pin_address(2): SlotCredential.empty()}
     )
 
     lock._check_duplicate_code(3, "")

--- a/tests/providers/test_seam.py
+++ b/tests/providers/test_seam.py
@@ -23,6 +23,7 @@ from custom_components.lock_code_manager.domain.credentials import (
     User,
     WriteResult,
     credential_from_slot,
+    pin_address,
     user_from_slot,
 )
 from custom_components.lock_code_manager.domain.exceptions import (
@@ -1070,8 +1071,8 @@ async def test_record_optimistic_write_pushes_unverified_and_tracks_pending(
     lock._record_optimistic_write(4, "1234")
 
     assert pushed == [({4: SlotCredential.known("1234")}, True)]
-    assert 4 in lock._pending_writes
-    assert lock._pending_writes[4][0] == "1234"
+    assert pin_address(4) in lock._pending_writes
+    assert lock._pending_writes[pin_address(4)][0] == "1234"
 
 
 async def test_clear_usercode_drops_stale_pending_write(
@@ -1081,12 +1082,12 @@ async def test_clear_usercode_drops_stale_pending_write(
     lock, _pushed = _slot_only_lock_with_coordinator(hass)
     lock._min_operation_delay = 0.0
     lock._record_optimistic_write(4, "1234")
-    assert 4 in lock._pending_writes
+    assert pin_address(4) in lock._pending_writes
 
     with patch.object(BaseLock, "async_is_integration_connected", return_value=True):
         await lock.async_internal_clear_usercode(4)
 
-    assert 4 not in lock._pending_writes
+    assert pin_address(4) not in lock._pending_writes
 
 
 async def test_optimistic_set_actively_confirms_instead_of_waiting(
@@ -1109,7 +1110,7 @@ async def test_optimistic_set_actively_confirms_instead_of_waiting(
     ):
         await lock.async_internal_set_usercode(4, "1234", "carol")
 
-    assert 4 in lock._pending_writes
+    assert pin_address(4) in lock._pending_writes
     lock.coordinator.async_confirm_pending_writes.assert_awaited_once()
 
 
@@ -1125,7 +1126,7 @@ async def test_confirm_slot_keeps_believed_value_on_present_observation(
     lock._confirm_slot(4, SlotCredential.unreadable())
 
     assert pushed == [({4: SlotCredential.known("1234")}, False)]
-    assert 4 not in lock._pending_writes
+    assert pin_address(4) not in lock._pending_writes
 
 
 async def test_confirm_slot_takes_observation_when_no_pending(
@@ -1149,7 +1150,7 @@ async def test_confirm_slot_empty_observation_clears_pending(
     lock._confirm_slot(4, SlotCredential.empty())
 
     assert pushed == [({4: SlotCredential.empty()}, False)]
-    assert 4 not in lock._pending_writes
+    assert pin_address(4) not in lock._pending_writes
 
 
 async def test_confirm_slot_takes_differing_readable_external_change(
@@ -1165,7 +1166,7 @@ async def test_confirm_slot_takes_differing_readable_external_change(
     lock._confirm_slot(4, SlotCredential.known("9999"))
 
     assert pushed == [({4: SlotCredential.known("9999")}, False)]
-    assert 4 not in lock._pending_writes
+    assert pin_address(4) not in lock._pending_writes
 
 
 async def test_confirm_slot_keeps_belief_when_readable_matches(
@@ -1179,7 +1180,7 @@ async def test_confirm_slot_keeps_belief_when_readable_matches(
     lock._confirm_slot(4, SlotCredential.known("1234"))
 
     assert pushed == [({4: SlotCredential.known("1234")}, False)]
-    assert 4 not in lock._pending_writes
+    assert pin_address(4) not in lock._pending_writes
 
 
 # Slot capacity pre-flight (issue #1398)

--- a/tests/providers/zigbee2mqtt/test_e2e.py
+++ b/tests/providers/zigbee2mqtt/test_e2e.py
@@ -8,6 +8,7 @@ import pytest
 
 from homeassistant.core import HomeAssistant
 
+from custom_components.lock_code_manager.domain.credentials import pin_address
 from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers.zigbee2mqtt import (
     Zigbee2MQTTLock,
@@ -78,7 +79,9 @@ class TestPushUpdatesViaMqtt:
         await hass.async_block_till_done()
         await hass.async_block_till_done()
 
-        assert z2m_lock.coordinator.data.get(1) == SlotCredential.known("1234")
+        assert z2m_lock.coordinator.data.get(pin_address(1)) == SlotCredential.known(
+            "1234"
+        )
 
     async def test_multiple_slots_in_single_message(
         self,
@@ -100,9 +103,13 @@ class TestPushUpdatesViaMqtt:
         await hass.async_block_till_done()
         await hass.async_block_till_done()
 
-        assert z2m_lock.coordinator.data.get(1) == SlotCredential.known("1111")
-        assert z2m_lock.coordinator.data.get(2) == SlotCredential.known("2222")
-        assert z2m_lock.coordinator.data.get(3) is SlotCredential.empty()
+        assert z2m_lock.coordinator.data.get(pin_address(1)) == SlotCredential.known(
+            "1111"
+        )
+        assert z2m_lock.coordinator.data.get(pin_address(2)) == SlotCredential.known(
+            "2222"
+        )
+        assert z2m_lock.coordinator.data.get(pin_address(3)) is SlotCredential.empty()
 
     async def test_disabled_slot_maps_to_empty(
         self,
@@ -118,7 +125,7 @@ class TestPushUpdatesViaMqtt:
         await hass.async_block_till_done()
         await hass.async_block_till_done()
 
-        assert z2m_lock.coordinator.data.get(5) is SlotCredential.empty()
+        assert z2m_lock.coordinator.data.get(pin_address(5)) is SlotCredential.empty()
 
 
 class TestSetAndClearUsercodes:
@@ -153,7 +160,9 @@ class TestSetAndClearUsercodes:
         """After set, the coordinator has the optimistic value."""
         await z2m_lock.async_set_usercode(1, "9999")
 
-        assert z2m_lock.coordinator.data.get(1) == SlotCredential.known("9999")
+        assert z2m_lock.coordinator.data.get(pin_address(1)) == SlotCredential.known(
+            "9999"
+        )
 
     async def test_clear_usercode_publishes_disable_payload(
         self,
@@ -182,7 +191,7 @@ class TestSetAndClearUsercodes:
         """After clear, the coordinator has SlotCredential.empty()."""
         await z2m_lock.async_clear_usercode(1)
 
-        assert z2m_lock.coordinator.data.get(1) is SlotCredential.empty()
+        assert z2m_lock.coordinator.data.get(pin_address(1)) is SlotCredential.empty()
 
 
 class TestGetUsercodes:

--- a/tests/providers/zwave_js/test_e2e.py
+++ b/tests/providers/zwave_js/test_e2e.py
@@ -24,7 +24,10 @@ from custom_components.lock_code_manager.const import (
     DOMAIN,
     EVENT_LOCK_STATE_CHANGED,
 )
-from custom_components.lock_code_manager.domain.credentials import WriteResult
+from custom_components.lock_code_manager.domain.credentials import (
+    WriteResult,
+    pin_address,
+)
 from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers.zwave_js import ZWaveJSLock
 from tests.providers.zwave_js.conftest import ZWAVE_JS_LCM_CONFIG_SLOTS
@@ -273,7 +276,10 @@ class TestEvents:
 
         # Credential events push unreadable (the lock doesn't expose the Personal
         # Identification Number value in the event; a coordinator refresh reads it).
-        assert e2e_zwave_lock.coordinator.data.get(1) == SlotCredential.unreadable()
+        assert (
+            e2e_zwave_lock.coordinator.data.get(pin_address(1))
+            == SlotCredential.unreadable()
+        )
 
 
 class TestColdStartRace:

--- a/tests/providers/zwave_js/test_events.py
+++ b/tests/providers/zwave_js/test_events.py
@@ -26,6 +26,7 @@ from custom_components.lock_code_manager.const import (
     DOMAIN,
     EVENT_LOCK_STATE_CHANGED,
 )
+from custom_components.lock_code_manager.domain.credentials import pin_address
 from custom_components.lock_code_manager.domain.exceptions import LockDisconnected
 from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers.zwave_js import ZWaveJSLock
@@ -557,7 +558,7 @@ async def test_credential_deleted_pin_pushes_empty(
 ) -> None:
     """Test that a 'credential deleted' event for a PIN pushes SlotCredential.empty()."""
     mock_coordinator = MagicMock()
-    mock_coordinator.data = {5: SlotCredential.unreadable()}
+    mock_coordinator.data = {pin_address(5): SlotCredential.unreadable()}
     zwave_js_lock.coordinator = mock_coordinator
 
     zwave_js_lock.subscribe_push_updates()
@@ -609,7 +610,7 @@ async def test_credential_deleted_non_pin_ignored(
 ) -> None:
     """Test that 'credential deleted' for a non-PIN credential type is ignored."""
     mock_coordinator = MagicMock()
-    mock_coordinator.data = {4: SlotCredential.unreadable()}
+    mock_coordinator.data = {pin_address(4): SlotCredential.unreadable()}
     zwave_js_lock.coordinator = mock_coordinator
 
     zwave_js_lock.subscribe_push_updates()
@@ -777,7 +778,7 @@ async def test_uc_shim_empty_code_pushes_empty(
 ) -> None:
     """An empty userCode value update pushes SlotCredential.empty()."""
     mock_coordinator = MagicMock()
-    mock_coordinator.data = {2: SlotCredential.known("1234")}
+    mock_coordinator.data = {pin_address(2): SlotCredential.known("1234")}
     zwave_js_lock.coordinator = mock_coordinator
 
     zwave_js_lock.subscribe_push_updates()
@@ -801,7 +802,7 @@ async def test_uc_shim_status_available_pushes_empty(
 ) -> None:
     """A userIdStatus=AVAILABLE update pushes empty when no PIN is expected."""
     mock_coordinator = MagicMock()
-    mock_coordinator.data = {2: SlotCredential.known("1234")}
+    mock_coordinator.data = {pin_address(2): SlotCredential.known("1234")}
     mock_coordinator.desired_credential.return_value = SlotCredential.empty()
     zwave_js_lock.coordinator = mock_coordinator
 
@@ -832,7 +833,7 @@ async def test_uc_shim_status_available_ignored_when_pin_expected(
     on them would cause infinite sync loops.
     """
     mock_coordinator = MagicMock()
-    mock_coordinator.data = {2: SlotCredential.known("1234")}
+    mock_coordinator.data = {pin_address(2): SlotCredential.known("1234")}
     mock_coordinator.desired_credential.return_value = SlotCredential.known("1234")
     zwave_js_lock.coordinator = mock_coordinator
 

--- a/tests/providers/zwave_js/test_events.py
+++ b/tests/providers/zwave_js/test_events.py
@@ -942,7 +942,7 @@ async def test_uc_shim_confirms_pending_optimistic_write(
     zwave_js_lock.coordinator = mock_coordinator
 
     zwave_js_lock.subscribe_push_updates()
-    zwave_js_lock._pending_writes[2] = ("8642", time.monotonic() + 60)
+    zwave_js_lock._pending_writes[pin_address(2)] = ("8642", time.monotonic() + 60)
 
     lock_schlage_be469.receive_event(
         _make_uc_value_event(lock_schlage_be469.node_id, "userCode", 2, "****")
@@ -952,6 +952,6 @@ async def test_uc_shim_confirms_pending_optimistic_write(
     mock_coordinator.push_update.assert_called_once_with(
         {2: SlotCredential.known("8642")}
     )
-    assert 2 not in zwave_js_lock._pending_writes
+    assert pin_address(2) not in zwave_js_lock._pending_writes
 
     zwave_js_lock.unsubscribe_push_updates()

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -43,6 +43,7 @@ from custom_components.lock_code_manager.const import (
 from custom_components.lock_code_manager.domain.coordinator import (
     LockUsercodeUpdateCoordinator,
 )
+from custom_components.lock_code_manager.domain.credentials import pin_address
 from custom_components.lock_code_manager.domain.exceptions import (
     DuplicateCodeError,
     LockCodeManagerError,
@@ -489,10 +490,10 @@ async def test_entities_track_availability(
     assert in_sync_entity_obj.available
 
     # The per-lock entity should also reflect missing coordinator data
-    coordinator.data.pop(1)
+    coordinator.data.pop(pin_address(1))
     assert not in_sync_entity_obj.available
 
-    coordinator.data[1] = SlotCredential.known("1234")
+    coordinator.data[pin_address(1)] = SlotCredential.known("1234")
     assert in_sync_entity_obj.available
 
 
@@ -1124,8 +1125,8 @@ async def test_unexpected_error_during_sync_suspends_slot(
     ):
         # Force out-of-sync state
         in_sync_entity_obj._sync_manager._state = SyncState.OUT_OF_SYNC
-        in_sync_entity_obj._sync_manager._coordinator.data[1] = SlotCredential.known(
-            "wrong_code"
+        in_sync_entity_obj._sync_manager._coordinator.data[pin_address(1)] = (
+            SlotCredential.known("wrong_code")
         )
 
         # Trigger tick to attempt sync (which will fail with unexpected error)
@@ -1147,7 +1148,7 @@ async def test_sync_manager_handles_string_slot_num(
     manager = in_sync_entity_obj._sync_manager
 
     assert isinstance(manager._slot_num, int)
-    assert manager._slot_num in manager._coordinator.data
+    assert pin_address(manager._slot_num) in manager._coordinator.data
 
 
 # ---------------------------------------------------------------------------
@@ -1197,7 +1198,7 @@ async def test_coordinator_poll_detects_external_change_and_syncs(
     await hass.async_block_till_done()
 
     # Coordinator data should now reflect the external change
-    assert coordinator.data[1] == SlotCredential.known("9999")
+    assert coordinator.data[pin_address(1)] == SlotCredential.known("9999")
 
     # Fire the tick timer to let the sync manager detect the mismatch
     await async_advance_time(hass, TICK_INTERVAL * 2)
@@ -1329,7 +1330,7 @@ async def test_slot_suspension_isolated_from_other_slots(
         side_effect=ValueError("Unexpected hardware error"),
     ):
         mgr_2._state = SyncState.OUT_OF_SYNC
-        coordinator.data[2] = SlotCredential.known("0000")
+        coordinator.data[pin_address(2)] = SlotCredential.known("0000")
         await mgr_2._async_tick()
         await hass.async_block_till_done()
 
@@ -1382,7 +1383,7 @@ async def test_drift_check_detects_external_change_and_triggers_sync(
     await hass.async_block_till_done()
 
     # Coordinator data should now have the drifted value
-    assert coordinator.data[1] == SlotCredential.known("5555")
+    assert coordinator.data[pin_address(1)] == SlotCredential.known("5555")
 
     # Fire tick to let the sync manager detect and correct
     await async_advance_time(hass, TICK_INTERVAL * 2)
@@ -1994,7 +1995,7 @@ async def test_slot_disabled_during_sync_resolves_correctly(
     # If present with empty value, the next tick resolves to IN_SYNC.
     # If absent, _resolve_credential_snapshot returns None and the tick is a no-op.
     # Either way, the important thing is that clear was called, not set.
-    if mgr._slot_num in coordinator.data:
+    if pin_address(mgr._slot_num) in coordinator.data:
         await async_trigger_sync_tick(hass, SLOT_1_IN_SYNC_ENTITY, set_dirty=False)
         assert mgr._state is SyncState.IN_SYNC
 
@@ -2035,7 +2036,7 @@ async def test_rapid_coordinator_updates_coalesce(
     assert mgr._state is SyncState.OUT_OF_SYNC
 
     # The coordinator should have the latest value
-    assert coordinator.data[1] == SlotCredential.known("0009")
+    assert coordinator.data[pin_address(1)] == SlotCredential.known("0009")
 
     # Clear service calls to track only what the tick does
     lock_provider.service_calls["set_usercode"].clear()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -175,16 +175,18 @@ async def test_push_update_updates_coordinator_data(
 ):
     """Test that push_update correctly updates coordinator data."""
     push_coordinator.data = {
-        1: SlotCredential.known("1111"),
-        2: SlotCredential.known("2222"),
+        pin_address(1): SlotCredential.known("1111"),
+        pin_address(2): SlotCredential.known("2222"),
     }
 
     # Push a single update
     push_coordinator.push_update({1: SlotCredential.known("9999")})
 
     # Verify data was updated
-    assert push_coordinator.data[1] == SlotCredential.known("9999")
-    assert push_coordinator.data[2] == SlotCredential.known("2222")  # Unchanged
+    assert push_coordinator.data[pin_address(1)] == SlotCredential.known("9999")
+    assert push_coordinator.data[pin_address(2)] == SlotCredential.known(
+        "2222"
+    )  # Unchanged
 
 
 async def test_push_update_bulk_updates(
@@ -192,9 +194,9 @@ async def test_push_update_bulk_updates(
 ):
     """Test that push_update correctly handles bulk updates."""
     push_coordinator.data = {
-        1: SlotCredential.known("1111"),
-        2: SlotCredential.known("2222"),
-        3: SlotCredential.known("3333"),
+        pin_address(1): SlotCredential.known("1111"),
+        pin_address(2): SlotCredential.known("2222"),
+        pin_address(3): SlotCredential.known("3333"),
     }
 
     # Push bulk update
@@ -203,9 +205,11 @@ async def test_push_update_bulk_updates(
     )
 
     # Verify all updates applied
-    assert push_coordinator.data[1] == SlotCredential.known("9999")
-    assert push_coordinator.data[2] == SlotCredential.known("2222")  # Unchanged
-    assert push_coordinator.data[3] == SlotCredential.empty()  # Cleared
+    assert push_coordinator.data[pin_address(1)] == SlotCredential.known("9999")
+    assert push_coordinator.data[pin_address(2)] == SlotCredential.known(
+        "2222"
+    )  # Unchanged
+    assert push_coordinator.data[pin_address(3)] == SlotCredential.empty()  # Cleared
 
 
 async def test_is_verified_defaults_true_for_absent_slot(
@@ -228,7 +232,7 @@ async def test_push_update_optimistic_marks_unverified(
 ):
     """An optimistic push marks the slot unverified."""
     push_coordinator.push_update({1: SlotCredential.known("9999")}, optimistic=True)
-    assert push_coordinator.data[1] == SlotCredential.known("9999")
+    assert push_coordinator.data[pin_address(1)] == SlotCredential.known("9999")
     assert push_coordinator.is_verified(pin_address(1)) is False
 
 
@@ -247,7 +251,7 @@ async def test_push_update_optimistic_same_value_flips_flag_without_notifying(
     push_coordinator: LockUsercodeUpdateCoordinator,
 ):
     """An optimistic re-push of the same value flips the flag but doesn't notify."""
-    push_coordinator.data = {1: SlotCredential.known("9999")}
+    push_coordinator.data = {pin_address(1): SlotCredential.known("9999")}
     with patch.object(push_coordinator, "async_set_updated_data") as mock_set_updated:
         push_coordinator.push_update({1: SlotCredential.known("9999")}, optimistic=True)
         mock_set_updated.assert_not_called()
@@ -267,7 +271,7 @@ async def test_push_update_ignores_empty_updates(
     push_coordinator: LockUsercodeUpdateCoordinator,
 ):
     """Test that push_update ignores empty update dict."""
-    push_coordinator.data = {1: SlotCredential.known("1111")}
+    push_coordinator.data = {pin_address(1): SlotCredential.known("1111")}
 
     # Track async_set_updated_data calls
     with patch.object(push_coordinator, "async_set_updated_data") as mock_set_updated:
@@ -281,7 +285,7 @@ async def test_push_update_notifies_listeners(
     push_coordinator: LockUsercodeUpdateCoordinator,
 ):
     """Test that push_update notifies coordinator listeners."""
-    push_coordinator.data = {1: SlotCredential.known("1111")}
+    push_coordinator.data = {pin_address(1): SlotCredential.known("1111")}
 
     # Track listener callbacks
     listener_called = [False]
@@ -452,7 +456,7 @@ async def test_drift_check_handles_hard_refresh_error(
 ):
     """Test that _async_drift_check handles hard refresh errors gracefully."""
     push_coordinator.last_update_success = True
-    push_coordinator.data = {1: SlotCredential.known("1234")}
+    push_coordinator.data = {pin_address(1): SlotCredential.known("1234")}
 
     # Mock hard refresh to raise an exception
     mock_hard_refresh = AsyncMock(side_effect=LockDisconnected("Lock offline"))
@@ -463,7 +467,7 @@ async def test_drift_check_handles_hard_refresh_error(
         await push_coordinator._async_drift_check(dt_util.utcnow())
 
         # Data should remain unchanged
-        assert push_coordinator.data == {1: SlotCredential.known("1234")}
+        assert push_coordinator.data == {pin_address(1): SlotCredential.known("1234")}
 
 
 # --- Backoff tests ---
@@ -634,7 +638,7 @@ async def test_backoff_resets_on_success(
     with patch.object(poll_lock, "async_internal_get_usercodes", mock_get_success):
         result = await poll_coordinator.async_get_usercodes()
 
-    assert result == {1: "1234"}
+    assert result == {pin_address(1): "1234"}
     assert poll_coordinator._lock_breaker.failure_count == 0
     assert poll_coordinator.update_interval == original_interval
 
@@ -650,7 +654,7 @@ async def test_backoff_no_reset_when_no_prior_failures(
     with patch.object(poll_lock, "async_internal_get_usercodes", mock_get):
         result = await poll_coordinator.async_get_usercodes()
 
-    assert result == {1: "1234"}
+    assert result == {pin_address(1): "1234"}
     assert poll_coordinator._lock_breaker.failure_count == 0
     assert poll_coordinator.update_interval == original_interval
 
@@ -785,7 +789,7 @@ async def test_push_update_resets_backoff(
     assert push_coordinator._lock_breaker.failure_count == BACKOFF_FAILURE_THRESHOLD + 2
 
     # Push update with new data should reset backoff
-    push_coordinator.data = {1: SlotCredential.known("old")}
+    push_coordinator.data = {pin_address(1): SlotCredential.known("old")}
     push_coordinator.push_update({1: SlotCredential.known("1234")})
 
     assert push_coordinator._lock_breaker.failure_count == 0
@@ -808,7 +812,7 @@ async def test_push_update_no_reset_when_data_unchanged(
     assert push_coordinator._lock_breaker.failure_count == BACKOFF_FAILURE_THRESHOLD + 1
 
     # Push update with same data should NOT reset backoff
-    push_coordinator.data = {1: SlotCredential.known("1234")}
+    push_coordinator.data = {pin_address(1): SlotCredential.known("1234")}
     push_coordinator.push_update({1: SlotCredential.known("1234")})
 
     assert push_coordinator._lock_breaker.failure_count == BACKOFF_FAILURE_THRESHOLD + 1
@@ -1056,7 +1060,7 @@ async def test_confirm_pending_writes_confirms_present_masked(
 
     assert 1 not in push_lock._pending_writes
     assert push_coordinator.is_verified(pin_address(1)) is True
-    assert push_coordinator.data[1] == SlotCredential.known("9999")
+    assert push_coordinator.data[pin_address(1)] == SlotCredential.known("9999")
 
 
 async def test_confirm_pending_writes_keeps_absent_slot_pending(
@@ -1205,9 +1209,9 @@ async def test_apply_read_takes_differing_readable_external_change(
     push_lock._pending_writes[1] = ("1234", time.monotonic() + 60.0)
     push_coordinator.push_update({1: SlotCredential.known("1234")}, optimistic=True)
 
-    out = push_coordinator._apply_read({1: SlotCredential.known("9999")})
+    out = push_coordinator._apply_read({pin_address(1): SlotCredential.known("9999")})
 
-    assert out[1] == SlotCredential.known("9999")
+    assert out[pin_address(1)] == SlotCredential.known("9999")
     assert 1 not in push_lock._pending_writes
     assert push_coordinator.is_verified(pin_address(1)) is True
 
@@ -1247,3 +1251,33 @@ async def test_string_slot_number_still_resolves(push_coordinator) -> None:
     assert push_coordinator.is_verified(pin_address("1")) is False
     push_coordinator.mark_verified(pin_address("1"))
     assert push_coordinator.is_verified(pin_address(1)) is True
+
+
+async def test_credentials_by_slot_filters_to_one_type(push_coordinator) -> None:
+    """The slot-keyed projection returns one credential type, never a blend.
+
+    Every stored credential is a Personal Identification Number today, so the
+    filter never excludes anything in practice and line coverage cannot pin
+    it. Seeding a second type directly is the only way to prove the websocket
+    and diagnostics boundaries will not start emitting, say, a Radio Frequency
+    Identification value under a PIN slot key once a second type is stored.
+    """
+    push_coordinator.data = {
+        pin_address(1): SlotCredential.known("1111"),
+        CredentialAddress(2, CredentialType.RFID): SlotCredential.known("A4B2C1"),
+    }
+
+    assert push_coordinator.credentials_by_slot() == {1: SlotCredential.known("1111")}
+    assert push_coordinator.credentials_by_slot(CredentialType.RFID) == {
+        2: SlotCredential.known("A4B2C1")
+    }
+
+
+async def test_credential_distinguishes_absent_from_empty(push_coordinator) -> None:
+    """None means "never reported"; empty() is a positive observation of no code."""
+    push_coordinator.data = {pin_address(1): SlotCredential.empty()}
+
+    assert push_coordinator.credential(pin_address(1)) is SlotCredential.empty()
+    assert push_coordinator.credential(pin_address(9)) is None
+    assert push_coordinator.has_credential(pin_address(1)) is True
+    assert push_coordinator.has_credential(pin_address(9)) is False

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1047,7 +1047,7 @@ async def test_confirm_pending_writes_confirms_present_masked(
     node-zwave-js never sends for a masked write: the slot reads back present
     (unreadable), so the believed PIN is confirmed and pending is cleared.
     """
-    push_lock._pending_writes[1] = ("9999", time.monotonic() + 60.0)
+    push_lock._pending_writes[pin_address(1)] = ("9999", time.monotonic() + 60.0)
     push_coordinator.push_update({1: SlotCredential.known("9999")}, optimistic=True)
     assert push_coordinator.is_verified(pin_address(1)) is False
 
@@ -1058,7 +1058,7 @@ async def test_confirm_pending_writes_confirms_present_masked(
     ):
         await push_coordinator.async_confirm_pending_writes()
 
-    assert 1 not in push_lock._pending_writes
+    assert pin_address(1) not in push_lock._pending_writes
     assert push_coordinator.is_verified(pin_address(1)) is True
     assert push_coordinator.data[pin_address(1)] == SlotCredential.known("9999")
 
@@ -1068,7 +1068,7 @@ async def test_confirm_pending_writes_keeps_absent_slot_pending(
     push_lock: MockLCMPushLock,
 ) -> None:
     """A confirm read that finds the slot absent leaves it pending to re-sync."""
-    push_lock._pending_writes[1] = ("9999", time.monotonic() + 60.0)
+    push_lock._pending_writes[pin_address(1)] = ("9999", time.monotonic() + 60.0)
     push_coordinator.push_update({1: SlotCredential.known("9999")}, optimistic=True)
 
     with patch.object(
@@ -1078,7 +1078,7 @@ async def test_confirm_pending_writes_keeps_absent_slot_pending(
     ):
         await push_coordinator.async_confirm_pending_writes()
 
-    assert 1 in push_lock._pending_writes
+    assert pin_address(1) in push_lock._pending_writes
     assert push_coordinator.is_verified(pin_address(1)) is False
 
 
@@ -1087,7 +1087,7 @@ async def test_confirm_pending_writes_tolerates_read_failure(
     push_lock: MockLCMPushLock,
 ) -> None:
     """A failed confirm read is non-fatal and leaves pending state untouched."""
-    push_lock._pending_writes[1] = ("9999", time.monotonic() + 60.0)
+    push_lock._pending_writes[pin_address(1)] = ("9999", time.monotonic() + 60.0)
     push_coordinator.push_update({1: SlotCredential.known("9999")}, optimistic=True)
 
     with patch.object(
@@ -1097,7 +1097,7 @@ async def test_confirm_pending_writes_tolerates_read_failure(
     ):
         await push_coordinator.async_confirm_pending_writes()
 
-    assert 1 in push_lock._pending_writes
+    assert pin_address(1) in push_lock._pending_writes
     assert push_coordinator.is_verified(pin_address(1)) is False
 
 
@@ -1118,7 +1118,7 @@ async def test_confirm_pending_writes_swallows_unexpected_error(
     push_lock: MockLCMPushLock,
 ) -> None:
     """A non-LCM error from the confirm read must not escape (it would suspend the slot)."""
-    push_lock._pending_writes[1] = ("9999", time.monotonic() + 60.0)
+    push_lock._pending_writes[pin_address(1)] = ("9999", time.monotonic() + 60.0)
     push_coordinator.push_update({1: SlotCredential.known("9999")}, optimistic=True)
 
     with patch.object(
@@ -1129,7 +1129,7 @@ async def test_confirm_pending_writes_swallows_unexpected_error(
         # Must not raise: the seam awaits this and a raise would suspend the slot.
         await push_coordinator.async_confirm_pending_writes()
 
-    assert 1 in push_lock._pending_writes
+    assert pin_address(1) in push_lock._pending_writes
     assert push_coordinator.is_verified(pin_address(1)) is False
 
 
@@ -1206,13 +1206,13 @@ async def test_apply_read_takes_differing_readable_external_change(
     Mirrors BaseLock._confirm_slot: a drift/poll read of an externally-changed
     readable code must not be masked by the believed value.
     """
-    push_lock._pending_writes[1] = ("1234", time.monotonic() + 60.0)
+    push_lock._pending_writes[pin_address(1)] = ("1234", time.monotonic() + 60.0)
     push_coordinator.push_update({1: SlotCredential.known("1234")}, optimistic=True)
 
     out = push_coordinator._apply_read({pin_address(1): SlotCredential.known("9999")})
 
     assert out[pin_address(1)] == SlotCredential.known("9999")
-    assert 1 not in push_lock._pending_writes
+    assert pin_address(1) not in push_lock._pending_writes
     assert push_coordinator.is_verified(pin_address(1)) is True
 
 

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -13,6 +13,7 @@ from custom_components.lock_code_manager.diagnostics import (
     async_get_config_entry_diagnostics,
     async_get_device_diagnostics,
 )
+from custom_components.lock_code_manager.domain.credentials import pin_address
 from custom_components.lock_code_manager.domain.models import SlotCredential
 
 from .common import BASE_CONFIG, LOCK_1_ENTITY_ID
@@ -211,7 +212,7 @@ async def test_mask_code_covers_missing_and_edge_case_credentials(
     }
     hass.config_entries.async_update_entry(entry, options=new_config)
     await hass.async_block_till_done()
-    assert 3 not in coordinator.data
+    assert pin_address(3) not in coordinator.data
 
     # Slot 1: cleared on the lock -> SlotCode.EMPTY sentinel.
     coordinator.push_update({1: SlotCredential.empty()})

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -5,6 +5,7 @@ import logging
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
+from custom_components.lock_code_manager.domain.credentials import pin_address
 from custom_components.lock_code_manager.domain.locks import async_create_lock_instance
 from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers import BaseLock
@@ -40,21 +41,21 @@ async def test_sensor_native_value_with_slot_code(
     assert coordinator is not None
 
     # Empty credential -> sensor shows empty string
-    coordinator.async_set_updated_data({1: SlotCredential.empty()})
+    coordinator.async_set_updated_data({pin_address(1): SlotCredential.empty()})
     await hass.async_block_till_done()
     state = hass.states.get("sensor.test_1_code_slot_1")
     assert state is not None
     assert state.state == ""
 
     # Unreadable credential -> sensor resolves to expected PIN from config
-    coordinator.async_set_updated_data({1: SlotCredential.unreadable()})
+    coordinator.async_set_updated_data({pin_address(1): SlotCredential.unreadable()})
     await hass.async_block_till_done()
     state = hass.states.get("sensor.test_1_code_slot_1")
     assert state is not None
     assert state.state == "1234"
 
     # Known credential -> sensor shows the code
-    coordinator.async_set_updated_data({1: SlotCredential.known("5678")})
+    coordinator.async_set_updated_data({pin_address(1): SlotCredential.known("5678")})
     await hass.async_block_till_done()
     state = hass.states.get("sensor.test_1_code_slot_1")
     assert state is not None

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -511,7 +511,7 @@ class TestLockOperationFailedRetry:
         # Force out-of-sync state so _perform_sync is called:
         # set coordinator data to EMPTY so the slot appears to need a set
         manager._state = SyncState.OUT_OF_SYNC
-        manager._coordinator.data[1] = SlotCredential.empty()
+        manager._coordinator.data[pin_address(1)] = SlotCredential.empty()
 
         with patch.object(
             manager,
@@ -533,7 +533,7 @@ class TestLockOperationFailedRetry:
     ) -> None:
         """Repeated LockOperationFailed suspends the slot, not the whole lock."""
         manager = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)._sync_manager
-        manager._coordinator.data[1] = SlotCredential.empty()
+        manager._coordinator.data[pin_address(1)] = SlotCredential.empty()
 
         with patch.object(
             manager,
@@ -564,7 +564,7 @@ class TestSuspensionRepairLinkHealth:
 
     async def _suspend_via_breaker(self, hass: HomeAssistant, manager) -> None:
         """Fail the slot until the breaker trips, then tick once more to suspend."""
-        manager._coordinator.data[1] = SlotCredential.empty()
+        manager._coordinator.data[pin_address(1)] = SlotCredential.empty()
         with patch.object(
             manager,
             "_perform_sync",
@@ -646,7 +646,7 @@ class TestLockOperationUnsupportedSuspend:
         entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
         manager = entity_obj._sync_manager
         manager._state = SyncState.OUT_OF_SYNC
-        manager._coordinator.data[1] = SlotCredential.empty()
+        manager._coordinator.data[pin_address(1)] = SlotCredential.empty()
 
         with patch.object(
             manager,
@@ -676,7 +676,7 @@ class TestLockOperationUnsupportedSuspend:
         entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
         manager = entity_obj._sync_manager
         manager._state = SyncState.OUT_OF_SYNC
-        manager._coordinator.data[1] = SlotCredential.empty()
+        manager._coordinator.data[pin_address(1)] = SlotCredential.empty()
         lock_entity_id = manager._lock.lock.entity_id
         entry_id = manager._config_entry.entry_id
 
@@ -727,7 +727,7 @@ class TestSyncStateMachine:
         manager = entity_obj._sync_manager
         manager._state = SyncState.LOADING
         # Make coordinator data mismatch (slot active but lock has empty code)
-        manager._coordinator.data[1] = SlotCredential.empty()
+        manager._coordinator.data[pin_address(1)] = SlotCredential.empty()
         await async_trigger_sync_tick(hass, SLOT_1_IN_SYNC_ENTITY, set_dirty=False)
         assert manager._state is SyncState.OUT_OF_SYNC
 
@@ -746,7 +746,7 @@ class TestSyncStateMachine:
         hass.states.async_set(SLOT_1_ACTIVE_ENTITY, STATE_OFF)
         hass.states.async_set(SLOT_1_PIN_ENTITY, STATE_UNKNOWN)
         # Coordinator has slot as EMPTY (no code on lock)
-        manager._coordinator.data[1] = SlotCredential.empty()
+        manager._coordinator.data[pin_address(1)] = SlotCredential.empty()
 
         await async_trigger_sync_tick(hass, SLOT_1_IN_SYNC_ENTITY, set_dirty=False)
 
@@ -765,7 +765,7 @@ class TestSyncStateMachine:
         manager._state = SyncState.LOADING
 
         hass.states.async_set(SLOT_1_ACTIVE_ENTITY, STATE_UNKNOWN)
-        manager._coordinator.data[1] = SlotCredential.empty()
+        manager._coordinator.data[pin_address(1)] = SlotCredential.empty()
 
         await async_trigger_sync_tick(hass, SLOT_1_IN_SYNC_ENTITY, set_dirty=False)
         assert manager._state is SyncState.LOADING
@@ -784,7 +784,7 @@ class TestSyncStateMachine:
         # Active=on but PIN unknown — can't sync without knowing what PIN to set
         hass.states.async_set(SLOT_1_ACTIVE_ENTITY, STATE_ON)
         hass.states.async_set(SLOT_1_PIN_ENTITY, STATE_UNKNOWN)
-        manager._coordinator.data[1] = SlotCredential.empty()
+        manager._coordinator.data[pin_address(1)] = SlotCredential.empty()
 
         await async_trigger_sync_tick(hass, SLOT_1_IN_SYNC_ENTITY, set_dirty=False)
         assert manager._state is SyncState.LOADING
@@ -815,7 +815,7 @@ class TestSyncStateMachine:
         await async_trigger_sync_tick(hass, SLOT_1_IN_SYNC_ENTITY)
         assert manager._state is SyncState.IN_SYNC
 
-        manager._coordinator.data[1] = SlotCredential.empty()
+        manager._coordinator.data[pin_address(1)] = SlotCredential.empty()
         manager.request_sync_check()
         assert manager._state is SyncState.OUT_OF_SYNC
 
@@ -833,7 +833,7 @@ class TestSyncStateMachine:
         await async_trigger_sync_tick(hass, SLOT_1_IN_SYNC_ENTITY, set_dirty=False)
         assert manager._state is SyncState.IN_SYNC
 
-        manager._coordinator.data[1] = SlotCredential.empty()
+        manager._coordinator.data[pin_address(1)] = SlotCredential.empty()
         manager.request_sync_check()
         assert manager._state is SyncState.OUT_OF_SYNC
 
@@ -993,7 +993,7 @@ class TestSyncStateMachine:
         manager = entity_obj._sync_manager
 
         manager._state = SyncState.OUT_OF_SYNC
-        manager._coordinator.data[1] = SlotCredential.empty()
+        manager._coordinator.data[pin_address(1)] = SlotCredential.empty()
 
         with patch.object(
             manager,
@@ -1027,7 +1027,7 @@ class TestSyncStateMachine:
         manager = entity_obj._sync_manager
 
         manager._state = SyncState.OUT_OF_SYNC
-        manager._coordinator.data[1] = SlotCredential.empty()
+        manager._coordinator.data[pin_address(1)] = SlotCredential.empty()
         manager._lock._setup_succeeded = False
 
         with patch.object(
@@ -1074,7 +1074,7 @@ class TestSyncStateMachine:
         manager = entity_obj._sync_manager
 
         manager._state = SyncState.OUT_OF_SYNC
-        manager._coordinator.data[1] = SlotCredential.empty()
+        manager._coordinator.data[pin_address(1)] = SlotCredential.empty()
 
         with patch.object(
             manager,
@@ -1099,7 +1099,7 @@ class TestSyncStateMachine:
         manager = entity_obj._sync_manager
 
         manager._state = SyncState.OUT_OF_SYNC
-        manager._coordinator.data[1] = SlotCredential.empty()
+        manager._coordinator.data[pin_address(1)] = SlotCredential.empty()
         for _ in range(MAX_SYNC_ATTEMPTS):
             manager._slot_breaker.record_failure()
 
@@ -1174,7 +1174,7 @@ class TestSyncStateMachine:
         manager = entity_obj._sync_manager
 
         manager._state = SyncState.OUT_OF_SYNC
-        manager._coordinator.data[1] = SlotCredential.empty()
+        manager._coordinator.data[pin_address(1)] = SlotCredential.empty()
 
         with (
             patch.object(
@@ -1206,7 +1206,7 @@ class TestSyncStateMachine:
         manager = entity_obj._sync_manager
 
         manager._state = SyncState.OUT_OF_SYNC
-        manager._coordinator.data[1] = SlotCredential.empty()
+        manager._coordinator.data[pin_address(1)] = SlotCredential.empty()
 
         with patch.object(
             manager,
@@ -1280,7 +1280,7 @@ class TestSyncStateMachine:
         manager = entity_obj._sync_manager
 
         manager._state = SyncState.OUT_OF_SYNC
-        manager._coordinator.data[1] = SlotCredential.empty()
+        manager._coordinator.data[pin_address(1)] = SlotCredential.empty()
 
         # _perform_sync succeeds but coordinator data stays EMPTY
         # (simulating a lock that silently rejects the code).
@@ -1317,7 +1317,7 @@ class TestSyncStateMachine:
 
         # Trip the failing slot's breaker so the next tick suspends it.
         failing._state = SyncState.OUT_OF_SYNC
-        failing._coordinator.data[1] = SlotCredential.empty()
+        failing._coordinator.data[pin_address(1)] = SlotCredential.empty()
         for _ in range(MAX_SYNC_ATTEMPTS):
             failing._slot_breaker.record_failure()
 
@@ -1338,7 +1338,7 @@ class TestSyncStateMachine:
     ) -> None:
         """Repeated LockDisconnected on set trips the lock breaker and suspends the tick."""
         manager = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)._sync_manager
-        manager._coordinator.data[1] = SlotCredential.empty()
+        manager._coordinator.data[pin_address(1)] = SlotCredential.empty()
 
         with patch.object(
             manager,
@@ -1371,7 +1371,7 @@ class TestSyncStateMachine:
 
         # Trip the slot breaker so the tick suspends for a non-converging code.
         manager._state = SyncState.OUT_OF_SYNC
-        manager._coordinator.data[1] = SlotCredential.empty()
+        manager._coordinator.data[pin_address(1)] = SlotCredential.empty()
         for _ in range(MAX_SYNC_ATTEMPTS):
             manager._slot_breaker.record_failure()
         await manager._async_tick()
@@ -1491,7 +1491,7 @@ class TestAsyncStopAwaitsInFlightTick:
         manager = entity_obj._sync_manager
 
         # Force an out-of-sync state so the next tick performs work.
-        manager._coordinator.data[1] = SlotCredential.known("9999")
+        manager._coordinator.data[pin_address(1)] = SlotCredential.known("9999")
         manager._state = SyncState.OUT_OF_SYNC
 
         mid_sync = asyncio.Event()
@@ -1579,7 +1579,7 @@ class TestAsyncStopAwaitsInFlightTick:
         entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
         manager = entity_obj._sync_manager
 
-        manager._coordinator.data[1] = SlotCredential.known("9999")
+        manager._coordinator.data[pin_address(1)] = SlotCredential.known("9999")
         manager._state = SyncState.OUT_OF_SYNC
 
         mid_sync = asyncio.Event()
@@ -1674,7 +1674,7 @@ class TestBreakerTickSoleMutatorInvariant:
         entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
         manager = entity_obj._sync_manager
 
-        manager._coordinator.data[1] = SlotCredential.known("9999")
+        manager._coordinator.data[pin_address(1)] = SlotCredential.known("9999")
         manager._state = SyncState.OUT_OF_SYNC
         # Seed the breaker so a mid-tick mutation would be observable.
         manager._slot_breaker.record_failure()
@@ -1770,7 +1770,7 @@ class TestBreakerTickSoleMutatorInvariant:
         entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
         manager = entity_obj._sync_manager
 
-        manager._coordinator.data[1] = SlotCredential.known("9999")
+        manager._coordinator.data[pin_address(1)] = SlotCredential.known("9999")
         manager._state = SyncState.OUT_OF_SYNC
         starting_count = manager._slot_breaker.failure_count
 
@@ -1796,7 +1796,7 @@ class TestBreakerTickSoleMutatorInvariant:
 
         # Branch 1: IN_SYNC -> OUT_OF_SYNC when target diverges.
         manager._state = SyncState.IN_SYNC
-        manager._coordinator.data[1] = SlotCredential.empty()
+        manager._coordinator.data[pin_address(1)] = SlotCredential.empty()
         manager._slot_breaker.record_failure()
         seeded = manager._slot_breaker.failure_count
         manager._breaker_reset_requested = False
@@ -1899,7 +1899,7 @@ class TestBreakerTickSoleMutatorInvariant:
         entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
         manager = entity_obj._sync_manager
 
-        manager._coordinator.data[1] = SlotCredential.known("9999")
+        manager._coordinator.data[pin_address(1)] = SlotCredential.known("9999")
         manager._state = SyncState.OUT_OF_SYNC
         starting_count = manager._slot_breaker.failure_count
         lock_provider = lock_code_manager_config_entry.runtime_data.locks[
@@ -1907,7 +1907,7 @@ class TestBreakerTickSoleMutatorInvariant:
         ]
 
         # async_set_usercode succeeds (was_set=True) but we no-op the
-        # refresh so coordinator.data[1] still reports the stale value and
+        # refresh so coordinator.data[pin_address(1)] still reports the stale value and
         # calculate_in_sync returns False -- the post-verification miss
         # branch must then record a failure.
         with (
@@ -1941,7 +1941,7 @@ class TestBreakerTickSoleMutatorInvariant:
         # entity must report STATE_OFF. Drive that via the entity.
         hass.states.async_set(SLOT_2_ACTIVE_ENTITY, STATE_OFF)
         # Coordinator still reports a code so verification will miss.
-        manager._coordinator.data[2] = SlotCredential.known("5678")
+        manager._coordinator.data[pin_address(2)] = SlotCredential.known("5678")
         starting_count = manager._slot_breaker.failure_count
         lock_provider = lock_code_manager_config_entry.runtime_data.locks[
             LOCK_1_ENTITY_ID
@@ -1979,7 +1979,7 @@ class TestOptimisticSetPendingConfirmation:
         await async_trigger_sync_tick(hass, SLOT_1_IN_SYNC_ENTITY, set_dirty=False)
         assert manager._state is SyncState.IN_SYNC
 
-        manager._coordinator.data[1] = SlotCredential.empty()
+        manager._coordinator.data[pin_address(1)] = SlotCredential.empty()
         manager.request_sync_check()
         assert manager._state is SyncState.OUT_OF_SYNC
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -855,7 +855,10 @@ class TestSyncStateMachine:
         await async_trigger_sync_tick(hass, SLOT_1_IN_SYNC_ENTITY, set_dirty=False)
 
         # Arrange an outstanding (unexpired) optimistic write.
-        manager._lock._pending_writes[1] = ("1234", time.monotonic() + 100.0)
+        manager._lock._pending_writes[pin_address(1)] = (
+            "1234",
+            time.monotonic() + 100.0,
+        )
         manager._coordinator.push_update(
             {1: SlotCredential.known("1234")}, optimistic=True
         )
@@ -886,7 +889,10 @@ class TestSyncStateMachine:
         await async_trigger_sync_tick(hass, SLOT_1_IN_SYNC_ENTITY, set_dirty=False)
 
         # Optimistic write outstanding (unexpired).
-        manager._lock._pending_writes[1] = ("1234", time.monotonic() + 100.0)
+        manager._lock._pending_writes[pin_address(1)] = (
+            "1234",
+            time.monotonic() + 100.0,
+        )
         manager._coordinator.push_update(
             {1: SlotCredential.known("1234")}, optimistic=True
         )
@@ -898,7 +904,7 @@ class TestSyncStateMachine:
         # The lock confirms the slot present but masked -> believed value kept,
         # marked verified, pending cleared.
         manager._lock._confirm_slot(1, SlotCredential.unreadable())
-        assert 1 not in manager._lock._pending_writes
+        assert pin_address(1) not in manager._lock._pending_writes
         assert manager._coordinator.is_verified(pin_address(1)) is True
 
         manager.request_sync_check()
@@ -920,7 +926,7 @@ class TestSyncStateMachine:
         # cannot confirm it. Arrange an already-expired optimistic write whose
         # value is NOT present on the lock.
         manager._lock.codes.pop(1, None)
-        manager._lock._pending_writes[1] = ("1234", time.monotonic() - 1.0)
+        manager._lock._pending_writes[pin_address(1)] = ("1234", time.monotonic() - 1.0)
         manager._coordinator.push_update(
             {1: SlotCredential.known("1234")}, optimistic=True
         )
@@ -935,7 +941,7 @@ class TestSyncStateMachine:
             # tick (so a concurrent confirming push could still land, and so the
             # breaker is not double-charged by a same-tick sync failure).
             await manager._async_tick()
-            assert 1 not in manager._lock._pending_writes
+            assert pin_address(1) not in manager._lock._pending_writes
             assert manager._slot_breaker.failure_count > before
             assert manager._state is SyncState.OUT_OF_SYNC
             mock_sync.assert_not_called()
@@ -963,7 +969,10 @@ class TestSyncStateMachine:
         # the deadline; it is dropped and the new target re-syncs.
         desired = manager._resolve_credential_snapshot().credential_state
         stale_pin = f"{desired}9"
-        manager._lock._pending_writes[1] = (stale_pin, time.monotonic() + 60.0)
+        manager._lock._pending_writes[pin_address(1)] = (
+            stale_pin,
+            time.monotonic() + 60.0,
+        )
         manager._coordinator.push_update(
             {1: SlotCredential.known(stale_pin)}, optimistic=True
         )
@@ -977,7 +986,7 @@ class TestSyncStateMachine:
 
         # Stale entry dropped; a desired-state change is not a sync failure, so
         # the breaker is not charged; the slot leaves PENDING_CONFIRMATION.
-        assert 1 not in manager._lock._pending_writes
+        assert pin_address(1) not in manager._lock._pending_writes
         assert manager._slot_breaker.failure_count == before
         assert manager._state is SyncState.OUT_OF_SYNC
         mock_sync.assert_not_called()
@@ -2006,7 +2015,7 @@ class TestOptimisticSetPendingConfirmation:
             await manager._async_tick()
 
         assert manager._state is SyncState.PENDING_CONFIRMATION
-        assert 1 in manager._lock._pending_writes
+        assert pin_address(1) in manager._lock._pending_writes
         assert manager._coordinator.is_verified(pin_address(1)) is False
 
 


### PR DESCRIPTION
## Proposed change

Flips the coordinator's internal storage from `dict[int, SlotCredential]` to `dict[CredentialAddress, SlotCredential]`, with `_unverified` following. This is what lets one slot hold more than one credential type — the capability the user-centric model needs.

Follows #1415, which introduced `CredentialAddress` and re-signed the coordinator's *accessors*. This one moves the *storage* behind them.

**Behavior is unchanged.** `user_ref` is still the slot number and the type is still Personal Identification Number, so every key is `(n, PIN)`.

**Boundaries deliberately keep their slot-keyed shape:**

- The **websocket payload** and **diagnostics output** are contracts with things outside this integration — the dashboard card reads one, and people paste the other into issue reports. Both now go through a new `credentials_by_slot()` projection. Lossless while PIN is the only stored type; the wire format re-keys later, shipping with the card.
- **`providers/_base.py::_pending_writes` is now address-keyed too.** An earlier revision of this PR left it slot-keyed and claimed that was correct permanently. Code review disproved that: once one slot holds two credential types, `_apply_read` iterates both `(5, PIN)` and `(5, RFID)`, both index `_pending_writes[5]`, and whichever is processed first consumes and deletes the entry — applying the pending PIN's believed value to the wrong credential, and leaving the second silently marked verified. The first is data corruption. Fixed in `7f9fae7c`.

That scoping is why this PR touches no TypeScript and needs no card change.

**New read accessors:** `credential(address)`, `has_credential(address)`, `credentials_by_slot(type)`. `credential()` returns `None` for "never reported", which stays distinct from `SlotCredential.empty()` — a positive observation that the slot holds no code.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- Full suite: **1494 passed, 3 skipped** (baseline 1492 on main)
- Coverage: **100.00%**, unchanged
- `ruff check`, `ruff format`, `pydocstyle`, `flake8`, `mypy`: all pass

Most of the test diff is mechanical — `coordinator.data[1]` becomes `coordinator.data[pin_address(1)]`, and iteration goes through `credentials_by_slot()`. Seeds via `async_set_updated_data` needed the same treatment, since they bypass `_normalize_keys`.

One test is not mechanical and is the point of the PR: `credentials_by_slot`'s type filter never excludes anything today, because every stored credential is a PIN. Line coverage therefore cannot pin it, so a test seeds a non-PIN address directly to prove the websocket and diagnostics boundaries will not start emitting an RFID value under a PIN slot key once a second type is stored.

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

🤖 Generated with [Claude Code](https://claude.com/claude-code)

