### PR TITLE
feat: key the configuration and the internal model by user

### DIFF
--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -91,7 +91,6 @@ from .domain.models import (
     LockCodeManagerConfigEntry,
     LockCodeManagerConfigEntryRuntimeData,
 )
-from .domain.names import normalize_slot_names
 from .domain.pin_generator import (
     DEFAULT_PIN_LENGTH,
     MAX_PIN_LENGTH,
@@ -106,6 +105,7 @@ from .domain.services import (
     async_set_usercode,
 )
 from .domain.slot_coordinator import SlotEntityCoordinator
+from .domain.user_migration import migrate_to_users
 from .domain.util import (
     PER_LOCK_ISSUE_KEYS,
     build_pin_deobfuscation_map,
@@ -209,18 +209,22 @@ async def async_migrate_entry(
             )
 
     if config_entry.version == 3:
-        # Give every slot a present, separator-free, entry-unique name. The
-        # name is becoming the identity Lock Code Manager keys on, so these
-        # three properties stop being cosmetic and start being load-bearing.
-        new_data = {**config_entry.data}
-        new_options = {**config_entry.options}
-        renamed: set[str] = set()
-        for data_dict in (new_data, new_options):
-            if CONF_SLOTS not in data_dict:
-                continue
-            repaired, changed = normalize_slot_names(data_dict[CONF_SLOTS])
-            data_dict[CONF_SLOTS] = repaired
-            renamed.update(changed)
+        # Two halves of ONE version bump, because they ship as one release and
+        # no released schema ever sat between them.
+        #
+        # First: give every slot a present, entry-unique name. The name is
+        # becoming the key the configuration is stored under, so an absent one
+        # has nothing to key on and a duplicate cannot be represented at all.
+        #
+        # Then: reshape from slots to users, demoting the slot number to
+        # internal bookkeeping.
+        #
+        # NO REGISTRY WRITES happen anywhere in here. Entity and device
+        # identifiers keep the slot number, so there is nothing to move --
+        # which is what makes a migration with no rollback safe to ship.
+        new_data, renamed_in_data = migrate_to_users(config_entry.data)
+        new_options, renamed_in_options = migrate_to_users(config_entry.options)
+        renamed = set(renamed_in_data) | set(renamed_in_options)
         hass.config_entries.async_update_entry(
             config_entry, data=new_data, options=new_options, version=4
         )

--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -567,15 +567,17 @@ def _setup_entry_after_start(
         # Move data into options so the update listener can work.
         #
         # Resolved through EntryConfig rather than by merging the two raw
-        # dicts. A non-empty options here holds an options-flow save the entry
-        # could not process while it was failed, and the two sides may be in
-        # different shapes; merging them raw yields a mapping carrying both,
-        # and reading a mix of shapes discards whichever loses. EntryConfig
-        # picks one side whole and emits one shape.
+        # dicts: the sides may be in different shapes, and reading a mix
+        # discards whichever loses. EntryConfig picks one side whole.
+        #
+        # Built from the entry, NOT from the cached view: the cache is only
+        # refreshed by the update listener, which has not run yet, so a
+        # service call during startup would be overwritten by a stale
+        # snapshot.
         hass.config_entries.async_update_entry(
             config_entry,
             data={},
-            options=get_entry_config(config_entry).to_dict(),
+            options=EntryConfig.from_entry(config_entry).to_dict(),
         )
     else:
         hass.async_create_task(

--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -209,19 +209,12 @@ async def async_migrate_entry(
             )
 
     if config_entry.version == 3:
-        # Two halves of ONE version bump, because they ship as one release and
-        # no released schema ever sat between them.
+        # Two halves of one version bump: name every slot, then key the
+        # configuration by that name and demote the slot number to internal
+        # bookkeeping.
         #
-        # First: give every slot a present, entry-unique name. The name is
-        # becoming the key the configuration is stored under, so an absent one
-        # has nothing to key on and a duplicate cannot be represented at all.
-        #
-        # Then: reshape from slots to users, demoting the slot number to
-        # internal bookkeeping.
-        #
-        # NO REGISTRY WRITES happen anywhere in here. Entity and device
-        # identifiers keep the slot number, so there is nothing to move --
-        # which is what makes a migration with no rollback safe to ship.
+        # No registry writes happen here. Entity and device identifiers keep
+        # the slot number, so there is nothing to move.
         new_data, renamed_in_data = migrate_to_users(config_entry.data)
         new_options, renamed_in_options = migrate_to_users(config_entry.options)
         renamed = set(renamed_in_data) | set(renamed_in_options)
@@ -571,16 +564,18 @@ def _setup_entry_after_start(
         config_entry.async_on_unload(_clear_listener_registered)
 
     if config_entry.data:
-        # Move data from data to options so update listener can work.
-        # Merge options-preferred (matching EntryConfig.from_entry): a
-        # non-empty options here holds an options-flow save the entry
-        # could not process (no listener was registered while it was
-        # failed) — overwriting it with data would silently discard the
-        # user's fix.
+        # Move data into options so the update listener can work.
+        #
+        # Resolved through EntryConfig rather than by merging the two raw
+        # dicts. A non-empty options here holds an options-flow save the entry
+        # could not process while it was failed, and the two sides may be in
+        # different shapes; merging them raw yields a mapping carrying both,
+        # and reading a mix of shapes discards whichever loses. EntryConfig
+        # picks one side whole and emits one shape.
         hass.config_entries.async_update_entry(
             config_entry,
             data={},
-            options={**config_entry.data, **config_entry.options},
+            options=get_entry_config(config_entry).to_dict(),
         )
     else:
         hass.async_create_task(

--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -732,10 +732,17 @@ class LockCodeManagerOptionsFlow(_ExistingCodesFlowMixin, config_entries.Options
                 return await self._maybe_confirm_then_persist(user_input)
 
         # Use to_dict() rather than .locks / .slots directly — to_dict
-        # returns plain mutable dict/list, while EntryConfig.slots is a
-        # deeply read-only MappingProxyType which the form selectors
-        # can't JSON-serialize.
-        defaults = get_entry_config(self.config_entry).to_dict()
+        # Plain dict/list, because the form selectors cannot serialize the
+        # deeply read-only mappings EntryConfig uses internally.
+        #
+        # Seeded from the SLOT-shaped view, because this editor still takes
+        # slot-shaped YAML. That is the next thing to change, and when it does
+        # this becomes `config.users` and the projection disappears with it.
+        config = get_entry_config(self.config_entry)
+        defaults = {
+            CONF_LOCKS: list(config.locks),
+            CONF_SLOTS: {num: dict(slot) for num, slot in config.slots.items()},
+        }
 
         return self.async_show_form(
             step_id="init",

--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -731,7 +731,6 @@ class LockCodeManagerOptionsFlow(_ExistingCodesFlowMixin, config_entries.Options
                 user_input[CONF_SLOTS] = parsed_slots
                 return await self._maybe_confirm_then_persist(user_input)
 
-        # Use to_dict() rather than .locks / .slots directly — to_dict
         # Plain dict/list, because the form selectors cannot serialize the
         # deeply read-only mappings EntryConfig uses internally.
         #

--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable, Iterable
+from collections.abc import Awaitable, Callable, Iterable, Mapping
 from functools import partial
 import logging
 from typing import Any
@@ -408,9 +408,6 @@ class LockCodeManagerFlowHandler(
         self.dev_reg: dr.DeviceRegistry = None
         self.slots_to_configure: list[int] = []
         self._init_existing_codes_state()
-        # See async_step_reauth: the entry's own data arrives as user_input,
-        # so only the flow's own history distinguishes a real submission.
-        self._form_shown = False
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -601,21 +598,26 @@ class LockCodeManagerFlowHandler(
             last_step=True,
         )
 
-    async def async_step_reauth(self, user_input: dict[str, Any] | None = None):
+    async def async_step_reauth(self, entry_data: Mapping[str, Any] | None = None):
         """
-        Handle reauth flow step.
+        Entry point for reauth. Home Assistant passes the ENTRY'S OWN DATA here.
 
-        ``async_start_reauth`` hands the ENTRY'S OWN DATA to this step as
-        ``user_input``, so "did the user submit the form?" cannot be answered
-        by inspecting it. It used to be answered by testing for the presence
-        of a configuration key, which stopped working the moment that key
-        left the entry: every initial invocation then read as a submission,
-        so the step updated the entry, reloaded it, and aborted -- and since
-        the reload fails setup again, that is an unbounded loop rather than a
-        wrong screen.
+        Delegated immediately, and the argument ignored, so the confirm step
+        can read ``user_input is None`` as "render the form" without having to
+        guess whether its caller was Home Assistant or the user. Answering
+        that by inspecting the payload -- testing for a configuration key --
+        turned into an unbounded setup loop the moment that key left the
+        entry, because a mistaken "the user submitted" updates the entry and
+        reloads it, and the reload fails setup again.
+        """
+        return await self.async_step_reauth_confirm()
 
-        ``_form_shown`` answers it directly instead. A flow instance shows
-        the form before it can receive one back.
+    async def async_step_reauth_confirm(self, user_input: dict[str, Any] | None = None):
+        """
+        Handle the reauth form.
+
+        Reached only through :meth:`async_step_reauth`, so ``user_input is
+        None`` unambiguously means "render the form".
         """
         config_entry = self.hass.config_entries.async_get_entry(
             self.context["entry_id"]
@@ -673,9 +675,8 @@ class LockCodeManagerFlowHandler(
                 )
                 return self.async_abort(reason="locks_updated")
 
-        self._form_shown = True
         return self.async_show_form(
-            step_id="reauth",
+            step_id="reauth_confirm",
             data_schema=vol.Schema(
                 {
                     vol.Required(

--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -408,6 +408,9 @@ class LockCodeManagerFlowHandler(
         self.dev_reg: dr.DeviceRegistry = None
         self.slots_to_configure: list[int] = []
         self._init_existing_codes_state()
+        # See async_step_reauth: the entry's own data arrives as user_input,
+        # so only the flow's own history distinguishes a real submission.
+        self._form_shown = False
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -599,7 +602,21 @@ class LockCodeManagerFlowHandler(
         )
 
     async def async_step_reauth(self, user_input: dict[str, Any] | None = None):
-        """Handle reauth flow step."""
+        """
+        Handle reauth flow step.
+
+        ``async_start_reauth`` hands the ENTRY'S OWN DATA to this step as
+        ``user_input``, so "did the user submit the form?" cannot be answered
+        by inspecting it. It used to be answered by testing for the presence
+        of a configuration key, which stopped working the moment that key
+        left the entry: every initial invocation then read as a submission,
+        so the step updated the entry, reloaded it, and aborted -- and since
+        the reload fails setup again, that is an unbounded loop rather than a
+        wrong screen.
+
+        ``_form_shown`` answers it directly instead. A flow instance shows
+        the form before it can receive one back.
+        """
         config_entry = self.hass.config_entries.async_get_entry(
             self.context["entry_id"]
         )
@@ -611,10 +628,11 @@ class LockCodeManagerFlowHandler(
         }
 
         if user_input is None:
-            # The frontend re-invokes the step with no input to render the
-            # form; seed the lock selector from the entry's current config.
+            # Either the frontend re-invoking the step to render the form, or
+            # the initial call carrying the entry's data. Seed the lock
+            # selector from the entry's current config either way.
             user_input = {CONF_LOCKS: list(get_entry_config(config_entry).locks)}
-        elif CONF_SLOTS not in user_input:
+        else:
             existing_slots = get_entry_config(config_entry).slots.keys()
             additional_errors, additional_placeholders = _check_common_slots(
                 self.hass,
@@ -655,6 +673,7 @@ class LockCodeManagerFlowHandler(
                 )
                 return self.async_abort(reason="locks_updated")
 
+        self._form_shown = True
         return self.async_show_form(
             step_id="reauth",
             data_schema=vol.Schema(

--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -603,12 +603,9 @@ class LockCodeManagerFlowHandler(
         Entry point for reauth. Home Assistant passes the ENTRY'S OWN DATA here.
 
         Delegated immediately, and the argument ignored, so the confirm step
-        can read ``user_input is None`` as "render the form" without having to
-        guess whether its caller was Home Assistant or the user. Answering
-        that by inspecting the payload -- testing for a configuration key --
-        turned into an unbounded setup loop the moment that key left the
-        entry, because a mistaken "the user submitted" updates the entry and
-        reloads it, and the reload fails setup again.
+        can read ``user_input is None`` as "render the form" rather than
+        inspecting the payload to guess whether its caller was Home Assistant
+        or the user. Guessing wrong updates the entry and reloads it.
         """
         return await self.async_step_reauth_confirm()
 
@@ -660,11 +657,13 @@ class LockCodeManagerFlowHandler(
                 # merges options-preferred, so leaving stale options in
                 # place would silently override this reauth fix on the
                 # next load.
+                # Resolved through EntryConfig, not by merging raw dicts: the
+                # two sides may be in different shapes, and a raw merge carries
+                # both, discarding the very save this block exists to consume.
                 self.hass.config_entries.async_update_entry(
                     config_entry,
                     data={
-                        **config_entry.data,
-                        **config_entry.options,
+                        **get_entry_config(config_entry).to_dict(),
                         **user_input,
                     },
                     options={},

--- a/custom_components/lock_code_manager/const.py
+++ b/custom_components/lock_code_manager/const.py
@@ -24,8 +24,6 @@ SERVICE_DEOBFUSCATE_LOG = "deobfuscate_log"
 
 ATTR_TEXT = "text"
 
-ATTR_ENTITIES_ADDED_TRACKER = "entities_added_tracker"
-ATTR_ENTITIES_REMOVED_TRACKER = "entities_removed_tracker"
 
 ATTR_CODE_SLOT = "code_slot"
 ATTR_USERCODE = "usercode"
@@ -50,7 +48,6 @@ ATTR_LAST_SYNCED = "last_synced"
 ATTR_CONFIG_ENTRY_ID = "config_entry_id"
 ATTR_CONFIG_ENTRY_TITLE = "config_entry_title"
 ATTR_EVENT_ENTITY_ID = "event_entity_id"
-ATTR_CALENDAR_ENTITY_ID = "calendar_entity_id"
 ATTR_CALENDAR = "calendar"
 ATTR_CALENDAR_NEXT = "calendar_next"
 ATTR_CALENDAR_ACTIVE = "active"

--- a/custom_components/lock_code_manager/const.py
+++ b/custom_components/lock_code_manager/const.py
@@ -87,6 +87,7 @@ CONF_CONDITIONS = "conditions"
 CONF_ENTITIES = "entities"
 CONF_LOCKS = "locks"
 CONF_SLOTS = "slots"
+CONF_USERS = "users"
 CONF_NUM_SLOTS = "num_slots"
 CONF_START_SLOT = "start_slot"
 

--- a/custom_components/lock_code_manager/domain/config.py
+++ b/custom_components/lock_code_manager/domain/config.py
@@ -11,40 +11,41 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME
 
 from ..const import CONF_LOCKS, CONF_SLOTS, CONF_USERS
+from .names import normalize_name
 from .slot_assignment import CONF_SLOT_ASSIGNMENT, SlotAssignment, _identity
 
-_EMPTY_SLOTS: Mapping[int, Mapping[str, Any]] = MappingProxyType({})
+_EMPTY_USERS: Mapping[str, Mapping[str, Any]] = MappingProxyType({})
 _EMPTY_EXTRA: Mapping[str, Any] = MappingProxyType({})
 
 # The keys EntryConfig models directly. Everything else in the entry is
 # internal bookkeeping and rides along in `extra`.
-_CONFIG_KEYS = frozenset({CONF_LOCKS, CONF_SLOTS})
+_CONFIG_KEYS = frozenset({CONF_LOCKS, CONF_SLOTS, CONF_USERS, CONF_SLOT_ASSIGNMENT})
 
 
-def _slots_from_users(mapping: Mapping[str, Any]) -> Mapping[Any, Mapping[str, Any]]:
+def _users_from_slot_shape(
+    raw_slots: Mapping[Any, Mapping[str, Any]],
+) -> tuple[Mapping[str, Mapping[str, Any]], SlotAssignment]:
     """
-    Rebuild the slot-keyed view from the user-keyed storage shape.
+    Accept the pre-version-3 slot-keyed shape as INPUT.
 
-    Storage moved to ``users`` in version 3; the rest of the integration still
-    works in slot numbers, and will for another increment or two. Rebuilding
-    here keeps that one change confined to this function -- every reader goes
-    through ``EntryConfig``, so none of them has to know which shape is on
-    disk.
+    One-directional and temporary. Nothing writes this shape any more --
+    :meth:`EntryConfig.to_dict` only ever emits the user-keyed one -- so there
+    is a single storage format and a single internal model. This exists purely
+    because the config flow still assembles slot-keyed input; it goes when
+    that does, and its absence will be a loud KeyError rather than a silent
+    reversion.
 
-    A user with no assigned slot is skipped rather than guessed at. Guessing
-    would put their code on a credential index somebody else may hold.
+    An unnamed slot falls back to its generated name rather than being
+    dropped, because a version 2 entry is allowed to have one.
     """
-    users = mapping.get(CONF_USERS)
-    if not users:
-        return {}
-    assignment = SlotAssignment.from_mapping(mapping)
-    rebuilt: dict[int, dict[str, Any]] = {}
-    for name, user in users.items():
-        slot_num = assignment.slot(name)
-        if slot_num is None:
-            continue
-        rebuilt[slot_num] = {CONF_NAME: name, **user}
-    return rebuilt
+    users: dict[str, dict[str, Any]] = {}
+    assignment: dict[str, int] = {}
+    for raw_num, slot in sorted(raw_slots.items(), key=lambda kv: int(kv[0])):
+        slot_num = int(raw_num)
+        name = normalize_name(slot.get(CONF_NAME)) or f"User {slot_num}"
+        users[name] = {k: v for k, v in slot.items() if k != CONF_NAME}
+        assignment[name] = slot_num
+    return MappingProxyType(users), SlotAssignment(slots=assignment)
 
 
 @dataclass(frozen=True, slots=True)
@@ -52,126 +53,158 @@ class EntryConfig:
     """
     Typed, normalized view of an LCM entry's configuration.
 
-    Slot keys are normalized to ``int`` at construction (the on-disk
-    JSON representation uses ``str``; voluptuous-validated user input
-    uses ``int``). ``slots`` is a deeply read-only mapping
-    (``MappingProxyType`` at both levels) so instances can be cached
-    without defensive copies.
+    Keyed by USER. The name is the identity: it is what the configuration is
+    stored under, what the dashboard shows, and what every layer above the
+    provider boundary works in. The slot number survives as internal
+    bookkeeping in :attr:`assignment`, and is looked up at exactly two places
+    -- provider writes, where it IS the lock's credential index, and registry
+    identifiers, which key on it so a rename moves nothing.
 
-    An instance is cached on ``LockCodeManagerConfigEntryRuntimeData.config``
-    and refreshed by the update listener. Most callers should access it
-    via ``entry.runtime_data.config``. Iteration helpers that walk
-    ``hass.config_entries.async_entries(DOMAIN)`` use
-    :func:`get_entry_config` to handle the unloaded-entry case.
+    Deeply read-only (``MappingProxyType`` throughout) so instances can be
+    cached without defensive copies. An instance is cached on
+    ``LockCodeManagerConfigEntryRuntimeData.config`` and refreshed by the
+    update listener; most callers should reach it via
+    ``entry.runtime_data.config``, or :func:`get_entry_config` for entries
+    that may not be loaded.
     """
 
     locks: tuple[str, ...]
-    slots: Mapping[int, Mapping[str, Any]]
+    users: Mapping[str, Mapping[str, Any]]
+    assignment: SlotAssignment
     # Every other top-level key in the entry, carried through verbatim.
     #
     # Deliberately has NO default. to_dict() feeds async_update_entry
     # directly, so a field that could be forgotten at a construction site
-    # would silently ERASE that bookkeeping on the next write. That is not
-    # hypothetical: without this, the update listener's terminal write dropped
-    # `users` and `slot_assignment` on every pass, so the migrated entry
-    # reverted to the slot-keyed shape and setup looped. Requiring the field
-    # makes mypy the check instead of memory.
+    # would silently ERASE whatever it holds on the next write. That is not
+    # hypothetical -- it erased the migrated shape on every listener pass and
+    # sent setup into a loop. Requiring it makes mypy the check, not memory.
     extra: Mapping[str, Any]
 
     @classmethod
     def empty(cls) -> EntryConfig:
-        """
-        Return a config representing an entry with no locks or slots.
-
-        Used as the initial value for ``runtime_data.config`` before the
-        entry's data has been read.
-        """
-        return cls(locks=(), slots=_EMPTY_SLOTS, extra=_EMPTY_EXTRA)
+        """Return a config for an entry with no locks and no users."""
+        return cls(
+            locks=(),
+            users=_EMPTY_USERS,
+            assignment=SlotAssignment.empty(),
+            extra=_EMPTY_EXTRA,
+        )
 
     @classmethod
     def from_entry(cls, entry: ConfigEntry) -> EntryConfig:
         """
         Build EntryConfig from a config entry, options-preferred.
 
-        Uses options-preferred precedence: during options-flow updates
-        the new config is in ``options`` while ``data`` still holds the
-        old config.
+        During an options-flow update the new configuration is in ``options``
+        while ``data`` still holds the old one. Bookkeeping is merged from
+        both sides rather than taken options-preferred: setup moves everything
+        from data into options and the listener moves it back, so which side
+        holds it depends on where in that cycle we are.
         """
-        # Bookkeeping is merged from BOTH sides rather than taken
-        # options-preferred the way configuration is. _setup_entry_after_start
-        # moves everything from data into options and the listener moves it
-        # back, so which side holds it depends on where in that cycle we are.
-        return cls.from_mapping(
-            {
-                **{k: v for k, v in entry.data.items() if k not in _CONFIG_KEYS},
-                **{k: v for k, v in entry.options.items() if k not in _CONFIG_KEYS},
-                CONF_LOCKS: entry.options.get(
-                    CONF_LOCKS, entry.data.get(CONF_LOCKS, [])
-                ),
-                # Only set when a side actually HAS it. Defaulting to {} here
-                # would hand from_mapping an empty mapping rather than an
-                # absent key, so it would never rebuild the slot view from
-                # `users` -- and every reader would see an entry with no users
-                # at all.
-                **(
-                    {CONF_SLOTS: slots}
-                    if (
-                        slots := entry.options.get(
-                            CONF_SLOTS, entry.data.get(CONF_SLOTS)
-                        )
-                    )
-                    is not None
-                    else {}
-                ),
-            }
-        )
+        merged: dict[str, Any] = {
+            **{k: v for k, v in entry.data.items() if k not in _CONFIG_KEYS},
+            **{k: v for k, v in entry.options.items() if k not in _CONFIG_KEYS},
+            CONF_LOCKS: entry.options.get(CONF_LOCKS, entry.data.get(CONF_LOCKS, [])),
+        }
+        for key in (CONF_USERS, CONF_SLOT_ASSIGNMENT, CONF_SLOTS):
+            # Only set when a side actually HAS it. Defaulting to an empty
+            # mapping would make "absent" indistinguishable from "empty", and
+            # from_mapping would read an entry with users as having none.
+            value = entry.options.get(key, entry.data.get(key))
+            if value is not None:
+                merged[key] = value
+        return cls.from_mapping(merged)
 
     @classmethod
     def from_mapping(cls, mapping: Mapping[str, Any]) -> EntryConfig:
         """
-        Build EntryConfig from a raw config mapping (data, options, or input).
+        Build EntryConfig from a raw config mapping.
 
-        Slot keys are normalized to ``int`` regardless of source. Inner
-        slot config dicts are wrapped in ``MappingProxyType`` so the
-        whole structure is read-only.
+        Accepts the pre-version-3 slot-keyed shape as input only; see
+        :func:`_users_from_slot_shape`. Nothing writes that shape any more.
         """
-        raw_slots = mapping.get(CONF_SLOTS)
-        if raw_slots is None:
-            raw_slots = _slots_from_users(mapping)
-        raw_locks = mapping.get(CONF_LOCKS, [])
+        raw_users = mapping.get(CONF_USERS)
+        if raw_users is None:
+            users, assignment = _users_from_slot_shape(mapping.get(CONF_SLOTS) or {})
+        else:
+            users = MappingProxyType(
+                {
+                    normalize_name(name): MappingProxyType(dict(user))
+                    for name, user in raw_users.items()
+                }
+            )
+            assignment = SlotAssignment.from_mapping(mapping)
         return cls(
-            locks=tuple(raw_locks),
-            slots=MappingProxyType(
-                {int(k): MappingProxyType(dict(v)) for k, v in raw_slots.items()}
+            locks=tuple(mapping.get(CONF_LOCKS, [])),
+            users=MappingProxyType(
+                {name: MappingProxyType(dict(user)) for name, user in users.items()}
             ),
+            assignment=assignment,
             extra=MappingProxyType(
                 {k: v for k, v in mapping.items() if k not in _CONFIG_KEYS}
             ),
+        )
+
+    @property
+    def slots(self) -> Mapping[int, Mapping[str, Any]]:
+        """
+        Return the slot-keyed view.
+
+        TEMPORARY, and derived rather than stored -- there is one model, and
+        this is a projection of it. It exists so the twenty-eight remaining
+        slot-keyed call sites can move one at a time instead of in a single
+        change nobody could review. Delete it, and this docstring, once they
+        have.
+
+        A user holding no slot is omitted: inventing a number would put their
+        code on a credential index somebody else may hold.
+        """
+        return MappingProxyType(
+            {
+                slot_num: MappingProxyType({CONF_NAME: name, **user})
+                for name, user in self.users.items()
+                if (slot_num := self.assignment.slot(name)) is not None
+            }
         )
 
     def has_lock(self, lock_entity_id: str) -> bool:
         """Return True if this entry manages the given lock."""
         return lock_entity_id in self.locks
 
-    def has_slot(self, slot_num: int | str) -> bool:
-        """
-        Return True if this entry manages the given slot number.
+    def has_user(self, name: str) -> bool:
+        """Return True if this entry configures a user with that name."""
+        return _identity(name) in {_identity(known) for known in self.users}
 
-        Accepts ``int`` or ``str`` to absorb the slot-key type variance
-        in the codebase (entities created during the listener may carry
-        either type as ``self.slot_num``). Internal storage is always
-        ``int``-keyed.
-        """
-        return int(slot_num) in self.slots
+    def user(self, name: str) -> Mapping[str, Any]:
+        """Return a user's configuration, or an empty mapping if absent."""
+        wanted = _identity(name)
+        return next(
+            (user for known, user in self.users.items() if _identity(known) == wanted),
+            _EMPTY_EXTRA,
+        )
+
+    def slot_for(self, name: str) -> int | None:
+        """Return the slot number a user occupies, or None if they hold none."""
+        return self.assignment.slot(name)
+
+    def name_for(self, slot_num: int | str) -> str | None:
+        """Return the user occupying a slot, or None if it is unoccupied."""
+        wanted = int(slot_num)
+        return next(
+            (name for name in self.users if self.assignment.slot(name) == wanted),
+            None,
+        )
+
+    def has_slot(self, slot_num: int | str) -> bool:
+        """Return True if a user occupies the given slot number."""
+        return self.name_for(slot_num) is not None
 
     def slot(self, slot_num: int | str) -> Mapping[str, Any]:
-        """
-        Return the slot config dict, or an empty mapping if absent.
-
-        Like :meth:`has_slot`, accepts ``int`` or ``str`` so callers
-        don't need to cast at every read site.
-        """
-        return self.slots.get(int(slot_num), {})
+        """Return the slot-shaped view of whoever occupies ``slot_num``."""
+        name = self.name_for(slot_num)
+        if name is None:
+            return _EMPTY_EXTRA
+        return MappingProxyType({CONF_NAME: name, **self.user(name)})
 
     def __sub__(self, other: EntryConfig) -> EntryConfigDiff:
         """
@@ -179,109 +212,79 @@ class EntryConfig:
 
         Sugar for ``EntryConfigDiff(old=self, new=other)``. Reads as
         ``old_config - new_config`` — note this is a *delta* (both adds
-        and removes), not strict set subtraction. The result includes
-        what changed in either direction.
+        and removes), not strict set subtraction.
 
         Returns ``NotImplemented`` for non-``EntryConfig`` operands so
-        Python's operator protocol falls back to ``__rsub__`` and
-        ultimately raises a clear ``TypeError`` rather than letting the
-        misuse fail deep inside ``EntryConfigDiff.__post_init__``.
+        Python's operator protocol raises a clear ``TypeError`` rather than
+        failing deep inside ``EntryConfigDiff.__post_init__``.
         """
         if not isinstance(other, EntryConfig):
             return NotImplemented
         return EntryConfigDiff(old=self, new=other)
 
+    def with_user_field_set(self, name: str, key: str, value: Any) -> EntryConfig:
+        """Return a copy with one user's field set, creating the user if new."""
+        stored = next(
+            (known for known in self.users if _identity(known) == _identity(name)),
+            normalize_name(name),
+        )
+        new_users = {k: dict(v) for k, v in self.users.items()}
+        new_users.setdefault(stored, {})[key] = value
+        return EntryConfig(
+            locks=self.locks,
+            users=MappingProxyType(
+                {k: MappingProxyType(v) for k, v in new_users.items()}
+            ),
+            assignment=self.assignment,
+            extra=self.extra,
+        )
+
+    def with_user_field_removed(self, name: str, key: str) -> EntryConfig:
+        """Return a copy with one user's field removed; a no-op if absent."""
+        stored = next(
+            (known for known in self.users if _identity(known) == _identity(name)), None
+        )
+        if stored is None or key not in self.users[stored]:
+            return self
+        new_users = {k: dict(v) for k, v in self.users.items()}
+        new_users[stored].pop(key, None)
+        return EntryConfig(
+            locks=self.locks,
+            users=MappingProxyType(
+                {k: MappingProxyType(v) for k, v in new_users.items()}
+            ),
+            assignment=self.assignment,
+            extra=self.extra,
+        )
+
     def with_slot_field_set(
         self, slot_num: int | str, key: str, value: Any
     ) -> EntryConfig:
-        """
-        Return a new EntryConfig with one slot's field set to ``value``.
-
-        Creates the slot if it doesn't already exist. Used by writer
-        paths (entity field updates, condition entity set service) to
-        produce the new config to hand to ``async_update_entry``, paired
-        with :meth:`to_dict`.
-        """
-        sn = int(slot_num)
-        new_slots: dict[int, dict[str, Any]] = {
-            k: dict(v) for k, v in self.slots.items()
-        }
-        new_slots.setdefault(sn, {})[key] = value
-        return EntryConfig(
-            locks=self.locks,
-            slots=MappingProxyType(
-                {k: MappingProxyType(v) for k, v in new_slots.items()}
-            ),
-            extra=self.extra,
-        )
+        """Set a field on whoever occupies ``slot_num``. TEMPORARY, as :attr:`slots`."""
+        name = self.name_for(slot_num)
+        if name is None:
+            return self
+        return self.with_user_field_set(name, key, value)
 
     def with_slot_field_removed(self, slot_num: int | str, key: str) -> EntryConfig:
-        """
-        Return a new EntryConfig with one slot's field removed.
-
-        No-op (returns ``self``) if the slot or key is already absent.
-        """
-        sn = int(slot_num)
-        if sn not in self.slots or key not in self.slots[sn]:
+        """Remove a field from whoever occupies ``slot_num``. TEMPORARY."""
+        name = self.name_for(slot_num)
+        if name is None:
             return self
-        new_slots: dict[int, dict[str, Any]] = {
-            k: dict(v) for k, v in self.slots.items()
-        }
-        new_slots[sn].pop(key, None)
-        return EntryConfig(
-            locks=self.locks,
-            slots=MappingProxyType(
-                {k: MappingProxyType(v) for k, v in new_slots.items()}
-            ),
-            extra=self.extra,
-        )
+        return self.with_user_field_removed(name, key)
 
     def to_dict(self) -> dict[str, Any]:
         """
         Return a plain mutable dict suitable for ``async_update_entry``.
 
-        Only includes the keys EntryConfig knows about (CONF_LOCKS and
-        CONF_SLOTS). Inner slot dicts are plain ``dict`` (not
-        ``MappingProxyType``) so HA's storage layer can serialize them.
-
-        Callers preserving other top-level keys in ``entry.data`` /
-        ``entry.options`` should merge: ``{**dict(entry.data),
-        **new_config.to_dict()}``. In practice LCM entries only carry
-        these two keys.
+        Emits the user-keyed shape only. There is one storage format, so a
+        write can never revert the entry to a previous one.
         """
-        # Emits the STORAGE shape, projected from the internal one. The
-        # internal view stays slot-keyed because the rest of the integration
-        # still works in slot numbers; only what reaches disk changed.
-        #
-        # Projected rather than carried through from `extra`, because edits
-        # land on the slot view -- a text entity setting a name or a code
-        # writes there. Re-emitting a stale copy of `users` would persist the
-        # configuration as it was before the edit.
-        #
-        # A slot with no name cannot be keyed by one, so the whole entry falls
-        # back to the slot-keyed form rather than dropping that user. Reachable
-        # only mid-config-flow, before validation has run.
-        carried = {
-            k: v
-            for k, v in self.extra.items()
-            if k not in (CONF_USERS, CONF_SLOT_ASSIGNMENT)
-        }
-        if any(not slot.get(CONF_NAME) for slot in self.slots.values()):
-            return {
-                **carried,
-                CONF_LOCKS: list(self.locks),
-                CONF_SLOTS: {k: dict(v) for k, v in self.slots.items()},
-            }
         return {
-            **carried,
+            **dict(self.extra),
             CONF_LOCKS: list(self.locks),
-            CONF_USERS: {
-                slot[CONF_NAME]: {k: v for k, v in slot.items() if k != CONF_NAME}
-                for slot in self.slots.values()
-            },
-            CONF_SLOT_ASSIGNMENT: {
-                _identity(slot[CONF_NAME]): num for num, slot in self.slots.items()
-            },
+            CONF_USERS: {name: dict(user) for name, user in self.users.items()},
+            CONF_SLOT_ASSIGNMENT: dict(self.assignment.slots),
         }
 
 

--- a/custom_components/lock_code_manager/domain/config.py
+++ b/custom_components/lock_code_manager/domain/config.py
@@ -111,14 +111,13 @@ class EntryConfig:
             **{k: v for k, v in entry.options.items() if k not in _CONFIG_KEYS},
             CONF_LOCKS: entry.options.get(CONF_LOCKS, entry.data.get(CONF_LOCKS, [])),
         }
-        for key in (CONF_USERS, CONF_SLOTS):
+        # The assignment comes from the SAME side as the users it numbers. A
+        # user-keyed side always carries its own, and a slot-keyed one derives
+        # it from the slot keys; taking it from the other side could pair
+        # users with numbering that predates them.
+        for key in (CONF_USERS, CONF_SLOTS, CONF_SLOT_ASSIGNMENT):
             if key in config_side:
                 merged[key] = config_side[key]
-        assignment = entry.options.get(
-            CONF_SLOT_ASSIGNMENT, entry.data.get(CONF_SLOT_ASSIGNMENT)
-        )
-        if assignment is not None:
-            merged[CONF_SLOT_ASSIGNMENT] = assignment
         return cls.from_mapping(merged)
 
     @classmethod
@@ -126,8 +125,9 @@ class EntryConfig:
         """
         Build EntryConfig from a raw config mapping.
 
-        Accepts the pre-version-3 slot-keyed shape as input only; see
-        :func:`_users_from_slot_shape`. Nothing writes that shape any more.
+        Accepts the pre-version-3 slot-keyed shape as input only, converted
+        by :func:`.slot_assignment.users_from_slots`. Nothing writes that
+        shape any more.
         """
         raw_users = mapping.get(CONF_USERS)
         if raw_users is None:
@@ -137,9 +137,16 @@ class EntryConfig:
             converted, assignment, _ = users_from_slots(mapping.get(CONF_SLOTS) or {})
             users = dict(converted)
         else:
-            users = {
-                normalize_name(name): dict(user) for name, user in raw_users.items()
-            }
+            # Two keys reducing to one identity keep the FIRST. Both
+            # surviving would put them on one slot while the name lookups
+            # disagreed about which of them holds it, so a display would show
+            # one user and a write would land on the other.
+            users = {}
+            for name, user in raw_users.items():
+                normalized = normalize_name(name)
+                if any(_identity(seen) == _identity(normalized) for seen in users):
+                    continue
+                users[normalized] = dict(user)
             assignment = SlotAssignment.from_mapping(mapping)
         return cls(
             locks=tuple(mapping.get(CONF_LOCKS, [])),

--- a/custom_components/lock_code_manager/domain/config.py
+++ b/custom_components/lock_code_manager/domain/config.py
@@ -171,10 +171,6 @@ class EntryConfig:
         """Return True if this entry manages the given lock."""
         return lock_entity_id in self.locks
 
-    def has_user(self, name: str) -> bool:
-        """Return True if this entry configures a user with that name."""
-        return _identity(name) in {_identity(known) for known in self.users}
-
     def user(self, name: str) -> Mapping[str, Any]:
         """Return a user's configuration, or an empty mapping if absent."""
         wanted = _identity(name)

--- a/custom_components/lock_code_manager/domain/config.py
+++ b/custom_components/lock_code_manager/domain/config.py
@@ -59,12 +59,10 @@ class EntryConfig:
     # Derived once at construction: the instance is immutable and cached, and
     # the slot view is read per entry per lock on some paths.
     _by_slot: Mapping[int, Mapping[str, Any]] = field(init=False, repr=False)
-    _slot_of: Mapping[str, int] = field(init=False, repr=False)
 
     def __post_init__(self) -> None:
-        """Build the slot-keyed projection and its reverse index."""
+        """Build the slot-keyed projection."""
         by_slot: dict[int, Mapping[str, Any]] = {}
-        slot_of: dict[str, int] = {}
         for name, user in self.users.items():
             slot_num = self.assignment.slot(name)
             if slot_num is None:
@@ -74,9 +72,7 @@ class EntryConfig:
             # Key LAST so it wins: a `name` surviving inside a user dict must
             # not shadow the identity this user is stored under.
             by_slot[slot_num] = MappingProxyType({**user, CONF_NAME: name})
-            slot_of[_identity(name)] = slot_num
         object.__setattr__(self, "_by_slot", MappingProxyType(by_slot))
-        object.__setattr__(self, "_slot_of", MappingProxyType(slot_of))
 
     @classmethod
     def empty(cls) -> EntryConfig:
@@ -170,18 +166,6 @@ class EntryConfig:
     def has_lock(self, lock_entity_id: str) -> bool:
         """Return True if this entry manages the given lock."""
         return lock_entity_id in self.locks
-
-    def user(self, name: str) -> Mapping[str, Any]:
-        """Return a user's configuration, or an empty mapping if absent."""
-        wanted = _identity(name)
-        return next(
-            (user for known, user in self.users.items() if _identity(known) == wanted),
-            _EMPTY_EXTRA,
-        )
-
-    def slot_for(self, name: str) -> int | None:
-        """Return the slot number a user occupies, or None if they hold none."""
-        return self._slot_of.get(_identity(name))
 
     def name_for(self, slot_num: int | str) -> str | None:
         """Return the user occupying a slot, or None if it is unoccupied."""

--- a/custom_components/lock_code_manager/domain/config.py
+++ b/custom_components/lock_code_manager/domain/config.py
@@ -27,32 +27,6 @@ _EMPTY_EXTRA: Mapping[str, Any] = MappingProxyType({})
 _CONFIG_KEYS = frozenset({CONF_LOCKS, CONF_SLOTS, CONF_USERS, CONF_SLOT_ASSIGNMENT})
 
 
-def _users_from_slot_shape(
-    raw_slots: Mapping[Any, Mapping[str, Any]],
-) -> tuple[Mapping[str, Mapping[str, Any]], SlotAssignment]:
-    """
-    Accept the pre-version-3 slot-keyed shape as INPUT.
-
-    One-directional and temporary. Nothing writes this shape any more --
-    :meth:`EntryConfig.to_dict` only ever emits the user-keyed one -- so there
-    is a single storage format and a single internal model. This exists purely
-    because the config flow still assembles slot-keyed input; it goes when
-    that does, and its absence will be a loud KeyError rather than a silent
-    reversion.
-
-    An unnamed slot falls back to its generated name rather than being
-    dropped, because a version 2 entry is allowed to have one.
-    """
-    # Delegated to the migration's own conversion so the two cannot disagree.
-    # They accept the same input, and a second implementation drifted: this one
-    # collapsed two names differing only by case into a single user -- losing
-    # one of them and their code -- where the migration deduplicates. It also
-    # minted the "User {n}" fallback itself, a second copy of a format that
-    # only fallback_name should own.
-    users, assignment, _ = users_from_slots(raw_slots)
-    return MappingProxyType(users), assignment
-
-
 @dataclass(frozen=True, slots=True)
 class EntryConfig:
     """
@@ -78,16 +52,12 @@ class EntryConfig:
     assignment: SlotAssignment
     # Every other top-level key in the entry, carried through verbatim.
     #
-    # Deliberately has NO default. to_dict() feeds async_update_entry
-    # directly, so a field that could be forgotten at a construction site
-    # would silently ERASE whatever it holds on the next write. That is not
-    # hypothetical -- it erased the migrated shape on every listener pass and
-    # sent setup into a loop. Requiring it makes mypy the check, not memory.
+    # No default: to_dict() feeds async_update_entry directly, so a field that
+    # could be omitted at a construction site would erase whatever it holds on
+    # the next write.
     extra: Mapping[str, Any]
-    # Derived once at construction rather than recomputed per access. The
-    # instance is immutable and cached on runtime_data, and the slot view is
-    # read on hot paths -- get_managed_slots walks every entry, and
-    # _check_common_slots does so per lock per entry.
+    # Derived once at construction: the instance is immutable and cached, and
+    # the slot view is read per entry per lock on some paths.
     _by_slot: Mapping[int, Mapping[str, Any]] = field(init=False, repr=False)
     _slot_of: Mapping[str, int] = field(init=False, repr=False)
 
@@ -101,8 +71,10 @@ class EntryConfig:
                 # No number: inventing one would put this user's code on a
                 # credential index somebody else may hold.
                 continue
-            by_slot[slot_num] = MappingProxyType({CONF_NAME: name, **user})
-            slot_of[name] = slot_num
+            # Key LAST so it wins: a `name` surviving inside a user dict must
+            # not shadow the identity this user is stored under.
+            by_slot[slot_num] = MappingProxyType({**user, CONF_NAME: name})
+            slot_of[_identity(name)] = slot_num
         object.__setattr__(self, "_by_slot", MappingProxyType(by_slot))
         object.__setattr__(self, "_slot_of", MappingProxyType(slot_of))
 
@@ -122,18 +94,14 @@ class EntryConfig:
         Build EntryConfig from a config entry, options-preferred.
 
         During an options-flow update the new configuration is in ``options``
-        while ``data`` still holds the old one. Bookkeeping is merged from
-        both sides rather than taken options-preferred: setup moves everything
-        from data into options and the listener moves it back, so which side
-        holds it depends on where in that cycle we are.
+        while ``data`` still holds the old one. Bookkeeping is merged from both
+        sides: setup moves it from data into options and the listener moves it
+        back, so either side may hold it.
         """
-        # ONE side holds the configuration, and it is read whole. Filling the
-        # shape keys independently let an entry carry both -- user-shaped data
-        # (the steady state) alongside a slot-shaped options save the entry
-        # could not process while it was failed -- and from_mapping prefers
-        # `users`, so the pending save was silently reverted and then
-        # persisted over. Options wins when it holds configuration at all,
-        # which is what _setup_entry_after_start's merge exists to preserve.
+        # ONE side holds the configuration and is read whole, options first.
+        # Taking the shape keys independently would let an entry carry both
+        # shapes at once, and reading a mix of them silently discards whichever
+        # one loses.
         config_side: Mapping[str, Any] = next(
             (
                 side
@@ -143,9 +111,6 @@ class EntryConfig:
             {},
         )
         merged: dict[str, Any] = {
-            # Bookkeeping is merged from both sides: setup moves it from data
-            # into options and the listener moves it back, so which side holds
-            # it depends on where in that cycle we are.
             **{k: v for k, v in entry.data.items() if k not in _CONFIG_KEYS},
             **{k: v for k, v in entry.options.items() if k not in _CONFIG_KEYS},
             CONF_LOCKS: entry.options.get(CONF_LOCKS, entry.data.get(CONF_LOCKS, [])),
@@ -170,14 +135,15 @@ class EntryConfig:
         """
         raw_users = mapping.get(CONF_USERS)
         if raw_users is None:
-            users, assignment = _users_from_slot_shape(mapping.get(CONF_SLOTS) or {})
+            # Slot-keyed input, converted by the migration's own function so
+            # the two cannot disagree. One-directional: nothing writes this
+            # shape. Goes when the config flow stops producing it.
+            converted, assignment, _ = users_from_slots(mapping.get(CONF_SLOTS) or {})
+            users = dict(converted)
         else:
-            users = MappingProxyType(
-                {
-                    normalize_name(name): MappingProxyType(dict(user))
-                    for name, user in raw_users.items()
-                }
-            )
+            users = {
+                normalize_name(name): dict(user) for name, user in raw_users.items()
+            }
             assignment = SlotAssignment.from_mapping(mapping)
         return cls(
             locks=tuple(mapping.get(CONF_LOCKS, [])),
@@ -195,10 +161,9 @@ class EntryConfig:
         """
         Return the slot-keyed view.
 
-        TEMPORARY, and a projection of the one model rather than a second one.
-        It exists so the remaining slot-keyed call sites can move one at a
-        time instead of in a single unreviewable change. Delete it, and this
-        docstring, once they have.
+        TEMPORARY. A projection of the one model, not a second model, kept
+        while the remaining slot-keyed call sites migrate. Delete it with the
+        last of them.
         """
         return self._by_slot
 
@@ -216,7 +181,7 @@ class EntryConfig:
 
     def slot_for(self, name: str) -> int | None:
         """Return the slot number a user occupies, or None if they hold none."""
-        return self.assignment.slot(name)
+        return self._slot_of.get(_identity(name))
 
     def name_for(self, slot_num: int | str) -> str | None:
         """Return the user occupying a slot, or None if it is unoccupied."""
@@ -232,10 +197,7 @@ class EntryConfig:
 
     def slot(self, slot_num: int | str) -> Mapping[str, Any]:
         """Return the slot-shaped view of whoever occupies ``slot_num``."""
-        name = self.name_for(slot_num)
-        if name is None:
-            return _EMPTY_EXTRA
-        return MappingProxyType({CONF_NAME: name, **self.user(name)})
+        return self._by_slot.get(int(slot_num), _EMPTY_EXTRA)
 
     def __sub__(self, other: EntryConfig) -> EntryConfigDiff:
         """
@@ -257,9 +219,9 @@ class EntryConfig:
         """
         Return a copy with a user re-keyed, keeping their slot.
 
-        A rename re-keys the configuration AND the assignment, so the slot
-        follows the person. Nothing in either registry moves: identifiers key
-        on the slot number, which is exactly why a rename is free.
+        Re-keys the configuration and the assignment together, so the slot
+        follows the person. Neither registry moves: identifiers key on the
+        slot number.
         """
         stored = next(
             (known for known in self.users if _identity(known) == _identity(old)), None
@@ -267,22 +229,30 @@ class EntryConfig:
         if stored is None:
             return self
         renamed = normalize_name(new)
+        # Renaming onto somebody else would collapse two users into one key,
+        # deleting one and freeing their slot. Refused here rather than relying
+        # on the callers that validate it.
+        if any(
+            _identity(known) == _identity(renamed) and known != stored
+            for known in self.users
+        ):
+            return self
         new_users = {
             (renamed if k == stored else k): dict(v) for k, v in self.users.items()
+        }
+        # Re-keyed directly rather than through reconcile, which allocates: a
+        # user holding no slot would be issued one here. A rename moves a
+        # number, it never issues one.
+        moved = {
+            (_identity(renamed) if name == _identity(stored) else name): slot
+            for name, slot in self.assignment.slots.items()
         }
         return EntryConfig(
             locks=self.locks,
             users=MappingProxyType(
                 {k: MappingProxyType(v) for k, v in new_users.items()}
             ),
-            # Through reconcile, which is the only allocator, so the rename
-            # cannot drift from how additions and removals are resolved. No
-            # allocation happens here -- every name already holds a slot -- so
-            # `start` is inert; it is required rather than defaulted precisely
-            # so a caller that DOES allocate has to think about it.
-            assignment=self.assignment.reconcile(
-                new_users, start=1, renames={stored: renamed}
-            ),
+            assignment=SlotAssignment(slots=moved),
             extra=self.extra,
         )
 
@@ -290,15 +260,12 @@ class EntryConfig:
         """
         Return a copy with one user's field set.
 
-        Setting the NAME re-keys the user rather than storing a field, because
-        the name is the identity here -- it is what the configuration is keyed
-        by and what the assignment records. Stored as a field it looked
-        correct through the slot projection, where the inner value shadows the
-        key, while the actual identity went permanently stale.
+        Setting the NAME re-keys the user rather than storing a field: the
+        name is the identity, and it is what both the configuration and the
+        assignment are keyed by.
 
-        A user who does not exist is NOT created: creating one also has to
-        allocate a slot, and this cannot. Until allocation is wired, creation
-        has no correct implementation to offer.
+        A user who does not exist is not created. Creating one also has to
+        allocate a slot, which this has no view to do.
         """
         if key == CONF_NAME:
             return self.with_user_renamed(name, value)
@@ -356,8 +323,8 @@ class EntryConfig:
         """
         Return a plain mutable dict suitable for ``async_update_entry``.
 
-        Emits the user-keyed shape only. There is one storage format, so a
-        write can never revert the entry to a previous one.
+        Emits the user-keyed shape only, so a write cannot leave the entry in
+        a different shape than it was read in.
         """
         return {
             **dict(self.extra),

--- a/custom_components/lock_code_manager/domain/config.py
+++ b/custom_components/lock_code_manager/domain/config.py
@@ -8,10 +8,43 @@ from types import MappingProxyType
 from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_NAME
 
-from ..const import CONF_LOCKS, CONF_SLOTS
+from ..const import CONF_LOCKS, CONF_SLOTS, CONF_USERS
+from .slot_assignment import CONF_SLOT_ASSIGNMENT, SlotAssignment, _identity
 
 _EMPTY_SLOTS: Mapping[int, Mapping[str, Any]] = MappingProxyType({})
+_EMPTY_EXTRA: Mapping[str, Any] = MappingProxyType({})
+
+# The keys EntryConfig models directly. Everything else in the entry is
+# internal bookkeeping and rides along in `extra`.
+_CONFIG_KEYS = frozenset({CONF_LOCKS, CONF_SLOTS})
+
+
+def _slots_from_users(mapping: Mapping[str, Any]) -> Mapping[Any, Mapping[str, Any]]:
+    """
+    Rebuild the slot-keyed view from the user-keyed storage shape.
+
+    Storage moved to ``users`` in version 3; the rest of the integration still
+    works in slot numbers, and will for another increment or two. Rebuilding
+    here keeps that one change confined to this function -- every reader goes
+    through ``EntryConfig``, so none of them has to know which shape is on
+    disk.
+
+    A user with no assigned slot is skipped rather than guessed at. Guessing
+    would put their code on a credential index somebody else may hold.
+    """
+    users = mapping.get(CONF_USERS)
+    if not users:
+        return {}
+    assignment = SlotAssignment.from_mapping(mapping)
+    rebuilt: dict[int, dict[str, Any]] = {}
+    for name, user in users.items():
+        slot_num = assignment.slot(name)
+        if slot_num is None:
+            continue
+        rebuilt[slot_num] = {CONF_NAME: name, **user}
+    return rebuilt
 
 
 @dataclass(frozen=True, slots=True)
@@ -34,6 +67,16 @@ class EntryConfig:
 
     locks: tuple[str, ...]
     slots: Mapping[int, Mapping[str, Any]]
+    # Every other top-level key in the entry, carried through verbatim.
+    #
+    # Deliberately has NO default. to_dict() feeds async_update_entry
+    # directly, so a field that could be forgotten at a construction site
+    # would silently ERASE that bookkeeping on the next write. That is not
+    # hypothetical: without this, the update listener's terminal write dropped
+    # `users` and `slot_assignment` on every pass, so the migrated entry
+    # reverted to the slot-keyed shape and setup looped. Requiring the field
+    # makes mypy the check instead of memory.
+    extra: Mapping[str, Any]
 
     @classmethod
     def empty(cls) -> EntryConfig:
@@ -43,7 +86,7 @@ class EntryConfig:
         Used as the initial value for ``runtime_data.config`` before the
         entry's data has been read.
         """
-        return cls(locks=(), slots=_EMPTY_SLOTS)
+        return cls(locks=(), slots=_EMPTY_SLOTS, extra=_EMPTY_EXTRA)
 
     @classmethod
     def from_entry(cls, entry: ConfigEntry) -> EntryConfig:
@@ -54,13 +97,31 @@ class EntryConfig:
         the new config is in ``options`` while ``data`` still holds the
         old config.
         """
+        # Bookkeeping is merged from BOTH sides rather than taken
+        # options-preferred the way configuration is. _setup_entry_after_start
+        # moves everything from data into options and the listener moves it
+        # back, so which side holds it depends on where in that cycle we are.
         return cls.from_mapping(
             {
+                **{k: v for k, v in entry.data.items() if k not in _CONFIG_KEYS},
+                **{k: v for k, v in entry.options.items() if k not in _CONFIG_KEYS},
                 CONF_LOCKS: entry.options.get(
                     CONF_LOCKS, entry.data.get(CONF_LOCKS, [])
                 ),
-                CONF_SLOTS: entry.options.get(
-                    CONF_SLOTS, entry.data.get(CONF_SLOTS, {})
+                # Only set when a side actually HAS it. Defaulting to {} here
+                # would hand from_mapping an empty mapping rather than an
+                # absent key, so it would never rebuild the slot view from
+                # `users` -- and every reader would see an entry with no users
+                # at all.
+                **(
+                    {CONF_SLOTS: slots}
+                    if (
+                        slots := entry.options.get(
+                            CONF_SLOTS, entry.data.get(CONF_SLOTS)
+                        )
+                    )
+                    is not None
+                    else {}
                 ),
             }
         )
@@ -74,12 +135,17 @@ class EntryConfig:
         slot config dicts are wrapped in ``MappingProxyType`` so the
         whole structure is read-only.
         """
-        raw_slots = mapping.get(CONF_SLOTS, {})
+        raw_slots = mapping.get(CONF_SLOTS)
+        if raw_slots is None:
+            raw_slots = _slots_from_users(mapping)
         raw_locks = mapping.get(CONF_LOCKS, [])
         return cls(
             locks=tuple(raw_locks),
             slots=MappingProxyType(
                 {int(k): MappingProxyType(dict(v)) for k, v in raw_slots.items()}
+            ),
+            extra=MappingProxyType(
+                {k: v for k, v in mapping.items() if k not in _CONFIG_KEYS}
             ),
         )
 
@@ -146,6 +212,7 @@ class EntryConfig:
             slots=MappingProxyType(
                 {k: MappingProxyType(v) for k, v in new_slots.items()}
             ),
+            extra=self.extra,
         )
 
     def with_slot_field_removed(self, slot_num: int | str, key: str) -> EntryConfig:
@@ -166,6 +233,7 @@ class EntryConfig:
             slots=MappingProxyType(
                 {k: MappingProxyType(v) for k, v in new_slots.items()}
             ),
+            extra=self.extra,
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -181,9 +249,39 @@ class EntryConfig:
         **new_config.to_dict()}``. In practice LCM entries only carry
         these two keys.
         """
+        # Emits the STORAGE shape, projected from the internal one. The
+        # internal view stays slot-keyed because the rest of the integration
+        # still works in slot numbers; only what reaches disk changed.
+        #
+        # Projected rather than carried through from `extra`, because edits
+        # land on the slot view -- a text entity setting a name or a code
+        # writes there. Re-emitting a stale copy of `users` would persist the
+        # configuration as it was before the edit.
+        #
+        # A slot with no name cannot be keyed by one, so the whole entry falls
+        # back to the slot-keyed form rather than dropping that user. Reachable
+        # only mid-config-flow, before validation has run.
+        carried = {
+            k: v
+            for k, v in self.extra.items()
+            if k not in (CONF_USERS, CONF_SLOT_ASSIGNMENT)
+        }
+        if any(not slot.get(CONF_NAME) for slot in self.slots.values()):
+            return {
+                **carried,
+                CONF_LOCKS: list(self.locks),
+                CONF_SLOTS: {k: dict(v) for k, v in self.slots.items()},
+            }
         return {
+            **carried,
             CONF_LOCKS: list(self.locks),
-            CONF_SLOTS: {k: dict(v) for k, v in self.slots.items()},
+            CONF_USERS: {
+                slot[CONF_NAME]: {k: v for k, v in slot.items() if k != CONF_NAME}
+                for slot in self.slots.values()
+            },
+            CONF_SLOT_ASSIGNMENT: {
+                _identity(slot[CONF_NAME]): num for num, slot in self.slots.items()
+            },
         }
 
 

--- a/custom_components/lock_code_manager/domain/config.py
+++ b/custom_components/lock_code_manager/domain/config.py
@@ -12,7 +12,12 @@ from homeassistant.const import CONF_NAME
 
 from ..const import CONF_LOCKS, CONF_SLOTS, CONF_USERS
 from .names import normalize_name
-from .slot_assignment import CONF_SLOT_ASSIGNMENT, SlotAssignment, _identity
+from .slot_assignment import (
+    CONF_SLOT_ASSIGNMENT,
+    SlotAssignment,
+    _identity,
+    users_from_slots,
+)
 
 _EMPTY_USERS: Mapping[str, Mapping[str, Any]] = MappingProxyType({})
 _EMPTY_EXTRA: Mapping[str, Any] = MappingProxyType({})
@@ -38,14 +43,14 @@ def _users_from_slot_shape(
     An unnamed slot falls back to its generated name rather than being
     dropped, because a version 2 entry is allowed to have one.
     """
-    users: dict[str, dict[str, Any]] = {}
-    assignment: dict[str, int] = {}
-    for raw_num, slot in sorted(raw_slots.items(), key=lambda kv: int(kv[0])):
-        slot_num = int(raw_num)
-        name = normalize_name(slot.get(CONF_NAME)) or f"User {slot_num}"
-        users[name] = {k: v for k, v in slot.items() if k != CONF_NAME}
-        assignment[name] = slot_num
-    return MappingProxyType(users), SlotAssignment(slots=assignment)
+    # Delegated to the migration's own conversion so the two cannot disagree.
+    # They accept the same input, and a second implementation drifted: this one
+    # collapsed two names differing only by case into a single user -- losing
+    # one of them and their code -- where the migration deduplicates. It also
+    # minted the "User {n}" fallback itself, a second copy of a format that
+    # only fallback_name should own.
+    users, assignment, _ = users_from_slots(raw_slots)
+    return MappingProxyType(users), assignment
 
 
 @dataclass(frozen=True, slots=True)
@@ -79,6 +84,27 @@ class EntryConfig:
     # hypothetical -- it erased the migrated shape on every listener pass and
     # sent setup into a loop. Requiring it makes mypy the check, not memory.
     extra: Mapping[str, Any]
+    # Derived once at construction rather than recomputed per access. The
+    # instance is immutable and cached on runtime_data, and the slot view is
+    # read on hot paths -- get_managed_slots walks every entry, and
+    # _check_common_slots does so per lock per entry.
+    _by_slot: Mapping[int, Mapping[str, Any]] = field(init=False, repr=False)
+    _slot_of: Mapping[str, int] = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        """Build the slot-keyed projection and its reverse index."""
+        by_slot: dict[int, Mapping[str, Any]] = {}
+        slot_of: dict[str, int] = {}
+        for name, user in self.users.items():
+            slot_num = self.assignment.slot(name)
+            if slot_num is None:
+                # No number: inventing one would put this user's code on a
+                # credential index somebody else may hold.
+                continue
+            by_slot[slot_num] = MappingProxyType({CONF_NAME: name, **user})
+            slot_of[name] = slot_num
+        object.__setattr__(self, "_by_slot", MappingProxyType(by_slot))
+        object.__setattr__(self, "_slot_of", MappingProxyType(slot_of))
 
     @classmethod
     def empty(cls) -> EntryConfig:
@@ -101,18 +127,37 @@ class EntryConfig:
         from data into options and the listener moves it back, so which side
         holds it depends on where in that cycle we are.
         """
+        # ONE side holds the configuration, and it is read whole. Filling the
+        # shape keys independently let an entry carry both -- user-shaped data
+        # (the steady state) alongside a slot-shaped options save the entry
+        # could not process while it was failed -- and from_mapping prefers
+        # `users`, so the pending save was silently reverted and then
+        # persisted over. Options wins when it holds configuration at all,
+        # which is what _setup_entry_after_start's merge exists to preserve.
+        config_side: Mapping[str, Any] = next(
+            (
+                side
+                for side in (entry.options, entry.data)
+                if CONF_USERS in side or CONF_SLOTS in side
+            ),
+            {},
+        )
         merged: dict[str, Any] = {
+            # Bookkeeping is merged from both sides: setup moves it from data
+            # into options and the listener moves it back, so which side holds
+            # it depends on where in that cycle we are.
             **{k: v for k, v in entry.data.items() if k not in _CONFIG_KEYS},
             **{k: v for k, v in entry.options.items() if k not in _CONFIG_KEYS},
             CONF_LOCKS: entry.options.get(CONF_LOCKS, entry.data.get(CONF_LOCKS, [])),
         }
-        for key in (CONF_USERS, CONF_SLOT_ASSIGNMENT, CONF_SLOTS):
-            # Only set when a side actually HAS it. Defaulting to an empty
-            # mapping would make "absent" indistinguishable from "empty", and
-            # from_mapping would read an entry with users as having none.
-            value = entry.options.get(key, entry.data.get(key))
-            if value is not None:
-                merged[key] = value
+        for key in (CONF_USERS, CONF_SLOTS):
+            if key in config_side:
+                merged[key] = config_side[key]
+        assignment = entry.options.get(
+            CONF_SLOT_ASSIGNMENT, entry.data.get(CONF_SLOT_ASSIGNMENT)
+        )
+        if assignment is not None:
+            merged[CONF_SLOT_ASSIGNMENT] = assignment
         return cls.from_mapping(merged)
 
     @classmethod
@@ -150,22 +195,12 @@ class EntryConfig:
         """
         Return the slot-keyed view.
 
-        TEMPORARY, and derived rather than stored -- there is one model, and
-        this is a projection of it. It exists so the twenty-eight remaining
-        slot-keyed call sites can move one at a time instead of in a single
-        change nobody could review. Delete it, and this docstring, once they
-        have.
-
-        A user holding no slot is omitted: inventing a number would put their
-        code on a credential index somebody else may hold.
+        TEMPORARY, and a projection of the one model rather than a second one.
+        It exists so the remaining slot-keyed call sites can move one at a
+        time instead of in a single unreviewable change. Delete it, and this
+        docstring, once they have.
         """
-        return MappingProxyType(
-            {
-                slot_num: MappingProxyType({CONF_NAME: name, **user})
-                for name, user in self.users.items()
-                if (slot_num := self.assignment.slot(name)) is not None
-            }
-        )
+        return self._by_slot
 
     def has_lock(self, lock_entity_id: str) -> bool:
         """Return True if this entry manages the given lock."""
@@ -218,14 +253,62 @@ class EntryConfig:
             return NotImplemented
         return EntryConfigDiff(old=self, new=other)
 
-    def with_user_field_set(self, name: str, key: str, value: Any) -> EntryConfig:
-        """Return a copy with one user's field set, creating the user if new."""
+    def with_user_renamed(self, old: str, new: str) -> EntryConfig:
+        """
+        Return a copy with a user re-keyed, keeping their slot.
+
+        A rename re-keys the configuration AND the assignment, so the slot
+        follows the person. Nothing in either registry moves: identifiers key
+        on the slot number, which is exactly why a rename is free.
+        """
         stored = next(
-            (known for known in self.users if _identity(known) == _identity(name)),
-            normalize_name(name),
+            (known for known in self.users if _identity(known) == _identity(old)), None
         )
+        if stored is None:
+            return self
+        renamed = normalize_name(new)
+        new_users = {
+            (renamed if k == stored else k): dict(v) for k, v in self.users.items()
+        }
+        return EntryConfig(
+            locks=self.locks,
+            users=MappingProxyType(
+                {k: MappingProxyType(v) for k, v in new_users.items()}
+            ),
+            # Through reconcile, which is the only allocator, so the rename
+            # cannot drift from how additions and removals are resolved. No
+            # allocation happens here -- every name already holds a slot -- so
+            # `start` is inert; it is required rather than defaulted precisely
+            # so a caller that DOES allocate has to think about it.
+            assignment=self.assignment.reconcile(
+                new_users, start=1, renames={stored: renamed}
+            ),
+            extra=self.extra,
+        )
+
+    def with_user_field_set(self, name: str, key: str, value: Any) -> EntryConfig:
+        """
+        Return a copy with one user's field set.
+
+        Setting the NAME re-keys the user rather than storing a field, because
+        the name is the identity here -- it is what the configuration is keyed
+        by and what the assignment records. Stored as a field it looked
+        correct through the slot projection, where the inner value shadows the
+        key, while the actual identity went permanently stale.
+
+        A user who does not exist is NOT created: creating one also has to
+        allocate a slot, and this cannot. Until allocation is wired, creation
+        has no correct implementation to offer.
+        """
+        if key == CONF_NAME:
+            return self.with_user_renamed(name, value)
+        stored = next(
+            (known for known in self.users if _identity(known) == _identity(name)), None
+        )
+        if stored is None:
+            return self
         new_users = {k: dict(v) for k, v in self.users.items()}
-        new_users.setdefault(stored, {})[key] = value
+        new_users[stored][key] = value
         return EntryConfig(
             locks=self.locks,
             users=MappingProxyType(

--- a/custom_components/lock_code_manager/domain/credentials.py
+++ b/custom_components/lock_code_manager/domain/credentials.py
@@ -214,10 +214,6 @@ class User:
         """
         return self.credentials_of_type(CredentialType.PIN)
 
-    def credential_for(self, credential_type: CredentialType) -> Credential | None:
-        """Return the first credential of ``credential_type``, else ``None``."""
-        return next(iter(self.credentials_of_type(credential_type)), None)
-
 
 class WriteResult(StrEnum):
     """
@@ -349,22 +345,6 @@ def credential_from_slot(slot: int, state: SlotCredential) -> Credential:
     at the same index, reusing the ``SlotCredential`` verbatim as its state.
     """
     return Credential(type=CredentialType.PIN, slot=slot, state=state)
-
-
-def slot_credential_of(credential: Credential) -> SlotCredential:
-    """
-    Project a Personal Identification Number credential back to a SlotCredential.
-
-    This is the inverse of ``credential_from_slot`` and is identity on the
-    state, so the coordinator can keep consuming ``SlotCredential`` unchanged.
-    It rejects non-PIN credentials because only PIN projects one-to-one onto a
-    managed slot today.
-    """
-    if credential.type is not CredentialType.PIN:
-        raise ValueError(
-            f"Only PIN credentials project to a slot, got {credential.type}"
-        )
-    return credential.state
 
 
 def user_from_slot(slot: int, state: SlotCredential, name: str | None = None) -> User:

--- a/custom_components/lock_code_manager/domain/names.py
+++ b/custom_components/lock_code_manager/domain/names.py
@@ -6,11 +6,6 @@ on -- the config entry will store a mapping of named users rather than one of
 slot numbers, and lock users will be tagged ``lcm:{name}``. That only works if
 every name is present and unique within its entry.
 
-Encodability used to be a third rule: a name could not contain ``|``, because
-entity and device identifiers were delimited by it and keyed by the name. They
-are keyed by the slot number, so nothing parses a name any more and the
-restriction had no reason left to exist.
-
 This module is the single place those rules live, so the config flow
 (validating new input) and the migration (repairing existing data) cannot
 drift from each other.

--- a/custom_components/lock_code_manager/domain/slot_assignment.py
+++ b/custom_components/lock_code_manager/domain/slot_assignment.py
@@ -6,12 +6,11 @@ bookkeeping. It still exists, because on most providers it IS the lock's
 credential index -- ``credential_index_follows_slot`` -- so it is bounded by
 the lock's advertised capacity and must be reusable when a user is deleted.
 
-That boundedness is why this is an assignment rather than a handle allocator:
-a number that can never be reused would eventually exceed every lock's
-capacity. Reuse is correct here. Deleting a user and creating another does
-hand the newcomer the departed user's slot, entity identifiers, and history
--- exactly as it does today, because the physical credential slot is genuinely
-being reused.
+That boundedness is why numbers are reused rather than issued monotonically:
+one that is never reused would eventually exceed every lock's capacity.
+Deleting a user and creating another does hand the newcomer the departed
+user's slot, entity identifiers, and history, which matches what the physical
+credential slot is doing.
 
 Entity and device identifiers keep keying on this number, so a rename moves
 nothing in either registry.
@@ -62,11 +61,10 @@ class SlotAssignment:
         Put the mapping into its canonical form, then freeze it.
 
         Names are reduced to their identity form and slot numbers coerced to
-        ``int``. Doing it here makes both invariants of the TYPE rather than
-        of whichever factory happened to build it -- the plain constructor
-        previously accepted a string slot number, and a caller reading
-        ``entry.data`` directly instead of through :meth:`from_mapping` would
-        reintroduce the double-booking that string keys caused.
+        ``int``. Doing it here makes both invariants of the TYPE rather than of
+        whichever factory built it, so a caller constructing directly from
+        stored data cannot introduce a string key that compares unequal to an
+        int one.
 
         Two keys reducing to one identity keeps the LOWER slot. That case
         means the stored bookkeeping was already inconsistent; raising would
@@ -207,16 +205,13 @@ class SlotAssignment:
         wanted = list(dict.fromkeys(_identity(name) for name in names))
         surviving = set(wanted)
 
-        # A move is only honoured when the source holds a slot AND the target
-        # is among the survivors. A rename whose target is absent contradicts
-        # the name set -- and left unfiltered it dropped the source from
-        # `kept` while `renamed` refused to take them, so a user who survived
-        # under their own name was reallocated from `start`.
+        # A move is honoured only when the source holds a slot AND the target
+        # is among the survivors; a rename whose target is absent contradicts
+        # the name set and is ignored.
         #
-        # Two sources renaming onto one target is likewise contradictory
-        # (``validate_slot_names`` rejects it upstream). Resolved by sorted
-        # order rather than by whichever the stored mapping happened to
-        # iterate first, so the same input always gives the same answer.
+        # Two sources renaming onto one target is likewise contradictory.
+        # Resolved in sorted order so the same input always gives the same
+        # answer regardless of mapping iteration order.
         # Reduce to identity form FIRST. Iterating the raw mapping let two
         # keys that mean the same user (``Alice`` and ``alice ``) each take a
         # turn: the later overwrote the earlier while the earlier's target

--- a/custom_components/lock_code_manager/domain/slot_coordinator.py
+++ b/custom_components/lock_code_manager/domain/slot_coordinator.py
@@ -209,23 +209,27 @@ class SlotEntityCoordinator:
         """
         Apply a slot name write requested by the text entity.
 
-        The name is the identity Lock Code Manager is moving to key on, so
-        this path enforces the same rules the config flow does. Without it
-        the ordinary way to rename a slot in the frontend would be a hole
-        straight through them: an empty name, one containing the reserved
-        separator, or a duplicate of another slot's would land in the
-        config entry unchallenged.
+        The name is the identity the configuration is keyed by, so this path
+        enforces the same rules the config flow does. Without it the ordinary
+        way to rename a user in the frontend would be a hole straight through
+        them: an empty name, or a duplicate of somebody else's, would land in
+        the config entry unchallenged.
         """
         name = normalize_name(value)
         if error := name_error(name):
             raise InvalidNameError(error, self._slot_num)
 
+        # Compared against every configured user, not only those holding a
+        # slot: a user without one is still a name that cannot be taken, and
+        # renaming onto them would be refused further down without an error
+        # ever reaching the caller.
+        config = get_entry_config(self._config_entry)
+        mine = config.name_for(self._slot_num)
         conflict = next(
             (
                 other
-                for other, slot in get_entry_config(self._config_entry).slots.items()
-                if other != self._slot_num
-                and normalize_name(slot.get(CONF_NAME)).casefold() == name.casefold()
+                for other in config.users
+                if other != mine and other.casefold() == name.casefold()
             ),
             None,
         )
@@ -469,14 +473,14 @@ class InvalidNameError(HomeAssistantError):
     """
 
     def __init__(
-        self, error_key: str, slot_num: int, conflicting_slot: int | None = None
+        self, error_key: str, slot_num: int, conflicting_name: str | None = None
     ) -> None:
-        """Store the error key and the slots involved."""
+        """Store the error key, the slot written to, and any user in the way."""
         self.error_key = error_key
         self.slot_num = slot_num
-        self.conflicting_slot = conflicting_slot
+        self.conflicting_name = conflicting_name
         self.placeholders = {
             "slot_num": str(slot_num),
-            "conflicting_slot": str(conflicting_slot),
+            "conflicting_name": str(conflicting_name),
         }
         super().__init__(f"{error_key} (slot {slot_num})")

--- a/custom_components/lock_code_manager/domain/user_migration.py
+++ b/custom_components/lock_code_manager/domain/user_migration.py
@@ -1,0 +1,72 @@
+"""
+Reshape a slot-keyed config entry into a user-keyed one.
+
+This is the version 3 release's whole point::
+
+    slots:                      users:
+      1:                 ->       raman:
+        name: Raman                 pin: "1234"
+        pin: "1234"
+
+with the slot number demoted to the internal ``slot_assignment`` bookkeeping
+that :mod:`.slot_assignment` owns.
+
+Kept pure, and separate from ``async_migrate_entry``, so the properties that
+matter can be stated over it directly: nothing lost, nobody renumbered, no
+retired key left behind. The migration has no rollback, so those are not
+stylistic preferences -- each failure is permanent for the user it happens to.
+
+**No registry writes happen here or anywhere in this migration.** Entity and
+device identifiers keep the slot number, so there is nothing to move. That is
+the property that makes this release safe to ship, and the reason the earlier
+name-keyed identifier design was abandoned.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from ..const import CONF_NUM_SLOTS, CONF_SLOTS, CONF_START_SLOT, CONF_USERS
+from .slot_assignment import CONF_SLOT_ASSIGNMENT, users_from_slots
+
+# Keys this migration consumes. Everything else in the entry is carried
+# through verbatim, so a key added by a later release is not silently dropped
+# by an older migration running against it.
+_CONSUMED = frozenset({CONF_SLOTS, CONF_START_SLOT, CONF_NUM_SLOTS})
+
+
+def migrate_to_users(
+    config: Mapping[str, Any],
+) -> tuple[dict[str, Any], list[str]]:
+    """
+    Return the user-keyed form of ``config``, and the slots whose name changed.
+
+    ``start_slot`` and ``num_slots`` are dropped rather than translated. There
+    is no start slot any more: allocation takes the lowest slot not already
+    occupied, which needs no configuration and cannot go stale. The number of
+    users is just the size of the mapping.
+
+    Already-migrated input is returned unchanged, so running twice is a no-op.
+    The version stamp should prevent a second run, but a migration with no
+    rollback should not rely on that for its safety.
+    """
+    if CONF_SLOTS not in config:
+        return {k: v for k, v in config.items() if k not in _CONSUMED}, []
+
+    users, assignment, renamed = users_from_slots(config[CONF_SLOTS])
+    return {
+        **{k: v for k, v in config.items() if k not in _CONSUMED},
+        # Keyed by the name AS DISPLAYED, not by the identity form. The
+        # configuration is hand-editable, so someone who typed "Raman" must
+        # get "Raman" back rather than a casefolded version of it -- and the
+        # name is the only place that capitalization now survives, since it
+        # stopped being a field.
+        #
+        # Uniqueness is still case-insensitive: names.deduplicate has already
+        # guaranteed no two users differ only by case, and SlotAssignment
+        # compares on the identity form. Storage keeps the display, lookups
+        # fold the case.
+        CONF_USERS: users,
+        CONF_SLOT_ASSIGNMENT: dict(assignment.slots),
+    }, renamed

--- a/custom_components/lock_code_manager/domain/user_migration.py
+++ b/custom_components/lock_code_manager/domain/user_migration.py
@@ -1,25 +1,23 @@
 """
 Reshape a slot-keyed config entry into a user-keyed one.
 
-This is the version 3 release's whole point::
+::
 
     slots:                      users:
-      1:                 ->       raman:
+      1:                 ->       Raman:
         name: Raman                 pin: "1234"
         pin: "1234"
 
-with the slot number demoted to the internal ``slot_assignment`` bookkeeping
-that :mod:`.slot_assignment` owns.
+The slot number is demoted to the ``slot_assignment`` bookkeeping that
+:mod:`.slot_assignment` owns.
 
-Kept pure, and separate from ``async_migrate_entry``, so the properties that
-matter can be stated over it directly: nothing lost, nobody renumbered, no
-retired key left behind. The migration has no rollback, so those are not
-stylistic preferences -- each failure is permanent for the user it happens to.
+Pure, and separate from ``async_migrate_entry``, so what it must guarantee can
+be stated over it directly: nothing lost, nobody renumbered, no retired key
+left behind. The migration has no rollback, so each of those failing is
+permanent for the user it happens to.
 
-**No registry writes happen here or anywhere in this migration.** Entity and
-device identifiers keep the slot number, so there is nothing to move. That is
-the property that makes this release safe to ship, and the reason the earlier
-name-keyed identifier design was abandoned.
+No registry writes happen here. Entity and device identifiers keep the slot
+number, so there is nothing to move.
 """
 
 from __future__ import annotations
@@ -30,9 +28,7 @@ from typing import Any
 from ..const import CONF_NUM_SLOTS, CONF_SLOTS, CONF_START_SLOT, CONF_USERS
 from .slot_assignment import CONF_SLOT_ASSIGNMENT, users_from_slots
 
-# Keys this migration consumes. Everything else in the entry is carried
-# through verbatim, so a key added by a later release is not silently dropped
-# by an older migration running against it.
+# Keys this migration consumes. Everything else is carried through verbatim.
 _CONSUMED = frozenset({CONF_SLOTS, CONF_START_SLOT, CONF_NUM_SLOTS})
 
 
@@ -42,14 +38,12 @@ def migrate_to_users(
     """
     Return the user-keyed form of ``config``, and the slots whose name changed.
 
-    ``start_slot`` and ``num_slots`` are dropped rather than translated. There
-    is no start slot any more: allocation takes the lowest slot not already
-    occupied, which needs no configuration and cannot go stale. The number of
-    users is just the size of the mapping.
+    ``start_slot`` and ``num_slots`` are dropped rather than translated:
+    allocation takes the lowest unoccupied slot, and the number of users is
+    the size of the mapping.
 
-    Already-migrated input is returned unchanged, so running twice is a no-op.
-    The version stamp should prevent a second run, but a migration with no
-    rollback should not rely on that for its safety.
+    Already-migrated input is returned unchanged, so running twice is a no-op
+    rather than relying on the version stamp for that.
     """
     if CONF_SLOTS not in config:
         return {k: v for k, v in config.items() if k not in _CONSUMED}, []
@@ -57,16 +51,10 @@ def migrate_to_users(
     users, assignment, renamed = users_from_slots(config[CONF_SLOTS])
     return {
         **{k: v for k, v in config.items() if k not in _CONSUMED},
-        # Keyed by the name AS DISPLAYED, not by the identity form. The
-        # configuration is hand-editable, so someone who typed "Raman" must
-        # get "Raman" back rather than a casefolded version of it -- and the
-        # name is the only place that capitalization now survives, since it
-        # stopped being a field.
-        #
-        # Uniqueness is still case-insensitive: names.deduplicate has already
-        # guaranteed no two users differ only by case, and SlotAssignment
-        # compares on the identity form. Storage keeps the display, lookups
-        # fold the case.
+        # Keyed by the name as displayed. The configuration is hand-editable,
+        # and this key is the only place a user's capitalization survives now
+        # that the name is not a field. Uniqueness stays case-insensitive:
+        # storage keeps the display form, comparison folds the case.
         CONF_USERS: users,
         CONF_SLOT_ASSIGNMENT: dict(assignment.slots),
     }, renamed

--- a/custom_components/lock_code_manager/strings.json
+++ b/custom_components/lock_code_manager/strings.json
@@ -236,7 +236,7 @@
   },
   "exceptions": {
     "name_not_unique": {
-      "message": "Code slot {conflicting_slot} already uses that name. Names must be unique within a Lock Code Manager entry."
+      "message": "{conflicting_name} already uses that name. Names must be unique within a Lock Code Manager entry."
     },
     "name_required": {
       "message": "Code slot {slot_num} needs a name. The name identifies this user on your locks."

--- a/custom_components/lock_code_manager/strings.json
+++ b/custom_components/lock_code_manager/strings.json
@@ -71,6 +71,13 @@
         },
         "description": "The config is expected to be a dictionary where the key is the slot number. For more information, check the docs.",
         "title": "Configure slots"
+      },
+      "reauth_confirm": {
+        "data": {
+          "locks": "Locks"
+        },
+        "description": "The lock `{lock}`, in the configuration for `{name}`, is no longer configured in Home Assistant and must be removed from your configuration. Choose new locks that this configuration is for. If you no longer need this configuration, delete the configuration entry.",
+        "title": "Update locks for {name}"
       }
     }
   },

--- a/custom_components/lock_code_manager/strings.json
+++ b/custom_components/lock_code_manager/strings.json
@@ -130,7 +130,6 @@
     },
     "error": {
       "invalid_config": "Slots configuration is invalid. For more information, check the logs and the docs.",
-      "locks_already_configured": "The following lock(s) are already managed by another config entry: {locks}.",
       "name_not_unique": "The name for code slot {slot_num} is already used by another code slot in this entry. Names must be unique.",
       "name_required": "Code slot {slot_num} needs a name. The name identifies this user on your locks.",
       "slot_out_of_range": "Lock {lock} reports only {num_slots} PIN code slots, so these slot numbers are out of range for it: {out_of_range_slots}. Renumber them to fall within 1-{num_slots}, or manage that lock from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity.",

--- a/custom_components/lock_code_manager/strings.json
+++ b/custom_components/lock_code_manager/strings.json
@@ -42,13 +42,6 @@
           "existing_codes_cancel": "Cancel"
         }
       },
-      "reauth": {
-        "data": {
-          "locks": "Locks"
-        },
-        "description": "The lock `{lock}`, in the configuration for `{name}`, is no longer configured in Home Assistant and must be removed from your configuration. Choose new locks that this configuration is for. If you no longer need this configuration, delete the configuration entry.",
-        "title": "Update locks for {name}"
-      },
       "ui": {
         "data": {
           "num_slots": "Number of slots",

--- a/custom_components/lock_code_manager/translations/en.json
+++ b/custom_components/lock_code_manager/translations/en.json
@@ -236,7 +236,7 @@
   },
   "exceptions": {
     "name_not_unique": {
-      "message": "Code slot {conflicting_slot} already uses that name. Names must be unique within a Lock Code Manager entry."
+      "message": "{conflicting_name} already uses that name. Names must be unique within a Lock Code Manager entry."
     },
     "name_required": {
       "message": "Code slot {slot_num} needs a name. The name identifies this user on your locks."

--- a/custom_components/lock_code_manager/translations/en.json
+++ b/custom_components/lock_code_manager/translations/en.json
@@ -71,6 +71,13 @@
         },
         "description": "The config is expected to be a dictionary where the key is the slot number. For more information, check the docs.",
         "title": "Configure slots"
+      },
+      "reauth_confirm": {
+        "data": {
+          "locks": "Locks"
+        },
+        "description": "The lock `{lock}`, in the configuration for `{name}`, is no longer configured in Home Assistant and must be removed from your configuration. Choose new locks that this configuration is for. If you no longer need this configuration, delete the configuration entry.",
+        "title": "Update locks for {name}"
       }
     }
   },

--- a/custom_components/lock_code_manager/translations/en.json
+++ b/custom_components/lock_code_manager/translations/en.json
@@ -130,7 +130,6 @@
     },
     "error": {
       "invalid_config": "Slots configuration is invalid. For more information, check the logs and the docs.",
-      "locks_already_configured": "The following lock(s) are already managed by another config entry: {locks}.",
       "name_not_unique": "The name for code slot {slot_num} is already used by another code slot in this entry. Names must be unique.",
       "name_required": "Code slot {slot_num} needs a name. The name identifies this user on your locks.",
       "slot_out_of_range": "Lock {lock} reports only {num_slots} PIN code slots, so these slot numbers are out of range for it: {out_of_range_slots}. Renumber them to fall within 1-{num_slots}, or manage that lock from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity.",

--- a/custom_components/lock_code_manager/translations/en.json
+++ b/custom_components/lock_code_manager/translations/en.json
@@ -42,13 +42,6 @@
           "existing_codes_cancel": "Cancel"
         }
       },
-      "reauth": {
-        "data": {
-          "locks": "Locks"
-        },
-        "description": "The lock `{lock}`, in the configuration for `{name}`, is no longer configured in Home Assistant and must be removed from your configuration. Choose new locks that this configuration is for. If you no longer need this configuration, delete the configuration entry.",
-        "title": "Update locks for {name}"
-      },
       "ui": {
         "data": {
           "num_slots": "Number of slots",

--- a/tests/properties/test_slot_assignment.py
+++ b/tests/properties/test_slot_assignment.py
@@ -61,14 +61,9 @@ def slot_mappings(draw: st.DrawFn) -> dict[int, dict]:
 def stored_slot_mappings(draw: st.DrawFn) -> dict:
     """Configurations shaped like STORAGE rather than like valid input.
 
-    Keys are strings, because that is what the on-disk JSON form yields and
-    what a migration reading stored data actually hands in. Names may repeat
-    or be missing, because both are reachable from a version 2 entry where
-    the name is optional.
-
-    The clean strategy above cannot expose either hazard, which is exactly
-    why the string-key slot collision survived the first round of these
-    properties.
+    Keys are strings, as the on-disk JSON form yields. Names may repeat or be
+    missing, both of which are reachable from a version 2 entry where the name
+    is optional. The clean strategy above can produce neither.
     """
     configs = draw(st.lists(SLOT_CONFIGS, max_size=4))
     start = draw(st.integers(min_value=1, max_value=4))
@@ -208,18 +203,13 @@ def test_renaming_keeps_the_users_slot(
 ) -> None:
     """A rename changes who holds a slot, never which slot they hold.
 
-    Two things make this property actually bite, and it did not before.
+    Filters on the IDENTITY form, since the stored keys are casefolded.
 
-    It filters on the IDENTITY form. Filtering on the raw name went vacuous
-    the moment keys became casefolded -- every generated name is capitalized,
-    so the filter emptied the map and every assertion was trivially true.
-
-    And it adds users in a SHUFFLED order alongside the rename. Without a
-    competing addition, ignoring renames entirely still passes: the newcomer
-    is handed the very slot the "departed" user just freed, so delete-plus-add
-    and rename coincide. They only diverge when somebody else is in line for
-    that slot, which is exactly the case that reorders two users' credential
-    indices on a real lock.
+    Adds users in a SHUFFLED order alongside the rename, because without a
+    competing addition a rename is indistinguishable from delete-plus-add: the
+    newcomer is handed the very slot the departed user freed. They diverge only
+    when somebody else is in line for that slot, which is the case that
+    reorders two users' credential indices on a real lock.
     """
     before = _reconcile(SlotAssignment.empty(), names, start=start)
     moves = {old: new for old, new in renames.items() if _identity(old) in before.slots}
@@ -385,15 +375,10 @@ def test_slots_never_exceed_the_most_users_ever_configured_at_once(
 ) -> None:
     """Numbers stay inside ``start`` plus the high-water mark of CONCURRENT users.
 
-    This is the property that justifies reusing slot numbers at all, and it
-    went missing in a rewrite while the pull request description went on
-    citing it by name. On most providers the slot IS the lock's credential
-    index, and a number above the advertised capacity can never be written.
-
-    A never-reused number satisfies this for no bound: it climbs with every
-    user ever created and eventually leaves the lock's range entirely. Reuse
-    is what keeps the numbering tight, which is why the slot number is the
-    right thing to key on and a monotonically increasing handle is not.
+    The property that justifies reusing slot numbers: on most providers the
+    slot IS the lock's credential index, and a number above the advertised
+    capacity can never be written. A monotonically increasing number satisfies
+    no such bound.
     """
     assignment = SlotAssignment.empty()
     high_water = 0
@@ -456,9 +441,8 @@ def test_a_rename_to_somebody_absent_leaves_the_source_alone(
 def test_a_double_booked_slot_is_repaired(slots: dict[str, int], start: int) -> None:
     """Two users on one credential index must not survive a reconcile.
 
-    Only reachable from bookkeeping that was already inconsistent, but nothing
-    else repairs it, so it would persist for good -- and both users would
-    write over each other on the lock every sync.
+    Only reachable from bookkeeping that is already inconsistent, but nothing
+    else repairs it and both users would write over each other every sync.
     """
     reconciled = SlotAssignment(slots=slots).reconcile(list(slots), start=start)
 
@@ -470,8 +454,8 @@ def test_a_double_booked_slot_is_repaired(slots: dict[str, int], start: int) -> 
 def test_a_collapsed_identity_keeps_the_lower_slot() -> None:
     """Two keys reducing to one identity keep the LOWER number, as documented.
 
-    Covered but unpinned before: mutating ``min`` to ``max`` passed every
-    property, because nothing constructed a mapping whose keys collapse.
+    Needs an example: the strategies cannot construct a mapping whose keys
+    collapse.
     """
     assert dict(SlotAssignment(slots={"Raman": 4, "raman ": 2}).slots) == {"raman": 2}
 
@@ -479,9 +463,8 @@ def test_a_collapsed_identity_keeps_the_lower_slot() -> None:
 def test_a_string_slot_number_is_coerced() -> None:
     """The constructor accepts what storage yields and normalizes it.
 
-    This coercion is the type-level defence against the string-key
-    double-booking the branch previously shipped, and mutating it away passed
-    every property -- no test handed a string slot value to the constructor.
+    The type-level defence against a string key comparing unequal to the int
+    one everything else uses.
     """
     assignment = SlotAssignment(slots={"alice": "3"})
 
@@ -495,11 +478,8 @@ def test_a_string_slot_number_is_coerced() -> None:
 def test_a_non_string_name_key_is_coerced_not_fatal() -> None:
     """Stored bookkeeping with a non-string key must load, not abort setup.
 
-    ``normalize_name`` calls ``.strip()``, so an integer key raised
-    AttributeError and took the whole entry setup down with it. Reachable
-    from hand-edited storage, or from a writer that persisted the slot number
-    as the key by mistake. Nothing pinned the coercion until this test: the
-    mutation removing it passed all 23 properties.
+    ``normalize_name`` calls ``.strip()``, so a non-string key would raise and
+    take entry setup down. Reachable from hand-edited storage.
     """
     assignment = SlotAssignment.from_mapping({CONF_SLOT_ASSIGNMENT: {1: 4}})
 
@@ -539,12 +519,9 @@ def test_renames_are_read_case_insensitively_too(
 ) -> None:
     """The rename map is reduced to identity form, like the stored names are.
 
-    ``__post_init__`` canonicalizes the assignment's keys, but the rename map
-    arrives from a caller and got none of that treatment. Two keys meaning the
-    same user each took a turn: the later overwrote the earlier while the
-    earlier's target stayed claimed, so a third user's legitimate rename onto
-    that target was refused and they were renumbered onto a different
-    credential index.
+    ``__post_init__`` canonicalizes the assignment's keys; the rename map
+    arrives from a caller and needs the same treatment, or two keys meaning one
+    user each take a turn.
     """
     before = SlotAssignment.empty().reconcile(names, start=start)
     shouted = {old.upper(): new for old, new in renames.items()}
@@ -604,15 +581,12 @@ def test_corrupt_stored_bookkeeping_degrades_instead_of_aborting_setup() -> None
 def test_two_rename_keys_meaning_one_user_resolve_deterministically() -> None:
     """``Alice`` and ``alice `` are one user, so they get one turn, not two.
 
-    Iterating the raw mapping gave each a turn: the later overwrote the
-    earlier in the move table while the earlier's target stayed CLAIMED. A
-    third user renaming onto that abandoned target was then refused and
-    renumbered onto a different credential index -- and which of the two won
-    depended on the mapping's insertion order.
+    Whichever of the two wins must not depend on the mapping's insertion
+    order, and the loser's target must not stay claimed against a third user
+    renaming onto it.
 
     Needs an example rather than a property: the strategies generate distinct
-    names, so they cannot produce two keys with one identity, which is why
-    the mutation removing this survived every property.
+    names, so they cannot produce two keys with one identity.
     """
     before = SlotAssignment(slots={"Alice": 1, "Bob": 5, "Carl": 2})
     forward = {"Alice": "Wren", "alice ": "Vic", "Bob": "Wren"}

--- a/tests/properties/test_user_migration.py
+++ b/tests/properties/test_user_migration.py
@@ -1,18 +1,13 @@
 """
 Property-based tests for the version 3 configuration migration.
 
-Written from `docs/superpowers/specs/2026-08-18-b2c-invariants.md` BEFORE the
-implementation, so they state what the migration must honour rather than
-describing what it happens to do. The numbered references below are that
-document's constraints.
-
-The migration has no rollback (constraint 12), so every failure mode here is
-permanent for the user it happens to:
+The migration has no rollback, so every failure mode here is permanent for
+the user it happens to:
 
 * **something is lost** -- a user, or a field of one. Silent, because the
   result is still a valid configuration.
 * **somebody is renumbered** -- the slot is the credential index on most
-  providers (constraint 1), so a changed number moves that person's code to a
+  providers, so a changed number moves that person's code to a
   different index on every lock and orphans their entities.
 * **a retired key survives** -- `start_slot` and `num_slots` no longer mean
   anything, and a stale one would be read by something eventually.
@@ -55,11 +50,10 @@ SLOT_CONFIGS = st.builds(
 def v2_entries(draw: st.DrawFn) -> dict:
     """Entry mappings shaped like STORAGE, including the awkward ones.
 
-    Keys are strings because that is the on-disk JSON form. Names may be
-    missing or duplicated, both reachable from a version 2 entry where the
-    name is optional (constraint 7). The start slot is drawn above 1 often
-    enough that "preserved, not renumbered" is a real assertion rather than a
-    coincidence of everything starting at 1.
+    Keys are strings, as the on-disk JSON form yields. Names may be missing or
+    duplicated, both reachable from a version 2 entry where the name is
+    optional. The start slot is drawn above 1 often enough that "preserved,
+    not renumbered" is a real assertion rather than a coincidence.
     """
     configs = draw(st.lists(SLOT_CONFIGS, max_size=4))
     start = draw(st.integers(min_value=1, max_value=12))
@@ -92,11 +86,11 @@ def test_every_slot_becomes_exactly_one_user(entry: dict) -> None:
 
 @given(entry=v2_entries())
 def test_nobody_is_renumbered(entry: dict) -> None:
-    """Each user keeps the slot number they already occupied (constraint 1).
+    """Each user keeps the slot number they already occupied.
 
-    The whole reason the migration is safe: the slot is what identifiers key
-    on and what addresses the credential on the lock, so a changed number
-    orphans that user's entities AND writes their code to a different index.
+    The slot is what identifiers key on and what addresses the credential on
+    the lock, so a changed number orphans that user's entities and writes
+    their code to a different index.
     """
     migrated, _ = migrate_to_users(entry)
     assignment = SlotAssignment(slots=migrated[CONF_SLOT_ASSIGNMENT])
@@ -128,10 +122,10 @@ def test_no_field_is_lost_except_the_name(entry: dict) -> None:
 
 @given(entry=v2_entries())
 def test_the_retired_keys_are_gone(entry: dict) -> None:
-    """slots, start_slot and num_slots no longer mean anything.
+    """slots, start_slot and num_slots have no meaning in the new shape.
 
-    There is no start slot any more -- allocation takes the lowest slot not
-    already occupied. A stale key would eventually be read by something.
+    Allocation takes the lowest unoccupied slot, so a start slot configures
+    nothing; a stale key would eventually be read by something.
     """
     migrated, _ = migrate_to_users(entry)
 
@@ -154,15 +148,12 @@ def test_everything_else_is_carried_through(entry: dict) -> None:
 def test_user_keys_keep_the_name_as_displayed(entry: dict) -> None:
     """The key is the name as typed, not a casefolded version of it.
 
-    This property said the opposite when first written, and implementing the
-    reader is what exposed it: the name stopped being a field when it became
-    the key, so the key is now the ONLY place capitalization survives. The
-    configuration is hand-editable, and someone who typed "Raman" getting
-    "raman" back is a bug.
+    The name stopped being a field when it became the key, so the key is the
+    only place a user's capitalization survives. The configuration is
+    hand-editable, and someone who typed "Raman" should get "Raman" back.
 
-    Uniqueness stays case-insensitive regardless (constraint 8) --
-    names.deduplicate guarantees no two differ only by case, and lookups fold
-    it. Storage keeps the display; comparison folds the case.
+    Uniqueness stays case-insensitive: storage keeps the display form,
+    comparison folds the case.
     """
     migrated, _ = migrate_to_users(entry)
 
@@ -176,8 +167,8 @@ def test_user_keys_keep_the_name_as_displayed(entry: dict) -> None:
 def test_migrating_twice_changes_nothing(entry: dict) -> None:
     """A migration that runs again must be a no-op.
 
-    It should not run twice -- the version stamp prevents it -- but a
-    migration with no rollback should not depend on that for its safety.
+    The version stamp should prevent a second run, but a migration with no
+    rollback should not depend on that.
     """
     once, _ = migrate_to_users(entry)
     twice, renamed = migrate_to_users(once)

--- a/tests/properties/test_user_migration.py
+++ b/tests/properties/test_user_migration.py
@@ -1,0 +1,205 @@
+"""
+Property-based tests for the version 3 configuration migration.
+
+Written from `docs/superpowers/specs/2026-08-18-b2c-invariants.md` BEFORE the
+implementation, so they state what the migration must honour rather than
+describing what it happens to do. The numbered references below are that
+document's constraints.
+
+The migration has no rollback (constraint 12), so every failure mode here is
+permanent for the user it happens to:
+
+* **something is lost** -- a user, or a field of one. Silent, because the
+  result is still a valid configuration.
+* **somebody is renumbered** -- the slot is the credential index on most
+  providers (constraint 1), so a changed number moves that person's code to a
+  different index on every lock and orphans their entities.
+* **a retired key survives** -- `start_slot` and `num_slots` no longer mean
+  anything, and a stale one would be read by something eventually.
+"""
+
+from __future__ import annotations
+
+from hypothesis import given, strategies as st
+
+from homeassistant.const import CONF_ENABLED, CONF_NAME, CONF_PIN
+
+from custom_components.lock_code_manager.const import (
+    CONF_LOCKS,
+    CONF_NUM_SLOTS,
+    CONF_SLOTS,
+    CONF_START_SLOT,
+    CONF_USERS,
+)
+from custom_components.lock_code_manager.domain.config import EntryConfig
+from custom_components.lock_code_manager.domain.slot_assignment import (
+    CONF_SLOT_ASSIGNMENT,
+    SlotAssignment,
+    _identity,
+)
+from custom_components.lock_code_manager.domain.user_migration import (
+    migrate_to_users,
+)
+
+NAMES = st.sampled_from(["Raman", "Alice", "Bob", "Cleaner", "Guest 1"])
+
+SLOT_CONFIGS = st.builds(
+    lambda name, pin, enabled: {CONF_NAME: name, CONF_PIN: pin, CONF_ENABLED: enabled},
+    NAMES,
+    st.text(alphabet="0123456789", min_size=4, max_size=6),
+    st.booleans(),
+)
+
+
+@st.composite
+def v2_entries(draw: st.DrawFn) -> dict:
+    """Entry mappings shaped like STORAGE, including the awkward ones.
+
+    Keys are strings because that is the on-disk JSON form. Names may be
+    missing or duplicated, both reachable from a version 2 entry where the
+    name is optional (constraint 7). The start slot is drawn above 1 often
+    enough that "preserved, not renumbered" is a real assertion rather than a
+    coincidence of everything starting at 1.
+    """
+    configs = draw(st.lists(SLOT_CONFIGS, max_size=4))
+    start = draw(st.integers(min_value=1, max_value=12))
+    slots = {}
+    for i, config in enumerate(configs):
+        nameless = draw(st.booleans())
+        slots[str(start + i)] = (
+            {k: v for k, v in config.items() if k != CONF_NAME} if nameless else config
+        )
+    entry = {
+        CONF_LOCKS: draw(
+            st.lists(st.sampled_from(["lock.front", "lock.back"]), max_size=2)
+        ),
+        CONF_SLOTS: slots,
+        CONF_START_SLOT: start,
+        CONF_NUM_SLOTS: len(slots),
+    }
+    if draw(st.booleans()):
+        entry["some_future_key"] = "kept"
+    return entry
+
+
+@given(entry=v2_entries())
+def test_every_slot_becomes_exactly_one_user(entry: dict) -> None:
+    """Nobody is lost, however badly the names were configured."""
+    migrated, _ = migrate_to_users(entry)
+
+    assert len(migrated[CONF_USERS]) == len(entry[CONF_SLOTS])
+
+
+@given(entry=v2_entries())
+def test_nobody_is_renumbered(entry: dict) -> None:
+    """Each user keeps the slot number they already occupied (constraint 1).
+
+    The whole reason the migration is safe: the slot is what identifiers key
+    on and what addresses the credential on the lock, so a changed number
+    orphans that user's entities AND writes their code to a different index.
+    """
+    migrated, _ = migrate_to_users(entry)
+    assignment = SlotAssignment(slots=migrated[CONF_SLOT_ASSIGNMENT])
+
+    assert sorted(assignment.slots.values()) == sorted(
+        int(k) for k in entry[CONF_SLOTS]
+    )
+    for name in migrated[CONF_USERS]:
+        assert assignment.slot(name) is not None
+
+
+@given(entry=v2_entries())
+def test_no_field_is_lost_except_the_name(entry: dict) -> None:
+    """The name stops being a field because it becomes the key.
+
+    Anything else going missing is silent: the result still validates, the
+    user simply has no code any more.
+    """
+    migrated, _ = migrate_to_users(entry)
+    assignment = SlotAssignment(slots=migrated[CONF_SLOT_ASSIGNMENT])
+    by_slot = {
+        assignment.slot(name): user for name, user in migrated[CONF_USERS].items()
+    }
+
+    for raw_slot, slot in entry[CONF_SLOTS].items():
+        migrated_user = by_slot[int(raw_slot)]
+        assert migrated_user == {k: v for k, v in slot.items() if k != CONF_NAME}
+
+
+@given(entry=v2_entries())
+def test_the_retired_keys_are_gone(entry: dict) -> None:
+    """slots, start_slot and num_slots no longer mean anything.
+
+    There is no start slot any more -- allocation takes the lowest slot not
+    already occupied. A stale key would eventually be read by something.
+    """
+    migrated, _ = migrate_to_users(entry)
+
+    assert CONF_SLOTS not in migrated
+    assert CONF_START_SLOT not in migrated
+    assert CONF_NUM_SLOTS not in migrated
+
+
+@given(entry=v2_entries())
+def test_everything_else_is_carried_through(entry: dict) -> None:
+    """Locks and any key this migration does not know about survive verbatim."""
+    migrated, _ = migrate_to_users(entry)
+
+    assert migrated[CONF_LOCKS] == entry[CONF_LOCKS]
+    if "some_future_key" in entry:
+        assert migrated["some_future_key"] == "kept"
+
+
+@given(entry=v2_entries())
+def test_user_keys_keep_the_name_as_displayed(entry: dict) -> None:
+    """The key is the name as typed, not a casefolded version of it.
+
+    This property said the opposite when first written, and implementing the
+    reader is what exposed it: the name stopped being a field when it became
+    the key, so the key is now the ONLY place capitalization survives. The
+    configuration is hand-editable, and someone who typed "Raman" getting
+    "raman" back is a bug.
+
+    Uniqueness stays case-insensitive regardless (constraint 8) --
+    names.deduplicate guarantees no two differ only by case, and lookups fold
+    it. Storage keeps the display; comparison folds the case.
+    """
+    migrated, _ = migrate_to_users(entry)
+
+    for name in migrated[CONF_USERS]:
+        assert name == name.strip()
+    folded = [_identity(name) for name in migrated[CONF_USERS]]
+    assert len(folded) == len(set(folded))
+
+
+@given(entry=v2_entries())
+def test_migrating_twice_changes_nothing(entry: dict) -> None:
+    """A migration that runs again must be a no-op.
+
+    It should not run twice -- the version stamp prevents it -- but a
+    migration with no rollback should not depend on that for its safety.
+    """
+    once, _ = migrate_to_users(entry)
+    twice, renamed = migrate_to_users(once)
+
+    assert twice == once
+    assert renamed == []
+
+
+def test_a_user_without_an_assigned_slot_is_skipped_not_guessed() -> None:
+    """A user the assignment does not cover has no slot, and none is invented.
+
+    Reachable from hand-edited storage, or from bookkeeping that lost an entry
+    while the users mapping kept one. Guessing a number would put that user's
+    code on a credential index somebody else may hold -- so they are left out
+    until an allocation gives them one deliberately.
+    """
+    config = EntryConfig.from_mapping(
+        {
+            CONF_LOCKS: ["lock.front"],
+            CONF_USERS: {"Raman": {CONF_PIN: "1234"}, "Ghost": {CONF_PIN: "9999"}},
+            CONF_SLOT_ASSIGNMENT: {"raman": 3},
+        }
+    )
+
+    assert {num: slot[CONF_NAME] for num, slot in config.slots.items()} == {3: "Raman"}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -25,9 +25,8 @@ from custom_components.lock_code_manager.domain.queries import get_entry_config
 def _slot(pin: str = "1234", name: str | None = None) -> dict:
     """Trivial slot config dict for tests.
 
-    Carries a name because the name is the key the configuration is stored
-    under now, so a slot without one gets a generated name rather than
-    staying nameless.
+    A slot without a name gets a generated one, since the name is the key the
+    configuration is stored under.
     """
     return {"pin": pin, "enabled": True, **({"name": name} if name else {})}
 
@@ -424,10 +423,8 @@ def test_get_entry_config_falls_back_when_runtime_data_lacks_config() -> None:
 def test_with_slot_field_set_cannot_create_a_user() -> None:
     """Setting a field on an unoccupied slot is a no-op, not a creation.
 
-    A user is created by NAME now, and a bare slot number does not supply
-    one. The slot-keyed setter is a temporary shim over the user-keyed one
-    and can only reach somebody who already exists; inventing a name here
-    would put a user on the lock that nobody asked for.
+    A user is created by name, and a bare slot number supplies none. Inventing
+    one would put a user on the lock that nobody asked for.
     """
     config = EntryConfig.from_mapping(
         {CONF_LOCKS: ["lock.a"], CONF_SLOTS: {1: _slot()}}
@@ -439,11 +436,9 @@ def test_with_slot_field_set_cannot_create_a_user() -> None:
 def test_with_user_field_set_does_not_create_a_user() -> None:
     """Setting a field on somebody who does not exist is a no-op.
 
-    Creating a user also has to allocate them a slot, and this cannot -- it
-    has no view of what is occupied on the locks. A user created without one
-    is persisted in `users`, omitted from every slot-keyed consumer, never
-    reaches a lock, and is dropped the next time the configuration round-trips.
-    Creation gets an implementation when allocation does.
+    Creating a user also has to allocate them a slot, which this has no view to
+    do. One created without a slot reaches no lock and is dropped the next time
+    the configuration round-trips.
     """
     config = EntryConfig.from_mapping(
         {CONF_LOCKS: ["lock.a"], CONF_SLOTS: {1: _slot()}}
@@ -455,10 +450,8 @@ def test_with_user_field_set_does_not_create_a_user() -> None:
 def test_setting_the_name_re_keys_the_user() -> None:
     """The name is the identity, so setting it moves the user, not a field.
 
-    Stored as a field it looks right through the slot projection -- the inner
-    value shadows the key -- while the actual identity goes permanently stale:
-    after a reload the user cannot be found by their new name and holds no
-    slot.
+    Stored as a field, the user could not be found by their new name after a
+    reload and would hold no slot.
     """
     config = EntryConfig.from_mapping(
         {CONF_LOCKS: ["lock.a"], CONF_SLOTS: {1: {**_slot(), "name": "Alice"}}}
@@ -717,11 +710,27 @@ def test_build_slot_unique_id_variants_never_collide() -> None:
 def test_renaming_somebody_who_does_not_exist_is_a_no_op() -> None:
     """A rename naming an unknown user changes nothing.
 
-    Reachable from a stale rename map -- one computed against a configuration
-    that has since moved on. Creating the target instead would add a user
-    holding no slot, who never reaches a lock and is dropped on the next
-    round-trip.
+    Reachable from a rename map computed against a configuration that has since
+    moved on. Creating the target would add a user holding no slot.
     """
     config = EntryConfig.from_mapping({CONF_SLOTS: {1: {**_slot(), "name": "Raman"}}})
 
     assert config.with_user_renamed("Ghost", "Wren") is config
+
+
+def test_renaming_onto_an_existing_user_is_refused() -> None:
+    """A rename onto somebody else's name must not collapse two users into one.
+
+    Re-keying without the check deletes the target: their configuration is
+    gone and their slot is freed for reallocation.
+    """
+    config = EntryConfig.from_mapping(
+        {
+            CONF_SLOTS: {
+                1: {**_slot("1111"), "name": "Alice"},
+                2: {**_slot("2222"), "name": "Bob"},
+            }
+        }
+    )
+
+    assert config.with_user_field_set("Bob", "name", "Alice") is config

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -20,6 +20,9 @@ from custom_components.lock_code_manager.domain.config import (
     parse_slot_device_identifier,
 )
 from custom_components.lock_code_manager.domain.queries import get_entry_config
+from custom_components.lock_code_manager.domain.slot_assignment import (
+    CONF_SLOT_ASSIGNMENT,
+)
 
 
 def _slot(pin: str = "1234", name: str | None = None) -> dict:
@@ -734,3 +737,20 @@ def test_renaming_onto_an_existing_user_is_refused() -> None:
     )
 
     assert config.with_user_field_set("Bob", "name", "Alice") is config
+
+
+def test_two_stored_names_with_one_identity_keep_the_first() -> None:
+    """Stored users differing only by case or padding collapse to one.
+
+    Keeping both would put them on a single slot while the name lookups
+    disagreed about which of them holds it, so a display would show one user
+    and a write would land on the other.
+    """
+    config = EntryConfig.from_mapping(
+        {
+            CONF_USERS: {"Bob": {"pin": "1111"}, "bob ": {"pin": "2222"}},
+            CONF_SLOT_ASSIGNMENT: {"bob": 1},
+        }
+    )
+
+    assert dict(config.users) == {"Bob": {"pin": "1111"}}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,6 +9,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.lock_code_manager.const import (
     CONF_LOCKS,
     CONF_SLOTS,
+    CONF_USERS,
     DOMAIN,
 )
 from custom_components.lock_code_manager.domain.config import (
@@ -21,9 +22,19 @@ from custom_components.lock_code_manager.domain.config import (
 from custom_components.lock_code_manager.domain.queries import get_entry_config
 
 
-def _slot(pin: str = "1234") -> dict:
-    """Trivial slot config dict for tests."""
-    return {"pin": pin, "enabled": True}
+def _slot(pin: str = "1234", name: str | None = None) -> dict:
+    """Trivial slot config dict for tests.
+
+    Carries a name because the name is the key the configuration is stored
+    under now, so a slot without one gets a generated name rather than
+    staying nameless.
+    """
+    return {"pin": pin, "enabled": True, **({"name": name} if name else {})}
+
+
+def _named(slot_num: int, pin: str = "1234") -> dict:
+    """The slot as EntryConfig returns it: with the name it was given."""
+    return {"name": f"User {slot_num}", "pin": pin, "enabled": True}
 
 
 def _cfg(mapping: dict | None = None) -> EntryConfig:
@@ -56,7 +67,7 @@ def test_diff_added_slots_and_locks() -> None:
 
     diff = EntryConfigDiff(new=new)
 
-    assert dict(diff.slots_added) == {1: _slot(), 2: _slot()}
+    assert dict(diff.slots_added) == {1: _named(1), 2: _named(2)}
     assert diff.locks_added == ("lock.a",)
     assert diff.pairs_added == frozenset({("lock.a", 1), ("lock.a", 2)})
     assert diff.has_changes
@@ -68,7 +79,7 @@ def test_diff_removed_slots_and_locks() -> None:
 
     diff = EntryConfigDiff(old=old)
 
-    assert dict(diff.slots_removed) == {1: _slot()}
+    assert dict(diff.slots_removed) == {1: _named(1)}
     assert diff.locks_removed == ("lock.a",)
     assert diff.pairs_removed == frozenset({("lock.a", 1)})
     assert diff.has_changes
@@ -146,7 +157,7 @@ def test_diff_pair_added_for_new_slot_on_existing_lock() -> None:
 
     diff = EntryConfigDiff(old=old, new=new)
 
-    assert dict(diff.slots_added) == {2: _slot()}
+    assert dict(diff.slots_added) == {2: _named(2)}
     assert diff.pairs_added == frozenset({("lock.a", 2), ("lock.b", 2)})
 
 
@@ -287,8 +298,9 @@ def test_entry_config_accessors_absorb_str_or_int_slot_num() -> None:
 
     assert config.has_slot(1)
     assert config.has_slot("1")
-    assert config.slot(1) == {"pin": "abc", "enabled": True}
-    assert config.slot("1") == {"pin": "abc", "enabled": True}
+    # The name comes back too: it is the identity now, not an optional field.
+    assert config.slot(1) == _named(1, pin="abc")
+    assert config.slot("1") == _named(1, pin="abc")
     # Missing slot returns empty mapping (not KeyError)
     assert config.slot(99) == {}
     assert config.slot("99") == {}
@@ -409,16 +421,32 @@ def test_get_entry_config_falls_back_when_runtime_data_lacks_config() -> None:
 # --- Immutable update helper tests ---
 
 
-def test_with_slot_field_set_creates_slot_when_missing() -> None:
-    """with_slot_field_set creates the slot if it wasn't already present."""
+def test_with_slot_field_set_cannot_create_a_user() -> None:
+    """Setting a field on an unoccupied slot is a no-op, not a creation.
+
+    A user is created by NAME now, and a bare slot number does not supply
+    one. The slot-keyed setter is a temporary shim over the user-keyed one
+    and can only reach somebody who already exists; inventing a name here
+    would put a user on the lock that nobody asked for.
+    """
     config = EntryConfig.from_mapping(
         {CONF_LOCKS: ["lock.a"], CONF_SLOTS: {1: _slot()}}
     )
 
-    updated = config.with_slot_field_set(2, "pin", "5678")
+    assert config.with_slot_field_set(2, "pin", "5678") is config
 
-    assert set(updated.slots.keys()) == {1, 2}
-    assert dict(updated.slots[2]) == {"pin": "5678"}
+
+def test_with_user_field_set_creates_the_user_when_missing() -> None:
+    """Creating goes through the name, which is what a new user actually needs."""
+    config = EntryConfig.from_mapping(
+        {CONF_LOCKS: ["lock.a"], CONF_SLOTS: {1: _slot()}}
+    )
+
+    updated = config.with_user_field_set("Alice", "pin", "5678")
+
+    assert dict(updated.users["Alice"]) == {"pin": "5678"}
+    # No slot yet: allocation is a separate, deliberate step.
+    assert updated.slot_for("Alice") is None
 
 
 def test_with_slot_field_set_updates_existing_field() -> None:
@@ -454,10 +482,10 @@ def test_with_slot_field_set_accepts_str_slot_num() -> None:
 def test_with_slot_field_set_output_is_deeply_immutable() -> None:
     """The returned EntryConfig is frozen with read-only mappings, same as the input."""
     config = EntryConfig.empty()
-    updated = config.with_slot_field_set(1, "pin", "1234")
+    updated = config.with_user_field_set("Raman", "pin", "1234")
 
     with pytest.raises(TypeError):
-        updated.slots[1]["pin"] = "9999"  # type: ignore[index]
+        updated.users["Raman"]["pin"] = "9999"  # type: ignore[index]
 
 
 def test_with_slot_field_removed_removes_key() -> None:
@@ -518,10 +546,10 @@ def test_to_dict_produces_plain_mutable_dicts() -> None:
     result = config.to_dict()
 
     assert isinstance(result, dict)
-    assert isinstance(result[CONF_SLOTS], dict)
-    assert isinstance(result[CONF_SLOTS][1], dict)
+    assert isinstance(result[CONF_USERS], dict)
+    assert isinstance(result[CONF_USERS]["User 1"], dict)
     # Mutability — the returned dicts are the caller's to modify
-    result[CONF_SLOTS][1]["pin"] = "9999"
+    result[CONF_USERS]["User 1"]["pin"] = "9999"
     result[CONF_LOCKS].append("lock.b")
     # Original EntryConfig is untouched by that mutation
     assert config.slots[1]["pin"] == "1234"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -462,8 +462,8 @@ def test_setting_the_name_re_keys_the_user() -> None:
 
     assert set(reloaded.users) == {"Bob"}
     assert "name" not in reloaded.users["Bob"]
-    assert reloaded.slot_for("Bob") == 1
-    assert reloaded.user("Alice") == {}
+    assert reloaded.assignment.slot("Bob") == 1
+    assert "Alice" not in reloaded.users
 
 
 def test_with_slot_field_set_updates_existing_field() -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -436,17 +436,41 @@ def test_with_slot_field_set_cannot_create_a_user() -> None:
     assert config.with_slot_field_set(2, "pin", "5678") is config
 
 
-def test_with_user_field_set_creates_the_user_when_missing() -> None:
-    """Creating goes through the name, which is what a new user actually needs."""
+def test_with_user_field_set_does_not_create_a_user() -> None:
+    """Setting a field on somebody who does not exist is a no-op.
+
+    Creating a user also has to allocate them a slot, and this cannot -- it
+    has no view of what is occupied on the locks. A user created without one
+    is persisted in `users`, omitted from every slot-keyed consumer, never
+    reaches a lock, and is dropped the next time the configuration round-trips.
+    Creation gets an implementation when allocation does.
+    """
     config = EntryConfig.from_mapping(
         {CONF_LOCKS: ["lock.a"], CONF_SLOTS: {1: _slot()}}
     )
 
-    updated = config.with_user_field_set("Alice", "pin", "5678")
+    assert config.with_user_field_set("Alice", "pin", "5678") is config
 
-    assert dict(updated.users["Alice"]) == {"pin": "5678"}
-    # No slot yet: allocation is a separate, deliberate step.
-    assert updated.slot_for("Alice") is None
+
+def test_setting_the_name_re_keys_the_user() -> None:
+    """The name is the identity, so setting it moves the user, not a field.
+
+    Stored as a field it looks right through the slot projection -- the inner
+    value shadows the key -- while the actual identity goes permanently stale:
+    after a reload the user cannot be found by their new name and holds no
+    slot.
+    """
+    config = EntryConfig.from_mapping(
+        {CONF_LOCKS: ["lock.a"], CONF_SLOTS: {1: {**_slot(), "name": "Alice"}}}
+    )
+
+    renamed = config.with_slot_field_set(1, "name", "Bob")
+    reloaded = EntryConfig.from_mapping(renamed.to_dict())
+
+    assert set(reloaded.users) == {"Bob"}
+    assert "name" not in reloaded.users["Bob"]
+    assert reloaded.slot_for("Bob") == 1
+    assert reloaded.user("Alice") == {}
 
 
 def test_with_slot_field_set_updates_existing_field() -> None:
@@ -481,11 +505,11 @@ def test_with_slot_field_set_accepts_str_slot_num() -> None:
 
 def test_with_slot_field_set_output_is_deeply_immutable() -> None:
     """The returned EntryConfig is frozen with read-only mappings, same as the input."""
-    config = EntryConfig.empty()
-    updated = config.with_user_field_set("Raman", "pin", "1234")
+    config = EntryConfig.from_mapping({CONF_SLOTS: {1: {**_slot(), "name": "Raman"}}})
+    updated = config.with_user_field_set("Raman", "pin", "9999")
 
     with pytest.raises(TypeError):
-        updated.users["Raman"]["pin"] = "9999"  # type: ignore[index]
+        updated.users["Raman"]["pin"] = "0000"  # type: ignore[index]
 
 
 def test_with_slot_field_removed_removes_key() -> None:
@@ -688,3 +712,16 @@ def test_build_slot_unique_id_variants_never_collide() -> None:
     per_lock = build_slot_unique_id("abc123", 4, "code", "lock.front_door")
     assert standard != per_lock
     assert per_lock.startswith(f"{standard}|")
+
+
+def test_renaming_somebody_who_does_not_exist_is_a_no_op() -> None:
+    """A rename naming an unknown user changes nothing.
+
+    Reachable from a stale rename map -- one computed against a configuration
+    that has since moved on. Creating the target instead would add a user
+    holding no slot, who never reaches a lock and is dropped on the next
+    round-trip.
+    """
+    config = EntryConfig.from_mapping({CONF_SLOTS: {1: {**_slot(), "name": "Raman"}}})
+
+    assert config.with_user_renamed("Ghost", "Wren") is config

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -269,7 +269,7 @@ async def test_config_flow_reauth(
     assert len(flows) == 1
     [result] = flows
 
-    assert result["step_id"] == "reauth"
+    assert result["step_id"] == "reauth_confirm"
     flow_id = result["flow_id"]
 
     result = await hass.config_entries.flow.async_configure(
@@ -300,7 +300,7 @@ async def test_config_flow_reauth_form_refetch(
     result = await hass.config_entries.flow.async_configure(flow["flow_id"], None)
 
     assert result["type"] == "form"
-    assert result["step_id"] == "reauth"
+    assert result["step_id"] == "reauth_confirm"
     assert result["data_schema"]({})[CONF_LOCKS] == [
         LOCK_1_ENTITY_ID,
         LOCK_2_ENTITY_ID,

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -17,7 +17,6 @@ from custom_components.lock_code_manager.domain.credentials import (
     WriteResult,
     credential_from_slot,
     pin_address,
-    slot_credential_of,
     user_from_slot,
 )
 from custom_components.lock_code_manager.domain.models import SlotCredential
@@ -205,14 +204,6 @@ class TestUser:
         user = User(user_id=3, credentials=[pin, password])
         assert user.pin_credentials == user.credentials_of_type(CredentialType.PIN)
 
-    def test_credential_for_returns_first_match_or_none(self) -> None:
-        empty_pin = Credential(
-            type=CredentialType.PIN, slot=3, state=SlotCredential.empty()
-        )
-        user = User(user_id=3, credentials=[empty_pin])
-        assert user.credential_for(CredentialType.PIN) is empty_pin
-        assert user.credential_for(CredentialType.RFID) is None
-
 
 class TestSetUserResult:
     """SetUserResult pairs the resolved user id with whether it was created."""
@@ -298,26 +289,6 @@ class TestProjectionHelpers:
         assert cred.slot == 5
         # The SlotCredential is reused verbatim as the credential state.
         assert cred.state is state
-
-    @pytest.mark.parametrize(
-        "state",
-        [
-            SlotCredential.known("1234"),
-            SlotCredential.unreadable(),
-            SlotCredential.empty(),
-        ],
-    )
-    def test_slot_credential_of_round_trips(self, state: SlotCredential) -> None:
-        cred = credential_from_slot(5, state)
-        # Projecting the PIN credential back to a SlotCredential is identity.
-        assert slot_credential_of(cred) is state
-
-    def test_slot_credential_of_rejects_non_pin(self) -> None:
-        rfid = Credential(
-            type=CredentialType.RFID, slot=5, state=SlotCredential.unreadable()
-        )
-        with pytest.raises(ValueError):
-            slot_credential_of(rfid)
 
     def test_user_from_slot_is_single_pin_user_sharing_index(self) -> None:
         state = SlotCredential.known("1234")

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -588,21 +588,22 @@ async def test_migration_v1_to_v2_calendar_to_entity_id(
     # Verify migration happened (v1 -> v2 calendar, then v2 -> v3 number_of_uses)
     assert config_entry.version == 4
 
-    # Get the migrated data (should be in .data after setup moves options to data)
-    migrated_data = config_entry.data
+    # Read through the typed view: the entry is keyed by user now, and this
+    # migration runs before that reshape in the same version bump.
+    migrated = get_entry_config(config_entry)
 
     # Slot 1 should be unchanged (no calendar)
-    assert CONF_CALENDAR not in migrated_data[CONF_SLOTS][1]
-    assert CONF_ENTITY_ID not in migrated_data[CONF_SLOTS][1]
+    assert CONF_CALENDAR not in migrated.slot(1)
+    assert CONF_ENTITY_ID not in migrated.slot(1)
 
     # Slot 2 should have CONF_ENTITY_ID instead of CONF_CALENDAR
-    assert CONF_CALENDAR not in migrated_data[CONF_SLOTS][2]
-    assert migrated_data[CONF_SLOTS][2][CONF_ENTITY_ID] == "calendar.test_1"
+    assert CONF_CALENDAR not in migrated.slot(2)
+    assert migrated.slot(2)[CONF_ENTITY_ID] == "calendar.test_1"
 
     # Slot 3 already had both fields set -- calendar is dropped and the
     # pre-existing entity_id value is preserved untouched.
-    assert CONF_CALENDAR not in migrated_data[CONF_SLOTS][3]
-    assert migrated_data[CONF_SLOTS][3][CONF_ENTITY_ID] == "calendar.test_2"
+    assert CONF_CALENDAR not in migrated.slot(3)
+    assert migrated.slot(3)[CONF_ENTITY_ID] == "calendar.test_2"
 
     await hass.config_entries.async_unload(config_entry.entry_id)
     await hass.config_entries.async_remove(config_entry.entry_id)
@@ -1546,8 +1547,12 @@ async def test_removing_slot_removes_its_device(
     slot_2_identifiers = {(DOMAIN, f"{entry_id}|2")}
     assert dev_reg.async_get_device(slot_2_identifiers) is not None
 
+    # Removing a user is removing them from `users`; the slot they occupied is
+    # freed with them.
     new_config = copy.deepcopy(dict(lock_code_manager_config_entry.data))
-    new_config[CONF_SLOTS].pop(2)
+    removed = get_entry_config(lock_code_manager_config_entry).name_for(2)
+    new_config[CONF_USERS].pop(removed)
+    new_config[CONF_SLOT_ASSIGNMENT].pop(removed.casefold(), None)
     assert hass.config_entries.async_update_entry(
         lock_code_manager_config_entry, options=new_config
     )

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -44,6 +44,7 @@ from custom_components.lock_code_manager.const import (
     CONF_CALENDAR,
     CONF_LOCKS,
     CONF_SLOTS,
+    CONF_USERS,
     DOMAIN,
     EVENT_PIN_USED,
     SERVICE_DEOBFUSCATE_LOG,
@@ -54,6 +55,10 @@ from custom_components.lock_code_manager.domain.exceptions import (
     LockDisconnected,
 )
 from custom_components.lock_code_manager.domain.models import SlotCredential, SyncState
+from custom_components.lock_code_manager.domain.queries import get_entry_config
+from custom_components.lock_code_manager.domain.slot_assignment import (
+    CONF_SLOT_ASSIGNMENT,
+)
 from custom_components.lock_code_manager.repairs import (
     AcknowledgeRepairFlow,
     async_create_fix_flow,
@@ -838,8 +843,8 @@ async def test_number_of_uses_auto_stripped_and_repair_raised(
     await hass.async_block_till_done()
 
     # Field stripped from both slots
-    assert LEGACY_NUMBER_OF_USES_KEY not in entry.data[CONF_SLOTS][1]
-    assert LEGACY_NUMBER_OF_USES_KEY not in entry.data[CONF_SLOTS][3]
+    assert LEGACY_NUMBER_OF_USES_KEY not in get_entry_config(entry).slot(1)
+    assert LEGACY_NUMBER_OF_USES_KEY not in get_entry_config(entry).slot(3)
 
     # Informational repair raised with impacted slot list
     issue_registry = ir.async_get(hass)
@@ -1727,7 +1732,7 @@ async def test_setup_entry_with_empty_data_uses_initial_listener_task(
 
     assert set(entry.runtime_data.locks) == {LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID}
     # The listener consolidates options back into data, as normal.
-    assert entry.data[CONF_SLOTS]
+    assert get_entry_config(entry).slots
     assert not entry.options
 
     await hass.config_entries.async_unload(entry.entry_id)
@@ -1889,13 +1894,17 @@ async def test_pairs_removed_skips_untracked_lock_and_logs_release_failure(
     await hass.config_entries.async_unload(entry.entry_id)
 
 
-async def test_migration_v3_to_v4_names_every_slot(hass: HomeAssistant) -> None:
-    """v4 gives every slot a present, entry-unique name.
+async def test_migration_v3_to_v4_reshapes_to_users(hass: HomeAssistant) -> None:
+    """v4 names every user, then keys the configuration by that name.
 
-    The name is becoming the identity Lock Code Manager keys on, so these
-    three properties stop being cosmetic. A name the user already chose is
-    left exactly as-is, because rewriting one would also rename that user on
-    every lock that stores a user name.
+    Both halves of one version bump. A name the user already chose is left
+    exactly as-is, because rewriting one also renames that user on every lock
+    that stores a user name.
+
+    The slot number survives as internal bookkeeping and NOBODY IS
+    RENUMBERED: it is the credential index on most providers, so a changed
+    number moves that person's code to a different index on every lock and
+    orphans their entities.
     """
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -1917,10 +1926,55 @@ async def test_migration_v3_to_v4_names_every_slot(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
     assert config_entry.version == 4
-    slots = config_entry.data[CONF_SLOTS]
-    assert slots[1][CONF_NAME] == "User 1"  # was unnamed
-    assert slots[2][CONF_NAME] == "Raman"  # user's choice, untouched
-    assert slots[3][CONF_NAME] == "Raman 2"  # collided with slot 2
-    assert slots[4][CONF_NAME] == "Ra|man"  # "|" is ordinary text now
+    config = get_entry_config(config_entry)
+
+    # Names: repaired where they had to be, untouched where they did not.
+    by_slot = {num: slot[CONF_NAME] for num, slot in config.slots.items()}
+    assert by_slot[1] == "User 1"  # was unnamed
+    assert by_slot[2] == "Raman"  # user's choice, untouched
+    assert by_slot[3] == "Raman 2"  # collided with slot 2
+    assert by_slot[4] == "Ra|man"  # "|" is ordinary text now
+
+    # Shape: keyed by user, with the slot number demoted to bookkeeping.
+    stored = {**config_entry.data, **config_entry.options}
+    assert CONF_SLOTS not in stored
+    assert set(stored[CONF_USERS]) == {"User 1", "Raman", "Raman 2", "Ra|man"}
+    # Nobody was renumbered, and the name is no longer a field of the user.
+    assert stored[CONF_SLOT_ASSIGNMENT] == {
+        "user 1": 1,
+        "raman": 2,
+        "raman 2": 3,
+        "ra|man": 4,
+    }
+    assert CONF_NAME not in stored[CONF_USERS]["Raman"]
     # Every other field survives.
-    assert slots[1][CONF_PIN] == "1234"
+    assert stored[CONF_USERS]["User 1"][CONF_PIN] == "1234"
+
+
+async def test_the_user_shape_survives_a_full_setup_cycle(
+    hass: HomeAssistant, mock_lock_config_entry, lock_code_manager_config_entry
+) -> None:
+    """The migrated shape is still on disk after setup has written the entry back.
+
+    Setup does not leave the entry alone: it moves data into options, the
+    update listener rebuilds the configuration, and the listener's terminal
+    write persists whatever ``EntryConfig.to_dict()`` emits. A to_dict that
+    dropped the bookkeeping would silently rewrite the entry back to the
+    slot-keyed shape on every single load.
+
+    Nothing else catches that. Behaviour is IDENTICAL either way, because the
+    integration still works in slot numbers internally -- so every behavioural
+    test passes while the migration quietly undoes itself. Verified by
+    mutation: removing the passthrough from to_dict leaves the whole suite
+    green without this test.
+    """
+    stored = {
+        **lock_code_manager_config_entry.data,
+        **lock_code_manager_config_entry.options,
+    }
+
+    assert CONF_SLOTS not in stored
+    assert set(stored[CONF_USERS]) == {"test1", "test2"}
+    assert stored[CONF_SLOT_ASSIGNMENT] == {"test1": 1, "test2": 2}
+    # And the reconstructed view still sees them, so nothing downstream broke.
+    assert set(get_entry_config(lock_code_manager_config_entry).slots) == {1, 2}

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -27,6 +27,7 @@ from custom_components.lock_code_manager.const import (
     SERVICE_SET_USERCODE,
 )
 from custom_components.lock_code_manager.domain.pin_generator import is_unsafe_pin
+from custom_components.lock_code_manager.domain.queries import get_entry_config
 from custom_components.lock_code_manager.domain.services import async_set_usercode
 from custom_components.lock_code_manager.domain.util import mask_pin
 
@@ -141,9 +142,9 @@ async def test_set_slot_condition_service(
     updated_entry = hass.config_entries.async_get_entry(entry.entry_id)
     # After update, data is written via options then moved to data
     # Check both options and data for the condition entity
-    slots = updated_entry.options.get("slots", updated_entry.data.get("slots", {}))
-    slot_key = 1 if 1 in slots else "1"
-    assert slots[slot_key][CONF_ENTITY_ID] == condition_entity_id
+    assert (
+        get_entry_config(updated_entry).slot(1)[CONF_ENTITY_ID] == condition_entity_id
+    )
 
 
 async def test_set_slot_condition_service_entry_not_found(
@@ -231,9 +232,7 @@ async def test_clear_slot_condition_service(
     await hass.async_block_till_done()
 
     updated_entry = hass.config_entries.async_get_entry(entry.entry_id)
-    slots = updated_entry.options.get("slots", updated_entry.data.get("slots", {}))
-    slot_key = 2 if 2 in slots else "2"
-    assert CONF_ENTITY_ID not in slots[slot_key]
+    assert CONF_ENTITY_ID not in get_entry_config(updated_entry).slot(2)
 
 
 async def test_clear_slot_condition_service_entry_not_found(

--- a/tests/test_slot_coordinator.py
+++ b/tests/test_slot_coordinator.py
@@ -40,6 +40,7 @@ from custom_components.lock_code_manager.const import (
     CONF_SLOTS,
     DOMAIN,
 )
+from custom_components.lock_code_manager.domain.config import EntryConfig
 from custom_components.lock_code_manager.domain.queries import get_entry_config
 from custom_components.lock_code_manager.domain.slot_coordinator import (
     PinRequiredError,
@@ -329,7 +330,7 @@ async def test_request_pin_update_auto_disables_in_single_write(
         await hass.async_block_till_done()
 
     assert len(captured) == 1
-    slot_1 = captured[0][CONF_SLOTS][1]
+    slot_1 = EntryConfig.from_mapping(captured[0]).slot(1)
     assert slot_1[CONF_PIN] == ""
     assert slot_1[CONF_ENABLED] is False
 

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -162,7 +162,11 @@ async def test_set_name_rejects_another_slots_name(
     mock_lock_config_entry,
     lock_code_manager_config_entry,
 ):
-    """Renaming a slot onto another slot's name is refused, ignoring case."""
+    """Renaming onto another user's name is refused, ignoring case.
+
+    The conflict is reported by NAME: a user who holds no slot still owns a
+    name, and has no number to point at.
+    """
     other = hass.states.get(SLOT_1_NAME_ENTITY).state
 
     with pytest.raises(ServiceValidationError) as err:
@@ -174,7 +178,7 @@ async def test_set_name_rejects_another_slots_name(
             blocking=True,
         )
     assert err.value.translation_key == "name_not_unique"
-    assert err.value.translation_placeholders["conflicting_slot"] == "1"
+    assert err.value.translation_placeholders["conflicting_name"] == other
 
 
 async def test_set_name_normalizes_whitespace(

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -68,6 +68,7 @@ from custom_components.lock_code_manager.const import (
 )
 from custom_components.lock_code_manager.domain.exceptions import DuplicateCodeError
 from custom_components.lock_code_manager.domain.models import SlotCode, SlotCredential
+from custom_components.lock_code_manager.domain.queries import get_entry_config
 from custom_components.lock_code_manager.providers import BaseLock
 from custom_components.lock_code_manager.websocket import (
     SlotEntities,
@@ -2241,7 +2242,7 @@ class TestSetSlotCondition:
 
         # Verify config entry was updated
         assert (
-            lock_code_manager_config_entry.data[CONF_SLOTS][1]["entity_id"]
+            get_entry_config(lock_code_manager_config_entry).slot(1)["entity_id"]
             == BINARY_SENSOR_TEST_ENTITY_ID
         )
 
@@ -2353,7 +2354,7 @@ class TestSetSlotCondition:
 
         # Verify update worked
         assert (
-            lock_code_manager_config_entry.data[CONF_SLOTS][1]["entity_id"]
+            get_entry_config(lock_code_manager_config_entry).slot(1)["entity_id"]
             == INPUT_BOOLEAN_TEST_ENTITY_ID
         )
 
@@ -2549,7 +2550,7 @@ class TestClearSlotCondition:
         ws_client = await hass_ws_client(hass)
 
         # Slot 2 has a calendar entity configured
-        assert "entity_id" in lock_code_manager_config_entry.data[CONF_SLOTS][2]
+        assert "entity_id" in get_entry_config(lock_code_manager_config_entry).slot(2)
 
         # Clear slot 2's entity_id
         await ws_client.send_json(
@@ -2564,7 +2565,9 @@ class TestClearSlotCondition:
         assert msg["success"]
 
         # Verify entity_id was removed from config
-        assert "entity_id" not in lock_code_manager_config_entry.data[CONF_SLOTS][2]
+        assert "entity_id" not in get_entry_config(lock_code_manager_config_entry).slot(
+            2
+        )
 
     async def test_clear_already_empty(
         self,
@@ -2577,7 +2580,9 @@ class TestClearSlotCondition:
         ws_client = await hass_ws_client(hass)
 
         # Slot 1 has no entity_id configured
-        assert "entity_id" not in lock_code_manager_config_entry.data[CONF_SLOTS][1]
+        assert "entity_id" not in get_entry_config(lock_code_manager_config_entry).slot(
+            1
+        )
 
         await ws_client.send_json(
             {


### PR DESCRIPTION
## Proposed change

Keys the configuration **and** the internal model by user, completing the reshape the v3 release exists for:

```yaml
slots:                      users:
  1:                 ->       Raman:
    name: Raman                 pin: "1234"
    pin: "1234"
```

`EntryConfig` stores `users` and a `SlotAssignment`. **The name is the identity everywhere above two boundaries**, and the slot number is looked up only at those two:

| Boundary | Needs the slot number because |
|---|---|
| **Provider writes** | On most providers the slot number *is* the lock's credential index (`credential_index_follows_slot`). |
| **Registry identifiers** | Entity unique IDs and device identifiers key on it, which is what makes a rename free and the migration registry-silent. |

The migration performs **zero registry writes** and **renumbers nobody**. Neither is stylistic: the slot addresses the credential on the lock, so a changed number moves that person's code to a different index on every lock and orphans their entities — permanently, since the migration has no rollback.

### Why the internal model changed too, not just storage

The first attempt changed storage only, keeping the model slot-keyed with a reconstruction on read and a projection on write. Every path touching raw storage sat on that seam, and each fix revealed another: `to_dict()` erasing the migrated shape on every listener pass; `from_entry` unable to distinguish an absent key from an empty one; and the reauth flow deciding *"did the user submit the form?"* by testing for a config key, which became an unbounded setup loop when that key left the entry.

Each fix was correct. The seam was not — two representations of one thing, translated at every boundary.

### Reauth

Home Assistant passes the entry's **own data** to `async_step_reauth`, so a single combined step must guess whether its caller is HA or the user. Guessing wrong updates the entry and reloads it, and the reload re-fails setup. Split into HA's canonical `async_step_reauth` → `async_step_reauth_confirm`, which removes the ambiguity structurally rather than patching the discriminator.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Behaviour changes worth a second look

- **`with_slot_field_set` can no longer create a user.** Creation happens by name, and a bare slot number supplies none. Creating also has to allocate a slot, which `EntryConfig` has no view to do.
- **An unnamed slot gets a generated name**, since the name is the key the configuration is stored under.
- **A name conflict is reported by name, not slot number** (`conflicting_name`). A user holding no slot still owns a name and has no number to point at — and it keeps a slot number out of a message users read.

## Known: `reconcile` has no production caller yet

`SlotAssignment.reconcile` is the slot allocator, and nothing allocates until the config flow stops assembling slots by hand. Its properties verify it directly, but **nothing exercises it end to end** — its passing suite is unit evidence, not integration evidence. Kept rather than deleted: the next PR consumes it, and it carries six rounds of hardening from #1425.

`EntryConfig.slots` likewise remains as an explicitly **temporary derived property** — a projection of the one model, not a second model — while the last four slot-keyed consumers (websocket, the YAML editor, diagnostics, `util.py`) migrate. It is deleted with the last of them.

## Additional information

Targets the long-lived `v3` branch.

Migration properties were written **from the invariants list before the implementation existed** — they failed with `ModuleNotFoundError` first, which is the point.

Verified under `HYPOTHESIS_PROFILE=ci` (200 examples) against a cleared `.hypothesis`; the default `dev` profile runs 15 and has produced false greens on this branch before.

**1591 Python tests passing at 100% coverage, 714 frontend tests passing, all hooks clean.**

Three review rounds so far, trending down: 7 findings (2 serious) → 7 (2 HIGH) → 5 (0 HIGH). Also removed along the way: `credential_for`, `slot_credential_of`, `EntryConfig.user()`, `slot_for()`, three dead constants and an orphaned error string — all with no production caller.

**Suggested review in two passes**, since they are different kinds of change:
1. **The model** — `domain/config.py`, `domain/slot_assignment.py`, `domain/user_migration.py`, and the reauth split. Every design decision lives here.
2. **The call-site migration** — mechanical.
