### PR TITLE
feat: allow "|" in user names again

### DIFF
--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -507,8 +507,8 @@ class LockCodeManagerFlowHandler(
                 errors[CONF_PIN] = "missing_pin_if_enabled"
 
             # The name is on its way to becoming the identity Lock Code
-            # Manager keys on, so it must be present, separator-free, and
-            # unique within the entry.
+            # Manager keys on, so it must be present and unique within the
+            # entry.
             if error := name_error(user_input.get(CONF_NAME)):
                 errors[CONF_NAME] = error
             else:

--- a/custom_components/lock_code_manager/domain/names.py
+++ b/custom_components/lock_code_manager/domain/names.py
@@ -2,11 +2,16 @@
 User-name rules for Lock Code Manager slots.
 
 A slot's name is on its way to becoming the identity Lock Code Manager keys
-on -- the config entry will store a set of named users rather than a mapping
-of slot numbers, and lock users will be tagged ``lcm:{name}``. That only
-works if every name is present, unique within its entry, and encodable.
+on -- the config entry will store a mapping of named users rather than one of
+slot numbers, and lock users will be tagged ``lcm:{name}``. That only works if
+every name is present and unique within its entry.
 
-This module is the single place those three rules live, so the config flow
+Encodability used to be a third rule: a name could not contain ``|``, because
+entity and device identifiers were delimited by it and keyed by the name. They
+are keyed by the slot number, so nothing parses a name any more and the
+restriction had no reason left to exist.
+
+This module is the single place those rules live, so the config flow
 (validating new input) and the migration (repairing existing data) cannot
 drift from each other.
 """
@@ -17,15 +22,6 @@ from collections.abc import Iterable, Mapping
 from typing import Any
 
 from homeassistant.const import CONF_NAME
-
-# Reserved because it delimits the identifiers Lock Code Manager builds from
-# entry-scoped parts: today the entity unique identifier
-# (``{entry_id}|{slot_num}|{key}``) and the device identifier
-# (``{entry_id}|{slot_num}``), and the name takes the slot number's place in
-# both once the configuration is keyed by user. A name containing it would
-# split into the wrong fields on the way back out -- see
-# ``parse_slot_device_identifier``.
-NAME_SEPARATOR = "|"
 
 
 def normalize_name(name: str | None) -> str:
@@ -49,8 +45,6 @@ def name_error(name: str | None) -> str | None:
     """
     if not normalize_name(name):
         return "name_required"
-    if NAME_SEPARATOR in name:  # type: ignore[operator]
-        return "name_has_separator"
     return None
 
 
@@ -128,9 +122,7 @@ def normalize_slot_names(
         if slot_num not in needs_repair:
             name = normalize_name(original)
         else:
-            name = normalize_name(
-                (original or "").replace(NAME_SEPARATOR, " ")
-            ) or fallback_name(int(slot_num))
+            name = normalize_name(original) or fallback_name(int(slot_num))
             name = deduplicate(name, taken)
             taken.append(name)
 

--- a/custom_components/lock_code_manager/strings.json
+++ b/custom_components/lock_code_manager/strings.json
@@ -10,7 +10,6 @@
       "excluded_platform": "Entities from the `{integration}` integration are not supported as condition entities. See the [wiki]({docs_url}) for details.",
       "invalid_config": "Slots configuration is invalid. For more information, check the logs and the docs.",
       "missing_pin_if_enabled": "PIN must be set if slot is enabled.",
-      "name_has_separator": "The name for code slot {slot_num} cannot contain the “|” character.",
       "name_not_unique": "The name for code slot {slot_num} is already used by another code slot in this entry. Names must be unique.",
       "name_required": "Code slot {slot_num} needs a name. The name identifies this user on your locks.",
       "slot_out_of_range": "Lock {lock} reports only {num_slots} PIN code slots, so these slot numbers are out of range for it: {out_of_range_slots}. Renumber them to fall within 1-{num_slots}, or manage that lock from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity.",
@@ -132,7 +131,6 @@
     "error": {
       "invalid_config": "Slots configuration is invalid. For more information, check the logs and the docs.",
       "locks_already_configured": "The following lock(s) are already managed by another config entry: {locks}.",
-      "name_has_separator": "The name for code slot {slot_num} cannot contain the “|” character.",
       "name_not_unique": "The name for code slot {slot_num} is already used by another code slot in this entry. Names must be unique.",
       "name_required": "Code slot {slot_num} needs a name. The name identifies this user on your locks.",
       "slot_out_of_range": "Lock {lock} reports only {num_slots} PIN code slots, so these slot numbers are out of range for it: {out_of_range_slots}. Renumber them to fall within 1-{num_slots}, or manage that lock from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity.",
@@ -238,9 +236,6 @@
     }
   },
   "exceptions": {
-    "name_has_separator": {
-      "message": "The name for code slot {slot_num} cannot contain the “|” character."
-    },
     "name_not_unique": {
       "message": "Code slot {conflicting_slot} already uses that name. Names must be unique within a Lock Code Manager entry."
     },

--- a/custom_components/lock_code_manager/translations/en.json
+++ b/custom_components/lock_code_manager/translations/en.json
@@ -10,7 +10,6 @@
       "excluded_platform": "Entities from the `{integration}` integration are not supported as condition entities. See the [wiki]({docs_url}) for details.",
       "invalid_config": "Slots configuration is invalid. For more information, check the logs and the docs.",
       "missing_pin_if_enabled": "PIN must be set if slot is enabled.",
-      "name_has_separator": "The name for code slot {slot_num} cannot contain the “|” character.",
       "name_not_unique": "The name for code slot {slot_num} is already used by another code slot in this entry. Names must be unique.",
       "name_required": "Code slot {slot_num} needs a name. The name identifies this user on your locks.",
       "slot_out_of_range": "Lock {lock} reports only {num_slots} PIN code slots, so these slot numbers are out of range for it: {out_of_range_slots}. Renumber them to fall within 1-{num_slots}, or manage that lock from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity.",
@@ -132,7 +131,6 @@
     "error": {
       "invalid_config": "Slots configuration is invalid. For more information, check the logs and the docs.",
       "locks_already_configured": "The following lock(s) are already managed by another config entry: {locks}.",
-      "name_has_separator": "The name for code slot {slot_num} cannot contain the “|” character.",
       "name_not_unique": "The name for code slot {slot_num} is already used by another code slot in this entry. Names must be unique.",
       "name_required": "Code slot {slot_num} needs a name. The name identifies this user on your locks.",
       "slot_out_of_range": "Lock {lock} reports only {num_slots} PIN code slots, so these slot numbers are out of range for it: {out_of_range_slots}. Renumber them to fall within 1-{num_slots}, or manage that lock from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity.",
@@ -238,9 +236,6 @@
     }
   },
   "exceptions": {
-    "name_has_separator": {
-      "message": "The name for code slot {slot_num} cannot contain the “|” character."
-    },
     "name_not_unique": {
       "message": "Code slot {conflicting_slot} already uses that name. Names must be unique within a Lock Code Manager entry."
     },

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1347,8 +1347,13 @@ async def test_config_flow_capacity_check_survives_unexpected_error(
     assert "provider blew up" in caplog.text
 
 
-async def test_config_flow_ui_rejects_name_with_separator(hass: HomeAssistant):
-    """A name containing the identifier separator is rejected up front."""
+async def test_config_flow_ui_accepts_a_name_containing_a_pipe(hass: HomeAssistant):
+    """A "|" in a name is ordinary text now, not a rejected character.
+
+    It was rejected only while entity and device identifiers were keyed by the
+    name and delimited by "|". They are keyed by the slot number, so nothing
+    parses a name any more and the restriction had no reason left.
+    """
     flow_id = await _start_ui_config_flow(hass)
 
     result = await hass.config_entries.flow.async_configure(
@@ -1356,7 +1361,23 @@ async def test_config_flow_ui_rejects_name_with_separator(hass: HomeAssistant):
     )
 
     assert result["type"] == "form"
-    assert result["errors"] == {CONF_NAME: "name_has_separator"}
+    assert not result["errors"]
+
+
+async def test_config_flow_ui_rejects_a_missing_name(hass: HomeAssistant):
+    """A slot must be named, because the name is becoming the identity.
+
+    Now the ONLY rule left in this branch: the separator rule that used to
+    share it is gone, and removing it left the error path with no test at all.
+    """
+    flow_id = await _start_ui_config_flow(hass)
+
+    result = await hass.config_entries.flow.async_configure(
+        flow_id, {CONF_NAME: "   ", CONF_ENABLED: True, CONF_PIN: "1234"}
+    )
+
+    assert result["type"] == "form"
+    assert result["errors"] == {CONF_NAME: "name_required"}
 
 
 async def test_config_flow_ui_rejects_duplicate_name(hass: HomeAssistant):
@@ -1380,12 +1401,6 @@ async def test_config_flow_ui_rejects_duplicate_name(hass: HomeAssistant):
 @pytest.mark.parametrize(
     ("slots", "expected_error"),
     [
-        (
-            {
-                1: {CONF_NAME: "Ra|man", CONF_ENABLED: True, CONF_PIN: "1234"},
-            },
-            "name_has_separator",
-        ),
         (
             {
                 1: {CONF_NAME: "Raman", CONF_ENABLED: True, CONF_PIN: "1234"},

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1890,7 +1890,7 @@ async def test_pairs_removed_skips_untracked_lock_and_logs_release_failure(
 
 
 async def test_migration_v3_to_v4_names_every_slot(hass: HomeAssistant) -> None:
-    """v4 gives every slot a present, separator-free, entry-unique name.
+    """v4 gives every slot a present, entry-unique name.
 
     The name is becoming the identity Lock Code Manager keys on, so these
     three properties stop being cosmetic. A name the user already chose is
@@ -1921,6 +1921,6 @@ async def test_migration_v3_to_v4_names_every_slot(hass: HomeAssistant) -> None:
     assert slots[1][CONF_NAME] == "User 1"  # was unnamed
     assert slots[2][CONF_NAME] == "Raman"  # user's choice, untouched
     assert slots[3][CONF_NAME] == "Raman 2"  # collided with slot 2
-    assert slots[4][CONF_NAME] == "Ra man"  # separator stripped
+    assert slots[4][CONF_NAME] == "Ra|man"  # "|" is ordinary text now
     # Every other field survives.
     assert slots[1][CONF_PIN] == "1234"

--- a/tests/test_names.py
+++ b/tests/test_names.py
@@ -21,12 +21,15 @@ from custom_components.lock_code_manager.domain.names import (
         (None, "name_required"),
         ("", "name_required"),
         ("   ", "name_required"),
-        ("Ra|man", "name_has_separator"),
-        ("|", "name_has_separator"),
+        # The separator rule is gone. It existed only while identifiers were
+        # keyed by name and delimited by "|"; they are keyed by slot number,
+        # so a name carrying one splits nothing.
+        ("Ra|man", None),
+        ("|", None),
     ],
 )
 def test_name_error(name: str | None, expected: str | None) -> None:
-    """A name must be present and free of the identifier separator."""
+    """A name only has to be present."""
     assert name_error(name) == expected
 
 
@@ -84,17 +87,22 @@ def test_normalize_names_unnamed_slots() -> None:
     assert sorted(changed) == ["1", "2"]
 
 
-def test_normalize_strips_the_separator() -> None:
-    """The separator is replaced rather than the name rejected."""
+def test_normalize_leaves_a_separator_alone() -> None:
+    """A "|" in a name is now ordinary text and must survive untouched.
+
+    The repair used to rewrite it to a space, which renamed the user on every
+    lock that stores names. That was only ever needed because identifiers were
+    delimited by "|" and keyed by the name; they are keyed by the slot number.
+    """
     repaired, changed = normalize_slot_names({1: {CONF_NAME: "Ra|man"}})
 
-    assert repaired[1][CONF_NAME] == "Ra man"
-    assert changed == ["1"]
+    assert repaired[1][CONF_NAME] == "Ra|man"
+    assert changed == []
 
 
-def test_normalize_falls_back_when_a_name_is_only_separators() -> None:
-    """A name that collapses to empty after stripping falls back."""
-    repaired, changed = normalize_slot_names({4: {CONF_NAME: "||"}})
+def test_normalize_falls_back_only_for_an_empty_name() -> None:
+    """A name that is empty or whitespace still falls back."""
+    repaired, changed = normalize_slot_names({4: {CONF_NAME: "   "}})
 
     assert repaired[4][CONF_NAME] == "User 4"
     assert changed == ["4"]
@@ -147,7 +155,6 @@ def test_normalize_accepts_string_slot_keys() -> None:
         ({1: {CONF_NAME: "Raman"}, 2: {CONF_NAME: "Alice"}}, None),
         ({1: {CONF_ENABLED: True}}, ("1", "name_required")),
         ({1: {CONF_NAME: "  "}}, ("1", "name_required")),
-        ({1: {CONF_NAME: "Ra|man"}}, ("1", "name_has_separator")),
         ({1: {CONF_NAME: "Raman"}, 2: {CONF_NAME: "raman"}}, ("2", "name_not_unique")),
         # Whitespace-padded duplicates must be caught in BOTH orders. Comparing
         # a stripped candidate against unstripped stored names caught only one.

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -124,7 +124,6 @@ async def test_whitespace_pin_normalized_to_empty(
     [
         ("", "name_required"),
         ("   ", "name_required"),
-        ("Ra|man", "name_has_separator"),
     ],
 )
 async def test_set_name_rejects_invalid_names(


### PR DESCRIPTION
## Proposed change

Removes the rule that rejected `|` in a user's name.

It existed for exactly one reason: entity and device identifiers are delimited by `|`, and under the design in the now-closed #1422 they were also **keyed by the user's name**, so a name carrying a `|` would have split into the wrong fields coming back out.

Identifiers are keyed by the **slot number**. Nothing parses a name any more, so the restriction has no reason left — keeping it would mean shipping a rejection users cannot be given an explanation for.

Removed:
- the `NAME_SEPARATOR` constant and the `name_has_separator` error
- both translation entries
- **the repair pass that rewrote `|` to a space** — the one that actually mattered, because it was a silent rename of the user on every lock that stores names, for a character that was never a problem

`v3` is unreleased, so this ships as part of it rather than as a change to behaviour anyone has seen.

### What remains, and why

**Present** and **unique within the entry** both keep their justification: the name becomes the mapping key in v3, so an absent name has nothing to key on and a duplicate cannot be represented at all.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

Targets the long-lived `v3` branch, not `main`.

Tests are **inverted rather than deleted**, so the removal is pinned rather than merely unobserved: a `|` name is now accepted by the config flow, survives the migration untouched, and passes `name_error`.

Removing the rule also left the config flow's validation-error branch with no test at all — `name_required` was only ever reached through the separator case — so that gained one.

Full suite: 1576 passed.
