### PR TITLE
feat: convert slot-keyed configuration to name-keyed users

### DIFF
--- a/custom_components/lock_code_manager/domain/slot_assignment.py
+++ b/custom_components/lock_code_manager/domain/slot_assignment.py
@@ -76,10 +76,35 @@ class SlotAssignment:
         """
         canonical: dict[str, int] = {}
         for name, slot in self.slots.items():
+            try:
+                number = int(slot)
+            except TypeError, ValueError:
+                # Unusable stored value. Dropping costs this user their slot,
+                # which reconcile then reissues; raising would take the whole
+                # entry down, and corrupt bookkeeping is exactly what the
+                # coercion above exists to survive.
+                continue
             key = _identity(str(name))
-            number = int(slot)
             canonical[key] = min(canonical.get(key, number), number)
-        object.__setattr__(self, "slots", MappingProxyType(canonical))
+
+        # No two users on one number, as an invariant of the TYPE. Reachable
+        # only from bookkeeping that was already inconsistent, but both users
+        # would otherwise write over each other on the lock every sync, and
+        # nothing else in the system repairs it.
+        #
+        # The loser is DROPPED rather than renumbered here, because this has
+        # no idea what the entry's start slot is -- reissuing from 1 could put
+        # them below it, on a code programmed by hand. reconcile knows, and
+        # gives them a number that respects it.
+        deduped: dict[str, int] = {}
+        held: set[int] = set()
+        for key in sorted(canonical):
+            number = canonical[key]
+            if number in held:
+                continue
+            held.add(number)
+            deduped[key] = number
+        object.__setattr__(self, "slots", MappingProxyType(deduped))
 
     def __hash__(self) -> int:
         """
@@ -108,7 +133,12 @@ class SlotAssignment:
         already-merged mapping rather than an entry, so there is no second
         precedence rule here to get out of step with the first.
         """
-        return cls(slots=mapping.get(CONF_SLOT_ASSIGNMENT) or {})
+        stored = mapping.get(CONF_SLOT_ASSIGNMENT)
+        # Anything that is not a mapping carries nothing worth keeping, and
+        # reconcile rebuilds the assignment from the configured users anyway.
+        # Raising here would abort entry setup over hand-edited storage, which
+        # is the same threat model the coercions below exist for.
+        return cls(slots=stored if isinstance(stored, Mapping) else {})
 
     def to_dict(self) -> dict[str, Any]:
         """Return the bookkeeping to persist beside the configuration."""
@@ -156,12 +186,20 @@ class SlotAssignment:
         silently, and on a real door. Required makes it a type error.
 
         A user already holding a slot keeps it even when ``start`` rises
-        above it or ``unavailable`` comes to include it. Never renumbering
-        somebody is the stronger guarantee: moving them rewrites their
-        credential on every lock and orphans their entities, whereas leaving
-        them put merely means the entry still holds a number it would not
-        choose today. ``start`` and ``unavailable`` therefore constrain
-        ALLOCATION, not tenure.
+        above it or ``unavailable`` comes to include it: both constrain
+        ALLOCATION, not tenure. Moving somebody rewrites their credential on
+        every lock and orphans their entities, which is worse than the entry
+        holding a number it would not choose today.
+
+        That trade is clean for ``start`` and NOT clean for ``unavailable``.
+        A tenured user on a number another entry owns means two entries
+        writing one credential index, which nothing here can repair -- this
+        type cannot see the other entry. It is left standing because the
+        alternative is renumbering somebody without being asked, and because
+        ``config_flow._check_common_slots`` is what prevents the overlap
+        arising in the first place. If a consumer ever needs the conflict
+        surfaced rather than absorbed, that belongs at the seam that knows
+        about other entries, not here.
 
         Returns ``self`` when nothing differs, so callers can use identity to
         decide whether a write is needed.
@@ -179,10 +217,20 @@ class SlotAssignment:
         # (``validate_slot_names`` rejects it upstream). Resolved by sorted
         # order rather than by whichever the stored mapping happened to
         # iterate first, so the same input always gives the same answer.
+        # Reduce to identity form FIRST. Iterating the raw mapping let two
+        # keys that mean the same user (``Alice`` and ``alice ``) each take a
+        # turn: the later overwrote the earlier while the earlier's target
+        # stayed claimed, so a third user's legitimate rename onto that target
+        # was refused and they were renumbered. It also made the answer depend
+        # on the mapping's insertion order.
+        wanted_moves: dict[str, str] = {}
+        for old in sorted(renames or {}, key=lambda key: (_identity(key), str(key))):
+            wanted_moves.setdefault(_identity(old), _identity((renames or {})[old]))
+
         honoured: dict[str, str] = {}
         claimed: set[str] = set()
-        for old in sorted(renames or {}, key=_identity):
-            source, target = _identity(old), _identity((renames or {})[old])
+        for source in sorted(wanted_moves):
+            target = wanted_moves[source]
             if source not in self.slots or target not in surviving:
                 continue
             if target in claimed:
@@ -201,19 +249,8 @@ class SlotAssignment:
             if name not in honoured and name in surviving and name not in renamed
         }
 
-        # Two users on one number would write over each other on the lock.
-        # Only reachable from bookkeeping that was already inconsistent, but
-        # nothing else repairs it, so it would persist for good.
-        carried: dict[str, int] = {}
-        held: set[int] = set()
-        for name in sorted({**kept, **renamed}):
-            slot = {**kept, **renamed}[name]
-            if slot in held:
-                continue
-            held.add(slot)
-            carried[name] = slot
-
-        taken = held | set(unavailable)
+        carried = {**kept, **renamed}
+        taken = set(carried.values()) | set(unavailable)
         candidate = start
         # Sorted so the answer does not depend on how the caller ordered
         # ``names``. The signature accepts any iterable, and a set or

--- a/custom_components/lock_code_manager/domain/slot_assignment.py
+++ b/custom_components/lock_code_manager/domain/slot_assignment.py
@@ -15,11 +15,16 @@ being reused.
 
 Entity and device identifiers keep keying on this number, so a rename moves
 nothing in either registry.
+
+Users are identified the way :mod:`.names` identifies them: whitespace
+normalized, compared case-insensitively. Storing a name in any other form
+would let it match on one path and miss on another, and missing means looking
+like a different user and being renumbered onto a different credential index.
 """
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Mapping
+from collections.abc import Collection, Iterable, Mapping
 from dataclasses import dataclass
 from types import MappingProxyType
 from typing import Any
@@ -33,6 +38,19 @@ CONF_SLOT_ASSIGNMENT = "slot_assignment"
 _EMPTY_ASSIGNMENT: Mapping[str, int] = MappingProxyType({})
 
 
+def _identity(name: str) -> str:
+    """
+    Return the form a user is recognized by.
+
+    Matches ``names.deduplicate`` and ``names.validate_slot_names``, which
+    both casefold. Comparing case-sensitively here would let ``Bob`` and
+    ``BOB`` hold two credential indices for someone the rest of the system
+    treats as one person, and would make a case-only rename read as a
+    deletion plus an addition.
+    """
+    return normalize_name(name).casefold()
+
+
 @dataclass(frozen=True, slots=True)
 class SlotAssignment:
     """The slot number held by each configured user, keyed by name."""
@@ -41,26 +59,27 @@ class SlotAssignment:
 
     def __post_init__(self) -> None:
         """
-        Normalize the names and freeze the mapping.
+        Put the mapping into its canonical form, then freeze it.
 
-        Normalizing here rather than at each method makes it an invariant of
-        the type: a name can only ever be stored in one form, so it cannot
-        match on one path and miss on another. Missing means looking like a
-        different user and being renumbered, which moves that user's
-        credential on every lock. Stored data predating this is normalized on
-        read for the same reason.
+        Names are reduced to their identity form and slot numbers coerced to
+        ``int``. Doing it here makes both invariants of the TYPE rather than
+        of whichever factory happened to build it -- the plain constructor
+        previously accepted a string slot number, and a caller reading
+        ``entry.data`` directly instead of through :meth:`from_mapping` would
+        reintroduce the double-booking that string keys caused.
 
-        Freezing closes the one hole the factories leave: the plain
-        constructor accepted a live dict, which a caller could then mutate
-        under the identity check ``assign`` uses to decide whether to write.
+        Two keys reducing to one identity keeps the LOWER slot. That case
+        means the stored bookkeeping was already inconsistent; raising would
+        make the entry unloadable, which is worse than picking
+        deterministically, and the lower number is the one likelier to
+        predate the corruption.
         """
-        object.__setattr__(
-            self,
-            "slots",
-            MappingProxyType(
-                {normalize_name(name): slot for name, slot in self.slots.items()}
-            ),
-        )
+        canonical: dict[str, int] = {}
+        for name, slot in self.slots.items():
+            key = _identity(name)
+            number = int(slot)
+            canonical[key] = min(canonical.get(key, number), number)
+        object.__setattr__(self, "slots", MappingProxyType(canonical))
 
     def __hash__(self) -> int:
         """
@@ -89,8 +108,7 @@ class SlotAssignment:
         already-merged mapping rather than an entry, so there is no second
         precedence rule here to get out of step with the first.
         """
-        raw = mapping.get(CONF_SLOT_ASSIGNMENT) or {}
-        return cls(slots=MappingProxyType({str(k): int(v) for k, v in raw.items()}))
+        return cls(slots=mapping.get(CONF_SLOT_ASSIGNMENT) or {})
 
     def to_dict(self) -> dict[str, Any]:
         """Return the bookkeeping to persist beside the configuration."""
@@ -98,7 +116,7 @@ class SlotAssignment:
 
     def slot(self, name: str) -> int | None:
         """Return the slot ``name`` occupies, or None if they hold none."""
-        return self.slots.get(name)
+        return self.slots.get(_identity(name))
 
     def with_renames(self, renames: Mapping[str, str]) -> SlotAssignment:
         """
@@ -113,55 +131,63 @@ class SlotAssignment:
 
         A rename target may be a name somebody else still holds, and that is
         legal rather than a conflict: the holder must be departing in the same
-        submission, since two users cannot share a name in the result. So the
-        renamed entry WINS and the entry sitting on the target is dropped.
-        Renaming into a target with a plain re-key instead lets whichever the
-        mapping happens to iterate last overwrite the other -- which for the
-        chain ``A -> B``, ``B -> C`` with ``C`` deleted moved the user
-        formerly named B from index 2 to index 3, and gave a different answer
-        for a different insertion order.
+        submission, since two users cannot share a name in the result. The
+        renamed entry therefore displaces the one sitting on the target.
 
-        The two halves are built over disjoint key sets, so the result does
-        not depend on iteration order for chains any more than for swaps.
+        A target is only displaced when a source actually surrendered a slot.
+        Dropping it unconditionally deleted an uninvolved user whenever the
+        map named a source holding nothing -- and made replaying an
+        already-applied map erase its own result, so the operation was not
+        idempotent.
         """
-        renames = {
-            normalize_name(old): normalize_name(new) for old, new in renames.items()
+        moves = {
+            _identity(old): _identity(new)
+            for old, new in renames.items()
+            if _identity(old) in self.slots
         }
-        targets = set(renames.values())
         renamed = {
-            renames[name]: slot for name, slot in self.slots.items() if name in renames
+            moves[name]: slot for name, slot in self.slots.items() if name in moves
         }
         kept = {
             name: slot
             for name, slot in self.slots.items()
-            if name not in renames and name not in targets
+            if name not in moves and name not in renamed
         }
         moved = {**kept, **renamed}
         if moved == dict(self.slots):
             return self
-        return SlotAssignment(slots=MappingProxyType(moved))
+        return SlotAssignment(slots=moved)
 
-    def assign(self, names: Iterable[str]) -> SlotAssignment:
+    def assign(
+        self,
+        names: Iterable[str],
+        *,
+        start: int = 1,
+        unavailable: Collection[int] = (),
+    ) -> SlotAssignment:
         """
         Return the assignment covering exactly ``names``.
 
         Users already holding a slot keep it, so a rename or an unrelated
-        edit never renumbers anyone. New users take the lowest free slot,
-        which is what keeps the numbers inside a lock's capacity -- counting
-        upward from the highest ever issued would drift past it.
+        edit never renumbers anyone. New users take the lowest free slot at or
+        above ``start``, skipping anything in ``unavailable``.
+
+        Those two are not decoration. The entry has a configured start slot
+        (``CONF_START_SLOT``), usually chosen because the numbers below it
+        hold codes programmed by hand that Lock Code Manager does not manage,
+        and ``config_flow._check_common_slots`` refuses ranges overlapping
+        another entry on a shared lock. Since the slot IS the credential index
+        on most providers, allocating from 1 unconditionally would write a new
+        user's code over one of those.
 
         Returns ``self`` when nothing differs, so callers can use identity to
         decide whether a write is needed.
         """
-        # Normalized here, not assumed. A name reaching this boundary in its
-        # raw form -- one caller storing the repaired name while another
-        # passes what the user typed -- would look like a different user and
-        # renumber them, moving their credential on every lock.
-        wanted = list(dict.fromkeys(normalize_name(name) for name in names))
+        wanted = list(dict.fromkeys(_identity(name) for name in names))
         assigned = {name: self.slots[name] for name in wanted if name in self.slots}
 
-        taken = set(assigned.values())
-        candidate = 1
+        taken = set(assigned.values()) | set(unavailable)
+        candidate = start
         for name in wanted:
             if name in assigned:
                 continue
@@ -172,7 +198,7 @@ class SlotAssignment:
 
         if assigned == dict(self.slots):
             return self
-        return SlotAssignment(slots=MappingProxyType(assigned))
+        return SlotAssignment(slots=assigned)
 
 
 def users_from_slots(
@@ -205,4 +231,4 @@ def users_from_slots(
         name = slot[CONF_NAME]
         users[name] = {k: v for k, v in slot.items() if k != CONF_NAME}
         assignment[name] = int(raw_slot_num)
-    return users, SlotAssignment(slots=MappingProxyType(assignment)), renamed
+    return users, SlotAssignment(slots=assignment), renamed

--- a/custom_components/lock_code_manager/domain/slot_assignment.py
+++ b/custom_components/lock_code_manager/domain/slot_assignment.py
@@ -155,37 +155,71 @@ class SlotAssignment:
         forgotten argument write a new user's code over one of those --
         silently, and on a real door. Required makes it a type error.
 
+        A user already holding a slot keeps it even when ``start`` rises
+        above it or ``unavailable`` comes to include it. Never renumbering
+        somebody is the stronger guarantee: moving them rewrites their
+        credential on every lock and orphans their entities, whereas leaving
+        them put merely means the entry still holds a number it would not
+        choose today. ``start`` and ``unavailable`` therefore constrain
+        ALLOCATION, not tenure.
+
         Returns ``self`` when nothing differs, so callers can use identity to
         decide whether a write is needed.
         """
-        moves = {
-            _identity(old): _identity(new)
-            for old, new in (renames or {}).items()
-            if _identity(old) in self.slots
-        }
         wanted = list(dict.fromkeys(_identity(name) for name in names))
         surviving = set(wanted)
 
-        # A renamed user displaces whoever held the target name, because two
-        # users cannot share a name in the result -- so that holder is
-        # departing in this same submission.
+        # A move is only honoured when the source holds a slot AND the target
+        # is among the survivors. A rename whose target is absent contradicts
+        # the name set -- and left unfiltered it dropped the source from
+        # `kept` while `renamed` refused to take them, so a user who survived
+        # under their own name was reallocated from `start`.
+        #
+        # Two sources renaming onto one target is likewise contradictory
+        # (``validate_slot_names`` rejects it upstream). Resolved by sorted
+        # order rather than by whichever the stored mapping happened to
+        # iterate first, so the same input always gives the same answer.
+        honoured: dict[str, str] = {}
+        claimed: set[str] = set()
+        for old in sorted(renames or {}, key=_identity):
+            source, target = _identity(old), _identity((renames or {})[old])
+            if source not in self.slots or target not in surviving:
+                continue
+            if target in claimed:
+                continue
+            honoured[source] = target
+            claimed.add(target)
+
         renamed = {
-            moves[name]: slot
+            honoured[name]: slot
             for name, slot in self.slots.items()
-            if name in moves and moves[name] in surviving
+            if name in honoured
         }
         kept = {
             name: slot
             for name, slot in self.slots.items()
-            if name not in moves and name in surviving and name not in renamed
+            if name not in honoured and name in surviving and name not in renamed
         }
-        carried = {**kept, **renamed}
 
-        taken = set(carried.values()) | set(unavailable)
-        candidate = start
-        for name in wanted:
-            if name in carried:
+        # Two users on one number would write over each other on the lock.
+        # Only reachable from bookkeeping that was already inconsistent, but
+        # nothing else repairs it, so it would persist for good.
+        carried: dict[str, int] = {}
+        held: set[int] = set()
+        for name in sorted({**kept, **renamed}):
+            slot = {**kept, **renamed}[name]
+            if slot in held:
                 continue
+            held.add(slot)
+            carried[name] = slot
+
+        taken = held | set(unavailable)
+        candidate = start
+        # Sorted so the answer does not depend on how the caller ordered
+        # ``names``. The signature accepts any iterable, and a set or
+        # ``dict.keys()`` from an unordered source would otherwise give the
+        # same configuration different credential indices from run to run.
+        for name in sorted(name for name in wanted if name not in carried):
             while candidate in taken:
                 candidate += 1
             carried[name] = candidate

--- a/custom_components/lock_code_manager/domain/slot_assignment.py
+++ b/custom_components/lock_code_manager/domain/slot_assignment.py
@@ -1,0 +1,110 @@
+"""
+Which slot number each user occupies.
+
+The slot number stops being configuration in version 3 and becomes internal
+bookkeeping. It still exists, because on most providers it IS the lock's
+credential index -- ``credential_index_follows_slot`` -- so it is bounded by
+the lock's advertised capacity and must be reusable when a user is deleted.
+
+That boundedness is why this is an assignment rather than a handle allocator:
+a number that can never be reused would eventually exceed every lock's
+capacity. Reuse is correct here. Deleting a user and creating another does
+hand the newcomer the departed user's slot, entity identifiers, and history
+-- exactly as it does today, because the physical credential slot is genuinely
+being reused.
+
+Entity and device identifiers keep keying on this number, so a rename moves
+nothing in either registry.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any
+
+from homeassistant.const import CONF_NAME
+
+CONF_SLOT_ASSIGNMENT = "slot_assignment"
+
+_EMPTY_ASSIGNMENT: Mapping[str, int] = MappingProxyType({})
+
+
+@dataclass(frozen=True, slots=True)
+class SlotAssignment:
+    """The slot number held by each configured user, keyed by name."""
+
+    slots: Mapping[str, int]
+
+    @classmethod
+    def empty(cls) -> SlotAssignment:
+        """Return the assignment for an entry with no users."""
+        return cls(slots=_EMPTY_ASSIGNMENT)
+
+    @classmethod
+    def from_mapping(cls, mapping: Mapping[str, Any]) -> SlotAssignment:
+        """Read the assignment out of an entry's stored bookkeeping."""
+        raw = mapping.get(CONF_SLOT_ASSIGNMENT) or {}
+        return cls(slots=MappingProxyType({str(k): int(v) for k, v in raw.items()}))
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the bookkeeping to persist beside the configuration."""
+        return {CONF_SLOT_ASSIGNMENT: dict(self.slots)}
+
+    def slot(self, name: str) -> int | None:
+        """Return the slot ``name`` occupies, or None if they hold none."""
+        return self.slots.get(name)
+
+    def assign(self, names: Iterable[str]) -> SlotAssignment:
+        """
+        Return the assignment covering exactly ``names``.
+
+        Users already holding a slot keep it, so a rename or an unrelated
+        edit never renumbers anyone. New users take the lowest free slot,
+        which is what keeps the numbers inside a lock's capacity -- counting
+        upward from the highest ever issued would drift past it.
+
+        Returns ``self`` when nothing differs, so callers can use identity to
+        decide whether a write is needed.
+        """
+        wanted = list(dict.fromkeys(names))
+        assigned = {name: self.slots[name] for name in wanted if name in self.slots}
+
+        taken = set(assigned.values())
+        candidate = 1
+        for name in wanted:
+            if name in assigned:
+                continue
+            while candidate in taken:
+                candidate += 1
+            assigned[name] = candidate
+            taken.add(candidate)
+
+        if assigned == dict(self.slots):
+            return self
+        return SlotAssignment(slots=MappingProxyType(assigned))
+
+
+def users_from_slots(
+    slots: Mapping[int, Mapping[str, Any]],
+) -> tuple[dict[str, dict[str, Any]], SlotAssignment]:
+    """
+    Convert slot-keyed configuration into name-keyed users plus an assignment.
+
+    The version 3 migration in one function, kept pure so the properties that
+    matter -- nothing lost, nobody renumbered -- can be stated over it
+    directly rather than through a config entry.
+
+    The name becomes the key and stops being a field, so a duplicate name is
+    no longer something to validate and reject: it cannot be represented.
+    Callers must have run the name repair first, since two slots sharing a
+    name would silently collapse into one user here.
+    """
+    users: dict[str, dict[str, Any]] = {}
+    assignment: dict[str, int] = {}
+    for slot_num, slot in sorted(slots.items()):
+        name = slot[CONF_NAME]
+        users[name] = {k: v for k, v in slot.items() if k != CONF_NAME}
+        assignment[name] = slot_num
+    return users, SlotAssignment(slots=MappingProxyType(assignment))

--- a/custom_components/lock_code_manager/domain/slot_assignment.py
+++ b/custom_components/lock_code_manager/domain/slot_assignment.py
@@ -26,6 +26,8 @@ from typing import Any
 
 from homeassistant.const import CONF_NAME
 
+from .names import normalize_slot_names
+
 CONF_SLOT_ASSIGNMENT = "slot_assignment"
 
 _EMPTY_ASSIGNMENT: Mapping[str, int] = MappingProxyType({})
@@ -55,6 +57,28 @@ class SlotAssignment:
     def slot(self, name: str) -> int | None:
         """Return the slot ``name`` occupies, or None if they hold none."""
         return self.slots.get(name)
+
+    def with_renames(self, renames: Mapping[str, str]) -> SlotAssignment:
+        """
+        Re-key the assignment so renamed users keep their slot.
+
+        Must be applied BEFORE :meth:`assign`, which cannot tell a rename from
+        a deletion plus an addition: it would free the old name's slot and
+        hand it out in iteration order. Two renames in one submission then
+        land each user on the other's index, rewriting both credentials on
+        every lock -- the failure this whole design exists to avoid, arriving
+        through the one operation that is supposed to be free.
+
+        Built as a fresh mapping rather than moved key by key, so a swap
+        (``A -> B`` and ``B -> A``) resolves without needing an order.
+        """
+        if not renames:
+            return self
+        return SlotAssignment(
+            slots=MappingProxyType(
+                {renames.get(name, name): slot for name, slot in self.slots.items()}
+            )
+        )
 
     def assign(self, names: Iterable[str]) -> SlotAssignment:
         """
@@ -87,24 +111,33 @@ class SlotAssignment:
 
 
 def users_from_slots(
-    slots: Mapping[int, Mapping[str, Any]],
-) -> tuple[dict[str, dict[str, Any]], SlotAssignment]:
+    slots: Mapping[Any, Mapping[str, Any]],
+) -> tuple[dict[str, dict[str, Any]], SlotAssignment, list[str]]:
     """
     Convert slot-keyed configuration into name-keyed users plus an assignment.
 
     The version 3 migration in one function, kept pure so the properties that
     matter -- nothing lost, nobody renumbered -- can be stated over it
-    directly rather than through a config entry.
+    directly rather than through a config entry. Also returns the slots whose
+    name the repair changed, so the migration can report them.
 
-    The name becomes the key and stops being a field, so a duplicate name is
-    no longer something to validate and reject: it cannot be represented.
-    Callers must have run the name repair first, since two slots sharing a
-    name would silently collapse into one user here.
+    Repairs the names ITSELF rather than documenting that callers must. The
+    name becomes the mapping key here, so two slots sharing one would collapse
+    into a single user -- losing a user and their code, and renumbering the
+    survivor -- and a slot with no name at all would raise mid-migration. Both
+    are reachable from a version 2 entry, where the name is optional. A
+    precondition is not good enough on a migration with no rollback.
+
+    Slot keys are coerced to ``int``. The on-disk JSON form is ``str``, so a
+    migration reading stored data hands strings straight in; a string here
+    survives into the assignment, where ``candidate in taken`` compares an int
+    against it, misses, and issues a slot that is already occupied.
     """
+    repaired, renamed = normalize_slot_names(slots)
     users: dict[str, dict[str, Any]] = {}
     assignment: dict[str, int] = {}
-    for slot_num, slot in sorted(slots.items()):
+    for raw_slot_num, slot in sorted(repaired.items(), key=lambda kv: int(kv[0])):
         name = slot[CONF_NAME]
         users[name] = {k: v for k, v in slot.items() if k != CONF_NAME}
-        assignment[name] = slot_num
-    return users, SlotAssignment(slots=MappingProxyType(assignment))
+        assignment[name] = int(raw_slot_num)
+    return users, SlotAssignment(slots=MappingProxyType(assignment)), renamed

--- a/custom_components/lock_code_manager/domain/slot_assignment.py
+++ b/custom_components/lock_code_manager/domain/slot_assignment.py
@@ -76,7 +76,7 @@ class SlotAssignment:
         """
         canonical: dict[str, int] = {}
         for name, slot in self.slots.items():
-            key = _identity(name)
+            key = _identity(str(name))
             number = int(slot)
             canonical[key] = min(canonical.get(key, number), number)
         object.__setattr__(self, "slots", MappingProxyType(canonical))
@@ -118,87 +118,82 @@ class SlotAssignment:
         """Return the slot ``name`` occupies, or None if they hold none."""
         return self.slots.get(_identity(name))
 
-    def with_renames(self, renames: Mapping[str, str]) -> SlotAssignment:
-        """
-        Re-key the assignment so renamed users keep their slot.
-
-        Must be applied BEFORE :meth:`assign`, which cannot tell a rename from
-        a deletion plus an addition: it would free the old name's slot and
-        hand it out in iteration order. Two renames in one submission then
-        land each user on the other's index, rewriting both credentials on
-        every lock -- the failure this whole design exists to avoid, arriving
-        through the one operation that is supposed to be free.
-
-        A rename target may be a name somebody else still holds, and that is
-        legal rather than a conflict: the holder must be departing in the same
-        submission, since two users cannot share a name in the result. The
-        renamed entry therefore displaces the one sitting on the target.
-
-        A target is only displaced when a source actually surrendered a slot.
-        Dropping it unconditionally deleted an uninvolved user whenever the
-        map named a source holding nothing -- and made replaying an
-        already-applied map erase its own result, so the operation was not
-        idempotent.
-        """
-        moves = {
-            _identity(old): _identity(new)
-            for old, new in renames.items()
-            if _identity(old) in self.slots
-        }
-        renamed = {
-            moves[name]: slot for name, slot in self.slots.items() if name in moves
-        }
-        kept = {
-            name: slot
-            for name, slot in self.slots.items()
-            if name not in moves and name not in renamed
-        }
-        moved = {**kept, **renamed}
-        if moved == dict(self.slots):
-            return self
-        return SlotAssignment(slots=moved)
-
-    def assign(
+    def reconcile(
         self,
         names: Iterable[str],
         *,
-        start: int = 1,
+        start: int,
+        renames: Mapping[str, str] | None = None,
         unavailable: Collection[int] = (),
     ) -> SlotAssignment:
         """
-        Return the assignment covering exactly ``names``.
+        Return the assignment covering exactly ``names``, applying ``renames``.
 
-        Users already holding a slot keep it, so a rename or an unrelated
-        edit never renumbers anyone. New users take the lowest free slot at or
-        above ``start``, skipping anything in ``unavailable``.
+        ONE operation rather than a rename step followed by an allocation
+        step. Splitting them put the order in the caller's hands, and the
+        order is the whole difficulty: a rename is indistinguishable from a
+        deletion plus an addition unless you already know who survives.
+        Getting that sequence wrong produced a high-severity defect in three
+        consecutive review rounds -- users deleted, users renumbered onto
+        another user's credential index -- so the sequence is gone rather
+        than documented.
 
-        Those two are not decoration. The entry has a configured start slot
-        (``CONF_START_SLOT``), usually chosen because the numbers below it
-        hold codes programmed by hand that Lock Code Manager does not manage,
-        and ``config_flow._check_common_slots`` refuses ranges overlapping
-        another entry on a shared lock. Since the slot IS the credential index
-        on most providers, allocating from 1 unconditionally would write a new
-        user's code over one of those.
+        ``names`` is the full set of users in the NEW configuration, which is
+        what resolves the ambiguity: a rename target that is not in ``names``
+        is departing, and one that is names the renamed user.
+
+        Users keep their slot through a rename and through anyone else's
+        arrival or departure. New users take the lowest free number at or
+        above ``start``, skipping ``unavailable``.
+
+        ``start`` is required, not defaulted. The entry's configured start
+        slot (``CONF_START_SLOT``) is usually chosen because the numbers below
+        it hold codes programmed by hand that Lock Code Manager does not
+        manage, and ``config_flow._check_common_slots`` refuses ranges that
+        overlap another entry on a shared lock. Since the slot IS the
+        credential index on most providers, defaulting to 1 would make a
+        forgotten argument write a new user's code over one of those --
+        silently, and on a real door. Required makes it a type error.
 
         Returns ``self`` when nothing differs, so callers can use identity to
         decide whether a write is needed.
         """
+        moves = {
+            _identity(old): _identity(new)
+            for old, new in (renames or {}).items()
+            if _identity(old) in self.slots
+        }
         wanted = list(dict.fromkeys(_identity(name) for name in names))
-        assigned = {name: self.slots[name] for name in wanted if name in self.slots}
+        surviving = set(wanted)
 
-        taken = set(assigned.values()) | set(unavailable)
+        # A renamed user displaces whoever held the target name, because two
+        # users cannot share a name in the result -- so that holder is
+        # departing in this same submission.
+        renamed = {
+            moves[name]: slot
+            for name, slot in self.slots.items()
+            if name in moves and moves[name] in surviving
+        }
+        kept = {
+            name: slot
+            for name, slot in self.slots.items()
+            if name not in moves and name in surviving and name not in renamed
+        }
+        carried = {**kept, **renamed}
+
+        taken = set(carried.values()) | set(unavailable)
         candidate = start
         for name in wanted:
-            if name in assigned:
+            if name in carried:
                 continue
             while candidate in taken:
                 candidate += 1
-            assigned[name] = candidate
+            carried[name] = candidate
             taken.add(candidate)
 
-        if assigned == dict(self.slots):
+        if carried == dict(self.slots):
             return self
-        return SlotAssignment(slots=assigned)
+        return SlotAssignment(slots=carried)
 
 
 def users_from_slots(

--- a/custom_components/lock_code_manager/domain/slot_assignment.py
+++ b/custom_components/lock_code_manager/domain/slot_assignment.py
@@ -26,7 +26,7 @@ from typing import Any
 
 from homeassistant.const import CONF_NAME
 
-from .names import normalize_slot_names
+from .names import normalize_name, normalize_slot_names
 
 CONF_SLOT_ASSIGNMENT = "slot_assignment"
 
@@ -39,6 +39,39 @@ class SlotAssignment:
 
     slots: Mapping[str, int]
 
+    def __post_init__(self) -> None:
+        """
+        Normalize the names and freeze the mapping.
+
+        Normalizing here rather than at each method makes it an invariant of
+        the type: a name can only ever be stored in one form, so it cannot
+        match on one path and miss on another. Missing means looking like a
+        different user and being renumbered, which moves that user's
+        credential on every lock. Stored data predating this is normalized on
+        read for the same reason.
+
+        Freezing closes the one hole the factories leave: the plain
+        constructor accepted a live dict, which a caller could then mutate
+        under the identity check ``assign`` uses to decide whether to write.
+        """
+        object.__setattr__(
+            self,
+            "slots",
+            MappingProxyType(
+                {normalize_name(name): slot for name, slot in self.slots.items()}
+            ),
+        )
+
+    def __hash__(self) -> int:
+        """
+        Hash by content.
+
+        ``frozen=True`` advertises hashability, but the generated ``__hash__``
+        hashes the mapping field and raises. Sorting to a tuple keeps the
+        promise the decorator makes instead of leaving a runtime trap.
+        """
+        return hash(tuple(sorted(self.slots.items())))
+
     @classmethod
     def empty(cls) -> SlotAssignment:
         """Return the assignment for an entry with no users."""
@@ -46,7 +79,16 @@ class SlotAssignment:
 
     @classmethod
     def from_mapping(cls, mapping: Mapping[str, Any]) -> SlotAssignment:
-        """Read the assignment out of an entry's stored bookkeeping."""
+        """
+        Read the assignment out of an entry's stored bookkeeping.
+
+        Takes ONE mapping deliberately. Configuration is read options-first
+        and falls back to data (``EntryConfig.from_entry``), but the
+        assignment must be read from the same side the users came from, or a
+        stale copy renumbers everyone on the next start. Consumers pass the
+        already-merged mapping rather than an entry, so there is no second
+        precedence rule here to get out of step with the first.
+        """
         raw = mapping.get(CONF_SLOT_ASSIGNMENT) or {}
         return cls(slots=MappingProxyType({str(k): int(v) for k, v in raw.items()}))
 
@@ -69,16 +111,35 @@ class SlotAssignment:
         every lock -- the failure this whole design exists to avoid, arriving
         through the one operation that is supposed to be free.
 
-        Built as a fresh mapping rather than moved key by key, so a swap
-        (``A -> B`` and ``B -> A``) resolves without needing an order.
+        A rename target may be a name somebody else still holds, and that is
+        legal rather than a conflict: the holder must be departing in the same
+        submission, since two users cannot share a name in the result. So the
+        renamed entry WINS and the entry sitting on the target is dropped.
+        Renaming into a target with a plain re-key instead lets whichever the
+        mapping happens to iterate last overwrite the other -- which for the
+        chain ``A -> B``, ``B -> C`` with ``C`` deleted moved the user
+        formerly named B from index 2 to index 3, and gave a different answer
+        for a different insertion order.
+
+        The two halves are built over disjoint key sets, so the result does
+        not depend on iteration order for chains any more than for swaps.
         """
-        if not renames:
+        renames = {
+            normalize_name(old): normalize_name(new) for old, new in renames.items()
+        }
+        targets = set(renames.values())
+        renamed = {
+            renames[name]: slot for name, slot in self.slots.items() if name in renames
+        }
+        kept = {
+            name: slot
+            for name, slot in self.slots.items()
+            if name not in renames and name not in targets
+        }
+        moved = {**kept, **renamed}
+        if moved == dict(self.slots):
             return self
-        return SlotAssignment(
-            slots=MappingProxyType(
-                {renames.get(name, name): slot for name, slot in self.slots.items()}
-            )
-        )
+        return SlotAssignment(slots=MappingProxyType(moved))
 
     def assign(self, names: Iterable[str]) -> SlotAssignment:
         """
@@ -92,7 +153,11 @@ class SlotAssignment:
         Returns ``self`` when nothing differs, so callers can use identity to
         decide whether a write is needed.
         """
-        wanted = list(dict.fromkeys(names))
+        # Normalized here, not assumed. A name reaching this boundary in its
+        # raw form -- one caller storing the repaired name while another
+        # passes what the user typed -- would look like a different user and
+        # renumber them, moving their credential on every lock.
+        wanted = list(dict.fromkeys(normalize_name(name) for name in names))
         assigned = {name: self.slots[name] for name in wanted if name in self.slots}
 
         taken = set(assigned.values())

--- a/tests/properties/test_slot_assignment.py
+++ b/tests/properties/test_slot_assignment.py
@@ -17,7 +17,7 @@ configurations and edit histories.
 
 from __future__ import annotations
 
-from hypothesis import given, strategies as st
+from hypothesis import assume, given, strategies as st
 
 from homeassistant.const import CONF_ENABLED, CONF_NAME, CONF_PIN
 
@@ -44,7 +44,7 @@ SLOT_CONFIGS = st.builds(
 
 @st.composite
 def slot_mappings(draw: st.DrawFn) -> dict[int, dict]:
-    """Slot-keyed configurations whose names are unique, as B1 guarantees."""
+    """Slot-keyed configurations with unique names and int keys."""
     configs = draw(st.lists(SLOT_CONFIGS, max_size=5))
     seen: set[str] = set()
     unique = [
@@ -54,10 +54,34 @@ def slot_mappings(draw: st.DrawFn) -> dict[int, dict]:
     return {starts + i: config for i, config in enumerate(unique)}
 
 
+@st.composite
+def stored_slot_mappings(draw: st.DrawFn) -> dict:
+    """Configurations shaped like STORAGE rather than like valid input.
+
+    Keys are strings, because that is what the on-disk JSON form yields and
+    what a migration reading stored data actually hands in. Names may repeat
+    or be missing, because both are reachable from a version 2 entry where
+    the name is optional.
+
+    The clean strategy above cannot expose either hazard, which is exactly
+    why the string-key slot collision survived the first round of these
+    properties.
+    """
+    configs = draw(st.lists(SLOT_CONFIGS, max_size=4))
+    start = draw(st.integers(min_value=1, max_value=4))
+    slots = {}
+    for i, config in enumerate(configs):
+        nameless = draw(st.booleans())
+        slots[str(start + i)] = (
+            {k: v for k, v in config.items() if k != CONF_NAME} if nameless else config
+        )
+    return slots
+
+
 @given(slots=slot_mappings())
 def test_conversion_loses_no_user(slots: dict[int, dict]) -> None:
     """Every configured slot becomes exactly one user."""
-    users, assignment = users_from_slots(slots)
+    users, assignment, _ = users_from_slots(slots)
 
     assert len(users) == len(slots)
     assert set(users) == {slot[CONF_NAME] for slot in slots.values()}
@@ -72,7 +96,7 @@ def test_conversion_loses_no_field(slots: dict[int, dict]) -> None:
     going missing is silent data loss -- the result still validates, the user
     just quietly has no code.
     """
-    users, _ = users_from_slots(slots)
+    users, _, _ = users_from_slots(slots)
 
     for slot in slots.values():
         user = users[slot[CONF_NAME]]
@@ -88,7 +112,7 @@ def test_conversion_renumbers_nobody(slots: dict[int, dict]) -> None:
     changed would have their entities orphaned AND their code written to a
     different index.
     """
-    _, assignment = users_from_slots(slots)
+    _, assignment, _ = users_from_slots(slots)
 
     for slot_num, slot in slots.items():
         assert assignment.slot(slot[CONF_NAME]) == slot_num
@@ -102,7 +126,7 @@ def test_conversion_round_trips(slots: dict[int, dict]) -> None:
     reshaping that happens to preserve counts and fields separately while
     still pairing them up wrongly.
     """
-    users, assignment = users_from_slots(slots)
+    users, assignment, _ = users_from_slots(slots)
 
     rebuilt = {
         assignment.slot(name): {CONF_NAME: name, **user} for name, user in users.items()
@@ -160,6 +184,70 @@ def test_slots_never_exceed_the_most_users_ever_configured_at_once(
         assignment = assignment.assign(configured)
         high_water = max(high_water, len(configured))
         assert all(1 <= s <= high_water for s in assignment.slots.values())
+
+
+@given(stored=stored_slot_mappings(), later=NAME_SETS)
+def test_editing_after_a_migration_never_double_books_a_slot(
+    stored: dict, later: list[str]
+) -> None:
+    """Migrate, then keep editing -- the two halves composed.
+
+    Every other assignment property starts from ``SlotAssignment.empty()``,
+    which is not how production reaches ``assign``: it reaches it from a
+    migrated assignment, built from storage. That gap hid a real defect --
+    string keys from JSON survived into the assignment, so ``candidate in
+    taken`` compared an int against a string, missed, and issued an occupied
+    slot to the next user. Two users on one credential index means one
+    overwrites the other on every lock.
+    """
+    _, assignment, _ = users_from_slots(stored)
+    after = assignment.assign([*assignment.slots, *later])
+
+    numbers = list(after.slots.values())
+    assert len(numbers) == len(set(numbers))
+    assert all(isinstance(s, int) for s in numbers)
+
+
+@given(stored=stored_slot_mappings())
+def test_migration_always_produces_one_user_per_slot(stored: dict) -> None:
+    """No slot is lost to a missing or duplicated name.
+
+    Both are reachable from a version 2 entry. Before the repair was folded
+    in, two slots sharing a name collapsed into one user -- losing that
+    user's code AND renumbering the survivor -- and a nameless slot raised
+    mid-migration, on a path with no rollback.
+    """
+    users, assignment, _ = users_from_slots(stored)
+
+    assert len(users) == len(stored)
+    assert len(assignment.slots) == len(stored)
+    assert set(assignment.slots.values()) == {int(k) for k in stored}
+
+
+@given(names=NAME_SETS, renames=st.dictionaries(NAMES, NAMES, max_size=3))
+def test_renaming_never_renumbers_anyone(
+    names: list[str], renames: dict[str, str]
+) -> None:
+    """A rename changes who holds a slot, never which slot they hold.
+
+    ``assign`` alone cannot see a rename -- it looks like a deletion plus an
+    addition, so it frees the old name's slot and reissues it in iteration
+    order, landing two renamed users on each other's index. Re-keying first
+    is what keeps the rename free, including for a swap.
+    """
+    before = SlotAssignment.empty().assign(names)
+    renames = {old: new for old, new in renames.items() if old in before.slots}
+    # A rename onto a name someone else still holds is a collision the name
+    # rules reject upstream, not something this has to resolve.
+    assume(len(set(renames.values())) == len(renames))
+    assume(not set(renames.values()) & (set(before.slots) - set(renames)))
+
+    after = before.with_renames(renames)
+
+    for old, new in renames.items():
+        assert after.slot(new) == before.slot(old)
+    for name in set(before.slots) - set(renames):
+        assert after.slot(name) == before.slot(name)
 
 
 @given(names=NAME_SETS)

--- a/tests/properties/test_slot_assignment.py
+++ b/tests/properties/test_slot_assignment.py
@@ -527,3 +527,99 @@ def test_two_renames_onto_one_target_resolve_the_same_way_every_time() -> None:
     assert dict(forward.reconcile(["Wren"], start=1, renames=renames).slots) == dict(
         backward.reconcile(["Wren"], start=1, renames=renames).slots
     )
+
+
+@given(
+    names=NAME_SETS,
+    start=START,
+    renames=st.dictionaries(NAMES, st.sampled_from(["Wren", "Vic"]), max_size=2),
+)
+def test_renames_are_read_case_insensitively_too(
+    names: list[str], start: int, renames: dict[str, str]
+) -> None:
+    """The rename map is reduced to identity form, like the stored names are.
+
+    ``__post_init__`` canonicalizes the assignment's keys, but the rename map
+    arrives from a caller and got none of that treatment. Two keys meaning the
+    same user each took a turn: the later overwrote the earlier while the
+    earlier's target stayed claimed, so a third user's legitimate rename onto
+    that target was refused and they were renumbered onto a different
+    credential index.
+    """
+    before = SlotAssignment.empty().reconcile(names, start=start)
+    shouted = {old.upper(): new for old, new in renames.items()}
+    after_names = [renames.get(n, n) for n in names]
+
+    assert dict(
+        before.reconcile(after_names, start=start, renames=renames).slots
+    ) == dict(before.reconcile(after_names, start=start, renames=shouted).slots)
+
+
+@given(
+    renames=st.dictionaries(NAMES, st.sampled_from(["Wren", "Vic"]), max_size=3),
+    start=START,
+)
+def test_the_rename_mapping_order_does_not_change_the_answer(
+    renames: dict[str, str], start: int
+) -> None:
+    """Rebuilding the same rename map in another order gives the same result."""
+    before = SlotAssignment.empty().reconcile(["Alice", "Bob", "Carl"], start=start)
+    flipped = dict(reversed(list(renames.items())))
+    after_names = [renames.get(n, n) for n in ["Alice", "Bob", "Carl"]]
+
+    assert dict(
+        before.reconcile(after_names, start=start, renames=renames).slots
+    ) == dict(before.reconcile(after_names, start=start, renames=flipped).slots)
+
+
+def test_a_migration_cannot_persist_two_users_on_one_number() -> None:
+    """Slot keys that coerce to the same number must not double-book.
+
+    ``'01'`` and ``'1'`` are distinct keys in stored JSON and the same number
+    after coercion. Reachable only from hand-edited storage, but it would be
+    persisted straight out of a migration that has no rollback, and both users
+    would overwrite each other on the lock every sync.
+    """
+    _, assignment, _ = users_from_slots(
+        {"01": {CONF_NAME: "A", CONF_PIN: "1"}, "1": {CONF_NAME: "B", CONF_PIN: "2"}}
+    )
+
+    numbers = list(assignment.slots.values())
+    assert len(numbers) == len(set(numbers))
+    # The displaced user is reissued a number that respects the start slot,
+    # rather than being handed one below it at construction time.
+    assert dict(assignment.reconcile(["A", "B"], start=5).slots) == {"a": 1, "b": 5}
+
+
+def test_corrupt_stored_bookkeeping_degrades_instead_of_aborting_setup() -> None:
+    """Junk in storage must not take the whole entry down.
+
+    The same threat model the ``str()`` key coercion exists for. A user whose
+    stored number is unusable simply has none, and reconcile reissues one.
+    """
+    assert dict(SlotAssignment.from_mapping({CONF_SLOT_ASSIGNMENT: ["x"]}).slots) == {}
+    assert dict(SlotAssignment(slots={"a": "zzz", "b": 2}).slots) == {"b": 2}
+
+
+def test_two_rename_keys_meaning_one_user_resolve_deterministically() -> None:
+    """``Alice`` and ``alice `` are one user, so they get one turn, not two.
+
+    Iterating the raw mapping gave each a turn: the later overwrote the
+    earlier in the move table while the earlier's target stayed CLAIMED. A
+    third user renaming onto that abandoned target was then refused and
+    renumbered onto a different credential index -- and which of the two won
+    depended on the mapping's insertion order.
+
+    Needs an example rather than a property: the strategies generate distinct
+    names, so they cannot produce two keys with one identity, which is why
+    the mutation removing this survived every property.
+    """
+    before = SlotAssignment(slots={"Alice": 1, "Bob": 5, "Carl": 2})
+    forward = {"Alice": "Wren", "alice ": "Vic", "Bob": "Wren"}
+    backward = {"Bob": "Wren", "alice ": "Vic", "Alice": "Wren"}
+
+    assert dict(
+        before.reconcile(["Wren", "Vic", "Carl"], start=1, renames=forward).slots
+    ) == dict(
+        before.reconcile(["Wren", "Vic", "Carl"], start=1, renames=backward).slots
+    )

--- a/tests/properties/test_slot_assignment.py
+++ b/tests/properties/test_slot_assignment.py
@@ -23,6 +23,7 @@ from homeassistant.const import CONF_ENABLED, CONF_NAME, CONF_PIN
 
 from custom_components.lock_code_manager.domain.names import normalize_slot_names
 from custom_components.lock_code_manager.domain.slot_assignment import (
+    CONF_SLOT_ASSIGNMENT,
     SlotAssignment,
     _identity,
     users_from_slots,
@@ -376,3 +377,153 @@ def test_assignment_survives_a_round_trip_through_storage(
     # for the first caller to use one as a dict key or in a set.
     assert restored == assignment
     assert hash(restored) == hash(assignment)
+
+
+@given(history=EDIT_HISTORIES, start=START)
+def test_slots_never_exceed_the_most_users_ever_configured_at_once(
+    history: list[list[str]], start: int
+) -> None:
+    """Numbers stay inside ``start`` plus the high-water mark of CONCURRENT users.
+
+    This is the property that justifies reusing slot numbers at all, and it
+    went missing in a rewrite while the pull request description went on
+    citing it by name. On most providers the slot IS the lock's credential
+    index, and a number above the advertised capacity can never be written.
+
+    A never-reused number satisfies this for no bound: it climbs with every
+    user ever created and eventually leaves the lock's range entirely. Reuse
+    is what keeps the numbering tight, which is why the slot number is the
+    right thing to key on and a monotonically increasing handle is not.
+    """
+    assignment = SlotAssignment.empty()
+    high_water = 0
+    for configured in history:
+        assignment = assignment.reconcile(configured, start=start)
+        high_water = max(high_water, len(configured))
+        assert all(
+            start <= s <= start + high_water - 1 for s in assignment.slots.values()
+        )
+
+
+@given(names=NAME_SETS, start=START)
+def test_allocation_does_not_depend_on_how_names_are_ordered(
+    names: list[str], start: int
+) -> None:
+    """The same users get the same numbers however the caller iterates them.
+
+    ``names`` is typed as an iterable, so a caller may hand over a set or a
+    ``dict.keys()`` view. Order-dependent allocation would give one
+    configuration different credential indices from run to run.
+    """
+    forward = SlotAssignment.empty().reconcile(names, start=start)
+    backward = SlotAssignment.empty().reconcile(list(reversed(names)), start=start)
+
+    assert dict(forward.slots) == dict(backward.slots)
+
+
+@given(
+    names=NAME_SETS,
+    start=START,
+    renames=st.dictionaries(NAMES, st.sampled_from(["Wren", "Vic"]), max_size=2),
+)
+def test_a_rename_to_somebody_absent_leaves_the_source_alone(
+    names: list[str], start: int, renames: dict[str, str]
+) -> None:
+    """A rename target missing from the new names must be inert, not destructive.
+
+    The input contradicts itself -- the user is being renamed to somebody the
+    configuration does not contain -- and the harmless reading is to ignore
+    it. Honouring it halfway dropped the source from the survivors and
+    reallocated them from ``start``, moving the credential of a user who was
+    never part of the edit.
+    """
+    before = SlotAssignment.empty().reconcile(names, start=start)
+    absent = {
+        old: new
+        for old, new in renames.items()
+        if _identity(new) not in {_identity(n) for n in names}
+    }
+
+    after = before.reconcile(names, start=start, renames=absent)
+
+    assert dict(after.slots) == dict(before.slots)
+
+
+@given(
+    slots=st.dictionaries(NAMES, st.integers(min_value=1, max_value=6), max_size=4),
+    start=START,
+)
+def test_a_double_booked_slot_is_repaired(slots: dict[str, int], start: int) -> None:
+    """Two users on one credential index must not survive a reconcile.
+
+    Only reachable from bookkeeping that was already inconsistent, but nothing
+    else repairs it, so it would persist for good -- and both users would
+    write over each other on the lock every sync.
+    """
+    reconciled = SlotAssignment(slots=slots).reconcile(list(slots), start=start)
+
+    numbers = list(reconciled.slots.values())
+    assert len(numbers) == len(set(numbers))
+    assert set(reconciled.slots) == {_identity(n) for n in slots}
+
+
+def test_a_collapsed_identity_keeps_the_lower_slot() -> None:
+    """Two keys reducing to one identity keep the LOWER number, as documented.
+
+    Covered but unpinned before: mutating ``min`` to ``max`` passed every
+    property, because nothing constructed a mapping whose keys collapse.
+    """
+    assert dict(SlotAssignment(slots={"Raman": 4, "raman ": 2}).slots) == {"raman": 2}
+
+
+def test_a_string_slot_number_is_coerced() -> None:
+    """The constructor accepts what storage yields and normalizes it.
+
+    This coercion is the type-level defence against the string-key
+    double-booking the branch previously shipped, and mutating it away passed
+    every property -- no test handed a string slot value to the constructor.
+    """
+    assignment = SlotAssignment(slots={"alice": "3"})
+
+    assert assignment.slot("Alice") == 3
+    assert dict(assignment.reconcile(["Alice", "Bob"], start=1).slots) == {
+        "alice": 3,
+        "bob": 1,
+    }
+
+
+def test_a_non_string_name_key_is_coerced_not_fatal() -> None:
+    """Stored bookkeeping with a non-string key must load, not abort setup.
+
+    ``normalize_name`` calls ``.strip()``, so an integer key raised
+    AttributeError and took the whole entry setup down with it. Reachable
+    from hand-edited storage, or from a writer that persisted the slot number
+    as the key by mistake. Nothing pinned the coercion until this test: the
+    mutation removing it passed all 23 properties.
+    """
+    assignment = SlotAssignment.from_mapping({CONF_SLOT_ASSIGNMENT: {1: 4}})
+
+    assert assignment.slot("1") == 4
+
+
+def test_two_renames_onto_one_target_resolve_the_same_way_every_time() -> None:
+    """Contradictory input still has to be deterministic.
+
+    ``validate_slot_names`` keeps two users from ending on one name, so this
+    is unreachable from the configuration flow -- but nothing in this type
+    enforces it, and the previous implementation let whichever entry the
+    stored mapping iterated first decide, so the same input produced
+    different credential indices on different runs. Resolved by sorted order
+    instead.
+
+    The property tests assume this case away, which is correct for them and
+    is why it needs an example here.
+    """
+    renames = {"alice": "Wren", "bob": "Wren"}
+
+    forward = SlotAssignment(slots={"alice": 1, "bob": 2})
+    backward = SlotAssignment(slots={"bob": 2, "alice": 1})
+
+    assert dict(forward.reconcile(["Wren"], start=1, renames=renames).slots) == dict(
+        backward.reconcile(["Wren"], start=1, renames=renames).slots
+    )

--- a/tests/properties/test_slot_assignment.py
+++ b/tests/properties/test_slot_assignment.py
@@ -21,6 +21,7 @@ from hypothesis import assume, given, strategies as st
 
 from homeassistant.const import CONF_ENABLED, CONF_NAME, CONF_PIN
 
+from custom_components.lock_code_manager.domain.names import normalize_slot_names
 from custom_components.lock_code_manager.domain.slot_assignment import (
     SlotAssignment,
     users_from_slots,
@@ -233,21 +234,96 @@ def test_renaming_never_renumbers_anyone(
     ``assign`` alone cannot see a rename -- it looks like a deletion plus an
     addition, so it frees the old name's slot and reissues it in iteration
     order, landing two renamed users on each other's index. Re-keying first
-    is what keeps the rename free, including for a swap.
+    is what keeps the rename free.
+
+    Chained renames are deliberately NOT excluded. An earlier version of this
+    property assumed away the case where a rename target is a name somebody
+    still holds, on the reasoning that the name rules reject it upstream. They
+    do not: ``A -> B``, ``B -> C`` with ``C`` deleted ends with the unique
+    names {B, C}, so it is a legal submission -- and it was the exact shape
+    that moved a user from index 2 to index 3. Filtering it out is what let
+    the defect through.
     """
     before = SlotAssignment.empty().assign(names)
     renames = {old: new for old, new in renames.items() if old in before.slots}
-    # A rename onto a name someone else still holds is a collision the name
-    # rules reject upstream, not something this has to resolve.
+    # Two users renaming to the SAME name is a genuine conflict the name
+    # rules reject, and not something this has to resolve.
     assume(len(set(renames.values())) == len(renames))
-    assume(not set(renames.values()) & (set(before.slots) - set(renames)))
 
     after = before.with_renames(renames)
 
     for old, new in renames.items():
         assert after.slot(new) == before.slot(old)
-    for name in set(before.slots) - set(renames):
+    # Anyone neither renamed nor displaced by a rename keeps their number.
+    for name in set(before.slots) - set(renames) - set(renames.values()):
         assert after.slot(name) == before.slot(name)
+
+
+@given(names=NAME_SETS, renames=st.dictionaries(NAMES, NAMES, max_size=3))
+def test_renaming_does_not_depend_on_insertion_order(
+    names: list[str], renames: dict[str, str]
+) -> None:
+    """The same renames give the same answer whatever order the map holds.
+
+    The first implementation re-keyed in place, so whichever entry iterated
+    last overwrote the other and a differently-ordered mapping produced a
+    different assignment. Order-dependence in bookkeeping that decides
+    credential indices is not a style question.
+    """
+    before = SlotAssignment.empty().assign(names)
+    renames = {old: new for old, new in renames.items() if old in before.slots}
+    assume(len(set(renames.values())) == len(renames))
+
+    reversed_order = SlotAssignment(slots=dict(reversed(list(before.slots.items()))))
+
+    assert dict(before.with_renames(renames).slots) == dict(
+        reversed_order.with_renames(renames).slots
+    )
+
+
+@given(stored=stored_slot_mappings())
+def test_repair_pairs_each_user_with_their_own_fields_and_slot(
+    stored: dict,
+) -> None:
+    """Repaired names stay attached to the right fields and the right slot.
+
+    The conversion properties run only on already-valid input, so nothing
+    pinned the pairing THROUGH the repair. A migration that swapped two
+    repaired slots' codes would satisfy every count-based property while
+    giving two people each other's code.
+    """
+    users, assignment, _ = users_from_slots(stored)
+    repaired, _ = normalize_slot_names(stored)
+
+    for raw_key, slot in repaired.items():
+        name = slot[CONF_NAME]
+        assert assignment.slot(name) == int(raw_key)
+        assert users[name] == {k: v for k, v in slot.items() if k != CONF_NAME}
+
+
+@given(names=NAME_SETS, pad=st.sampled_from([" ", "  ", "\t"]))
+def test_a_whitespace_variant_is_the_same_user(names: list[str], pad: str) -> None:
+    """``"Raman "`` and ``"Raman"`` must never be two different users.
+
+    Names arrive here from more than one place -- the repaired configuration,
+    and whatever a caller passes straight through -- and the two forms are
+    indistinguishable on screen. Treating them as different users renumbers
+    somebody, which moves their credential on every lock.
+
+    Covers both directions, because normalizing only the incoming names left
+    a stored key in its raw form still missing: assignment stored padded and
+    looked up bare, and assignment stored bare and looked up padded.
+    """
+    bare = SlotAssignment.empty().assign(names)
+    padded_lookup = bare.assign([f"{pad}{name}{pad}" for name in names])
+
+    assert padded_lookup is bare
+
+    stored_padded = SlotAssignment(
+        slots={f"{pad}{n}{pad}": s for n, s in bare.slots.items()}
+    )
+    for name in names:
+        assert stored_padded.slot(name) == bare.slot(name)
 
 
 @given(names=NAME_SETS)
@@ -274,3 +350,9 @@ def test_assignment_survives_a_round_trip_through_storage(
     restored = SlotAssignment.from_mapping(assignment.to_dict())
 
     assert dict(restored.slots) == dict(assignment.slots)
+    # Equal assignments must hash equally. ``frozen=True`` advertises
+    # hashability, but the generated __hash__ hashes the mapping field and
+    # raises, so the promise has to be kept explicitly or it is a runtime trap
+    # for the first caller to use one as a dict key or in a set.
+    assert restored == assignment
+    assert hash(restored) == hash(assignment)

--- a/tests/properties/test_slot_assignment.py
+++ b/tests/properties/test_slot_assignment.py
@@ -24,6 +24,7 @@ from homeassistant.const import CONF_ENABLED, CONF_NAME, CONF_PIN
 from custom_components.lock_code_manager.domain.names import normalize_slot_names
 from custom_components.lock_code_manager.domain.slot_assignment import (
     SlotAssignment,
+    _identity,
     users_from_slots,
 )
 
@@ -139,74 +140,192 @@ def test_conversion_round_trips(slots: dict[int, dict]) -> None:
     assert rebuilt == slots
 
 
-@given(history=EDIT_HISTORIES)
-def test_a_surviving_user_is_never_renumbered(history: list[list[str]]) -> None:
+START = st.integers(min_value=1, max_value=6)
+
+
+def _reconcile(assignment, names, **kwargs):
+    """Reconcile with a start slot supplied, since it is required."""
+    return assignment.reconcile(names, start=kwargs.pop("start", 1), **kwargs)
+
+
+@given(history=EDIT_HISTORIES, start=START)
+def test_a_surviving_user_is_never_renumbered(
+    history: list[list[str]], start: int
+) -> None:
     """Adding or removing users must not move anyone else.
 
     Renumbering a bystander rewrites their credential to a different index on
-    every lock. This is the invariant that a naive "renumber from one on every
-    edit" implementation violates, and it needs a sequence to expose.
+    every lock.
     """
     assignment = SlotAssignment.empty()
     for configured in history:
-        after = assignment.assign(configured)
-        for name in set(assignment.slots) & set(configured):
+        after = _reconcile(assignment, configured, start=start)
+        for name in set(assignment.slots) & {_identity(n) for n in configured}:
             assert after.slot(name) == assignment.slot(name)
         assignment = after
 
 
-@given(history=EDIT_HISTORIES)
-def test_two_users_never_share_a_slot(history: list[list[str]]) -> None:
-    """A slot addresses one credential, so two users in it would overwrite each other."""
+@given(history=EDIT_HISTORIES, start=START)
+def test_two_users_never_share_a_slot(history: list[list[str]], start: int) -> None:
+    """A slot addresses one credential, so two users in it overwrite each other."""
     assignment = SlotAssignment.empty()
     for configured in history:
-        assignment = assignment.assign(configured)
+        assignment = _reconcile(assignment, configured, start=start)
         numbers = list(assignment.slots.values())
         assert len(numbers) == len(set(numbers))
 
 
-@given(history=EDIT_HISTORIES)
-def test_slots_never_exceed_the_most_users_ever_configured_at_once(
-    history: list[list[str]],
+@given(history=EDIT_HISTORIES, start=START)
+def test_every_configured_user_holds_a_slot(
+    history: list[list[str]], start: int
 ) -> None:
-    """Numbers stay inside the high-water mark of CONCURRENT users.
-
-    Not the current count -- a survivor keeps their number when someone below
-    them leaves, which is required and is the property above. The bound that
-    does hold is the most users ever configured simultaneously, and it is the
-    one that matters: capacity is sized against how many users exist at once,
-    and on most providers the slot IS the lock's credential index, where a
-    number above the advertised count can never be written.
-
-    A never-reused number satisfies neither bound: it climbs with every user
-    ever created and eventually leaves the lock's range entirely. Reuse is
-    what keeps the numbering inside capacity, which is why the slot number is
-    the right thing to key on and a monotonic handle is not.
-    """
+    """Nobody configured is left without a slot, however the set churns."""
     assignment = SlotAssignment.empty()
-    high_water = 0
     for configured in history:
-        assignment = assignment.assign(configured)
-        high_water = max(high_water, len(configured))
-        assert all(1 <= s <= high_water for s in assignment.slots.values())
+        assignment = _reconcile(assignment, configured, start=start)
+        assert {_identity(n) for n in configured} == set(assignment.slots)
 
 
-@given(stored=stored_slot_mappings(), later=NAME_SETS)
+NEWCOMERS = st.lists(st.sampled_from(["Zoe", "Yan", "Xavier"]), max_size=2).map(
+    lambda ns: list(dict.fromkeys(ns))
+)
+
+
+@given(
+    names=NAME_SETS,
+    renames=st.dictionaries(NAMES, st.sampled_from(["Wren", "Vic"]), max_size=2),
+    newcomers=NEWCOMERS,
+    start=START,
+    data=st.data(),
+)
+def test_renaming_keeps_the_users_slot(
+    names: list[str],
+    renames: dict[str, str],
+    newcomers: list[str],
+    start: int,
+    data: st.DataObject,
+) -> None:
+    """A rename changes who holds a slot, never which slot they hold.
+
+    Two things make this property actually bite, and it did not before.
+
+    It filters on the IDENTITY form. Filtering on the raw name went vacuous
+    the moment keys became casefolded -- every generated name is capitalized,
+    so the filter emptied the map and every assertion was trivially true.
+
+    And it adds users in a SHUFFLED order alongside the rename. Without a
+    competing addition, ignoring renames entirely still passes: the newcomer
+    is handed the very slot the "departed" user just freed, so delete-plus-add
+    and rename coincide. They only diverge when somebody else is in line for
+    that slot, which is exactly the case that reorders two users' credential
+    indices on a real lock.
+    """
+    before = _reconcile(SlotAssignment.empty(), names, start=start)
+    moves = {old: new for old, new in renames.items() if _identity(old) in before.slots}
+    assume(len({_identity(v) for v in moves.values()}) == len(moves))
+
+    after_names = data.draw(
+        st.permutations([moves.get(n, n) for n in names] + newcomers)
+    )
+
+    after = _reconcile(before, after_names, renames=moves, start=start)
+
+    for old, new in moves.items():
+        assert after.slot(new) == before.slot(old)
+    for name in names:
+        if name not in moves:
+            assert after.slot(name) == before.slot(name)
+
+
+@given(names=NAME_SETS, renames=st.dictionaries(NAMES, NAMES, max_size=3), start=START)
+def test_renaming_does_not_depend_on_insertion_order(
+    names: list[str], renames: dict[str, str], start: int
+) -> None:
+    """The same edit gives the same answer whatever order the mapping holds."""
+    before = _reconcile(SlotAssignment.empty(), names, start=start)
+    moves = {old: new for old, new in renames.items() if _identity(old) in before.slots}
+    assume(len({_identity(v) for v in moves.values()}) == len(moves))
+    after_names = [moves.get(n, n) for n in names]
+
+    flipped = SlotAssignment(slots=dict(reversed(list(before.slots.items()))))
+
+    assert dict(
+        _reconcile(before, after_names, renames=moves, start=start).slots
+    ) == dict(_reconcile(flipped, after_names, renames=moves, start=start).slots)
+
+
+@given(names=NAME_SETS, start=START)
+def test_reconciling_the_same_users_twice_changes_nothing(
+    names: list[str], start: int
+) -> None:
+    """No renames and the same names is a no-op, so callers do not write."""
+    once = _reconcile(SlotAssignment.empty(), names, start=start)
+
+    assert once.reconcile(names, start=start) is once
+
+
+@given(
+    names=NAME_SETS,
+    start=START,
+    unavailable=st.sets(st.integers(min_value=1, max_value=12), max_size=4),
+)
+def test_new_users_respect_the_start_slot_and_reserved_numbers(
+    names: list[str], start: int, unavailable: set[int]
+) -> None:
+    """A newly issued slot is never below the start, nor one already spoken for.
+
+    The start slot is usually chosen because the numbers below it hold codes
+    programmed by hand, and another entry may own slots on the same lock. The
+    slot IS the credential index on most providers, so issuing one of those
+    overwrites a real code on a real door.
+    """
+    assignment = SlotAssignment.empty().reconcile(
+        names, start=start, unavailable=unavailable
+    )
+
+    for number in assignment.slots.values():
+        assert number >= start
+        assert number not in unavailable
+
+
+@given(names=NAME_SETS, start=START)
+def test_case_only_differences_are_the_same_user(names: list[str], start: int) -> None:
+    """``Bob`` and ``BOB`` are one user, as ``names.deduplicate`` already says."""
+    assignment = _reconcile(SlotAssignment.empty(), names, start=start)
+
+    for name in names:
+        assert assignment.slot(name.upper()) == assignment.slot(name.lower())
+    assert assignment.reconcile([n.upper() for n in names], start=start) is assignment
+
+
+@given(names=NAME_SETS, pad=st.sampled_from([" ", "  ", "\t"]), start=START)
+def test_a_whitespace_variant_is_the_same_user(
+    names: list[str], pad: str, start: int
+) -> None:
+    """``"Raman "`` and ``"Raman"`` must never be two different users."""
+    bare = _reconcile(SlotAssignment.empty(), names, start=start)
+
+    assert bare.reconcile([f"{pad}{n}{pad}" for n in names], start=start) is bare
+
+    stored_padded = SlotAssignment(
+        slots={f"{pad}{n}{pad}": s for n, s in bare.slots.items()}
+    )
+    for name in names:
+        assert stored_padded.slot(name) == bare.slot(name)
+
+
+@given(stored=stored_slot_mappings(), later=NAME_SETS, start=START)
 def test_editing_after_a_migration_never_double_books_a_slot(
-    stored: dict, later: list[str]
+    stored: dict, later: list[str], start: int
 ) -> None:
     """Migrate, then keep editing -- the two halves composed.
 
-    Every other assignment property starts from ``SlotAssignment.empty()``,
-    which is not how production reaches ``assign``: it reaches it from a
-    migrated assignment, built from storage. That gap hid a real defect --
-    string keys from JSON survived into the assignment, so ``candidate in
-    taken`` compared an int against a string, missed, and issued an occupied
-    slot to the next user. Two users on one credential index means one
-    overwrites the other on every lock.
+    Production reaches reconcile from a MIGRATED assignment built out of
+    storage, never from ``empty()``. That gap hid a string-key collision that
+    issued one credential index to two users.
     """
     _, assignment, _ = users_from_slots(stored)
-    after = assignment.assign([*assignment.slots, *later])
+    after = _reconcile(assignment, [*assignment.slots, *later], start=start)
 
     numbers = list(after.slots.values())
     assert len(numbers) == len(set(numbers))
@@ -215,13 +334,7 @@ def test_editing_after_a_migration_never_double_books_a_slot(
 
 @given(stored=stored_slot_mappings())
 def test_migration_always_produces_one_user_per_slot(stored: dict) -> None:
-    """No slot is lost to a missing or duplicated name.
-
-    Both are reachable from a version 2 entry. Before the repair was folded
-    in, two slots sharing a name collapsed into one user -- losing that
-    user's code AND renumbering the survivor -- and a nameless slot raised
-    mid-migration, on a path with no rollback.
-    """
+    """No slot is lost to a missing or duplicated name."""
     users, assignment, _ = users_from_slots(stored)
 
     assert len(users) == len(stored)
@@ -229,73 +342,9 @@ def test_migration_always_produces_one_user_per_slot(stored: dict) -> None:
     assert set(assignment.slots.values()) == {int(k) for k in stored}
 
 
-@given(names=NAME_SETS, renames=st.dictionaries(NAMES, NAMES, max_size=3))
-def test_renaming_never_renumbers_anyone(
-    names: list[str], renames: dict[str, str]
-) -> None:
-    """A rename changes who holds a slot, never which slot they hold.
-
-    ``assign`` alone cannot see a rename -- it looks like a deletion plus an
-    addition, so it frees the old name's slot and reissues it in iteration
-    order, landing two renamed users on each other's index. Re-keying first
-    is what keeps the rename free.
-
-    Chained renames are deliberately NOT excluded. An earlier version of this
-    property assumed away the case where a rename target is a name somebody
-    still holds, on the reasoning that the name rules reject it upstream. They
-    do not: ``A -> B``, ``B -> C`` with ``C`` deleted ends with the unique
-    names {B, C}, so it is a legal submission -- and it was the exact shape
-    that moved a user from index 2 to index 3. Filtering it out is what let
-    the defect through.
-    """
-    before = SlotAssignment.empty().assign(names)
-    renames = {old: new for old, new in renames.items() if old in before.slots}
-    # Two users renaming to the SAME name is a genuine conflict the name
-    # rules reject, and not something this has to resolve.
-    assume(len(set(renames.values())) == len(renames))
-
-    after = before.with_renames(renames)
-
-    for old, new in renames.items():
-        assert after.slot(new) == before.slot(old)
-    # Anyone neither renamed nor displaced by a rename keeps their number.
-    for name in set(before.slots) - set(renames) - set(renames.values()):
-        assert after.slot(name) == before.slot(name)
-
-
-@given(names=NAME_SETS, renames=st.dictionaries(NAMES, NAMES, max_size=3))
-def test_renaming_does_not_depend_on_insertion_order(
-    names: list[str], renames: dict[str, str]
-) -> None:
-    """The same renames give the same answer whatever order the map holds.
-
-    The first implementation re-keyed in place, so whichever entry iterated
-    last overwrote the other and a differently-ordered mapping produced a
-    different assignment. Order-dependence in bookkeeping that decides
-    credential indices is not a style question.
-    """
-    before = SlotAssignment.empty().assign(names)
-    renames = {old: new for old, new in renames.items() if old in before.slots}
-    assume(len(set(renames.values())) == len(renames))
-
-    reversed_order = SlotAssignment(slots=dict(reversed(list(before.slots.items()))))
-
-    assert dict(before.with_renames(renames).slots) == dict(
-        reversed_order.with_renames(renames).slots
-    )
-
-
 @given(stored=stored_slot_mappings())
-def test_repair_pairs_each_user_with_their_own_fields_and_slot(
-    stored: dict,
-) -> None:
-    """Repaired names stay attached to the right fields and the right slot.
-
-    The conversion properties run only on already-valid input, so nothing
-    pinned the pairing THROUGH the repair. A migration that swapped two
-    repaired slots' codes would satisfy every count-based property while
-    giving two people each other's code.
-    """
+def test_repair_pairs_each_user_with_their_own_fields_and_slot(stored: dict) -> None:
+    """Repaired names stay attached to the right fields and the right slot."""
     users, assignment, _ = users_from_slots(stored)
     repaired, _ = normalize_slot_names(stored)
 
@@ -305,129 +354,9 @@ def test_repair_pairs_each_user_with_their_own_fields_and_slot(
         assert users[name] == {k: v for k, v in slot.items() if k != CONF_NAME}
 
 
-@given(names=NAME_SETS, pad=st.sampled_from([" ", "  ", "\t"]))
-def test_a_whitespace_variant_is_the_same_user(names: list[str], pad: str) -> None:
-    """``"Raman "`` and ``"Raman"`` must never be two different users.
-
-    Names arrive here from more than one place -- the repaired configuration,
-    and whatever a caller passes straight through -- and the two forms are
-    indistinguishable on screen. Treating them as different users renumbers
-    somebody, which moves their credential on every lock.
-
-    Covers both directions, because normalizing only the incoming names left
-    a stored key in its raw form still missing: assignment stored padded and
-    looked up bare, and assignment stored bare and looked up padded.
-    """
-    bare = SlotAssignment.empty().assign(names)
-    padded_lookup = bare.assign([f"{pad}{name}{pad}" for name in names])
-
-    assert padded_lookup is bare
-
-    stored_padded = SlotAssignment(
-        slots={f"{pad}{n}{pad}": s for n, s in bare.slots.items()}
-    )
-    for name in names:
-        assert stored_padded.slot(name) == bare.slot(name)
-
-
-@given(names=NAME_SETS, renames=st.dictionaries(NAMES, NAMES, max_size=3))
-def test_renaming_never_removes_a_user(
-    names: list[str], renames: dict[str, str]
-) -> None:
-    """Nobody loses their slot to a rename they were not part of.
-
-    A rename map naming a source that holds nothing -- a stale replay, or a
-    name already renamed -- previously deleted whoever sat on the TARGET,
-    because the target was vacated whether or not anything moved into it. The
-    following ``assign`` then renumbered that bystander onto a different
-    credential index.
-    """
-    before = SlotAssignment.empty().assign(names)
-    assume(len({v.casefold() for v in renames.values()}) == len(renames))
-
-    after = before.with_renames(renames)
-
-    moved_from = {k.casefold() for k in renames if k.casefold() in before.slots}
-    for name in set(before.slots) - moved_from:
-        assert after.slot(name) == before.slot(name)
-
-
-@given(names=NAME_SETS, renames=st.dictionaries(NAMES, NAMES, max_size=3))
-def test_replaying_a_rename_never_loses_a_user(
-    names: list[str], renames: dict[str, str]
-) -> None:
-    """Applying a rename map again must not delete anyone.
-
-    Deliberately NOT stated as "changes nothing", which is false and was my
-    first attempt: a swap map is its own inverse, so replaying it legitimately
-    flips the two names back. A map is computed for one transition and is not
-    meaningful against its own result.
-
-    What must never happen is a user disappearing. Vacating a rename target
-    whether or not anything moved into it made a replayed map erase its own
-    result -- the user who had just been renamed was deleted outright, and the
-    following assign handed their slot to somebody else.
-    """
-    before = SlotAssignment.empty().assign(names)
-    assume(len({v.casefold() for v in renames.values()}) == len(renames))
-
-    once = before.with_renames(renames)
-    twice = once.with_renames(renames)
-
-    assert len(twice.slots) == len(once.slots)
-    assert set(twice.slots.values()) == set(once.slots.values())
-
-
-@given(
-    names=NAME_SETS,
-    start=st.integers(min_value=1, max_value=8),
-    unavailable=st.sets(st.integers(min_value=1, max_value=12), max_size=4),
-)
-def test_new_users_respect_the_start_slot_and_reserved_numbers(
-    names: list[str], start: int, unavailable: set[int]
-) -> None:
-    """A newly issued slot is never below the start, nor one that is spoken for.
-
-    The start slot is usually chosen because the numbers below it hold codes
-    programmed by hand that Lock Code Manager does not manage, and another
-    entry may own slots on the same lock. The slot IS the credential index on
-    most providers, so issuing one of those overwrites a real code on a real
-    door.
-    """
-    assignment = SlotAssignment.empty().assign(
-        names, start=start, unavailable=unavailable
-    )
-
-    for number in assignment.slots.values():
-        assert number >= start
-        assert number not in unavailable
-
-
-@given(names=NAME_SETS)
-def test_case_only_differences_are_the_same_user(names: list[str]) -> None:
-    """``Bob`` and ``BOB`` are one user, as ``names.deduplicate`` already says.
-
-    Two credential indices for one person otherwise, and a case-only rename
-    reading as a deletion plus an addition.
-    """
-    assignment = SlotAssignment.empty().assign(names)
-
-    for name in names:
-        assert assignment.slot(name.upper()) == assignment.slot(name.lower())
-    assert assignment.assign([name.upper() for name in names]) is assignment
-
-
-@given(names=NAME_SETS)
-def test_assignment_is_idempotent(names: list[str]) -> None:
-    """Assigning the same users twice changes nothing."""
-    once = SlotAssignment.empty().assign(names)
-
-    assert once.assign(names) is once
-
-
-@given(history=EDIT_HISTORIES)
+@given(history=EDIT_HISTORIES, start=START)
 def test_assignment_survives_a_round_trip_through_storage(
-    history: list[list[str]],
+    history: list[list[str]], start: int
 ) -> None:
     """What is persisted reloads identically.
 
@@ -436,7 +365,7 @@ def test_assignment_survives_a_round_trip_through_storage(
     """
     assignment = SlotAssignment.empty()
     for configured in history:
-        assignment = assignment.assign(configured)
+        assignment = assignment.reconcile(configured, start=start)
 
     restored = SlotAssignment.from_mapping(assignment.to_dict())
 

--- a/tests/properties/test_slot_assignment.py
+++ b/tests/properties/test_slot_assignment.py
@@ -86,7 +86,11 @@ def test_conversion_loses_no_user(slots: dict[int, dict]) -> None:
 
     assert len(users) == len(slots)
     assert set(users) == {slot[CONF_NAME] for slot in slots.values()}
-    assert set(assignment.slots) == set(users)
+    # Compared through slot(), not by key set: users are keyed by the name as
+    # displayed while the assignment keys by the identity form the rest of
+    # the system compares on (whitespace-normalized, casefolded).
+    assert len(assignment.slots) == len(users)
+    assert all(assignment.slot(name) is not None for name in users)
 
 
 @given(slots=slot_mappings())
@@ -324,6 +328,93 @@ def test_a_whitespace_variant_is_the_same_user(names: list[str], pad: str) -> No
     )
     for name in names:
         assert stored_padded.slot(name) == bare.slot(name)
+
+
+@given(names=NAME_SETS, renames=st.dictionaries(NAMES, NAMES, max_size=3))
+def test_renaming_never_removes_a_user(
+    names: list[str], renames: dict[str, str]
+) -> None:
+    """Nobody loses their slot to a rename they were not part of.
+
+    A rename map naming a source that holds nothing -- a stale replay, or a
+    name already renamed -- previously deleted whoever sat on the TARGET,
+    because the target was vacated whether or not anything moved into it. The
+    following ``assign`` then renumbered that bystander onto a different
+    credential index.
+    """
+    before = SlotAssignment.empty().assign(names)
+    assume(len({v.casefold() for v in renames.values()}) == len(renames))
+
+    after = before.with_renames(renames)
+
+    moved_from = {k.casefold() for k in renames if k.casefold() in before.slots}
+    for name in set(before.slots) - moved_from:
+        assert after.slot(name) == before.slot(name)
+
+
+@given(names=NAME_SETS, renames=st.dictionaries(NAMES, NAMES, max_size=3))
+def test_replaying_a_rename_never_loses_a_user(
+    names: list[str], renames: dict[str, str]
+) -> None:
+    """Applying a rename map again must not delete anyone.
+
+    Deliberately NOT stated as "changes nothing", which is false and was my
+    first attempt: a swap map is its own inverse, so replaying it legitimately
+    flips the two names back. A map is computed for one transition and is not
+    meaningful against its own result.
+
+    What must never happen is a user disappearing. Vacating a rename target
+    whether or not anything moved into it made a replayed map erase its own
+    result -- the user who had just been renamed was deleted outright, and the
+    following assign handed their slot to somebody else.
+    """
+    before = SlotAssignment.empty().assign(names)
+    assume(len({v.casefold() for v in renames.values()}) == len(renames))
+
+    once = before.with_renames(renames)
+    twice = once.with_renames(renames)
+
+    assert len(twice.slots) == len(once.slots)
+    assert set(twice.slots.values()) == set(once.slots.values())
+
+
+@given(
+    names=NAME_SETS,
+    start=st.integers(min_value=1, max_value=8),
+    unavailable=st.sets(st.integers(min_value=1, max_value=12), max_size=4),
+)
+def test_new_users_respect_the_start_slot_and_reserved_numbers(
+    names: list[str], start: int, unavailable: set[int]
+) -> None:
+    """A newly issued slot is never below the start, nor one that is spoken for.
+
+    The start slot is usually chosen because the numbers below it hold codes
+    programmed by hand that Lock Code Manager does not manage, and another
+    entry may own slots on the same lock. The slot IS the credential index on
+    most providers, so issuing one of those overwrites a real code on a real
+    door.
+    """
+    assignment = SlotAssignment.empty().assign(
+        names, start=start, unavailable=unavailable
+    )
+
+    for number in assignment.slots.values():
+        assert number >= start
+        assert number not in unavailable
+
+
+@given(names=NAME_SETS)
+def test_case_only_differences_are_the_same_user(names: list[str]) -> None:
+    """``Bob`` and ``BOB`` are one user, as ``names.deduplicate`` already says.
+
+    Two credential indices for one person otherwise, and a case-only rename
+    reading as a deletion plus an addition.
+    """
+    assignment = SlotAssignment.empty().assign(names)
+
+    for name in names:
+        assert assignment.slot(name.upper()) == assignment.slot(name.lower())
+    assert assignment.assign([name.upper() for name in names]) is assignment
 
 
 @given(names=NAME_SETS)

--- a/tests/properties/test_slot_assignment.py
+++ b/tests/properties/test_slot_assignment.py
@@ -1,0 +1,188 @@
+"""
+Property-based tests for the slot-to-user configuration shape.
+
+The version 3 release is one change: ``slots: {1: {name: Raman, pin: ...}}``
+becomes ``users: {Raman: {pin: ...}}``, with the slot number demoted to
+internal bookkeeping. Two things can go wrong, and both are invariants over
+the whole configuration rather than any single slot:
+
+* **something is lost** -- a field, or a whole user, disappears in the
+  conversion, which is silent because the result is still valid;
+* **somebody is renumbered** -- a user's slot changes, which moves their
+  credential to a different index on every lock and orphans their entities.
+
+Neither is a property of one call. Both are stated here over generated
+configurations and edit histories.
+"""
+
+from __future__ import annotations
+
+from hypothesis import given, strategies as st
+
+from homeassistant.const import CONF_ENABLED, CONF_NAME, CONF_PIN
+
+from custom_components.lock_code_manager.domain.slot_assignment import (
+    SlotAssignment,
+    users_from_slots,
+)
+
+NAMES = st.sampled_from(["Raman", "Alice", "Bob", "Cleaner", "Guest 1"])
+NAME_SETS = st.lists(NAMES, max_size=5).map(lambda ns: list(dict.fromkeys(ns)))
+EDIT_HISTORIES = st.lists(NAME_SETS, min_size=1, max_size=8)
+
+SLOT_CONFIGS = st.builds(
+    lambda name, pin, enabled: {
+        CONF_NAME: name,
+        CONF_PIN: pin,
+        CONF_ENABLED: enabled,
+    },
+    NAMES,
+    st.text(alphabet="0123456789", min_size=4, max_size=6),
+    st.booleans(),
+)
+
+
+@st.composite
+def slot_mappings(draw: st.DrawFn) -> dict[int, dict]:
+    """Slot-keyed configurations whose names are unique, as B1 guarantees."""
+    configs = draw(st.lists(SLOT_CONFIGS, max_size=5))
+    seen: set[str] = set()
+    unique = [
+        c for c in configs if not (c[CONF_NAME] in seen or seen.add(c[CONF_NAME]))
+    ]
+    starts = draw(st.integers(min_value=1, max_value=4))
+    return {starts + i: config for i, config in enumerate(unique)}
+
+
+@given(slots=slot_mappings())
+def test_conversion_loses_no_user(slots: dict[int, dict]) -> None:
+    """Every configured slot becomes exactly one user."""
+    users, assignment = users_from_slots(slots)
+
+    assert len(users) == len(slots)
+    assert set(users) == {slot[CONF_NAME] for slot in slots.values()}
+    assert set(assignment.slots) == set(users)
+
+
+@given(slots=slot_mappings())
+def test_conversion_loses_no_field(slots: dict[int, dict]) -> None:
+    """Every field except the name survives, unchanged.
+
+    The name stops being a field because it becomes the key. Anything else
+    going missing is silent data loss -- the result still validates, the user
+    just quietly has no code.
+    """
+    users, _ = users_from_slots(slots)
+
+    for slot in slots.values():
+        user = users[slot[CONF_NAME]]
+        assert user == {k: v for k, v in slot.items() if k != CONF_NAME}
+
+
+@given(slots=slot_mappings())
+def test_conversion_renumbers_nobody(slots: dict[int, dict]) -> None:
+    """Each user keeps the slot number they already occupied.
+
+    This is what makes the migration free: the slot is what identifiers key
+    on and what addresses the credential on the lock, so a user whose number
+    changed would have their entities orphaned AND their code written to a
+    different index.
+    """
+    _, assignment = users_from_slots(slots)
+
+    for slot_num, slot in slots.items():
+        assert assignment.slot(slot[CONF_NAME]) == slot_num
+
+
+@given(slots=slot_mappings())
+def test_conversion_round_trips(slots: dict[int, dict]) -> None:
+    """The original slot-keyed configuration can be reconstructed exactly.
+
+    A stronger statement than the two above together: it rules out any
+    reshaping that happens to preserve counts and fields separately while
+    still pairing them up wrongly.
+    """
+    users, assignment = users_from_slots(slots)
+
+    rebuilt = {
+        assignment.slot(name): {CONF_NAME: name, **user} for name, user in users.items()
+    }
+    assert rebuilt == slots
+
+
+@given(history=EDIT_HISTORIES)
+def test_a_surviving_user_is_never_renumbered(history: list[list[str]]) -> None:
+    """Adding or removing users must not move anyone else.
+
+    Renumbering a bystander rewrites their credential to a different index on
+    every lock. This is the invariant that a naive "renumber from one on every
+    edit" implementation violates, and it needs a sequence to expose.
+    """
+    assignment = SlotAssignment.empty()
+    for configured in history:
+        after = assignment.assign(configured)
+        for name in set(assignment.slots) & set(configured):
+            assert after.slot(name) == assignment.slot(name)
+        assignment = after
+
+
+@given(history=EDIT_HISTORIES)
+def test_two_users_never_share_a_slot(history: list[list[str]]) -> None:
+    """A slot addresses one credential, so two users in it would overwrite each other."""
+    assignment = SlotAssignment.empty()
+    for configured in history:
+        assignment = assignment.assign(configured)
+        numbers = list(assignment.slots.values())
+        assert len(numbers) == len(set(numbers))
+
+
+@given(history=EDIT_HISTORIES)
+def test_slots_never_exceed_the_most_users_ever_configured_at_once(
+    history: list[list[str]],
+) -> None:
+    """Numbers stay inside the high-water mark of CONCURRENT users.
+
+    Not the current count -- a survivor keeps their number when someone below
+    them leaves, which is required and is the property above. The bound that
+    does hold is the most users ever configured simultaneously, and it is the
+    one that matters: capacity is sized against how many users exist at once,
+    and on most providers the slot IS the lock's credential index, where a
+    number above the advertised count can never be written.
+
+    A never-reused number satisfies neither bound: it climbs with every user
+    ever created and eventually leaves the lock's range entirely. Reuse is
+    what keeps the numbering inside capacity, which is why the slot number is
+    the right thing to key on and a monotonic handle is not.
+    """
+    assignment = SlotAssignment.empty()
+    high_water = 0
+    for configured in history:
+        assignment = assignment.assign(configured)
+        high_water = max(high_water, len(configured))
+        assert all(1 <= s <= high_water for s in assignment.slots.values())
+
+
+@given(names=NAME_SETS)
+def test_assignment_is_idempotent(names: list[str]) -> None:
+    """Assigning the same users twice changes nothing."""
+    once = SlotAssignment.empty().assign(names)
+
+    assert once.assign(names) is once
+
+
+@given(history=EDIT_HISTORIES)
+def test_assignment_survives_a_round_trip_through_storage(
+    history: list[list[str]],
+) -> None:
+    """What is persisted reloads identically.
+
+    The assignment shares the entry with the configuration; a write that
+    dropped it would renumber every user on the next start.
+    """
+    assignment = SlotAssignment.empty()
+    for configured in history:
+        assignment = assignment.assign(configured)
+
+    restored = SlotAssignment.from_mapping(assignment.to_dict())
+
+    assert dict(restored.slots) == dict(assignment.slots)


### PR DESCRIPTION
## Proposed change

Adds the data model for the version 3 configuration shape change:

```yaml
slots:                      users:
  1:                 ->       Raman:
    name: Raman                 pin: "1234"
    pin: "1234"
```

The slot number is **demoted to internal bookkeeping, not removed**. On most providers it *is* the lock's credential index (`credential_index_follows_slot`), so it stays bounded by the lock's advertised capacity and stays reusable — deleting a user frees their number for the next one, exactly as today, because the physical credential slot genuinely is being reused.

Entity and device identifiers keep keying on that number. So the migration performs **zero registry writes**, and a rename moves nothing in either registry — it re-keys two dictionaries.

This PR adds only the pure data model and its properties. Nothing consumes it yet, so there is no behaviour change. The migration, the config flow, and the entity topology follow.

### Why this shape

This supersedes #1422, which keyed identifiers on the user's *name* and therefore had to move registry rows on every rename, resolving cycles and collisions atomically. That took 1,158 lines and produced a high-severity finding in four of eleven review rounds. The cause was an inversion: the **mutable** value (the name) sat in the **immutable** position (the identifier), while the **immutable** value (the slot number) sat in the **mutable** position (the display name).

An intermediate design using a monotonically increasing, never-reused handle was also tried and rejected. A number that is never reused climbs with every user ever created and eventually leaves the lock's credential range. Reuse is the requirement here, not a compromise — `test_slots_never_exceed_the_most_users_ever_configured_at_once` states that as a property, and it is exactly the one a monotonic handle cannot satisfy.

> **Correction (review round 5):** that property was lost in a later rewrite and this description went on citing it. It has been restored. Treat the claim as true only from `581b5d4c` onward.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

Targets the long-lived `v3` branch, not `main`.

The properties are stated over whole configurations and edit *histories*, because both failure modes need a sequence to expose rather than a single call:

- **something is lost** — a field or a user disappears in the conversion, silently, because the result is still valid;
- **somebody is renumbered** — a user's slot changes, moving their credential to a different index on every lock and orphaning their entities.

All nine were verified against mutations: renumbering everyone on each edit falsifies the never-renumber property, and dropping a field falsifies both the field and round-trip properties.

One property was wrong when first written, and is recorded in the commit message rather than quietly fixed: bounding slots by the *current* user count contradicts keeping a survivor's number when someone below them leaves. Hypothesis produced `[['Raman', 'Alice'], ['Alice']]` immediately. The bound that holds is the most users ever configured at once, which is also what capacity is sized against.

Full suite: 1545 passed, 100% coverage.

