### PR TITLE
feat: require a present, unique, separator-free name on every slot

### DIFF
--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -91,6 +91,7 @@ from .domain.models import (
     LockCodeManagerConfigEntry,
     LockCodeManagerConfigEntryRuntimeData,
 )
+from .domain.names import normalize_slot_names
 from .domain.pin_generator import (
     DEFAULT_PIN_LENGTH,
     MAX_PIN_LENGTH,
@@ -205,6 +206,32 @@ async def async_migrate_entry(
                 "Use the Slot Usage Limiter blueprint instead.",
                 config_entry.title,
                 ", ".join(impacted_slots),
+            )
+
+    if config_entry.version == 3:
+        # Give every slot a present, separator-free, entry-unique name. The
+        # name is becoming the identity Lock Code Manager keys on, so these
+        # three properties stop being cosmetic and start being load-bearing.
+        new_data = {**config_entry.data}
+        new_options = {**config_entry.options}
+        renamed: set[str] = set()
+        for data_dict in (new_data, new_options):
+            if CONF_SLOTS not in data_dict:
+                continue
+            repaired, changed = normalize_slot_names(data_dict[CONF_SLOTS])
+            data_dict[CONF_SLOTS] = repaired
+            renamed.update(changed)
+        hass.config_entries.async_update_entry(
+            config_entry, data=new_data, options=new_options, version=4
+        )
+        if renamed:
+            _LOGGER.info(
+                "%s (%s): named %d previously-unnamed or conflicting slot(s): %s. "
+                "Locks that store a user name will pick this up on the next sync",
+                config_entry.entry_id,
+                config_entry.title,
+                len(renamed),
+                ", ".join(sorted(renamed, key=int)),
             )
 
     return True

--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -37,7 +37,7 @@ from .domain.config import EntryConfig
 from .domain.credentials import CredentialType
 from .domain.exceptions import LockCodeManagerError
 from .domain.models import SlotCredential
-from .domain.names import name_error
+from .domain.names import name_error, normalize_name, validate_slot_names
 from .domain.queries import get_entry_config
 from .providers import INTEGRATIONS_CLASS_MAP
 
@@ -190,7 +190,18 @@ async def _async_validate_slots_yaml(
         parsed_slots = CODE_SLOTS_SCHEMA(raw_slots)
     except vol.Invalid as err:
         _LOGGER.error("Invalid YAML: %s", err)
+        # A missing name is now the most likely reason a previously-valid
+        # slots block fails, so name it rather than sending the user to the
+        # logs for the one error we can predict.
+        if CONF_NAME in str(err):
+            return None, {"base": "name_required"}, {}
         return None, {"base": "invalid_config"}, {}
+
+    # The single-slot flow checks one name at a time; these paths submit the
+    # whole set, so the set has to be checked together.
+    if problem := validate_slot_names(parsed_slots):
+        slot_num, error = problem
+        return None, {"base": error}, {"slot_num": slot_num}
 
     errors, placeholders = _check_common_slots(hass, locks, parsed_slots, config_entry)
     if not errors:
@@ -494,12 +505,17 @@ class LockCodeManagerFlowHandler(
             # unique within the entry.
             if error := name_error(user_input.get(CONF_NAME)):
                 errors[CONF_NAME] = error
-            elif any(
-                slot.get(CONF_NAME, "").casefold()
-                == user_input[CONF_NAME].strip().casefold()
-                for slot in self.data[CONF_SLOTS].values()
-            ):
-                errors[CONF_NAME] = "name_not_unique"
+            else:
+                # Normalize BOTH sides. Comparing a stripped candidate
+                # against unstripped stored names lets "Raman " and "Raman"
+                # both through in one order but not the other.
+                user_input[CONF_NAME] = normalize_name(user_input[CONF_NAME])
+                if any(
+                    normalize_name(slot.get(CONF_NAME)).casefold()
+                    == user_input[CONF_NAME].casefold()
+                    for slot in self.data[CONF_SLOTS].values()
+                ):
+                    errors[CONF_NAME] = "name_not_unique"
 
             # Check for excluded platforms with a single registry lookup
             # self.ent_reg is set in async_step_user which always runs first

--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -193,7 +193,13 @@ async def _async_validate_slots_yaml(
         # A missing name is now the most likely reason a previously-valid
         # slots block fails, so name it rather than sending the user to the
         # logs for the one error we can predict.
-        if CONF_NAME in str(err):
+        #
+        # Match on the error PATH, not the rendered text. CONF_NAME is
+        # "name", which is a substring of any key containing it
+        # ("friendly_name", "username"), so a text match reports an
+        # unrelated schema failure as a missing name -- sending the user to
+        # exactly the logs this branch exists to avoid.
+        if CONF_NAME in getattr(err, "path", []):
             return None, {"base": "name_required"}, {}
         return None, {"base": "invalid_config"}, {}
 

--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -37,6 +37,7 @@ from .domain.config import EntryConfig
 from .domain.credentials import CredentialType
 from .domain.exceptions import LockCodeManagerError
 from .domain.models import SlotCredential
+from .domain.names import name_error
 from .domain.queries import get_entry_config
 from .providers import INTEGRATIONS_CLASS_MAP
 
@@ -44,7 +45,7 @@ _LOGGER = logging.getLogger(__name__)
 
 CODE_SLOT_SCHEMA = vol.Schema(
     {
-        vol.Optional(CONF_NAME): cv.string,
+        vol.Required(CONF_NAME): cv.string,
         vol.Optional(CONF_PIN): cv.string,
         vol.Required(CONF_ENABLED, default=True): cv.boolean,
         vol.Optional(CONF_ENTITY_ID): sel.EntitySelector(
@@ -379,7 +380,7 @@ class LockCodeManagerFlowHandler(
 ):
     """Config flow for Lock Code Manager."""
 
-    VERSION = 3
+    VERSION = 4
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
 
     def __init__(self) -> None:
@@ -487,6 +488,18 @@ class LockCodeManagerFlowHandler(
         if user_input is not None:
             if _slot_enabled_without_pin(user_input):
                 errors[CONF_PIN] = "missing_pin_if_enabled"
+
+            # The name is on its way to becoming the identity Lock Code
+            # Manager keys on, so it must be present, separator-free, and
+            # unique within the entry.
+            if error := name_error(user_input.get(CONF_NAME)):
+                errors[CONF_NAME] = error
+            elif any(
+                slot.get(CONF_NAME, "").casefold()
+                == user_input[CONF_NAME].strip().casefold()
+                for slot in self.data[CONF_SLOTS].values()
+            ):
+                errors[CONF_NAME] = "name_not_unique"
 
             # Check for excluded platforms with a single registry lookup
             # self.ent_reg is set in async_step_user which always runs first

--- a/custom_components/lock_code_manager/domain/names.py
+++ b/custom_components/lock_code_manager/domain/names.py
@@ -1,0 +1,112 @@
+"""
+User-name rules for Lock Code Manager slots.
+
+A slot's name is on its way to becoming the identity Lock Code Manager keys
+on -- the config entry will store a set of named users rather than a mapping
+of slot numbers, and lock users will be tagged ``lcm:{name}``. That only
+works if every name is present, unique within its entry, and encodable.
+
+This module is the single place those three rules live, so the config flow
+(validating new input) and the migration (repairing existing data) cannot
+drift from each other.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from homeassistant.const import CONF_NAME
+
+# Reserved because it delimits both the entity unique identifier
+# (``{entry_id}|{name}|{key}``) and the device identifier
+# (``{entry_id}|{name}``). A name containing it would split into the wrong
+# fields on the way back out -- see ``parse_slot_device_identifier``.
+NAME_SEPARATOR = "|"
+
+
+def name_error(name: str | None) -> str | None:
+    """
+    Return the validation error key for ``name``, or ``None`` when valid.
+
+    Returns a translation key rather than a message so the config flow can
+    surface it in the user's language.
+    """
+    if name is None or not name.strip():
+        return "name_required"
+    if NAME_SEPARATOR in name:
+        return "name_has_separator"
+    return None
+
+
+def fallback_name(slot_num: int) -> str:
+    """
+    Return the name given to a slot that has none.
+
+    Deliberately mirrors the "Code slot N" language users already see in the
+    frontend, so an auto-named slot reads as the same thing it was rather
+    than as something new.
+    """
+    return f"User {slot_num}"
+
+
+def deduplicate(name: str, taken: Iterable[str]) -> str:
+    """
+    Return ``name``, suffixed if needed so it does not collide with ``taken``.
+
+    Suffixes with " 2", " 3", and so on. Comparison is case-insensitive
+    because two users differing only in case would be indistinguishable in
+    the frontend and would collide once slugified into an entity identifier.
+    """
+    lowered = {existing.casefold() for existing in taken}
+    if name.casefold() not in lowered:
+        return name
+    suffix = 2
+    while f"{name} {suffix}".casefold() in lowered:
+        suffix += 1
+    return f"{name} {suffix}"
+
+
+def normalize_slot_names(
+    slots: Mapping[Any, Mapping[str, Any]],
+) -> tuple[dict[Any, dict[str, Any]], list[str]]:
+    """
+    Give every slot a present, separator-free, entry-unique name.
+
+    Returns the repaired slots alongside the slot numbers that were changed,
+    so a caller can report what it touched. Slots are processed in numeric
+    order so the result does not depend on mapping iteration order, which
+    would make the migration non-deterministic across restarts.
+
+    Names already valid and unique are left exactly as they are: this runs
+    over live user configuration, and rewriting a name the user chose would
+    also rename the user on every lock that stores one.
+    """
+    repaired: dict[Any, dict[str, Any]] = {}
+    changed: list[str] = []
+    taken: list[str] = []
+
+    for slot_num in sorted(slots, key=int):
+        slot = dict(slots[slot_num])
+        original = slot.get(CONF_NAME)
+
+        name = original
+        if name_error(name) == "name_required":
+            name = fallback_name(int(slot_num))
+        elif name is not None:
+            name = name.replace(NAME_SEPARATOR, " ").strip()
+
+        # ``name`` is non-empty by construction here, but a name consisting
+        # only of separators collapses to empty after the replacement above.
+        if not name:
+            name = fallback_name(int(slot_num))
+
+        name = deduplicate(name, taken)
+        taken.append(name)
+
+        if name != original:
+            slot[CONF_NAME] = name
+            changed.append(str(slot_num))
+        repaired[slot_num] = slot
+
+    return repaired, changed

--- a/custom_components/lock_code_manager/domain/names.py
+++ b/custom_components/lock_code_manager/domain/names.py
@@ -18,35 +18,44 @@ from typing import Any
 
 from homeassistant.const import CONF_NAME
 
-# Reserved because it delimits both the entity unique identifier
-# (``{entry_id}|{name}|{key}``) and the device identifier
-# (``{entry_id}|{name}``). A name containing it would split into the wrong
-# fields on the way back out -- see ``parse_slot_device_identifier``.
+# Reserved because it delimits the identifiers Lock Code Manager builds from
+# entry-scoped parts: today the entity unique identifier
+# (``{entry_id}|{slot_num}|{key}``) and the device identifier
+# (``{entry_id}|{slot_num}``), and the name takes the slot number's place in
+# both once the configuration is keyed by user. A name containing it would
+# split into the wrong fields on the way back out -- see
+# ``parse_slot_device_identifier``.
 NAME_SEPARATOR = "|"
+
+
+def normalize_name(name: str | None) -> str:
+    """
+    Return ``name`` in the form Lock Code Manager stores and compares.
+
+    Surrounding whitespace is removed so two names that differ only by
+    padding cannot both be stored. An identity that can differ invisibly is
+    worse than useless -- the user would see two identical rows and Lock
+    Code Manager would treat them as distinct users.
+    """
+    return (name or "").strip()
 
 
 def name_error(name: str | None) -> str | None:
     """
     Return the validation error key for ``name``, or ``None`` when valid.
 
-    Returns a translation key rather than a message so the config flow can
-    surface it in the user's language.
+    Returns a translation key rather than a message so callers can surface
+    it in the user's language.
     """
-    if name is None or not name.strip():
+    if not normalize_name(name):
         return "name_required"
-    if NAME_SEPARATOR in name:
+    if NAME_SEPARATOR in name:  # type: ignore[operator]
         return "name_has_separator"
     return None
 
 
 def fallback_name(slot_num: int) -> str:
-    """
-    Return the name given to a slot that has none.
-
-    Deliberately mirrors the "Code slot N" language users already see in the
-    frontend, so an auto-named slot reads as the same thing it was rather
-    than as something new.
-    """
+    """Return the name given to a slot that has none."""
     return f"User {slot_num}"
 
 
@@ -78,31 +87,52 @@ def normalize_slot_names(
     order so the result does not depend on mapping iteration order, which
     would make the migration non-deterministic across restarts.
 
-    Names already valid and unique are left exactly as they are: this runs
-    over live user configuration, and rewriting a name the user chose would
-    also rename the user on every lock that stores one.
+    A name that is already valid and unique keeps its text; the only change
+    it can undergo is whitespace normalization. That restraint matters
+    because this runs over live user configuration, and every rewrite here
+    renames that user on every lock that stores user names -- so a rewrite
+    is a device write, not a config edit.
+
+    Whitespace is the one exception worth paying for: ``"Raman "`` and
+    ``"Raman"`` are indistinguishable on screen, so leaving both storable
+    would let two rows that look identical be two different users.
     """
+    ordered = sorted(slots, key=int)
+
+    # Two passes, because a single pass lets a repaired name consume a later
+    # slot's name and force that slot to be renamed too. With
+    # {1: "Raman", 2: "Raman", 3: "Raman 2"}, one pass renames slot 2 to
+    # "Raman 2" and then pushes slot 3 -- which was valid and unique all
+    # along -- to "Raman 2 2". Reserving the already-good names first means
+    # only the slots that actually needed repairing are touched, and each
+    # avoided rewrite is an avoided rename on every lock storing user names.
+    reserved: list[str] = []
+    needs_repair: set[Any] = set()
+    for slot_num in ordered:
+        name = slots[slot_num].get(CONF_NAME)
+        if name_error(name) is None and normalize_name(name).casefold() not in {
+            existing.casefold() for existing in reserved
+        }:
+            reserved.append(normalize_name(name))
+        else:
+            needs_repair.add(slot_num)
+
     repaired: dict[Any, dict[str, Any]] = {}
     changed: list[str] = []
-    taken: list[str] = []
+    taken = list(reserved)
 
-    for slot_num in sorted(slots, key=int):
+    for slot_num in ordered:
         slot = dict(slots[slot_num])
         original = slot.get(CONF_NAME)
 
-        name = original
-        if name_error(name) == "name_required":
-            name = fallback_name(int(slot_num))
-        elif name is not None:
-            name = name.replace(NAME_SEPARATOR, " ").strip()
-
-        # ``name`` is non-empty by construction here, but a name consisting
-        # only of separators collapses to empty after the replacement above.
-        if not name:
-            name = fallback_name(int(slot_num))
-
-        name = deduplicate(name, taken)
-        taken.append(name)
+        if slot_num not in needs_repair:
+            name = normalize_name(original)
+        else:
+            name = normalize_name(
+                (original or "").replace(NAME_SEPARATOR, " ")
+            ) or fallback_name(int(slot_num))
+            name = deduplicate(name, taken)
+            taken.append(name)
 
         if name != original:
             slot[CONF_NAME] = name
@@ -110,3 +140,31 @@ def normalize_slot_names(
         repaired[slot_num] = slot
 
     return repaired, changed
+
+
+def validate_slot_names(
+    slots: Mapping[Any, Mapping[str, Any]],
+) -> tuple[str, str] | None:
+    """
+    Return the first ``(slot_num, error_key)`` problem in ``slots``, else None.
+
+    The single-slot config flow validates one name at a time against the
+    slots already accepted, but the YAML and options flows submit every slot
+    at once and need the whole set checked together. Returning the offending
+    slot number lets the caller name it in the error, since "one of your
+    slots has a duplicate name" is not actionable.
+
+    Uniqueness is compared on the normalized, case-folded name, matching how
+    the migration deduplicates -- otherwise a pair the migration would repair
+    could be re-entered by hand.
+    """
+    seen: dict[str, str] = {}
+    for slot_num in sorted(slots, key=int):
+        name = slots[slot_num].get(CONF_NAME)
+        if error := name_error(name):
+            return str(slot_num), error
+        key = normalize_name(name).casefold()
+        if key in seen:
+            return str(slot_num), "name_not_unique"
+        seen[key] = str(slot_num)
+    return None

--- a/custom_components/lock_code_manager/domain/slot_coordinator.py
+++ b/custom_components/lock_code_manager/domain/slot_coordinator.py
@@ -33,6 +33,7 @@ from homeassistant.core import (
     HomeAssistant,
     callback,
 )
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.issue_registry import (
     IssueSeverity,
@@ -42,7 +43,7 @@ from homeassistant.helpers.issue_registry import (
 
 from ..const import ATTR_IN_SYNC, DOMAIN, EVENT_PIN_USED
 from .config import EntryConfig
-from .names import NAME_SEPARATOR, name_error, normalize_name
+from .names import name_error, normalize_name
 from .queries import get_entry_config
 
 if TYPE_CHECKING:
@@ -456,12 +457,15 @@ class PinRequiredError(Exception):
     """Raised when a slot cannot be enabled because no PIN is configured."""
 
 
-class InvalidNameError(Exception):
+class InvalidNameError(HomeAssistantError):
     """
     Raised when a slot name write would break the name rules.
 
-    Carries the translation key so the entity can render the same message
-    the config flow shows, rather than inventing a second wording.
+    Subclasses ``HomeAssistantError`` so a caller that forgets to translate
+    it still surfaces as a validation refusal rather than an unknown-error
+    500. Carries the translation key and placeholders so the entity renders
+    the same localized message the config flow shows for the same rule,
+    instead of inventing a second English-only wording.
     """
 
     def __init__(
@@ -471,14 +475,8 @@ class InvalidNameError(Exception):
         self.error_key = error_key
         self.slot_num = slot_num
         self.conflicting_slot = conflicting_slot
-        messages = {
-            "name_required": "A code slot name cannot be empty",
-            "name_has_separator": (
-                f"A code slot name cannot contain '{NAME_SEPARATOR}'"
-            ),
-            "name_not_unique": (
-                f"Slot {conflicting_slot} already uses that name; "
-                "names must be unique within a Lock Code Manager entry"
-            ),
+        self.placeholders = {
+            "slot_num": str(slot_num),
+            "conflicting_slot": str(conflicting_slot),
         }
-        super().__init__(messages[error_key])
+        super().__init__(f"{error_key} (slot {slot_num})")

--- a/custom_components/lock_code_manager/domain/slot_coordinator.py
+++ b/custom_components/lock_code_manager/domain/slot_coordinator.py
@@ -42,6 +42,7 @@ from homeassistant.helpers.issue_registry import (
 
 from ..const import ATTR_IN_SYNC, DOMAIN, EVENT_PIN_USED
 from .config import EntryConfig
+from .names import NAME_SEPARATOR, name_error, normalize_name
 from .queries import get_entry_config
 
 if TYPE_CHECKING:
@@ -204,8 +205,33 @@ class SlotEntityCoordinator:
     # -- Intent dispatch -----------------------------------------------------
 
     async def async_request_name_update(self, value: str) -> None:
-        """Apply a slot name write requested by the text entity."""
-        self._write_config_fields({CONF_NAME: value})
+        """
+        Apply a slot name write requested by the text entity.
+
+        The name is the identity Lock Code Manager is moving to key on, so
+        this path enforces the same rules the config flow does. Without it
+        the ordinary way to rename a slot in the frontend would be a hole
+        straight through them: an empty name, one containing the reserved
+        separator, or a duplicate of another slot's would land in the
+        config entry unchallenged.
+        """
+        name = normalize_name(value)
+        if error := name_error(name):
+            raise InvalidNameError(error, self._slot_num)
+
+        conflict = next(
+            (
+                other
+                for other, slot in get_entry_config(self._config_entry).slots.items()
+                if other != self._slot_num
+                and normalize_name(slot.get(CONF_NAME)).casefold() == name.casefold()
+            ),
+            None,
+        )
+        if conflict is not None:
+            raise InvalidNameError("name_not_unique", self._slot_num, conflict)
+
+        self._write_config_fields({CONF_NAME: name})
 
     async def async_request_pin_update(self, value: str) -> None:
         """
@@ -428,3 +454,31 @@ class SlotEntityCoordinator:
 
 class PinRequiredError(Exception):
     """Raised when a slot cannot be enabled because no PIN is configured."""
+
+
+class InvalidNameError(Exception):
+    """
+    Raised when a slot name write would break the name rules.
+
+    Carries the translation key so the entity can render the same message
+    the config flow shows, rather than inventing a second wording.
+    """
+
+    def __init__(
+        self, error_key: str, slot_num: int, conflicting_slot: int | None = None
+    ) -> None:
+        """Store the error key and the slots involved."""
+        self.error_key = error_key
+        self.slot_num = slot_num
+        self.conflicting_slot = conflicting_slot
+        messages = {
+            "name_required": "A code slot name cannot be empty",
+            "name_has_separator": (
+                f"A code slot name cannot contain '{NAME_SEPARATOR}'"
+            ),
+            "name_not_unique": (
+                f"Slot {conflicting_slot} already uses that name; "
+                "names must be unique within a Lock Code Manager entry"
+            ),
+        }
+        super().__init__(messages[error_key])

--- a/custom_components/lock_code_manager/strings.json
+++ b/custom_components/lock_code_manager/strings.json
@@ -10,9 +10,9 @@
       "excluded_platform": "Entities from the `{integration}` integration are not supported as condition entities. See the [wiki]({docs_url}) for details.",
       "invalid_config": "Slots configuration is invalid. For more information, check the logs and the docs.",
       "missing_pin_if_enabled": "PIN must be set if slot is enabled.",
-      "name_has_separator": "A name cannot contain the “|” character.",
-      "name_not_unique": "Another code slot in this entry already uses that name. Names must be unique.",
-      "name_required": "Every code slot needs a name. The name identifies this user on your locks.",
+      "name_has_separator": "The name for code slot {slot_num} cannot contain the “|” character.",
+      "name_not_unique": "The name for code slot {slot_num} is already used by another code slot in this entry. Names must be unique.",
+      "name_required": "Code slot {slot_num} needs a name. The name identifies this user on your locks.",
       "slot_out_of_range": "Lock {lock} reports only {num_slots} PIN code slots, so these slot numbers are out of range for it: {out_of_range_slots}. Renumber them to fall within 1-{num_slots}, or manage that lock from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity.",
       "slots_already_configured": "The following slots for lock {lock} are already managed by another config entry ({entry_title}) and can't be added to this configuration without being removed from the other one: {common_slots}"
     },
@@ -132,10 +132,11 @@
     "error": {
       "invalid_config": "Slots configuration is invalid. For more information, check the logs and the docs.",
       "locks_already_configured": "The following lock(s) are already managed by another config entry: {locks}.",
-      "name_has_separator": "A name cannot contain the “|” character.",
-      "name_not_unique": "Another code slot in this entry already uses that name. Names must be unique.",
-      "name_required": "Every code slot needs a name. The name identifies this user on your locks.",
-      "slot_out_of_range": "Lock {lock} reports only {num_slots} PIN code slots, so these slot numbers are out of range for it: {out_of_range_slots}. Renumber them to fall within 1-{num_slots}, or manage that lock from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity."
+      "name_has_separator": "The name for code slot {slot_num} cannot contain the “|” character.",
+      "name_not_unique": "The name for code slot {slot_num} is already used by another code slot in this entry. Names must be unique.",
+      "name_required": "Code slot {slot_num} needs a name. The name identifies this user on your locks.",
+      "slot_out_of_range": "Lock {lock} reports only {num_slots} PIN code slots, so these slot numbers are out of range for it: {out_of_range_slots}. Renumber them to fall within 1-{num_slots}, or manage that lock from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity.",
+      "slots_already_configured": "The following slots for lock {lock} are already managed by another config entry ({entry_title}) and can't be added to this configuration without being removed from the other one: {common_slots}"
     },
     "step": {
       "init": {
@@ -234,6 +235,17 @@
     "lock_setup_failed": {
       "title": "Lock setup failed: {lock_entity_id}",
       "description": "Lock Code Manager could not set up `{lock_entity_id}`: {error}\n\nIts entities are created but unavailable, and code synchronization is paused for this lock. After addressing the cause, reload the lock's integration (or Lock Code Manager) to retry. This issue will be automatically dismissed when setup succeeds."
+    }
+  },
+  "exceptions": {
+    "name_has_separator": {
+      "message": "The name for code slot {slot_num} cannot contain the “|” character."
+    },
+    "name_not_unique": {
+      "message": "Code slot {conflicting_slot} already uses that name. Names must be unique within a Lock Code Manager entry."
+    },
+    "name_required": {
+      "message": "Code slot {slot_num} needs a name. The name identifies this user on your locks."
     }
   }
 }

--- a/custom_components/lock_code_manager/strings.json
+++ b/custom_components/lock_code_manager/strings.json
@@ -10,6 +10,9 @@
       "excluded_platform": "Entities from the `{integration}` integration are not supported as condition entities. See the [wiki]({docs_url}) for details.",
       "invalid_config": "Slots configuration is invalid. For more information, check the logs and the docs.",
       "missing_pin_if_enabled": "PIN must be set if slot is enabled.",
+      "name_has_separator": "A name cannot contain the “|” character.",
+      "name_not_unique": "Another code slot in this entry already uses that name. Names must be unique.",
+      "name_required": "Every code slot needs a name. The name identifies this user on your locks.",
       "slot_out_of_range": "Lock {lock} reports only {num_slots} PIN code slots, so these slot numbers are out of range for it: {out_of_range_slots}. Renumber them to fall within 1-{num_slots}, or manage that lock from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity.",
       "slots_already_configured": "The following slots for lock {lock} are already managed by another config entry ({entry_title}) and can't be added to this configuration without being removed from the other one: {common_slots}"
     },
@@ -129,6 +132,9 @@
     "error": {
       "invalid_config": "Slots configuration is invalid. For more information, check the logs and the docs.",
       "locks_already_configured": "The following lock(s) are already managed by another config entry: {locks}.",
+      "name_has_separator": "A name cannot contain the “|” character.",
+      "name_not_unique": "Another code slot in this entry already uses that name. Names must be unique.",
+      "name_required": "Every code slot needs a name. The name identifies this user on your locks.",
       "slot_out_of_range": "Lock {lock} reports only {num_slots} PIN code slots, so these slot numbers are out of range for it: {out_of_range_slots}. Renumber them to fall within 1-{num_slots}, or manage that lock from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity."
     },
     "step": {

--- a/custom_components/lock_code_manager/text.py
+++ b/custom_components/lock_code_manager/text.py
@@ -11,6 +11,7 @@ from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from .const import DOMAIN
 from .domain.models import LockCodeManagerConfigEntry
 from .domain.slot_coordinator import InvalidNameError
 from .entity import BaseLockCodeManagerEntity
@@ -80,7 +81,11 @@ class LockCodeManagerText(BaseLockCodeManagerEntity, TextEntity):
             try:
                 await coordinator.async_request_name_update(value)
             except InvalidNameError as err:
-                raise ServiceValidationError(str(err)) from err
+                raise ServiceValidationError(
+                    translation_domain=DOMAIN,
+                    translation_key=err.error_key,
+                    translation_placeholders=err.placeholders,
+                ) from err
         self.async_write_ha_state()
 
     async def async_added_to_hass(self) -> None:

--- a/custom_components/lock_code_manager/text.py
+++ b/custom_components/lock_code_manager/text.py
@@ -7,10 +7,12 @@ import logging
 from homeassistant.components.text import TextEntity, TextMode
 from homeassistant.const import CONF_NAME, CONF_PIN
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .domain.models import LockCodeManagerConfigEntry
+from .domain.slot_coordinator import InvalidNameError
 from .entity import BaseLockCodeManagerEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -75,7 +77,10 @@ class LockCodeManagerText(BaseLockCodeManagerEntity, TextEntity):
         if self.key == CONF_PIN:
             await coordinator.async_request_pin_update(value)
         else:
-            await coordinator.async_request_name_update(value)
+            try:
+                await coordinator.async_request_name_update(value)
+            except InvalidNameError as err:
+                raise ServiceValidationError(str(err)) from err
         self.async_write_ha_state()
 
     async def async_added_to_hass(self) -> None:

--- a/custom_components/lock_code_manager/translations/en.json
+++ b/custom_components/lock_code_manager/translations/en.json
@@ -10,9 +10,9 @@
       "excluded_platform": "Entities from the `{integration}` integration are not supported as condition entities. See the [wiki]({docs_url}) for details.",
       "invalid_config": "Slots configuration is invalid. For more information, check the logs and the docs.",
       "missing_pin_if_enabled": "PIN must be set if slot is enabled.",
-      "name_has_separator": "A name cannot contain the “|” character.",
-      "name_not_unique": "Another code slot in this entry already uses that name. Names must be unique.",
-      "name_required": "Every code slot needs a name. The name identifies this user on your locks.",
+      "name_has_separator": "The name for code slot {slot_num} cannot contain the “|” character.",
+      "name_not_unique": "The name for code slot {slot_num} is already used by another code slot in this entry. Names must be unique.",
+      "name_required": "Code slot {slot_num} needs a name. The name identifies this user on your locks.",
       "slot_out_of_range": "Lock {lock} reports only {num_slots} PIN code slots, so these slot numbers are out of range for it: {out_of_range_slots}. Renumber them to fall within 1-{num_slots}, or manage that lock from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity.",
       "slots_already_configured": "The following slots for lock {lock} are already managed by another config entry ({entry_title}) and can't be added to this configuration without being removed from the other one: {common_slots}"
     },
@@ -132,10 +132,11 @@
     "error": {
       "invalid_config": "Slots configuration is invalid. For more information, check the logs and the docs.",
       "locks_already_configured": "The following lock(s) are already managed by another config entry: {locks}.",
-      "name_has_separator": "A name cannot contain the “|” character.",
-      "name_not_unique": "Another code slot in this entry already uses that name. Names must be unique.",
-      "name_required": "Every code slot needs a name. The name identifies this user on your locks.",
-      "slot_out_of_range": "Lock {lock} reports only {num_slots} PIN code slots, so these slot numbers are out of range for it: {out_of_range_slots}. Renumber them to fall within 1-{num_slots}, or manage that lock from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity."
+      "name_has_separator": "The name for code slot {slot_num} cannot contain the “|” character.",
+      "name_not_unique": "The name for code slot {slot_num} is already used by another code slot in this entry. Names must be unique.",
+      "name_required": "Code slot {slot_num} needs a name. The name identifies this user on your locks.",
+      "slot_out_of_range": "Lock {lock} reports only {num_slots} PIN code slots, so these slot numbers are out of range for it: {out_of_range_slots}. Renumber them to fall within 1-{num_slots}, or manage that lock from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity.",
+      "slots_already_configured": "The following slots for lock {lock} are already managed by another config entry ({entry_title}) and can't be added to this configuration without being removed from the other one: {common_slots}"
     },
     "step": {
       "init": {
@@ -234,6 +235,17 @@
     "lock_setup_failed": {
       "title": "Lock setup failed: {lock_entity_id}",
       "description": "Lock Code Manager could not set up `{lock_entity_id}`: {error}\n\nIts entities are created but unavailable, and code synchronization is paused for this lock. After addressing the cause, reload the lock's integration (or Lock Code Manager) to retry. This issue will be automatically dismissed when setup succeeds."
+    }
+  },
+  "exceptions": {
+    "name_has_separator": {
+      "message": "The name for code slot {slot_num} cannot contain the “|” character."
+    },
+    "name_not_unique": {
+      "message": "Code slot {conflicting_slot} already uses that name. Names must be unique within a Lock Code Manager entry."
+    },
+    "name_required": {
+      "message": "Code slot {slot_num} needs a name. The name identifies this user on your locks."
     }
   }
 }

--- a/custom_components/lock_code_manager/translations/en.json
+++ b/custom_components/lock_code_manager/translations/en.json
@@ -10,6 +10,9 @@
       "excluded_platform": "Entities from the `{integration}` integration are not supported as condition entities. See the [wiki]({docs_url}) for details.",
       "invalid_config": "Slots configuration is invalid. For more information, check the logs and the docs.",
       "missing_pin_if_enabled": "PIN must be set if slot is enabled.",
+      "name_has_separator": "A name cannot contain the “|” character.",
+      "name_not_unique": "Another code slot in this entry already uses that name. Names must be unique.",
+      "name_required": "Every code slot needs a name. The name identifies this user on your locks.",
       "slot_out_of_range": "Lock {lock} reports only {num_slots} PIN code slots, so these slot numbers are out of range for it: {out_of_range_slots}. Renumber them to fall within 1-{num_slots}, or manage that lock from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity.",
       "slots_already_configured": "The following slots for lock {lock} are already managed by another config entry ({entry_title}) and can't be added to this configuration without being removed from the other one: {common_slots}"
     },
@@ -129,6 +132,9 @@
     "error": {
       "invalid_config": "Slots configuration is invalid. For more information, check the logs and the docs.",
       "locks_already_configured": "The following lock(s) are already managed by another config entry: {locks}.",
+      "name_has_separator": "A name cannot contain the “|” character.",
+      "name_not_unique": "Another code slot in this entry already uses that name. Names must be unique.",
+      "name_required": "Every code slot needs a name. The name identifies this user on your locks.",
       "slot_out_of_range": "Lock {lock} reports only {num_slots} PIN code slots, so these slot numbers are out of range for it: {out_of_range_slots}. Renumber them to fall within 1-{num_slots}, or manage that lock from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity."
     },
     "step": {

--- a/tests/common.py
+++ b/tests/common.py
@@ -44,6 +44,7 @@ BASE_CONFIG = {
 SLOT_1_ACTIVE_ENTITY = "binary_sensor.mock_title_code_slot_1_active"
 SLOT_1_ENABLED_ENTITY = "switch.mock_title_code_slot_1_enabled"
 SLOT_1_EVENT_ENTITY = "event.mock_title_code_slot_1"
+SLOT_1_NAME_ENTITY = "text.mock_title_code_slot_1_name"
 SLOT_1_PIN_ENTITY = "text.mock_title_code_slot_1_pin"
 SLOT_1_IN_SYNC_ENTITY = "binary_sensor.test_1_code_slot_1_in_sync"
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -131,7 +131,8 @@ async def test_config_flow_ui(hass: HomeAssistant):
         is_last = slot_num == len(pins)
 
         result = await hass.config_entries.flow.async_configure(
-            flow_id, {CONF_ENABLED: True, CONF_PIN: pin}
+            flow_id,
+            {CONF_NAME: f"User {slot_num}", CONF_ENABLED: True, CONF_PIN: pin},
         )
 
         if is_last:
@@ -146,10 +147,10 @@ async def test_config_flow_ui(hass: HomeAssistant):
     assert result["data"] == {
         CONF_LOCKS: [LOCK_1_ENTITY_ID],
         CONF_SLOTS: {
-            1: {CONF_ENABLED: True, CONF_PIN: "1234"},
-            2: {CONF_ENABLED: True, CONF_PIN: "5678"},
-            3: {CONF_ENABLED: True, CONF_PIN: "9012"},
-            4: {CONF_ENABLED: True, CONF_PIN: "3456"},
+            1: {CONF_NAME: "User 1", CONF_ENABLED: True, CONF_PIN: "1234"},
+            2: {CONF_NAME: "User 2", CONF_ENABLED: True, CONF_PIN: "5678"},
+            3: {CONF_NAME: "User 3", CONF_ENABLED: True, CONF_PIN: "9012"},
+            4: {CONF_NAME: "User 4", CONF_ENABLED: True, CONF_PIN: "3456"},
         },
     }
 
@@ -159,7 +160,7 @@ async def test_config_flow_ui_error(hass: HomeAssistant):
     flow_id = await _start_ui_config_flow(hass)
 
     result = await hass.config_entries.flow.async_configure(
-        flow_id, {CONF_ENABLED: True, CONF_PIN: ""}
+        flow_id, {CONF_NAME: "User 1", CONF_ENABLED: True, CONF_PIN: ""}
     )
 
     assert result["type"] == "form"
@@ -176,8 +177,8 @@ async def test_config_flow_yaml(hass: HomeAssistant):
         flow_id,
         {
             CONF_SLOTS: {
-                1: {CONF_ENABLED: True, CONF_PIN: "1234"},
-                2: {CONF_ENABLED: True, CONF_PIN: "5678"},
+                1: {CONF_NAME: "User 1", CONF_ENABLED: True, CONF_PIN: "1234"},
+                2: {CONF_NAME: "User 2", CONF_ENABLED: True, CONF_PIN: "5678"},
             }
         },
     )
@@ -187,8 +188,8 @@ async def test_config_flow_yaml(hass: HomeAssistant):
     assert result["data"] == {
         CONF_LOCKS: [LOCK_1_ENTITY_ID],
         CONF_SLOTS: {
-            1: {CONF_ENABLED: True, CONF_PIN: "1234"},
-            2: {CONF_ENABLED: True, CONF_PIN: "5678"},
+            1: {CONF_NAME: "User 1", CONF_ENABLED: True, CONF_PIN: "1234"},
+            2: {CONF_NAME: "User 2", CONF_ENABLED: True, CONF_PIN: "5678"},
         },
     }
 
@@ -199,7 +200,7 @@ async def test_config_flow_yaml_error(hass: HomeAssistant):
 
     result = await hass.config_entries.flow.async_configure(
         flow_id,
-        {CONF_SLOTS: {1: {CONF_ENABLED: True, CONF_PIN: ""}}},
+        {CONF_SLOTS: {1: {CONF_NAME: "User 1", CONF_ENABLED: True, CONF_PIN: ""}}},
     )
 
     assert result["type"] == "form"
@@ -224,7 +225,7 @@ async def test_options_flow(hass: HomeAssistant):
                 CONF_ENABLED: True,
                 CONF_ENTITY_ID: "calendar.test_1",
             },
-            3: {CONF_ENABLED: True, CONF_PIN: ""},
+            3: {CONF_NAME: "User 3", CONF_ENABLED: True, CONF_PIN: ""},
         },
     }
     result = await hass.config_entries.options.async_init(entry.entry_id)
@@ -241,7 +242,11 @@ async def test_options_flow(hass: HomeAssistant):
     assert result["step_id"] == "init"
     assert result["errors"] == {"base": "invalid_config"}
 
-    new_config[CONF_SLOTS][3] = {CONF_ENABLED: True, CONF_PIN: "1234"}
+    new_config[CONF_SLOTS][3] = {
+        CONF_NAME: "User 1",
+        CONF_ENABLED: True,
+        CONF_PIN: "1234",
+    }
     result = await hass.config_entries.options.async_configure(
         flow_id, user_input=new_config
     )
@@ -344,7 +349,7 @@ async def test_config_flow_slots_already_configured(
 
     result = await hass.config_entries.flow.async_configure(
         flow_id,
-        {CONF_SLOTS: {2: {CONF_ENABLED: False, CONF_PIN: "0123"}}},
+        {CONF_SLOTS: {2: {CONF_NAME: "User 2", CONF_ENABLED: False, CONF_PIN: "0123"}}},
     )
     assert result["errors"] == {"base": "slots_already_configured"}
 
@@ -357,7 +362,7 @@ async def test_config_flow_two_entries_same_locks(
 
     result = await hass.config_entries.flow.async_configure(
         flow_id,
-        {CONF_SLOTS: {3: {CONF_ENABLED: False, CONF_PIN: "0123"}}},
+        {CONF_SLOTS: {3: {CONF_NAME: "User 3", CONF_ENABLED: False, CONF_PIN: "0123"}}},
     )
     assert result["type"] == "create_entry"
 
@@ -380,7 +385,12 @@ async def test_config_flow_ui_scheduler_entity_excluded(hass: HomeAssistant):
     # Try to configure slot 1 with a scheduler entity as condition
     result = await hass.config_entries.flow.async_configure(
         flow_id,
-        {CONF_ENABLED: True, CONF_PIN: "1234", CONF_ENTITY_ID: "switch.my_schedule"},
+        {
+            CONF_NAME: "User 1",
+            CONF_ENABLED: True,
+            CONF_PIN: "1234",
+            CONF_ENTITY_ID: "switch.my_schedule",
+        },
     )
 
     # Should show error for excluded platform
@@ -432,14 +442,14 @@ async def test_ui_existing_codes_confirm_continue(hass: HomeAssistant):
 
     # Configure slot 1
     result = await hass.config_entries.flow.async_configure(
-        flow_id, {CONF_ENABLED: True, CONF_PIN: "1234"}
+        flow_id, {CONF_NAME: "User 2", CONF_ENABLED: True, CONF_PIN: "1234"}
     )
 
     assert result["step_id"] == "code_slot"
 
     # Configure slot 2 -> create entry (sync manager handles reconciliation)
     result = await hass.config_entries.flow.async_configure(
-        flow_id, {CONF_ENABLED: True, CONF_PIN: "5678"}
+        flow_id, {CONF_NAME: "User 3", CONF_ENABLED: True, CONF_PIN: "5678"}
     )
 
     assert result["type"] == "create_entry"
@@ -493,7 +503,7 @@ async def test_yaml_existing_codes_confirm_continue(hass: HomeAssistant):
 
     result = await hass.config_entries.flow.async_configure(
         flow_id,
-        {CONF_SLOTS: {1: {CONF_ENABLED: True, CONF_PIN: "1234"}}},
+        {CONF_SLOTS: {1: {CONF_NAME: "User 1", CONF_ENABLED: True, CONF_PIN: "1234"}}},
     )
 
     assert result["type"] == "menu"
@@ -524,7 +534,7 @@ async def test_yaml_existing_codes_confirm_cancel(hass: HomeAssistant):
     )
     result = await hass.config_entries.flow.async_configure(
         flow_id,
-        {CONF_SLOTS: {1: {CONF_ENABLED: True, CONF_PIN: "1234"}}},
+        {CONF_SLOTS: {1: {CONF_NAME: "User 1", CONF_ENABLED: True, CONF_PIN: "1234"}}},
     )
 
     assert result["type"] == "menu"
@@ -574,7 +584,7 @@ async def test_yaml_no_existing_codes_skips_confirm(hass: HomeAssistant):
     )
     result = await hass.config_entries.flow.async_configure(
         flow_id,
-        {CONF_SLOTS: {1: {CONF_ENABLED: True, CONF_PIN: "1234"}}},
+        {CONF_SLOTS: {1: {CONF_NAME: "User 1", CONF_ENABLED: True, CONF_PIN: "1234"}}},
     )
 
     # Goes directly to create_entry, no confirm step
@@ -765,7 +775,13 @@ async def test_async_get_all_codes_returns_all_codes(hass: HomeAssistant):
         domain=DOMAIN,
         data={
             CONF_LOCKS: [LOCK_1_ENTITY_ID],
-            CONF_SLOTS: {1: {CONF_ENABLED: True, CONF_PIN: "1234", CONF_NAME: "S1"}},
+            CONF_SLOTS: {
+                1: {
+                    CONF_NAME: "S1",
+                    CONF_ENABLED: True,
+                    CONF_PIN: "1234",
+                }
+            },
         },
     )
     lcm_entry.add_to_hass(hass)
@@ -859,7 +875,7 @@ async def test_existing_codes_detected_across_multiple_locks(hass: HomeAssistant
     )
     result = await hass.config_entries.flow.async_configure(
         flow_id,
-        {CONF_SLOTS: {1: {CONF_ENABLED: True, CONF_PIN: "5678"}}},
+        {CONF_SLOTS: {1: {CONF_NAME: "User 1", CONF_ENABLED: True, CONF_PIN: "5678"}}},
     )
 
     # Confirm step shown because slot 1 has existing codes on some locks
@@ -905,7 +921,8 @@ async def _start_options_flow(
         title="test",
         data={
             CONF_LOCKS: locks or [LOCK_1_ENTITY_ID],
-            CONF_SLOTS: slots or {1: {CONF_ENABLED: True, CONF_PIN: "1234"}},
+            CONF_SLOTS: slots
+            or {1: {CONF_NAME: "User 1", CONF_ENABLED: True, CONF_PIN: "1234"}},
         },
     )
     entry.add_to_hass(hass)
@@ -924,7 +941,9 @@ async def test_options_flow_no_added_pairs_persists_immediately(hass: HomeAssist
             flow_id,
             {
                 CONF_LOCKS: [LOCK_1_ENTITY_ID],
-                CONF_SLOTS: {1: {CONF_ENABLED: True, CONF_PIN: "1234"}},
+                CONF_SLOTS: {
+                    1: {CONF_NAME: "User 1", CONF_ENABLED: True, CONF_PIN: "1234"}
+                },
             },
         )
 
@@ -947,8 +966,8 @@ async def test_options_flow_added_pair_no_existing_code_persists(hass: HomeAssis
             {
                 CONF_LOCKS: [LOCK_1_ENTITY_ID],
                 CONF_SLOTS: {
-                    1: {CONF_ENABLED: True, CONF_PIN: "1234"},
-                    2: {CONF_ENABLED: True, CONF_PIN: "5678"},
+                    1: {CONF_NAME: "User 1", CONF_ENABLED: True, CONF_PIN: "1234"},
+                    2: {CONF_NAME: "User 2", CONF_ENABLED: True, CONF_PIN: "5678"},
                 },
             },
         )
@@ -978,8 +997,8 @@ async def test_options_flow_added_pair_with_existing_code_confirm(
             {
                 CONF_LOCKS: [LOCK_1_ENTITY_ID],
                 CONF_SLOTS: {
-                    1: {CONF_ENABLED: True, CONF_PIN: "1234"},
-                    2: {CONF_ENABLED: True, CONF_PIN: "5678"},
+                    1: {CONF_NAME: "User 1", CONF_ENABLED: True, CONF_PIN: "1234"},
+                    2: {CONF_NAME: "User 2", CONF_ENABLED: True, CONF_PIN: "5678"},
                 },
             },
         )
@@ -1014,7 +1033,9 @@ async def test_options_flow_added_lock_with_existing_code_confirm(
             flow_id,
             {
                 CONF_LOCKS: [LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID],
-                CONF_SLOTS: {1: {CONF_ENABLED: True, CONF_PIN: "1234"}},
+                CONF_SLOTS: {
+                    1: {CONF_NAME: "User 1", CONF_ENABLED: True, CONF_PIN: "1234"}
+                },
             },
         )
 
@@ -1040,8 +1061,8 @@ async def test_options_flow_existing_codes_cancel_aborts(hass: HomeAssistant):
             {
                 CONF_LOCKS: [LOCK_1_ENTITY_ID],
                 CONF_SLOTS: {
-                    1: {CONF_ENABLED: True, CONF_PIN: "1234"},
-                    2: {CONF_ENABLED: True, CONF_PIN: "5678"},
+                    1: {CONF_NAME: "User 1", CONF_ENABLED: True, CONF_PIN: "1234"},
+                    2: {CONF_NAME: "User 2", CONF_ENABLED: True, CONF_PIN: "5678"},
                 },
             },
         )
@@ -1069,8 +1090,8 @@ async def test_options_flow_added_pair_empty_code_persists(hass: HomeAssistant):
             {
                 CONF_LOCKS: [LOCK_1_ENTITY_ID],
                 CONF_SLOTS: {
-                    1: {CONF_ENABLED: True, CONF_PIN: "1234"},
-                    2: {CONF_ENABLED: True, CONF_PIN: "5678"},
+                    1: {CONF_NAME: "User 1", CONF_ENABLED: True, CONF_PIN: "1234"},
+                    2: {CONF_NAME: "User 2", CONF_ENABLED: True, CONF_PIN: "5678"},
                 },
             },
         )
@@ -1151,7 +1172,11 @@ async def test_config_flow_yaml_rejects_slot_beyond_lock_capacity(
     with probe_registered, probe_capabilities:
         result = await hass.config_entries.flow.async_configure(
             flow_id,
-            {CONF_SLOTS: {50: {CONF_ENABLED: True, CONF_PIN: "2222"}}},
+            {
+                CONF_SLOTS: {
+                    50: {CONF_NAME: "User 50", CONF_ENABLED: True, CONF_PIN: "2222"}
+                }
+            },
         )
 
     assert result["type"] == "form"
@@ -1172,7 +1197,11 @@ async def test_config_flow_yaml_accepts_slot_within_capacity(
     with probe_registered, probe_capabilities:
         result = await hass.config_entries.flow.async_configure(
             flow_id,
-            {CONF_SLOTS: {30: {CONF_ENABLED: True, CONF_PIN: "2222"}}},
+            {
+                CONF_SLOTS: {
+                    30: {CONF_NAME: "User 30", CONF_ENABLED: True, CONF_PIN: "2222"}
+                }
+            },
         )
 
     assert result["type"] == "create_entry"
@@ -1219,7 +1248,11 @@ async def test_config_flow_capacity_check_skipped_when_lock_unreachable(
     with probe_registered, probe_capabilities:
         result = await hass.config_entries.flow.async_configure(
             flow_id,
-            {CONF_SLOTS: {50: {CONF_ENABLED: True, CONF_PIN: "2222"}}},
+            {
+                CONF_SLOTS: {
+                    50: {CONF_NAME: "User 50", CONF_ENABLED: True, CONF_PIN: "2222"}
+                }
+            },
         )
 
     assert result["type"] == "create_entry"
@@ -1237,7 +1270,11 @@ async def test_config_flow_capacity_check_skipped_when_capacity_unknown(
     with probe_registered, probe_capabilities:
         result = await hass.config_entries.flow.async_configure(
             flow_id,
-            {CONF_SLOTS: {50: {CONF_ENABLED: True, CONF_PIN: "2222"}}},
+            {
+                CONF_SLOTS: {
+                    50: {CONF_NAME: "User 50", CONF_ENABLED: True, CONF_PIN: "2222"}
+                }
+            },
         )
 
     assert result["type"] == "create_entry"
@@ -1270,7 +1307,11 @@ async def test_config_flow_capacity_check_skipped_when_lock_allocates_index(
     ):
         result = await hass.config_entries.flow.async_configure(
             flow_id,
-            {CONF_SLOTS: {50: {CONF_ENABLED: True, CONF_PIN: "2222"}}},
+            {
+                CONF_SLOTS: {
+                    50: {CONF_NAME: "User 50", CONF_ENABLED: True, CONF_PIN: "2222"}
+                }
+            },
         )
 
     assert result["type"] == "create_entry"
@@ -1295,8 +1336,42 @@ async def test_config_flow_capacity_check_survives_unexpected_error(
     with probe_registered, probe_capabilities:
         result = await hass.config_entries.flow.async_configure(
             flow_id,
-            {CONF_SLOTS: {50: {CONF_ENABLED: True, CONF_PIN: "2222"}}},
+            {
+                CONF_SLOTS: {
+                    50: {CONF_NAME: "User 50", CONF_ENABLED: True, CONF_PIN: "2222"}
+                }
+            },
         )
 
     assert result["type"] == "create_entry"
     assert "provider blew up" in caplog.text
+
+
+async def test_config_flow_ui_rejects_name_with_separator(hass: HomeAssistant):
+    """A name containing the identifier separator is rejected up front."""
+    flow_id = await _start_ui_config_flow(hass)
+
+    result = await hass.config_entries.flow.async_configure(
+        flow_id, {CONF_NAME: "Ra|man", CONF_ENABLED: True, CONF_PIN: "1234"}
+    )
+
+    assert result["type"] == "form"
+    assert result["errors"] == {CONF_NAME: "name_has_separator"}
+
+
+async def test_config_flow_ui_rejects_duplicate_name(hass: HomeAssistant):
+    """Two slots in one entry cannot share a name, ignoring case."""
+    flow_id = await _start_ui_config_flow(hass)
+
+    result = await hass.config_entries.flow.async_configure(
+        flow_id, {CONF_NAME: "Raman", CONF_ENABLED: True, CONF_PIN: "1234"}
+    )
+    assert result["type"] == "form"
+    assert not result["errors"]
+
+    result = await hass.config_entries.flow.async_configure(
+        flow_id, {CONF_NAME: "  raman  ", CONF_ENABLED: True, CONF_PIN: "5678"}
+    )
+
+    assert result["type"] == "form"
+    assert result["errors"] == {CONF_NAME: "name_not_unique"}

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1375,3 +1375,58 @@ async def test_config_flow_ui_rejects_duplicate_name(hass: HomeAssistant):
 
     assert result["type"] == "form"
     assert result["errors"] == {CONF_NAME: "name_not_unique"}
+
+
+@pytest.mark.parametrize(
+    ("slots", "expected_error"),
+    [
+        (
+            {
+                1: {CONF_NAME: "Ra|man", CONF_ENABLED: True, CONF_PIN: "1234"},
+            },
+            "name_has_separator",
+        ),
+        (
+            {
+                1: {CONF_NAME: "Raman", CONF_ENABLED: True, CONF_PIN: "1234"},
+                2: {CONF_NAME: " raman ", CONF_ENABLED: True, CONF_PIN: "5678"},
+            },
+            "name_not_unique",
+        ),
+    ],
+)
+async def test_config_flow_yaml_enforces_name_rules(
+    hass: HomeAssistant, mock_lock_config_entry, slots, expected_error
+):
+    """The YAML path enforces the same name rules as the single-slot path.
+
+    Without this the migration's repair could be undone by the very next
+    submission, and the options flow -- the only way to edit slots after
+    setup -- goes through the same validator.
+    """
+    flow_id = await _start_yaml_config_flow(hass)
+
+    result = await hass.config_entries.flow.async_configure(
+        flow_id, {CONF_SLOTS: slots}
+    )
+
+    assert result["type"] == "form"
+    assert result["errors"] == {"base": expected_error}
+
+
+async def test_config_flow_yaml_missing_name_says_so(
+    hass: HomeAssistant, mock_lock_config_entry
+):
+    """A slots block predating the name requirement names the actual problem.
+
+    Falling through to the generic invalid_config would send the user to the
+    logs for the one failure we can predict.
+    """
+    flow_id = await _start_yaml_config_flow(hass)
+
+    result = await hass.config_entries.flow.async_configure(
+        flow_id, {CONF_SLOTS: {1: {CONF_ENABLED: True, CONF_PIN: "1234"}}}
+    )
+
+    assert result["type"] == "form"
+    assert result["errors"] == {"base": "name_required"}

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -400,7 +400,9 @@ async def test_two_entries_same_locks(
 ):
     """Test two entries that use same locks but different slots set up successfully."""
     new_config = copy.deepcopy(BASE_CONFIG)
-    new_config[CONF_SLOTS] = {3: {CONF_ENABLED: False, CONF_PIN: "0123"}}
+    new_config[CONF_SLOTS] = {
+        3: {CONF_NAME: "User 3", CONF_ENABLED: False, CONF_PIN: "0123"}
+    }
     new_entry = MockConfigEntry(
         domain=DOMAIN, data=new_config, unique_id="Mock Title 2", title="Mock Title 2"
     )
@@ -579,7 +581,7 @@ async def test_migration_v1_to_v2_calendar_to_entity_id(
     await hass.async_block_till_done()
 
     # Verify migration happened (v1 -> v2 calendar, then v2 -> v3 number_of_uses)
-    assert config_entry.version == 3
+    assert config_entry.version == 4
 
     # Get the migrated data (should be in .data after setup moves options to data)
     migrated_data = config_entry.data
@@ -1885,3 +1887,40 @@ async def test_pairs_removed_skips_untracked_lock_and_logs_release_failure(
     assert LOCK_1_ENTITY_ID in caplog.text
 
     await hass.config_entries.async_unload(entry.entry_id)
+
+
+async def test_migration_v3_to_v4_names_every_slot(hass: HomeAssistant) -> None:
+    """v4 gives every slot a present, separator-free, entry-unique name.
+
+    The name is becoming the identity Lock Code Manager keys on, so these
+    three properties stop being cosmetic. A name the user already chose is
+    left exactly as-is, because rewriting one would also rename that user on
+    every lock that stores a user name.
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_LOCKS: [LOCK_1_ENTITY_ID],
+            CONF_SLOTS: {
+                1: {CONF_ENABLED: True, CONF_PIN: "1234"},
+                2: {CONF_NAME: "Raman", CONF_ENABLED: True, CONF_PIN: "5678"},
+                3: {CONF_NAME: "Raman", CONF_ENABLED: True, CONF_PIN: "9012"},
+                4: {CONF_NAME: "Ra|man", CONF_ENABLED: True, CONF_PIN: "3456"},
+            },
+        },
+        unique_id="Name Migration Test",
+        version=3,
+    )
+    config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.version == 4
+    slots = config_entry.data[CONF_SLOTS]
+    assert slots[1][CONF_NAME] == "User 1"  # was unnamed
+    assert slots[2][CONF_NAME] == "Raman"  # user's choice, untouched
+    assert slots[3][CONF_NAME] == "Raman 2"  # collided with slot 2
+    assert slots[4][CONF_NAME] == "Ra man"  # separator stripped
+    # Every other field survives.
+    assert slots[1][CONF_PIN] == "1234"

--- a/tests/test_names.py
+++ b/tests/test_names.py
@@ -1,0 +1,140 @@
+"""Tests for the user-name rules that make the name a usable identity."""
+
+import pytest
+
+from homeassistant.const import CONF_ENABLED, CONF_NAME, CONF_PIN
+
+from custom_components.lock_code_manager.domain.names import (
+    deduplicate,
+    fallback_name,
+    name_error,
+    normalize_slot_names,
+)
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("Raman", None),
+        ("  Raman  ", None),
+        (None, "name_required"),
+        ("", "name_required"),
+        ("   ", "name_required"),
+        ("Ra|man", "name_has_separator"),
+        ("|", "name_has_separator"),
+    ],
+)
+def test_name_error(name: str | None, expected: str | None) -> None:
+    """A name must be present and free of the identifier separator."""
+    assert name_error(name) == expected
+
+
+def test_fallback_name_reads_like_the_slot_it_replaces() -> None:
+    """An auto-named slot should not read as something new."""
+    assert fallback_name(3) == "User 3"
+
+
+@pytest.mark.parametrize(
+    ("name", "taken", "expected"),
+    [
+        ("Raman", [], "Raman"),
+        ("Raman", ["Alice"], "Raman"),
+        ("Raman", ["Raman"], "Raman 2"),
+        ("Raman", ["Raman", "Raman 2"], "Raman 3"),
+        # Case-insensitive: two users differing only in case would be
+        # indistinguishable in the frontend and would collide once slugified.
+        ("raman", ["Raman"], "raman 2"),
+        ("RAMAN", ["raman", "RAMAN 2"], "RAMAN 3"),
+    ],
+)
+def test_deduplicate(name: str, taken: list[str], expected: str) -> None:
+    """Colliding names gain the lowest free numeric suffix."""
+    assert deduplicate(name, taken) == expected
+
+
+def test_normalize_leaves_valid_unique_names_untouched() -> None:
+    """A name the user chose is never rewritten.
+
+    Rewriting one would also rename that user on every lock that stores a
+    user name, so an unnecessary rewrite is a device write, not a no-op.
+    """
+    slots = {
+        1: {CONF_NAME: "Raman", CONF_ENABLED: True, CONF_PIN: "1234"},
+        2: {CONF_NAME: "Alice", CONF_ENABLED: True},
+    }
+
+    repaired, changed = normalize_slot_names(slots)
+
+    assert changed == []
+    assert repaired[1][CONF_NAME] == "Raman"
+    assert repaired[2][CONF_NAME] == "Alice"
+    # Other fields survive untouched.
+    assert repaired[1][CONF_PIN] == "1234"
+
+
+def test_normalize_names_unnamed_slots() -> None:
+    """A slot with no name gets one derived from its number."""
+    slots = {1: {CONF_ENABLED: True}, 2: {CONF_NAME: None, CONF_ENABLED: True}}
+
+    repaired, changed = normalize_slot_names(slots)
+
+    assert repaired[1][CONF_NAME] == "User 1"
+    assert repaired[2][CONF_NAME] == "User 2"
+    assert sorted(changed) == ["1", "2"]
+
+
+def test_normalize_strips_the_separator() -> None:
+    """The separator is replaced rather than the name rejected."""
+    repaired, changed = normalize_slot_names({1: {CONF_NAME: "Ra|man"}})
+
+    assert repaired[1][CONF_NAME] == "Ra man"
+    assert changed == ["1"]
+
+
+def test_normalize_falls_back_when_a_name_is_only_separators() -> None:
+    """A name that collapses to empty after stripping falls back."""
+    repaired, changed = normalize_slot_names({4: {CONF_NAME: "||"}})
+
+    assert repaired[4][CONF_NAME] == "User 4"
+    assert changed == ["4"]
+
+
+def test_normalize_deduplicates_across_slots() -> None:
+    """Two slots sharing a name are made unique, lowest slot number winning."""
+    slots = {2: {CONF_NAME: "Raman"}, 1: {CONF_NAME: "Raman"}}
+
+    repaired, changed = normalize_slot_names(slots)
+
+    assert repaired[1][CONF_NAME] == "Raman"
+    assert repaired[2][CONF_NAME] == "Raman 2"
+    assert changed == ["2"]
+
+
+def test_normalize_is_deterministic_regardless_of_mapping_order() -> None:
+    """Iteration order must not decide who keeps the undecorated name.
+
+    Slots are processed in numeric order, so a migration that runs twice --
+    or on two machines -- produces the same names. Mapping order would make
+    it a coin flip which slot got renamed.
+    """
+    forward = {1: {CONF_NAME: "Raman"}, 2: {CONF_NAME: "Raman"}}
+    reverse = {2: {CONF_NAME: "Raman"}, 1: {CONF_NAME: "Raman"}}
+
+    assert normalize_slot_names(forward) == normalize_slot_names(reverse)
+
+
+def test_normalize_is_idempotent() -> None:
+    """Running the repair over its own output changes nothing."""
+    once, _ = normalize_slot_names({1: {CONF_ENABLED: True}, 2: {CONF_NAME: "|"}})
+    twice, changed = normalize_slot_names(once)
+
+    assert twice == once
+    assert changed == []
+
+
+def test_normalize_accepts_string_slot_keys() -> None:
+    """On-disk JSON uses string slot keys; the repair must handle them."""
+    repaired, changed = normalize_slot_names({"1": {CONF_ENABLED: True}})
+
+    assert repaired["1"][CONF_NAME] == "User 1"
+    assert changed == ["1"]

--- a/tests/test_names.py
+++ b/tests/test_names.py
@@ -9,6 +9,7 @@ from custom_components.lock_code_manager.domain.names import (
     fallback_name,
     name_error,
     normalize_slot_names,
+    validate_slot_names,
 )
 
 
@@ -137,4 +138,55 @@ def test_normalize_accepts_string_slot_keys() -> None:
     repaired, changed = normalize_slot_names({"1": {CONF_ENABLED: True}})
 
     assert repaired["1"][CONF_NAME] == "User 1"
+    assert changed == ["1"]
+
+
+@pytest.mark.parametrize(
+    ("slots", "expected"),
+    [
+        ({1: {CONF_NAME: "Raman"}, 2: {CONF_NAME: "Alice"}}, None),
+        ({1: {CONF_ENABLED: True}}, ("1", "name_required")),
+        ({1: {CONF_NAME: "  "}}, ("1", "name_required")),
+        ({1: {CONF_NAME: "Ra|man"}}, ("1", "name_has_separator")),
+        ({1: {CONF_NAME: "Raman"}, 2: {CONF_NAME: "raman"}}, ("2", "name_not_unique")),
+        # Whitespace-padded duplicates must be caught in BOTH orders. Comparing
+        # a stripped candidate against unstripped stored names caught only one.
+        ({1: {CONF_NAME: "Raman "}, 2: {CONF_NAME: "Raman"}}, ("2", "name_not_unique")),
+        (
+            {1: {CONF_NAME: "Raman"}, 2: {CONF_NAME: " Raman "}},
+            ("2", "name_not_unique"),
+        ),
+    ],
+)
+def test_validate_slot_names(slots, expected) -> None:
+    """Whole-set validation reports the offending slot and why."""
+    assert validate_slot_names(slots) == expected
+
+
+def test_normalize_does_not_steal_a_later_slots_valid_name() -> None:
+    """Repairing a duplicate must not push an innocent slot off its name.
+
+    A single pass renames slot 2 to "Raman 2" and then finds slot 3 already
+    holds that, pushing it to "Raman 2 2" -- renaming a user who did nothing
+    wrong, and costing a write on every lock that stores names.
+    """
+    slots = {
+        1: {CONF_NAME: "Raman"},
+        2: {CONF_NAME: "Raman"},
+        3: {CONF_NAME: "Raman 2"},
+    }
+
+    repaired, changed = normalize_slot_names(slots)
+
+    assert repaired[1][CONF_NAME] == "Raman"
+    assert repaired[3][CONF_NAME] == "Raman 2"  # untouched
+    assert repaired[2][CONF_NAME] == "Raman 3"  # took the next free suffix
+    assert changed == ["2"]
+
+
+def test_normalize_strips_whitespace_from_otherwise_valid_names() -> None:
+    """Padding is normalized away so two identical-looking names cannot coexist."""
+    repaired, changed = normalize_slot_names({1: {CONF_NAME: "  Raman  "}})
+
+    assert repaired[1][CONF_NAME] == "Raman"
     assert changed == ["1"]

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -120,11 +120,11 @@ async def test_whitespace_pin_normalized_to_empty(
 
 
 @pytest.mark.parametrize(
-    ("value", "message_fragment"),
+    ("value", "translation_key"),
     [
-        ("", "cannot be empty"),
-        ("   ", "cannot be empty"),
-        ("Ra|man", "cannot contain"),
+        ("", "name_required"),
+        ("   ", "name_required"),
+        ("Ra|man", "name_has_separator"),
     ],
 )
 async def test_set_name_rejects_invalid_names(
@@ -132,7 +132,7 @@ async def test_set_name_rejects_invalid_names(
     mock_lock_config_entry,
     lock_code_manager_config_entry,
     value: str,
-    message_fragment: str,
+    translation_key: str,
 ):
     """The name text entity enforces the name rules.
 
@@ -142,7 +142,10 @@ async def test_set_name_rejects_invalid_names(
     """
     original = hass.states.get(SLOT_2_NAME_ENTITY).state
 
-    with pytest.raises(ServiceValidationError, match=message_fragment):
+    # Assert the translation key, not the English text: the message is
+    # localized, and pinning the wording would make every translation edit a
+    # test failure.
+    with pytest.raises(ServiceValidationError) as err:
         await hass.services.async_call(
             TEXT_DOMAIN,
             SERVICE_SET_VALUE,
@@ -150,6 +153,7 @@ async def test_set_name_rejects_invalid_names(
             target={ATTR_ENTITY_ID: SLOT_2_NAME_ENTITY},
             blocking=True,
         )
+    assert err.value.translation_key == translation_key
 
     assert hass.states.get(SLOT_2_NAME_ENTITY).state == original
 
@@ -162,7 +166,7 @@ async def test_set_name_rejects_another_slots_name(
     """Renaming a slot onto another slot's name is refused, ignoring case."""
     other = hass.states.get(SLOT_1_NAME_ENTITY).state
 
-    with pytest.raises(ServiceValidationError, match="already uses that name"):
+    with pytest.raises(ServiceValidationError) as err:
         await hass.services.async_call(
             TEXT_DOMAIN,
             SERVICE_SET_VALUE,
@@ -170,6 +174,8 @@ async def test_set_name_rejects_another_slots_name(
             target={ATTR_ENTITY_ID: SLOT_2_NAME_ENTITY},
             blocking=True,
         )
+    assert err.value.translation_key == "name_not_unique"
+    assert err.value.translation_placeholders["conflicting_slot"] == "1"
 
 
 async def test_set_name_normalizes_whitespace(

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -2,6 +2,8 @@
 
 import logging
 
+import pytest
+
 from homeassistant.components.text import (
     ATTR_VALUE,
     DOMAIN as TEXT_DOMAIN,
@@ -9,8 +11,14 @@ from homeassistant.components.text import (
 )
 from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
 
-from .common import SLOT_2_ENABLED_ENTITY, SLOT_2_NAME_ENTITY, SLOT_2_PIN_ENTITY
+from .common import (
+    SLOT_1_NAME_ENTITY,
+    SLOT_2_ENABLED_ENTITY,
+    SLOT_2_NAME_ENTITY,
+    SLOT_2_PIN_ENTITY,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -109,3 +117,73 @@ async def test_whitespace_pin_normalized_to_empty(
     state = hass.states.get(SLOT_2_ENABLED_ENTITY)
     assert state
     assert state.state == STATE_OFF
+
+
+@pytest.mark.parametrize(
+    ("value", "message_fragment"),
+    [
+        ("", "cannot be empty"),
+        ("   ", "cannot be empty"),
+        ("Ra|man", "cannot contain"),
+    ],
+)
+async def test_set_name_rejects_invalid_names(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+    value: str,
+    message_fragment: str,
+):
+    """The name text entity enforces the name rules.
+
+    This is the ordinary way to rename a slot in the frontend. If it did not
+    validate, the "present, unique, encodable" invariant the migration
+    establishes would not survive first contact with the UI.
+    """
+    original = hass.states.get(SLOT_2_NAME_ENTITY).state
+
+    with pytest.raises(ServiceValidationError, match=message_fragment):
+        await hass.services.async_call(
+            TEXT_DOMAIN,
+            SERVICE_SET_VALUE,
+            service_data={ATTR_VALUE: value},
+            target={ATTR_ENTITY_ID: SLOT_2_NAME_ENTITY},
+            blocking=True,
+        )
+
+    assert hass.states.get(SLOT_2_NAME_ENTITY).state == original
+
+
+async def test_set_name_rejects_another_slots_name(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """Renaming a slot onto another slot's name is refused, ignoring case."""
+    other = hass.states.get(SLOT_1_NAME_ENTITY).state
+
+    with pytest.raises(ServiceValidationError, match="already uses that name"):
+        await hass.services.async_call(
+            TEXT_DOMAIN,
+            SERVICE_SET_VALUE,
+            service_data={ATTR_VALUE: f"  {other.upper()}  "},
+            target={ATTR_ENTITY_ID: SLOT_2_NAME_ENTITY},
+            blocking=True,
+        )
+
+
+async def test_set_name_normalizes_whitespace(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """A padded name is stored stripped, so it cannot shadow an existing one."""
+    await hass.services.async_call(
+        TEXT_DOMAIN,
+        SERVICE_SET_VALUE,
+        service_data={ATTR_VALUE: "  Raman  "},
+        target={ATTR_ENTITY_ID: SLOT_2_NAME_ENTITY},
+        blocking=True,
+    )
+
+    assert hass.states.get(SLOT_2_NAME_ENTITY).state == "Raman"


### PR DESCRIPTION
## Proposed change

First step of the user-centric credential model. The slot **name** is becoming the identity Lock Code Manager keys on — the config entry will store named users rather than a slot-number mapping, and lock users will be tagged `lcm:{name}`. That only works if every name is present, unique within its entry, and encodable.

This PR establishes those three properties and nothing else. **The storage shape is unchanged** — slots are still keyed by number. Re-keying comes later, and it depends on this precondition holding.

**New `domain/names.py`** is the single place the rules live, so the config flow (validating new input) and the migration (repairing existing data) cannot drift apart.

- `CONF_NAME` becomes `vol.Required`. The config flow rejects a name containing the reserved separator, and one that collides with another slot in the same entry (case-insensitively — two users differing only in case are indistinguishable in the frontend and collide once slugified).
- **Migration v3 → v4** repairs existing entries: unnamed slots become `User {N}`, the separator is replaced, and collisions gain a numeric suffix.

The separator is reserved because it delimits both the entity unique identifier (`{entry_id}|{name}|{key}`) and the device identifier, and `parse_slot_device_identifier` splits on it.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

**Two design points worth reviewing:**

*The repair leaves a valid, unique name exactly as the user wrote it.* That is deliberate and not just politeness — rewriting a name is not a no-op, it renames that user on every lock that stores a user name. Auto-naming a previously-unnamed slot does cause one such rename on the next sync (`lcm:3:` becomes `lcm:3:User 3`). That one-time device write is the cost of making the name load-bearing, and it only affects slots that had no name to begin with.

*Slots are repaired in numeric order*, so the result cannot depend on mapping iteration order. Without that, which of two colliding slots keeps the undecorated name would be a coin flip, and the migration would produce different results across restarts and machines. There is a test pinning this.

- Full suite: **1536 passed, 3 skipped** (baseline 1494; +42 new tests)
- Coverage: **100.00%**
- `ruff check`, `ruff format`, `pydocstyle`, `flake8`, `mypy`: all pass

Tests cover the rules in isolation (`tests/test_names.py`), the config-flow rejection paths, and the migration end-to-end — including idempotency, string slot keys as they appear in on-disk JSON, and the ordering determinism above.

**Not a breaking change.** `CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)` (`__init__.py:120`) means this integration reads no YAML from `configuration.yaml` — the YAML step is a text field in the config/options flow, validated and converted on submit. There is no persisted YAML that could fail to load, existing entries are repaired by the migration, and no automation, dashboard, or blueprint reference changes. A new submission missing a name is simply rejected with a precise error naming the slot.

The wiki's `Configuration-Structure.md` does still show `name` as optional and needs updating before v3.0.0 ships — a documentation accuracy item, tracked in the B sequencing spec rather than changed here, since the wiki documents released behavior.

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

🤖 Generated with [Claude Code](https://claude.com/claude-code)


