### PR TITLE
feat: choose slot numbers instead of asking for them

### DIFF
--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -761,7 +761,7 @@ async def async_unload_entry(
     # ``_setup_entry_after_start`` migrates the entry's data to options
     # at first setup, so ``config_entry.data`` is empty for any
     # normally-loaded entry.
-    curr_slots = list(get_entry_config(config_entry).slots)
+    curr_slots = sorted(get_entry_config(config_entry).slot_numbers)
     if curr_slots:
         _LOGGER.debug("Unload: removing slots %s", curr_slots)
         await asyncio.gather(
@@ -831,7 +831,7 @@ async def async_remove_entry(
     """
     entry_id = config_entry.entry_id
     config = get_entry_config(config_entry)
-    for slot_num in config.slots:
+    for slot_num in config.slot_numbers:
         async_delete_issue(hass, DOMAIN, f"slot_disabled_{entry_id}_{slot_num}")
         async_delete_issue(hass, DOMAIN, f"pin_required_{entry_id}_{slot_num}")
     for lock_entity_id in config.locks:
@@ -841,7 +841,7 @@ async def async_remove_entry(
                 async_delete_issue(
                     hass, DOMAIN, per_lock_issue_id(issue_key, lock_entity_id)
                 )
-        for slot_num in config.slots:
+        for slot_num in config.slot_numbers:
             async_delete_issue(
                 hass,
                 DOMAIN,
@@ -958,7 +958,7 @@ def _async_prune_orphaned_slot_devices(
     """
     dev_reg = dr.async_get(hass)
     entry_id = config_entry.entry_id
-    configured = get_entry_config(config_entry).slots
+    configured = get_entry_config(config_entry).slot_numbers
     orphaned = {
         slot_num
         for device in dr.async_entries_for_config_entry(dev_reg, entry_id)
@@ -1002,7 +1002,7 @@ async def async_remove_config_entry_device(
     # outlive every slot -- it is what the slot devices hang off of.
     if not slot_nums:
         return False
-    return slot_nums.isdisjoint(get_entry_config(config_entry).slots)
+    return slot_nums.isdisjoint(get_entry_config(config_entry).slot_numbers)
 
 
 async def _async_setup_new_locks(
@@ -1093,7 +1093,7 @@ async def _async_setup_new_locks(
                 result.lock.entity_id,
             )
 
-        for slot_num in new_config.slots:
+        for slot_num in new_config.slot_numbers:
             _LOGGER.debug(
                 "%s (%s): Adding lock %s slot %s sensor and event entity",
                 entry_id,

--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -219,6 +219,25 @@ async def _async_validate_slots_yaml(
     return parsed_slots, errors, placeholders
 
 
+def _too_many_users_placeholders(
+    placeholders: dict[str, Any], num_users: int, taken: int
+) -> dict[str, Any]:
+    """
+    Describe a count that will not fit, in terms of the room actually left.
+
+    The YAML path can tell the user to renumber. Here the count is the only
+    thing they picked, and how much room they have depends on what the locks
+    already hold, so both numbers have to be in the message.
+    """
+    num_slots = int(placeholders.get("num_slots", 0))
+    return {
+        **placeholders,
+        "num_users": str(num_users),
+        "taken": str(taken),
+        "room": str(max(num_slots - taken, 0)),
+    }
+
+
 class _LockQuerySkipped(LockCodeManagerError):
     """
     Raised when no provider could be built for a lock.
@@ -343,28 +362,6 @@ async def _async_query_locks(
     return results
 
 
-def _occupancy_from(
-    queries: Iterable[_LockQuery], claimed_by_other_entries: Iterable[int]
-) -> Occupancy:
-    """Build the allocation view of what those locks reported."""
-    return Occupancy(
-        locks=tuple(
-            LockOccupancy(
-                lock_entity_id=query.lock_entity_id,
-                credential_index_follows_slot=query.credential_index_follows_slot,
-                managed=query.managed,
-                occupied=None
-                if query.codes is None
-                else frozenset(
-                    slot for slot, code in query.codes.items() if code.is_present
-                ),
-            )
-            for query in queries
-        ),
-        claimed_by_other_entries=frozenset(claimed_by_other_entries),
-    )
-
-
 def _codes_by_lock(
     queries: Iterable[_LockQuery],
 ) -> dict[str, dict[int, SlotCredential]]:
@@ -475,6 +472,9 @@ class LockCodeManagerFlowHandler(
         self.dev_reg: dr.DeviceRegistry = None
         self._users_to_configure = 0
         self._lock_queries: list[_LockQuery] = []
+        # The numbers allocation must avoid, settled when the user said how
+        # many users they wanted.
+        self._unavailable: frozenset[int] = frozenset()
         self._init_existing_codes_state()
 
     async def async_step_user(
@@ -518,44 +518,142 @@ class LockCodeManagerFlowHandler(
         """Allow user to choose a path for configuration."""
         return self.async_show_menu(step_id="choose_path", menu_options=["ui", "yaml"])
 
-    def _occupancy(self) -> Occupancy:
-        """Return what the configured locks reported about their contents."""
-        return _occupancy_from(
-            self._lock_queries,
-            {
+    async def _async_read_occupancy(self, window: int) -> Occupancy:
+        """Ask every configured lock which of the numbers 1..window it holds."""
+        dev_reg = dr.async_get(self.hass)
+        ent_reg = er.async_get(self.hass)
+        locks: list[LockOccupancy] = []
+        for lock_entity_id in self.data[CONF_LOCKS]:
+            try:
+                lock_instance = _async_build_lock_instance(
+                    self.hass, dev_reg, ent_reg, lock_entity_id
+                )
+            except _LockQuerySkipped as skipped:
+                locks.append(
+                    LockOccupancy(
+                        lock_entity_id=lock_entity_id,
+                        # Unknowable without a provider. Assuming the lock
+                        # addresses credentials by slot number is the
+                        # assumption that makes allocation refuse rather than
+                        # guess.
+                        credential_index_follows_slot=skipped.managed,
+                        managed=skipped.managed,
+                        occupied=None,
+                    )
+                )
+                continue
+            locks.append(
+                LockOccupancy(
+                    lock_entity_id=lock_entity_id,
+                    credential_index_follows_slot=(
+                        lock_instance.credential_index_follows_slot
+                    ),
+                    managed=True,
+                    occupied=await lock_instance.async_internal_get_occupied_indices(
+                        window
+                    ),
+                )
+            )
+        return Occupancy(
+            locks=tuple(locks),
+            claimed_by_other_entries=frozenset(
                 slot
                 for lock_entity_id in self.data[CONF_LOCKS]
                 for slot in get_managed_slots(self.hass, lock_entity_id)
-            },
+            ),
         )
+
+    async def _async_allocate_for(
+        self, num_users: int
+    ) -> tuple[frozenset[int] | None, dict[str, str], dict[str, Any]]:
+        """
+        Find numbers for ``num_users``, reading only as far as it has to.
+
+        Locks that answer one index per round trip make the width of this
+        read the cost of it, so it starts at the number of users and widens
+        only by what turned out to be in the way. A lock is never walked to
+        its advertised capacity to place a handful of users.
+
+        Widening stops when the numbers it would need are past what a lock
+        can hold, which is the same refusal as asking for too many users --
+        because on a full lock that is what it is.
+
+        Returns the numbers allocation must avoid, verified across a window
+        wide enough to hold everyone. The users themselves are numbered from
+        it later, once they have names.
+        """
+        window = num_users
+        while True:
+            occupancy = await self._async_read_occupancy(window)
+            if not occupancy.is_known:
+                # Unreadable is not free: issuing a number could overwrite a
+                # credential programmed by hand on a lock that did not answer.
+                return (
+                    None,
+                    {"base": "occupancy_unknown"},
+                    {"locks": ", ".join(occupancy.unreadable)},
+                )
+
+            unavailable = occupancy.unavailable
+            taken_in_window = sum(1 for slot in unavailable if slot <= window)
+            if window - taken_in_window >= num_users:
+                break
+
+            # Every number in the way pushes the last user one further out.
+            wider = num_users + taken_in_window
+            errors, placeholders = await _async_check_slot_capacity(
+                self.hass, self.data[CONF_LOCKS], [wider]
+            )
+            if errors or wider <= window:
+                return (
+                    None,
+                    {"base": "too_many_users"},
+                    _too_many_users_placeholders(
+                        placeholders, num_users, taken_in_window
+                    ),
+                )
+            window = wider
+
+        assignment = SlotAssignment.empty().reconcile(
+            map(str, range(num_users)), start=1, unavailable=unavailable
+        )
+        errors, placeholders = await _async_check_slot_capacity(
+            self.hass, self.data[CONF_LOCKS], assignment.slots.values()
+        )
+        if errors:
+            return (
+                None,
+                {"base": "too_many_users"},
+                _too_many_users_placeholders(placeholders, num_users, taken_in_window),
+            )
+        return unavailable, {}, {}
 
     async def async_step_ui(
         self, user_input: dict[str, Any] | None = None
     ) -> dict[str, Any]:
         """Ask how many users to configure."""
-        occupancy = self._occupancy()
-        if not occupancy.is_known:
-            # Unreadable is not free: issuing a number could overwrite a
-            # credential programmed by hand on a lock that simply did not
-            # answer. The locks were read before this step and nothing after
-            # it can change the answer, so refusing here costs the user
-            # nothing -- refusing later would discard every name and PIN they
-            # had already typed.
-            return self.async_abort(
-                reason="occupancy_unknown",
-                description_placeholders={"locks": ", ".join(occupancy.unreadable)},
-            )
-
         errors: dict[str, str] = {}
         description_placeholders: dict[str, Any] = {}
         if user_input is not None:
             num_users = user_input[CONF_NUM_USERS]
-            errors, description_placeholders = await self._async_check_room_for(
-                num_users, occupancy
-            )
-            if not errors:
+            # Settled before a single name is collected. Which users get
+            # configured does not change which numbers allocation issues, so
+            # the count alone decides whether they fit -- and a refusal here
+            # is one the user can still act on.
+            (
+                unavailable,
+                errors,
+                description_placeholders,
+            ) = await self._async_allocate_for(num_users)
+            if unavailable is not None:
                 self._users_to_configure = num_users
+                self._unavailable = unavailable
                 return await self.async_step_code_slot()
+            if "occupancy_unknown" in errors.values():
+                return self.async_abort(
+                    reason="occupancy_unknown",
+                    description_placeholders=description_placeholders,
+                )
 
         return self.async_show_form(
             step_id="ui",
@@ -569,43 +667,6 @@ class LockCodeManagerFlowHandler(
             errors=errors,
             description_placeholders=description_placeholders,
             last_step=False,
-        )
-
-    async def _async_check_room_for(
-        self, num_users: int, occupancy: Occupancy
-    ) -> tuple[dict[str, str], dict[str, Any]]:
-        """
-        Reject a count the locks cannot hold, while it can still be corrected.
-
-        Which users are configured does not affect WHICH numbers allocation
-        issues -- it always takes the lowest free ones -- so the count alone
-        decides whether they fit. Checking it here turns what would be a dead
-        end after the last user form into a corrigible answer on this one.
-        """
-        errors, placeholders = await _async_check_slot_capacity(
-            self.hass,
-            self.data[CONF_LOCKS],
-            self._allocate(map(str, range(num_users))).slots.values(),
-        )
-        if not errors:
-            return {}, {}
-
-        # The YAML path can tell the user to renumber. Here the count is the
-        # only thing they picked, and how much room they have depends on what
-        # the locks already hold, so both numbers have to be in the message.
-        num_slots = int(placeholders["num_slots"])
-        taken = sum(1 for slot in occupancy.unavailable if 1 <= slot <= num_slots)
-        return {"base": "too_many_users"}, {
-            **placeholders,
-            "num_users": str(num_users),
-            "taken": str(taken),
-            "room": str(num_slots - taken),
-        }
-
-    def _allocate(self, users: Iterable[str]) -> SlotAssignment:
-        """Give every user the lowest slot number nothing else holds."""
-        return SlotAssignment.empty().reconcile(
-            users, start=1, unavailable=self._occupancy().unavailable
         )
 
     async def async_step_code_slot(
@@ -674,7 +735,9 @@ class LockCodeManagerFlowHandler(
         # Both refusals -- unreadable locks and a count that will not fit --
         # were settled in async_step_ui, against the same occupancy and the
         # same count. Nothing collected since can change either answer.
-        assignment = self._allocate(self.data[CONF_USERS])
+        assignment = SlotAssignment.empty().reconcile(
+            self.data[CONF_USERS], start=1, unavailable=self._unavailable
+        )
         self.data[CONF_SLOT_ASSIGNMENT] = dict(assignment.slots)
         return await self._create_entry(title=self.title, data=self.data)
 

--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable, Iterable, Mapping
+from collections.abc import Awaitable, Callable, Collection, Iterable, Mapping
 from dataclasses import dataclass
 from functools import partial
 import logging
@@ -107,7 +107,9 @@ def _check_common_slots(
             for entry in hass.config_entries.async_entries(DOMAIN)
             if (config := get_entry_config(entry)).has_lock(lock)
             and (
-                common_slots := sorted(set(config.slots) & {int(s) for s in slots_list})
+                common_slots := sorted(
+                    config.slot_numbers & {int(s) for s in slots_list}
+                )
             )
             and not (config_entry and config_entry == entry)
         )
@@ -291,13 +293,13 @@ def _async_build_lock_instance(
 
 @dataclass(frozen=True, slots=True)
 class _LockQuery:
-    """What one lock answered when asked for its credentials."""
+    """What one lock answered when asked what codes it is holding."""
 
     lock_entity_id: str
-    managed: bool
-    credential_index_follows_slot: bool
     # ``None`` means the read FAILED. An empty mapping means the lock answered
-    # and holds nothing.
+    # and holds nothing. Both render as "nothing to confirm" here; the
+    # difference matters to allocation, which reads occupancy itself rather
+    # than from this.
     codes: dict[int, SlotCredential] | None
 
 
@@ -313,10 +315,10 @@ async def _async_query_locks(
     Queried sequentially to avoid flooding a Z-Wave or Matter network with
     simultaneous requests.
 
-    A lock that could not be built is reported as unmanaged rather than
-    dropped, and one whose read failed is reported with ``codes=None`` rather
-    than as empty. Both distinctions matter to allocation, which must not
-    issue a number it could not verify is free.
+    Feeds the confirmation that shows which of the slots a user asked for
+    already hold codes. Allocation does not read this -- it asks the locks
+    itself, over the range it is considering -- so a lock that could not be
+    read simply contributes nothing to show.
     """
     results: list[_LockQuery] = []
     for lock_entity_id in lock_entity_ids:
@@ -324,21 +326,10 @@ async def _async_query_locks(
             lock_instance = _async_build_lock_instance(
                 hass, dev_reg, ent_reg, lock_entity_id
             )
-        except _LockQuerySkipped as skipped:
-            results.append(
-                _LockQuery(
-                    lock_entity_id=lock_entity_id,
-                    managed=skipped.managed,
-                    # Unknowable without a provider. Assuming the lock
-                    # addresses credentials by slot number is the assumption
-                    # that makes allocation refuse rather than guess.
-                    credential_index_follows_slot=skipped.managed,
-                    codes=None,
-                )
-            )
+        except _LockQuerySkipped:
+            results.append(_LockQuery(lock_entity_id=lock_entity_id, codes=None))
             continue
 
-        follows_slot = lock_instance.credential_index_follows_slot
         try:
             codes = await lock_instance.async_internal_get_usercodes()
         except LockCodeManagerError as err:
@@ -351,7 +342,7 @@ async def _async_query_locks(
                 exc_info=True,
             )
             codes = None
-        results.append(_LockQuery(lock_entity_id, True, follows_slot, codes))
+        results.append(_LockQuery(lock_entity_id, codes))
     return results
 
 
@@ -464,7 +455,6 @@ class LockCodeManagerFlowHandler(
         self.ent_reg: er.EntityRegistry = None
         self.dev_reg: dr.DeviceRegistry = None
         self._users_to_configure = 0
-        self._lock_queries: list[_LockQuery] = []
         # The numbers allocation must avoid, settled when the user said how
         # many users they wanted.
         self._unavailable: frozenset[int] = frozenset()
@@ -484,14 +474,6 @@ class LockCodeManagerFlowHandler(
             await self.async_set_unique_id(slugify(self.title))
             self._abort_if_unique_id_configured()
             self.data = user_input
-            # Scan locks for existing codes once upfront
-            # Queried once here and kept: the same answers decide which
-            # numbers allocation may issue and which existing codes the gate
-            # renders, and asking a Z-Wave network twice is not free.
-            self._lock_queries = await _async_query_locks(
-                self.hass, self.dev_reg, self.ent_reg, user_input[CONF_LOCKS]
-            )
-            self._all_codes = _codes_by_lock(self._lock_queries)
             return await self.async_step_choose_path()
 
         return self.async_show_form(
@@ -511,9 +493,9 @@ class LockCodeManagerFlowHandler(
         """Allow user to choose a path for configuration."""
         return self.async_show_menu(step_id="choose_path", menu_options=["ui", "yaml"])
 
-    async def _async_read_occupancy(self, window: int) -> Occupancy:
+    async def _async_read_occupancy(self, indices: Collection[int]) -> Occupancy:
         """
-        Ask every configured lock which of the numbers 1..window it holds.
+        Ask every configured lock which of ``indices`` it holds.
 
         A lock that cannot answer reports ``None``, never an empty set: that
         difference is what makes allocation refuse instead of issuing a
@@ -568,7 +550,7 @@ class LockCodeManagerFlowHandler(
                 # nothing reads.
                 try:
                     occupied = await lock_instance.async_internal_get_occupied_indices(
-                        window
+                        indices
                     )
                 except Exception:
                     _LOGGER.warning(
@@ -601,8 +583,10 @@ class LockCodeManagerFlowHandler(
 
         Locks that answer one index per round trip make the width of this
         read the cost of it, so it starts at the number of users and widens
-        only by what turned out to be in the way. A lock is never walked to
-        its advertised capacity to place a handful of users.
+        only by what turned out to be in the way -- and each pass asks only
+        about the numbers no earlier pass covered. Every index is read at
+        most once, so placing a handful of users never costs more round trips
+        than the highest number they land on.
 
         Widening stops when the numbers it would need are past what a lock
         can hold, which is the same refusal as asking for too many users --
@@ -632,9 +616,16 @@ class LockCodeManagerFlowHandler(
                 {**placeholders, "num_users": str(num_users)},
             )
 
+        unavailable: set[int] = set()
+        read_up_to = 0
         window = num_users
         while True:
-            occupancy = await self._async_read_occupancy(window)
+            # Only the part nobody has asked about yet. Re-reading from one
+            # every pass would cost a nearly-full lock several times its own
+            # capacity to place a couple of users.
+            occupancy = await self._async_read_occupancy(
+                range(read_up_to + 1, window + 1)
+            )
             if not occupancy.is_known:
                 # Unreadable is not free: issuing a number could overwrite a
                 # credential programmed by hand on a lock that did not answer.
@@ -643,8 +634,9 @@ class LockCodeManagerFlowHandler(
                     {"base": "occupancy_unknown"},
                     {"locks": ", ".join(occupancy.unreadable)},
                 )
+            unavailable |= occupancy.unavailable
+            read_up_to = window
 
-            unavailable = occupancy.unavailable
             taken_in_window = sum(1 for slot in unavailable if slot <= window)
             if window - taken_in_window >= num_users:
                 break
@@ -666,7 +658,7 @@ class LockCodeManagerFlowHandler(
         # before it was accepted -- the first as the bare count, each wider
         # one before widening to it -- and allocation only issues numbers
         # inside the window.
-        return unavailable, {}, {}
+        return frozenset(unavailable), {}, {}
 
     async def async_step_ui(
         self, user_input: dict[str, Any] | None = None
@@ -689,11 +681,6 @@ class LockCodeManagerFlowHandler(
                 self._users_to_configure = num_users
                 self._unavailable = unavailable
                 return await self.async_step_code_slot()
-            if "occupancy_unknown" in errors.values():
-                return self.async_abort(
-                    reason="occupancy_unknown",
-                    description_placeholders=description_placeholders,
-                )
 
         return self.async_show_form(
             step_id="ui",
@@ -801,6 +788,15 @@ class LockCodeManagerFlowHandler(
             if not errors:
                 assert slots is not None
                 self.data[CONF_SLOTS] = slots
+                # Read here rather than on the way in: only this path shows
+                # the user what its chosen numbers already hold. The path
+                # that chooses numbers itself reads what it needs, when it
+                # knows how much of the lock that is.
+                self._all_codes = _codes_by_lock(
+                    await _async_query_locks(
+                        self.hass, self.dev_reg, self.ent_reg, self.data[CONF_LOCKS]
+                    )
+                )
                 self._occupied_lock_slots = self._find_occupied_lock_slots(slots.keys())
                 if self._occupied_lock_slots:
                     self._next_step = partial(
@@ -859,7 +855,7 @@ class LockCodeManagerFlowHandler(
             # selector from the entry's current config either way.
             user_input = {CONF_LOCKS: list(get_entry_config(config_entry).locks)}
         else:
-            existing_slots = get_entry_config(config_entry).slots.keys()
+            existing_slots = get_entry_config(config_entry).slot_numbers
             additional_errors, additional_placeholders = _check_common_slots(
                 self.hass,
                 user_input[CONF_LOCKS],

--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -220,7 +220,21 @@ async def _async_validate_slots_yaml(
 
 
 class _LockQuerySkipped(LockCodeManagerError):
-    """Raised when a lock should be skipped before any provider call."""
+    """
+    Raised when no provider could be built for a lock.
+
+    ``managed`` says whether Lock Code Manager will write credentials to the
+    lock anyway. Only an unsupported platform means it will not. A lock
+    missing from the entity registry, or whose integration's entry has gone,
+    is one this entry still owns and merely could not reach -- reporting it
+    as unmanaged would drop it from the occupancy check entirely and let
+    allocation issue numbers against a lock it never read.
+    """
+
+    def __init__(self, lock_entity_id: str, *, managed: bool) -> None:
+        """Record whether the lock is one credentials still get written to."""
+        super().__init__(lock_entity_id)
+        self.managed = managed
 
 
 def _async_build_lock_instance(
@@ -242,21 +256,21 @@ def _async_build_lock_instance(
             "Entity %s not found in registry; skipping usercode check",
             lock_entity_id,
         )
-        raise _LockQuerySkipped(lock_entity_id)
+        raise _LockQuerySkipped(lock_entity_id, managed=True)
     if lock_entry.platform not in INTEGRATIONS_CLASS_MAP:
         _LOGGER.debug(
             "Lock %s uses unsupported platform %s; skipping usercode check",
             lock_entity_id,
             lock_entry.platform,
         )
-        raise _LockQuerySkipped(lock_entity_id)
+        raise _LockQuerySkipped(lock_entity_id, managed=False)
     lock_config_entry = hass.config_entries.async_get_entry(lock_entry.config_entry_id)
     if lock_config_entry is None:
         _LOGGER.warning(
             "Config entry for lock %s not found; skipping usercode check",
             lock_entity_id,
         )
-        raise _LockQuerySkipped(lock_entity_id)
+        raise _LockQuerySkipped(lock_entity_id, managed=True)
 
     return INTEGRATIONS_CLASS_MAP[lock_entry.platform](
         hass, dev_reg, ent_reg, lock_config_entry, lock_entry
@@ -298,8 +312,18 @@ async def _async_query_locks(
             lock_instance = _async_build_lock_instance(
                 hass, dev_reg, ent_reg, lock_entity_id
             )
-        except _LockQuerySkipped:
-            results.append(_LockQuery(lock_entity_id, False, False, None))
+        except _LockQuerySkipped as skipped:
+            results.append(
+                _LockQuery(
+                    lock_entity_id=lock_entity_id,
+                    managed=skipped.managed,
+                    # Unknowable without a provider. Assuming the lock
+                    # addresses credentials by slot number is the assumption
+                    # that makes allocation refuse rather than guess.
+                    credential_index_follows_slot=skipped.managed,
+                    codes=None,
+                )
+            )
             continue
 
         follows_slot = lock_instance.credential_index_follows_slot
@@ -494,13 +518,44 @@ class LockCodeManagerFlowHandler(
         """Allow user to choose a path for configuration."""
         return self.async_show_menu(step_id="choose_path", menu_options=["ui", "yaml"])
 
+    def _occupancy(self) -> Occupancy:
+        """Return what the configured locks reported about their contents."""
+        return _occupancy_from(
+            self._lock_queries,
+            {
+                slot
+                for lock_entity_id in self.data[CONF_LOCKS]
+                for slot in get_managed_slots(self.hass, lock_entity_id)
+            },
+        )
+
     async def async_step_ui(
         self, user_input: dict[str, Any] | None = None
     ) -> dict[str, Any]:
         """Ask how many users to configure."""
+        occupancy = self._occupancy()
+        if not occupancy.is_known:
+            # Unreadable is not free: issuing a number could overwrite a
+            # credential programmed by hand on a lock that simply did not
+            # answer. The locks were read before this step and nothing after
+            # it can change the answer, so refusing here costs the user
+            # nothing -- refusing later would discard every name and PIN they
+            # had already typed.
+            return self.async_abort(
+                reason="occupancy_unknown",
+                description_placeholders={"locks": ", ".join(occupancy.unreadable)},
+            )
+
+        errors: dict[str, str] = {}
+        description_placeholders: dict[str, Any] = {}
         if user_input is not None:
-            self._users_to_configure = user_input[CONF_NUM_USERS]
-            return await self.async_step_code_slot()
+            num_users = user_input[CONF_NUM_USERS]
+            errors, description_placeholders = await self._async_check_room_for(
+                num_users, occupancy
+            )
+            if not errors:
+                self._users_to_configure = num_users
+                return await self.async_step_code_slot()
 
         return self.async_show_form(
             step_id="ui",
@@ -511,44 +566,47 @@ class LockCodeManagerFlowHandler(
                     ): POSITIVE_INT,
                 }
             ),
+            errors=errors,
+            description_placeholders=description_placeholders,
             last_step=False,
         )
 
-    async def _async_assign_slots(
-        self, users: dict[str, dict[str, Any]]
-    ) -> tuple[SlotAssignment | None, dict[str, str], dict[str, Any]]:
+    async def _async_check_room_for(
+        self, num_users: int, occupancy: Occupancy
+    ) -> tuple[dict[str, str], dict[str, Any]]:
         """
-        Give every user a slot number, or explain why none can be given.
+        Reject a count the locks cannot hold, while it can still be corrected.
 
-        The numbers are not asked for. They are chosen as the lowest that no
-        lock already holds a credential at and no other entry manages, which
-        is why there is no start slot to configure.
+        Which users are configured does not affect WHICH numbers allocation
+        issues -- it always takes the lowest free ones -- so the count alone
+        decides whether they fit. Checking it here turns what would be a dead
+        end after the last user form into a corrigible answer on this one.
         """
-        occupancy = _occupancy_from(
-            self._lock_queries,
-            {
-                slot
-                for lock_entity_id in self.data[CONF_LOCKS]
-                for slot in get_managed_slots(self.hass, lock_entity_id)
-            },
-        )
-        if not occupancy.is_known:
-            # Unreadable is not free. Issuing a number here could overwrite a
-            # credential programmed by hand on a lock that simply did not
-            # answer.
-            return (
-                None,
-                {"base": "occupancy_unknown"},
-                {"locks": ", ".join(occupancy.unreadable)},
-            )
-
-        assignment = SlotAssignment.empty().reconcile(
-            users, start=1, unavailable=occupancy.unavailable
-        )
         errors, placeholders = await _async_check_slot_capacity(
-            self.hass, self.data[CONF_LOCKS], list(assignment.slots.values())
+            self.hass,
+            self.data[CONF_LOCKS],
+            self._allocate(map(str, range(num_users))).slots.values(),
         )
-        return (None if errors else assignment), errors, placeholders
+        if not errors:
+            return {}, {}
+
+        # The YAML path can tell the user to renumber. Here the count is the
+        # only thing they picked, and how much room they have depends on what
+        # the locks already hold, so both numbers have to be in the message.
+        num_slots = int(placeholders["num_slots"])
+        taken = sum(1 for slot in occupancy.unavailable if 1 <= slot <= num_slots)
+        return {"base": "too_many_users"}, {
+            **placeholders,
+            "num_users": str(num_users),
+            "taken": str(taken),
+            "room": str(num_slots - taken),
+        }
+
+    def _allocate(self, users: Iterable[str]) -> SlotAssignment:
+        """Give every user the lowest slot number nothing else holds."""
+        return SlotAssignment.empty().reconcile(
+            users, start=1, unavailable=self._occupancy().unavailable
+        )
 
     async def async_step_code_slot(
         self, user_input: dict[str, Any] | None = None
@@ -613,26 +671,10 @@ class LockCodeManagerFlowHandler(
 
     async def _async_finish_ui_setup(self) -> dict[str, Any]:
         """Assign slots to the collected users and create the entry."""
-        assignment, errors, placeholders = await self._async_assign_slots(
-            self.data[CONF_USERS]
-        )
-        if assignment is None:
-            # Nothing to go back to -- the numbers were never the user's to
-            # choose -- so the refusal ends the flow rather than re-asking.
-            reason = next(iter(errors.values()))
-            if reason == "slot_out_of_range":
-                # Shared with the YAML path, which can tell the user to
-                # renumber. Here the count is the only thing they picked, so
-                # it has to be what the refusal talks about.
-                reason = "too_many_users"
-                placeholders = {
-                    **placeholders,
-                    "num_users": str(len(self.data[CONF_USERS])),
-                }
-            return self.async_abort(
-                reason=reason, description_placeholders=placeholders
-            )
-
+        # Both refusals -- unreadable locks and a count that will not fit --
+        # were settled in async_step_ui, against the same occupancy and the
+        # same count. Nothing collected since can change either answer.
+        assignment = self._allocate(self.data[CONF_USERS])
         self.data[CONF_SLOT_ASSIGNMENT] = dict(assignment.slots)
         return await self._create_entry(title=self.title, data=self.data)
 

--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -86,6 +86,13 @@ SLOTS_YAML_SELECTOR = sel.ObjectSelector(sel.ObjectSelectorConfig())
 POSITIVE_INT = vol.All(vol.Coerce(int), vol.Range(min=1))
 
 
+# The per-slot wording for the errors ``validate_slot_names`` reports.
+_SLOT_NAME_ERRORS = {
+    "name_required": "slot_name_required",
+    "name_not_unique": "slot_name_not_unique",
+}
+
+
 def _check_common_slots(
     hass: HomeAssistant,
     locks: Iterable[str],
@@ -209,7 +216,12 @@ async def _async_validate_slots_yaml(
     # whole set, so the set has to be checked together.
     if problem := validate_slot_names(parsed_slots):
         slot_num, error = problem
-        return None, {"base": error}, {"slot_num": slot_num}
+        # This is the one path that knows which slot failed, so it uses the
+        # messages that name one. Everywhere else the user is looking at a
+        # single user and there is no slot number to give -- the shared
+        # messages must not ask for one, or they render as a translation
+        # error instead of an explanation.
+        return None, {"base": _SLOT_NAME_ERRORS[error]}, {"slot_num": slot_num}
 
     errors, placeholders = _check_common_slots(hass, locks, parsed_slots, config_entry)
     if not errors:
@@ -217,25 +229,6 @@ async def _async_validate_slots_yaml(
             hass, locks, parsed_slots
         )
     return parsed_slots, errors, placeholders
-
-
-def _too_many_users_placeholders(
-    placeholders: dict[str, Any], num_users: int, taken: int
-) -> dict[str, Any]:
-    """
-    Describe a count that will not fit, in terms of the room actually left.
-
-    The YAML path can tell the user to renumber. Here the count is the only
-    thing they picked, and how much room they have depends on what the locks
-    already hold, so both numbers have to be in the message.
-    """
-    num_slots = int(placeholders.get("num_slots", 0))
-    return {
-        **placeholders,
-        "num_users": str(num_users),
-        "taken": str(taken),
-        "room": str(max(num_slots - taken, 0)),
-    }
 
 
 class _LockQuerySkipped(LockCodeManagerError):
@@ -519,7 +512,15 @@ class LockCodeManagerFlowHandler(
         return self.async_show_menu(step_id="choose_path", menu_options=["ui", "yaml"])
 
     async def _async_read_occupancy(self, window: int) -> Occupancy:
-        """Ask every configured lock which of the numbers 1..window it holds."""
+        """
+        Ask every configured lock which of the numbers 1..window it holds.
+
+        A lock that cannot answer reports ``None``, never an empty set: that
+        difference is what makes allocation refuse instead of issuing a
+        number over a credential it never checked for. Every way of failing
+        to answer has to arrive that way, including the ones no provider
+        promised.
+        """
         dev_reg = dr.async_get(self.hass)
         ent_reg = er.async_get(self.hass)
         locks: list[LockOccupancy] = []
@@ -542,16 +543,45 @@ class LockCodeManagerFlowHandler(
                     )
                 )
                 continue
+            except Exception:
+                _LOGGER.warning(
+                    "Could not build a provider for %s; its contents are unknown",
+                    lock_entity_id,
+                    exc_info=True,
+                )
+                locks.append(
+                    LockOccupancy(
+                        lock_entity_id=lock_entity_id,
+                        credential_index_follows_slot=True,
+                        managed=True,
+                        occupied=None,
+                    )
+                )
+                continue
+
+            follows_slot = lock_instance.credential_index_follows_slot
+            occupied: frozenset[int] | None = None
+            if follows_slot:
+                # A lock that allocates its own credential index cannot
+                # constrain the numbering, so asking it spends a round trip
+                # -- one per index on some providers -- on an answer that
+                # nothing reads.
+                try:
+                    occupied = await lock_instance.async_internal_get_occupied_indices(
+                        window
+                    )
+                except Exception:
+                    _LOGGER.warning(
+                        "Failed to read the contents of %s; treating them as unknown",
+                        lock_entity_id,
+                        exc_info=True,
+                    )
             locks.append(
                 LockOccupancy(
                     lock_entity_id=lock_entity_id,
-                    credential_index_follows_slot=(
-                        lock_instance.credential_index_follows_slot
-                    ),
+                    credential_index_follows_slot=follows_slot,
                     managed=True,
-                    occupied=await lock_instance.async_internal_get_occupied_indices(
-                        window
-                    ),
+                    occupied=occupied,
                 )
             )
         return Occupancy(
@@ -578,10 +608,30 @@ class LockCodeManagerFlowHandler(
         can hold, which is the same refusal as asking for too many users --
         because on a full lock that is what it is.
 
+        It also stops on its own. Each pass either finds enough free numbers
+        or discovers strictly more occupied ones than the pass before -- a
+        pass that discovered no more would have found the window big enough,
+        since the window is exactly the count plus what was in the way -- and
+        the locks hold finitely many credentials.
+
+        The count itself is checked before the first read: one no lock could
+        ever hold is refused without asking a lock about it, rather than
+        after a round trip per user.
+
         Returns the numbers allocation must avoid, verified across a window
         wide enough to hold everyone. The users themselves are numbered from
         it later, once they have names.
         """
+        errors, placeholders = await _async_check_slot_capacity(
+            self.hass, self.data[CONF_LOCKS], [num_users]
+        )
+        if errors:
+            return (
+                None,
+                {"base": "too_many_users"},
+                {**placeholders, "num_users": str(num_users)},
+            )
+
         window = num_users
         while True:
             occupancy = await self._async_read_occupancy(window)
@@ -604,28 +654,18 @@ class LockCodeManagerFlowHandler(
             errors, placeholders = await _async_check_slot_capacity(
                 self.hass, self.data[CONF_LOCKS], [wider]
             )
-            if errors or wider <= window:
+            if errors:
                 return (
                     None,
                     {"base": "too_many_users"},
-                    _too_many_users_placeholders(
-                        placeholders, num_users, taken_in_window
-                    ),
+                    {**placeholders, "num_users": str(num_users)},
                 )
             window = wider
 
-        assignment = SlotAssignment.empty().reconcile(
-            map(str, range(num_users)), start=1, unavailable=unavailable
-        )
-        errors, placeholders = await _async_check_slot_capacity(
-            self.hass, self.data[CONF_LOCKS], assignment.slots.values()
-        )
-        if errors:
-            return (
-                None,
-                {"base": "too_many_users"},
-                _too_many_users_placeholders(placeholders, num_users, taken_in_window),
-            )
+        # No capacity check here: every window this loop accepted was checked
+        # before it was accepted -- the first as the bare count, each wider
+        # one before widening to it -- and allocation only issues numbers
+        # inside the window.
         return unavailable, {}, {}
 
     async def async_step_ui(

--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -650,10 +650,20 @@ class LockCodeManagerFlowHandler(
                 self.hass, self.data[CONF_LOCKS], [wider]
             )
             if errors:
+                # A different statement from the count being too large: the
+                # count fits the lock, and the numbers it would have to reach
+                # around what is already there do not. Saying "N users will
+                # not fit" of a count the lock could hold reads as a bug, and
+                # sends the user to re-interview a lock whose interview is
+                # fine.
                 return (
                     None,
-                    {"base": "too_many_users"},
-                    {**placeholders, "num_users": str(num_users)},
+                    {"base": "numbers_needed_exceed_capacity"},
+                    {
+                        **placeholders,
+                        "num_users": str(num_users),
+                        "needed": str(wider),
+                    },
                 )
             window = wider
 
@@ -697,7 +707,7 @@ class LockCodeManagerFlowHandler(
                 ),
                 # A refusal comes back to this form, so it comes back holding
                 # what was refused rather than making the user find it again.
-                user_input or {},
+                user_input,
             ),
             errors=errors,
             description_placeholders=description_placeholders,

--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -515,10 +515,13 @@ class LockCodeManagerFlowHandler(
                 locks.append(
                     LockOccupancy(
                         lock_entity_id=lock_entity_id,
-                        # Unknowable without a provider. Assuming the lock
-                        # addresses credentials by slot number is the
-                        # assumption that makes allocation refuse rather than
-                        # guess.
+                        # A lock this integration writes to constrains the
+                        # numbering, and without a provider there is no way
+                        # to ask whether it addresses credentials by slot
+                        # number -- so assume it does, which is the
+                        # assumption that refuses rather than guesses. A lock
+                        # on an unsupported platform is written to by nobody
+                        # and constrains nothing.
                         credential_index_follows_slot=skipped.managed,
                         managed=skipped.managed,
                         occupied=None,
@@ -684,12 +687,17 @@ class LockCodeManagerFlowHandler(
 
         return self.async_show_form(
             step_id="ui",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(
-                        CONF_NUM_USERS, default=DEFAULT_NUM_USERS
-                    ): POSITIVE_INT,
-                }
+            data_schema=self.add_suggested_values_to_schema(
+                vol.Schema(
+                    {
+                        vol.Required(
+                            CONF_NUM_USERS, default=DEFAULT_NUM_USERS
+                        ): POSITIVE_INT,
+                    }
+                ),
+                # A refusal comes back to this form, so it comes back holding
+                # what was refused rather than making the user find it again.
+                user_input or {},
             ),
             errors=errors,
             description_placeholders=description_placeholders,

--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable, Iterable, Mapping
+from dataclasses import dataclass
 from functools import partial
 import logging
 from typing import Any
@@ -25,11 +26,10 @@ from homeassistant.util import slugify
 from .const import (
     CONDITION_ENTITY_DOMAINS,
     CONF_LOCKS,
-    CONF_NUM_SLOTS,
+    CONF_NUM_USERS,
     CONF_SLOTS,
-    CONF_START_SLOT,
-    DEFAULT_NUM_SLOTS,
-    DEFAULT_START,
+    CONF_USERS,
+    DEFAULT_NUM_USERS,
     DOMAIN,
     EXCLUDED_CONDITION_PLATFORMS,
 )
@@ -38,7 +38,9 @@ from .domain.credentials import CredentialType
 from .domain.exceptions import LockCodeManagerError
 from .domain.models import SlotCredential
 from .domain.names import name_error, normalize_name, validate_slot_names
-from .domain.queries import get_entry_config
+from .domain.occupancy import LockOccupancy, Occupancy
+from .domain.queries import get_entry_config, get_managed_slots
+from .domain.slot_assignment import CONF_SLOT_ASSIGNMENT, SlotAssignment
 from .providers import INTEGRATIONS_CLASS_MAP
 
 _LOGGER = logging.getLogger(__name__)
@@ -261,48 +263,89 @@ def _async_build_lock_instance(
     )
 
 
-async def _async_get_all_codes(
+@dataclass(frozen=True, slots=True)
+class _LockQuery:
+    """What one lock answered when asked for its credentials."""
+
+    lock_entity_id: str
+    managed: bool
+    credential_index_follows_slot: bool
+    # ``None`` means the read FAILED. An empty mapping means the lock answered
+    # and holds nothing.
+    codes: dict[int, SlotCredential] | None
+
+
+async def _async_query_locks(
     hass: HomeAssistant,
     dev_reg: dr.DeviceRegistry,
     ent_reg: er.EntityRegistry,
-    lock_entity_ids: list[str],
-) -> dict[str, dict[int, SlotCredential]]:
+    lock_entity_ids: Iterable[str],
+) -> list[_LockQuery]:
     """
-    Query locks for all usercodes.
+    Ask every lock what credentials it holds.
 
-    Returns ``codes_by_lock`` mapping each lock entity ID to its slot/credential
-    dict (``SlotCredential.empty()`` for empty slots).  Locks that fail to query
-    are skipped with logging.
+    Queried sequentially to avoid flooding a Z-Wave or Matter network with
+    simultaneous requests.
+
+    A lock that could not be built is reported as unmanaged rather than
+    dropped, and one whose read failed is reported with ``codes=None`` rather
+    than as empty. Both distinctions matter to allocation, which must not
+    issue a number it could not verify is free.
     """
-    result: dict[str, dict[int, SlotCredential]] = {}
-    # Query sequentially to avoid flooding networks (e.g. Z-Wave, Matter)
-    # with simultaneous requests across multiple locks
+    results: list[_LockQuery] = []
     for lock_entity_id in lock_entity_ids:
         try:
             lock_instance = _async_build_lock_instance(
                 hass, dev_reg, ent_reg, lock_entity_id
             )
-            usercodes = await lock_instance.async_internal_get_usercodes()
         except _LockQuerySkipped:
+            results.append(_LockQuery(lock_entity_id, False, False, None))
             continue
+
+        follows_slot = lock_instance.credential_index_follows_slot
+        try:
+            codes = await lock_instance.async_internal_get_usercodes()
         except LockCodeManagerError as err:
-            _LOGGER.warning(
-                "Failed to get usercodes from %s: %s",
-                lock_entity_id,
-                err,
-            )
-            continue
+            _LOGGER.warning("Failed to get usercodes from %s: %s", lock_entity_id, err)
+            codes = None
         except Exception:
             _LOGGER.warning(
                 "Failed to get usercodes from %s; this lock's codes will not be shown",
                 lock_entity_id,
                 exc_info=True,
             )
-            continue
+            codes = None
+        results.append(_LockQuery(lock_entity_id, True, follows_slot, codes))
+    return results
 
-        if usercodes:
-            result[lock_entity_id] = usercodes
-    return result
+
+def _occupancy_from(
+    queries: Iterable[_LockQuery], claimed_by_other_entries: Iterable[int]
+) -> Occupancy:
+    """Build the allocation view of what those locks reported."""
+    return Occupancy(
+        locks=tuple(
+            LockOccupancy(
+                lock_entity_id=query.lock_entity_id,
+                credential_index_follows_slot=query.credential_index_follows_slot,
+                managed=query.managed,
+                occupied=None
+                if query.codes is None
+                else frozenset(
+                    slot for slot, code in query.codes.items() if code.is_present
+                ),
+            )
+            for query in queries
+        ),
+        claimed_by_other_entries=frozenset(claimed_by_other_entries),
+    )
+
+
+def _codes_by_lock(
+    queries: Iterable[_LockQuery],
+) -> dict[str, dict[int, SlotCredential]]:
+    """Project the query results back to the lock/slot view the gate renders."""
+    return {q.lock_entity_id: q.codes for q in queries if q.codes}
 
 
 def _scope_codes_to_pairs(
@@ -406,7 +449,8 @@ class LockCodeManagerFlowHandler(
         self.title: str = ""
         self.ent_reg: er.EntityRegistry = None
         self.dev_reg: dr.DeviceRegistry = None
-        self.slots_to_configure: list[int] = []
+        self._users_to_configure = 0
+        self._lock_queries: list[_LockQuery] = []
         self._init_existing_codes_state()
 
     async def async_step_user(
@@ -424,9 +468,13 @@ class LockCodeManagerFlowHandler(
             self._abort_if_unique_id_configured()
             self.data = user_input
             # Scan locks for existing codes once upfront
-            self._all_codes = await _async_get_all_codes(
+            # Queried once here and kept: the same answers decide which
+            # numbers allocation may issue and which existing codes the gate
+            # renders, and asking a Z-Wave network twice is not free.
+            self._lock_queries = await _async_query_locks(
                 self.hass, self.dev_reg, self.ent_reg, user_input[CONF_LOCKS]
             )
+            self._all_codes = _codes_by_lock(self._lock_queries)
             return await self.async_step_choose_path()
 
         return self.async_show_form(
@@ -449,82 +497,90 @@ class LockCodeManagerFlowHandler(
     async def async_step_ui(
         self, user_input: dict[str, Any] | None = None
     ) -> dict[str, Any]:
-        """Handle a UI oriented flow."""
-        errors = {}
-        description_placeholders = {}
+        """Ask how many users to configure."""
         if user_input is not None:
-            start = user_input[CONF_START_SLOT]
-            num_slots = user_input[CONF_NUM_SLOTS]
-            requested_slots = list(range(start, start + num_slots))
-            additional_errors, additional_placeholders = _check_common_slots(
-                self.hass, self.data[CONF_LOCKS], requested_slots
-            )
-            if not additional_errors:
-                (
-                    additional_errors,
-                    additional_placeholders,
-                ) = await _async_check_slot_capacity(
-                    self.hass, self.data[CONF_LOCKS], requested_slots
-                )
-            errors.update(additional_errors)
-            description_placeholders.update(additional_placeholders)
-            if not errors:
-                self.slots_to_configure = requested_slots
-                self._occupied_lock_slots = self._find_occupied_lock_slots(
-                    self.slots_to_configure
-                )
-                if self._occupied_lock_slots:
-                    self._next_step = self.async_step_code_slot
-                    return await self.async_step_existing_codes_confirm()
-                return await self.async_step_code_slot()
+            self._users_to_configure = user_input[CONF_NUM_USERS]
+            return await self.async_step_code_slot()
 
         return self.async_show_form(
             step_id="ui",
             data_schema=vol.Schema(
                 {
-                    vol.Required(CONF_START_SLOT, default=DEFAULT_START): POSITIVE_INT,
                     vol.Required(
-                        CONF_NUM_SLOTS, default=DEFAULT_NUM_SLOTS
+                        CONF_NUM_USERS, default=DEFAULT_NUM_USERS
                     ): POSITIVE_INT,
                 }
             ),
-            errors=errors,
-            description_placeholders=description_placeholders,
             last_step=False,
         )
+
+    async def _async_assign_slots(
+        self, users: dict[str, dict[str, Any]]
+    ) -> tuple[SlotAssignment | None, dict[str, str], dict[str, Any]]:
+        """
+        Give every user a slot number, or explain why none can be given.
+
+        The numbers are not asked for. They are chosen as the lowest that no
+        lock already holds a credential at and no other entry manages, which
+        is why there is no start slot to configure.
+        """
+        occupancy = _occupancy_from(
+            self._lock_queries,
+            {
+                slot
+                for lock_entity_id in self.data[CONF_LOCKS]
+                for slot in get_managed_slots(self.hass, lock_entity_id)
+            },
+        )
+        if not occupancy.is_known:
+            # Unreadable is not free. Issuing a number here could overwrite a
+            # credential programmed by hand on a lock that simply did not
+            # answer.
+            return (
+                None,
+                {"base": "occupancy_unknown"},
+                {"locks": ", ".join(occupancy.unreadable)},
+            )
+
+        assignment = SlotAssignment.empty().reconcile(
+            users, start=1, unavailable=occupancy.unavailable
+        )
+        errors, placeholders = await _async_check_slot_capacity(
+            self.hass, self.data[CONF_LOCKS], list(assignment.slots.values())
+        )
+        return (None if errors else assignment), errors, placeholders
 
     async def async_step_code_slot(
         self, user_input: dict[str, Any] | None = None
     ) -> dict[str, Any]:
-        """Handle code slots step."""
+        """Collect one user's configuration, repeating until the count is met."""
         errors: dict[str, str] = {}
-        current_slot = self.slots_to_configure[0]
-        description_placeholders: dict[str, Any] = {"slot_num": current_slot}
-        self.data.setdefault(CONF_SLOTS, {})
+        self.data.setdefault(CONF_USERS, {})
+        configured = len(self.data[CONF_USERS])
+        description_placeholders: dict[str, Any] = {
+            "user_num": configured + 1,
+            "num_users": self._users_to_configure,
+        }
 
         if user_input is not None:
             if _slot_enabled_without_pin(user_input):
                 errors[CONF_PIN] = "missing_pin_if_enabled"
 
-            # The name is on its way to becoming the identity Lock Code
-            # Manager keys on, so it must be present and unique within the
-            # entry.
             if error := name_error(user_input.get(CONF_NAME)):
                 errors[CONF_NAME] = error
             else:
-                # Normalize BOTH sides. Comparing a stripped candidate
-                # against unstripped stored names lets "Raman " and "Raman"
-                # both through in one order but not the other.
+                # Normalize BOTH sides. Comparing a stripped candidate against
+                # unstripped stored names lets "Raman " and "Raman" both
+                # through in one order but not the other.
                 user_input[CONF_NAME] = normalize_name(user_input[CONF_NAME])
                 if any(
-                    normalize_name(slot.get(CONF_NAME)).casefold()
-                    == user_input[CONF_NAME].casefold()
-                    for slot in self.data[CONF_SLOTS].values()
+                    name.casefold() == user_input[CONF_NAME].casefold()
+                    for name in self.data[CONF_USERS]
                 ):
                     errors[CONF_NAME] = "name_not_unique"
 
-            # Check for excluded platforms with a single registry lookup
-            # self.ent_reg is set in async_step_user which always runs first
+            # A single registry lookup covers the excluded-platform check.
+            # self.ent_reg is set in async_step_user, which always runs first.
             if entity_id := user_input.get(CONF_ENTITY_ID):
                 entity_entry = self.ent_reg.async_get(entity_id)
                 if (
@@ -539,20 +595,46 @@ class LockCodeManagerFlowHandler(
                     )
 
             if not errors:
-                slot_num = int(self.slots_to_configure.pop(0))
-                self.data[CONF_SLOTS][slot_num] = CODE_SLOT_SCHEMA(user_input)
-                if not self.slots_to_configure:
-                    return await self._create_entry(title=self.title, data=self.data)
-                current_slot = self.slots_to_configure[0]
-                description_placeholders["slot_num"] = current_slot
+                validated = CODE_SLOT_SCHEMA(user_input)
+                name = validated.pop(CONF_NAME)
+                self.data[CONF_USERS][name] = validated
+                configured = len(self.data[CONF_USERS])
+                if configured >= self._users_to_configure:
+                    return await self._async_finish_ui_setup()
+                description_placeholders["user_num"] = configured + 1
 
         return self.async_show_form(
             step_id="code_slot",
             data_schema=CODE_SLOT_SCHEMA,
             errors=errors,
             description_placeholders=description_placeholders,
-            last_step=len(self.slots_to_configure) == 1,
+            last_step=len(self.data[CONF_USERS]) + 1 == self._users_to_configure,
         )
+
+    async def _async_finish_ui_setup(self) -> dict[str, Any]:
+        """Assign slots to the collected users and create the entry."""
+        assignment, errors, placeholders = await self._async_assign_slots(
+            self.data[CONF_USERS]
+        )
+        if assignment is None:
+            # Nothing to go back to -- the numbers were never the user's to
+            # choose -- so the refusal ends the flow rather than re-asking.
+            reason = next(iter(errors.values()))
+            if reason == "slot_out_of_range":
+                # Shared with the YAML path, which can tell the user to
+                # renumber. Here the count is the only thing they picked, so
+                # it has to be what the refusal talks about.
+                reason = "too_many_users"
+                placeholders = {
+                    **placeholders,
+                    "num_users": str(len(self.data[CONF_USERS])),
+                }
+            return self.async_abort(
+                reason=reason, description_placeholders=placeholders
+            )
+
+        self.data[CONF_SLOT_ASSIGNMENT] = dict(assignment.slots)
+        return await self._create_entry(title=self.title, data=self.data)
 
     async def async_step_yaml(self, user_input: dict[str, Any] | None = None):
         """Handle yaml flow step."""
@@ -781,8 +863,8 @@ class LockCodeManagerOptionsFlow(_ExistingCodesFlowMixin, config_entries.Options
         locks_to_query = sorted({lock for lock, _ in diff.pairs_added})
         ent_reg = er.async_get(self.hass)
         dev_reg = dr.async_get(self.hass)
-        all_codes = await _async_get_all_codes(
-            self.hass, dev_reg, ent_reg, locks_to_query
+        all_codes = _codes_by_lock(
+            await _async_query_locks(self.hass, dev_reg, ent_reg, locks_to_query)
         )
 
         # Scope to ONLY the added pairs so the confirmation dialog only

--- a/custom_components/lock_code_manager/const.py
+++ b/custom_components/lock_code_manager/const.py
@@ -85,6 +85,10 @@ CONF_ENTITIES = "entities"
 CONF_LOCKS = "locks"
 CONF_SLOTS = "slots"
 CONF_USERS = "users"
+CONF_NUM_USERS = "num_users"
+
+# Retired from the configuration in version 3, but still recognised so the
+# migration can drop them from a version 2 entry.
 CONF_NUM_SLOTS = "num_slots"
 CONF_START_SLOT = "start_slot"
 
@@ -125,8 +129,7 @@ SYNC_ATTEMPT_WINDOW = timedelta(minutes=5)
 
 
 # Defaults
-DEFAULT_NUM_SLOTS = 3
-DEFAULT_START = 1
+DEFAULT_NUM_USERS = 3
 
 PLATFORM_MAP = {
     CONF_CALENDAR: Platform.CALENDAR,

--- a/custom_components/lock_code_manager/diagnostics.py
+++ b/custom_components/lock_code_manager/diagnostics.py
@@ -205,7 +205,7 @@ async def async_get_config_entry_diagnostics(
             str(slot_num): _slot_diagnostic(
                 hass, config_entry, slot_num, all_locks, instance_id, ent_reg, dev_reg
             )
-            for slot_num in entry_config.slots
+            for slot_num in entry_config.slot_numbers
         },
     }
 

--- a/custom_components/lock_code_manager/domain/config.py
+++ b/custom_components/lock_code_manager/domain/config.py
@@ -164,11 +164,25 @@ class EntryConfig:
         """
         Return the slot-keyed view.
 
-        TEMPORARY. A projection of the one model, not a second model, kept
-        while the remaining slot-keyed call sites migrate. Delete it with the
-        last of them.
+        A projection of the one model, not a second model. It exists for the
+        consumers that are slot-shaped by nature rather than by habit: the
+        entity lifecycle diff, which decides what to create and remove by
+        slot because entity identifiers key on it; the YAML editor, which
+        edits a slot-keyed document; and diagnostics. Everything that only
+        wanted to know WHICH numbers exist uses :attr:`slot_numbers`.
         """
         return self._by_slot
+
+    @property
+    def slot_numbers(self) -> frozenset[int]:
+        """
+        Return the slot numbers this entry's users occupy.
+
+        The answer most callers of the slot-shaped view actually wanted: the
+        registries key on the number, so plenty of code needs to know which
+        numbers exist without caring who holds them.
+        """
+        return frozenset(self._by_slot)
 
     def has_lock(self, lock_entity_id: str) -> bool:
         """Return True if this entry manages the given lock."""
@@ -297,14 +311,14 @@ class EntryConfig:
     def with_slot_field_set(
         self, slot_num: int | str, key: str, value: Any
     ) -> EntryConfig:
-        """Set a field on whoever occupies ``slot_num``. TEMPORARY, as :attr:`slots`."""
+        """Set a field on whoever occupies ``slot_num``."""
         name = self.name_for(slot_num)
         if name is None:
             return self
         return self.with_user_field_set(name, key, value)
 
     def with_slot_field_removed(self, slot_num: int | str, key: str) -> EntryConfig:
-        """Remove a field from whoever occupies ``slot_num``. TEMPORARY."""
+        """Remove a field from whoever occupies ``slot_num``."""
         name = self.name_for(slot_num)
         if name is None:
             return self

--- a/custom_components/lock_code_manager/domain/occupancy.py
+++ b/custom_components/lock_code_manager/domain/occupancy.py
@@ -78,6 +78,5 @@ class Occupancy:
                 lock.occupied
                 for lock in self.locks
                 if lock.constrains_allocation and lock.occupied
-            ),
-            frozenset(),
+            )
         )

--- a/custom_components/lock_code_manager/domain/occupancy.py
+++ b/custom_components/lock_code_manager/domain/occupancy.py
@@ -1,0 +1,83 @@
+"""
+Which slot numbers allocation may use, and whether that is knowable.
+
+On most providers the slot number IS the lock's credential index, so issuing
+an occupied one writes a user's code over a credential already on the door.
+Occupancy is read from the locks to avoid that.
+
+A failed read is therefore not the same as an empty one, and is not treated as
+free. But refusing on every unreadable lock would block allocation for setups
+that contain one permanently, so a lock constrains the numbering only when
+Lock Code Manager writes to it AND addresses it by slot number.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class LockOccupancy:
+    """What one lock reports about the credential indices it already holds."""
+
+    lock_entity_id: str
+    # False on providers that allocate their own credential index, where slot
+    # ``n`` says nothing about credential ``n``.
+    credential_index_follows_slot: bool
+    # False when Lock Code Manager will not write credentials here at all --
+    # an unsupported platform, or a lock it could not build a provider for.
+    managed: bool
+    # ``None`` means the read FAILED. An empty set means the lock answered and
+    # holds nothing.
+    occupied: frozenset[int] | None
+
+    @property
+    def constrains_allocation(self) -> bool:
+        """Return whether this lock's contents bound the numbers we may issue."""
+        return self.managed and self.credential_index_follows_slot
+
+
+@dataclass(frozen=True, slots=True)
+class Occupancy:
+    """The numbers allocation must avoid, across every lock in an entry."""
+
+    locks: tuple[LockOccupancy, ...]
+    # Numbers another Lock Code Manager entry manages on a shared lock.
+    # Nothing outside the config flow prevents two entries claiming one
+    # credential index, so allocation has to.
+    claimed_by_other_entries: frozenset[int]
+
+    @property
+    def is_known(self) -> bool:
+        """Return whether every lock that constrains allocation could be read."""
+        return not any(
+            lock.occupied is None and lock.constrains_allocation for lock in self.locks
+        )
+
+    @property
+    def unreadable(self) -> tuple[str, ...]:
+        """Return the constraining locks that could not be read."""
+        return tuple(
+            lock.lock_entity_id
+            for lock in self.locks
+            if lock.occupied is None and lock.constrains_allocation
+        )
+
+    @property
+    def unavailable(self) -> frozenset[int]:
+        """
+        Return the numbers allocation must not issue.
+
+        Only counts locks that constrain allocation: reserving a number
+        because an unaddressed lock happens to hold something there would push
+        real users past the advertised capacity of the locks that do follow
+        the slot number.
+        """
+        return self.claimed_by_other_entries.union(
+            *(
+                lock.occupied
+                for lock in self.locks
+                if lock.constrains_allocation and lock.occupied
+            ),
+            frozenset(),
+        )

--- a/custom_components/lock_code_manager/domain/queries.py
+++ b/custom_components/lock_code_manager/domain/queries.py
@@ -35,7 +35,7 @@ def get_managed_slots(hass: HomeAssistant, lock_entity_id: str) -> set[int]:
         slot_num
         for entry in hass.config_entries.async_entries(DOMAIN)
         if (config := get_entry_config(entry)).has_lock(lock_entity_id)
-        for slot_num in config.slots
+        for slot_num in config.slot_numbers
     }
 
 

--- a/custom_components/lock_code_manager/domain/slot_assignment.py
+++ b/custom_components/lock_code_manager/domain/slot_assignment.py
@@ -174,14 +174,9 @@ class SlotAssignment:
         arrival or departure. New users take the lowest free number at or
         above ``start``, skipping ``unavailable``.
 
-        ``start`` is required, not defaulted. The entry's configured start
-        slot (``CONF_START_SLOT``) is usually chosen because the numbers below
-        it hold codes programmed by hand that Lock Code Manager does not
-        manage, and ``config_flow._check_common_slots`` refuses ranges that
-        overlap another entry on a shared lock. Since the slot IS the
-        credential index on most providers, defaulting to 1 would make a
-        forgotten argument write a new user's code over one of those --
-        silently, and on a real door. Required makes it a type error.
+        ``start`` is required, not defaulted, so a caller has to decide where
+        issuing begins rather than inheriting a default that happens to be
+        safe today.
 
         A user already holding a slot keeps it even when ``start`` rises
         above it or ``unavailable`` comes to include it: both constrain

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -1840,10 +1840,15 @@ class BaseLock:
 
     @final
     async def async_internal_get_occupied_indices(
-        self, limit: int
+        self, indices: Collection[int]
     ) -> frozenset[int] | None:
         """
-        Return which slot numbers in 1..limit this lock holds, or None.
+        Return which of ``indices`` this lock holds, or None.
+
+        Takes the numbers to ask about rather than a ceiling, so a caller
+        widening its search can ask only about what it has not asked about
+        yet. On a lock that answers one index per round trip, asking again
+        from one would cost it the whole range every time.
 
         These are slot numbers, not device credential indices. The two
         coincide on every provider where allocation consults this, because
@@ -1867,9 +1872,12 @@ class BaseLock:
         ``None`` means the lock could not be read at all, which callers must
         treat as unknown rather than free.
         """
+        wanted = frozenset(indices)
+        if not wanted:
+            return frozenset()
         try:
             codes = await self._execute_rate_limited(
-                "get", partial(self.async_get_usercodes, range(1, limit + 1))
+                "get", partial(self.async_get_usercodes, wanted)
             )
         except LockCodeManagerError as err:
             _LOGGER.debug(
@@ -1881,7 +1889,7 @@ class BaseLock:
         return frozenset(
             slot
             for slot, credential in codes.items()
-            if credential.is_present and 1 <= slot <= limit
+            if credential.is_present and slot in wanted
         )
 
     @final

--- a/custom_components/lock_code_manager/strings.json
+++ b/custom_components/lock_code_manager/strings.json
@@ -11,11 +11,13 @@
       "excluded_platform": "Entities from the `{integration}` integration are not supported as condition entities. See the [wiki]({docs_url}) for details.",
       "invalid_config": "Slots configuration is invalid. For more information, check the logs and the docs.",
       "missing_pin_if_enabled": "PIN must be set if slot is enabled.",
-      "name_not_unique": "The name for code slot {slot_num} is already used by another code slot in this entry. Names must be unique.",
-      "name_required": "Code slot {slot_num} needs a name. The name identifies this user on your locks.",
+      "name_not_unique": "That name is already used by another user in this configuration. Names must be unique.",
+      "name_required": "Every user needs a name. The name identifies them on your locks.",
+      "slot_name_not_unique": "The name for code slot {slot_num} is already used by another code slot in this entry. Names must be unique.",
+      "slot_name_required": "Code slot {slot_num} needs a name. The name identifies this user on your locks.",
       "slot_out_of_range": "Lock {lock} reports only {num_slots} PIN code slots, so these slot numbers are out of range for it: {out_of_range_slots}. Renumber them to fall within 1-{num_slots}, or manage that lock from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity.",
       "slots_already_configured": "The following slots for lock {lock} are already managed by another config entry ({entry_title}) and can't be added to this configuration without being removed from the other one: {common_slots}",
-      "too_many_users": "Lock {lock} has {num_slots} PIN code slots and {taken} of them already hold a code, leaving room for {room} more. Set up at most {room} users here, or manage the rest from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity."
+      "too_many_users": "Lock {lock} has {num_slots} PIN code slots, so {num_users} users will not fit alongside the codes already on it. Set up fewer users here, or manage the rest from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity."
     },
     "step": {
       "choose_path": {
@@ -131,8 +133,10 @@
     },
     "error": {
       "invalid_config": "Slots configuration is invalid. For more information, check the logs and the docs.",
-      "name_not_unique": "The name for code slot {slot_num} is already used by another code slot in this entry. Names must be unique.",
-      "name_required": "Code slot {slot_num} needs a name. The name identifies this user on your locks.",
+      "name_not_unique": "That name is already used by another user in this configuration. Names must be unique.",
+      "name_required": "Every user needs a name. The name identifies them on your locks.",
+      "slot_name_not_unique": "The name for code slot {slot_num} is already used by another code slot in this entry. Names must be unique.",
+      "slot_name_required": "Code slot {slot_num} needs a name. The name identifies this user on your locks.",
       "slot_out_of_range": "Lock {lock} reports only {num_slots} PIN code slots, so these slot numbers are out of range for it: {out_of_range_slots}. Renumber them to fall within 1-{num_slots}, or manage that lock from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity.",
       "slots_already_configured": "The following slots for lock {lock} are already managed by another config entry ({entry_title}) and can't be added to this configuration without being removed from the other one: {common_slots}"
     },

--- a/custom_components/lock_code_manager/strings.json
+++ b/custom_components/lock_code_manager/strings.json
@@ -4,6 +4,8 @@
       "already_configured": "Lock Code Manager config entry with same slugified name already exists.",
       "existing_codes_cancelled": "Setup cancelled. Existing codes were not modified.",
       "locks_updated": "The locks for your config entry have been updated.",
+      "occupancy_unknown": "Could not read the existing codes from {locks}, so Lock Code Manager cannot tell which code slots are free. Setting a user up now could overwrite a code already on the lock. Check the lock is reachable and try again.",
+      "too_many_users": "Lock {lock} has room for {num_slots} PIN codes, and {num_users} users were requested. Configure at most {num_slots} here, or manage the rest from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity.",
       "unknown": "An unexpected error occurred during setup."
     },
     "error": {
@@ -31,8 +33,7 @@
           "name": "Name",
           "pin": "PIN Code"
         },
-        "description": "**Configure slot {slot_num}:** A slot is active when the condition entity (if configured) is 'on'. For calendars, 'on' means an event is in progress. Supported entity types: calendar, binary_sensor, switch, schedule, input_boolean.",
-        "title": "Configure Slot {slot_num}"
+        "title": "User {user_num} of {num_users}"
       },
       "existing_codes_confirm": {
         "title": "Existing Codes Detected",
@@ -44,10 +45,9 @@
       },
       "ui": {
         "data": {
-          "num_slots": "Number of slots",
-          "start_slot": "Start from slot #"
+          "num_users": "Number of users"
         },
-        "description": "Configure slots for all codes you want on the lock. You can add and remove slots later using the integration services.",
+        "description": "How many users do you want to set up? You can add or remove users later. Lock Code Manager picks which code slot each user occupies, skipping any slot that already holds a code.",
         "title": "How Many Slots?"
       },
       "user": {

--- a/custom_components/lock_code_manager/strings.json
+++ b/custom_components/lock_code_manager/strings.json
@@ -5,7 +5,6 @@
       "existing_codes_cancelled": "Setup cancelled. Existing codes were not modified.",
       "locks_updated": "The locks for your config entry have been updated.",
       "occupancy_unknown": "Could not read the existing codes from {locks}, so Lock Code Manager cannot tell which code slots are free. Setting a user up now could overwrite a code already on the lock. Check the lock is reachable and try again.",
-      "too_many_users": "Lock {lock} has room for {num_slots} PIN codes, and {num_users} users were requested. Configure at most {num_slots} here, or manage the rest from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity.",
       "unknown": "An unexpected error occurred during setup."
     },
     "error": {
@@ -15,7 +14,8 @@
       "name_not_unique": "The name for code slot {slot_num} is already used by another code slot in this entry. Names must be unique.",
       "name_required": "Code slot {slot_num} needs a name. The name identifies this user on your locks.",
       "slot_out_of_range": "Lock {lock} reports only {num_slots} PIN code slots, so these slot numbers are out of range for it: {out_of_range_slots}. Renumber them to fall within 1-{num_slots}, or manage that lock from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity.",
-      "slots_already_configured": "The following slots for lock {lock} are already managed by another config entry ({entry_title}) and can't be added to this configuration without being removed from the other one: {common_slots}"
+      "slots_already_configured": "The following slots for lock {lock} are already managed by another config entry ({entry_title}) and can't be added to this configuration without being removed from the other one: {common_slots}",
+      "too_many_users": "Lock {lock} has {num_slots} PIN code slots and {taken} of them already hold a code, leaving room for {room} more. Set up at most {room} users here, or manage the rest from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity."
     },
     "step": {
       "choose_path": {
@@ -33,6 +33,7 @@
           "name": "Name",
           "pin": "PIN Code"
         },
+        "description": "A user is active when their condition entity (if configured) is 'on'. For calendars, 'on' means an event is in progress. Supported entity types: calendar, binary_sensor, switch, schedule, input_boolean.",
         "title": "User {user_num} of {num_users}"
       },
       "existing_codes_confirm": {
@@ -48,7 +49,7 @@
           "num_users": "Number of users"
         },
         "description": "How many users do you want to set up? You can add or remove users later. Lock Code Manager picks which code slot each user occupies, skipping any slot that already holds a code.",
-        "title": "How Many Slots?"
+        "title": "How Many Users?"
       },
       "user": {
         "data": {

--- a/custom_components/lock_code_manager/strings.json
+++ b/custom_components/lock_code_manager/strings.json
@@ -4,7 +4,6 @@
       "already_configured": "Lock Code Manager config entry with same slugified name already exists.",
       "existing_codes_cancelled": "Setup cancelled. Existing codes were not modified.",
       "locks_updated": "The locks for your config entry have been updated.",
-      "occupancy_unknown": "Could not read the existing codes from {locks}, so Lock Code Manager cannot tell which code slots are free. Setting a user up now could overwrite a code already on the lock. Check the lock is reachable and try again.",
       "unknown": "An unexpected error occurred during setup."
     },
     "error": {
@@ -13,6 +12,7 @@
       "missing_pin_if_enabled": "PIN must be set if slot is enabled.",
       "name_not_unique": "That name is already used by another user in this configuration. Names must be unique.",
       "name_required": "Every user needs a name. The name identifies them on your locks.",
+      "occupancy_unknown": "Could not read the existing codes on {locks}. Lock Code Manager will not choose slot numbers it could not check, because one of them may already hold a code. Wake the lock or check it is reachable, then try again.",
       "slot_name_not_unique": "The name for code slot {slot_num} is already used by another code slot in this entry. Names must be unique.",
       "slot_name_required": "Code slot {slot_num} needs a name. The name identifies this user on your locks.",
       "slot_out_of_range": "Lock {lock} reports only {num_slots} PIN code slots, so these slot numbers are out of range for it: {out_of_range_slots}. Renumber them to fall within 1-{num_slots}, or manage that lock from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity.",
@@ -133,7 +133,6 @@
     },
     "error": {
       "invalid_config": "Slots configuration is invalid. For more information, check the logs and the docs.",
-      "name_not_unique": "That name is already used by another user in this configuration. Names must be unique.",
       "name_required": "Every user needs a name. The name identifies them on your locks.",
       "slot_name_not_unique": "The name for code slot {slot_num} is already used by another code slot in this entry. Names must be unique.",
       "slot_name_required": "Code slot {slot_num} needs a name. The name identifies this user on your locks.",

--- a/custom_components/lock_code_manager/strings.json
+++ b/custom_components/lock_code_manager/strings.json
@@ -12,6 +12,7 @@
       "missing_pin_if_enabled": "PIN must be set if slot is enabled.",
       "name_not_unique": "That name is already used by another user in this configuration. Names must be unique.",
       "name_required": "Every user needs a name. The name identifies them on your locks.",
+      "numbers_needed_exceed_capacity": "Placing {num_users} users would need slot numbers up to {needed}, and lock {lock} has {num_slots} PIN code slots -- some of them already holding codes. Set up fewer users here, or manage the rest from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity.",
       "occupancy_unknown": "Could not read the existing codes on {locks}. Lock Code Manager will not choose slot numbers it could not check, because one of them may already hold a code. Wake the lock or check it is reachable, then try again.",
       "slot_name_not_unique": "The name for code slot {slot_num} is already used by another code slot in this entry. Names must be unique.",
       "slot_name_required": "Code slot {slot_num} needs a name. The name identifies this user on your locks.",

--- a/custom_components/lock_code_manager/strings.json
+++ b/custom_components/lock_code_manager/strings.json
@@ -17,7 +17,7 @@
       "slot_name_required": "Code slot {slot_num} needs a name. The name identifies this user on your locks.",
       "slot_out_of_range": "Lock {lock} reports only {num_slots} PIN code slots, so these slot numbers are out of range for it: {out_of_range_slots}. Renumber them to fall within 1-{num_slots}, or manage that lock from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity.",
       "slots_already_configured": "The following slots for lock {lock} are already managed by another config entry ({entry_title}) and can't be added to this configuration without being removed from the other one: {common_slots}",
-      "too_many_users": "Lock {lock} has {num_slots} PIN code slots, so {num_users} users will not fit alongside the codes already on it. Set up fewer users here, or manage the rest from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity."
+      "too_many_users": "Lock {lock} has {num_slots} PIN code slots, so {num_users} users will not fit. Set up fewer users here, or manage the rest from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity."
     },
     "step": {
       "choose_path": {

--- a/custom_components/lock_code_manager/translations/en.json
+++ b/custom_components/lock_code_manager/translations/en.json
@@ -11,11 +11,13 @@
       "excluded_platform": "Entities from the `{integration}` integration are not supported as condition entities. See the [wiki]({docs_url}) for details.",
       "invalid_config": "Slots configuration is invalid. For more information, check the logs and the docs.",
       "missing_pin_if_enabled": "PIN must be set if slot is enabled.",
-      "name_not_unique": "The name for code slot {slot_num} is already used by another code slot in this entry. Names must be unique.",
-      "name_required": "Code slot {slot_num} needs a name. The name identifies this user on your locks.",
+      "name_not_unique": "That name is already used by another user in this configuration. Names must be unique.",
+      "name_required": "Every user needs a name. The name identifies them on your locks.",
+      "slot_name_not_unique": "The name for code slot {slot_num} is already used by another code slot in this entry. Names must be unique.",
+      "slot_name_required": "Code slot {slot_num} needs a name. The name identifies this user on your locks.",
       "slot_out_of_range": "Lock {lock} reports only {num_slots} PIN code slots, so these slot numbers are out of range for it: {out_of_range_slots}. Renumber them to fall within 1-{num_slots}, or manage that lock from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity.",
       "slots_already_configured": "The following slots for lock {lock} are already managed by another config entry ({entry_title}) and can't be added to this configuration without being removed from the other one: {common_slots}",
-      "too_many_users": "Lock {lock} has {num_slots} PIN code slots and {taken} of them already hold a code, leaving room for {room} more. Set up at most {room} users here, or manage the rest from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity."
+      "too_many_users": "Lock {lock} has {num_slots} PIN code slots, so {num_users} users will not fit alongside the codes already on it. Set up fewer users here, or manage the rest from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity."
     },
     "step": {
       "choose_path": {
@@ -131,8 +133,10 @@
     },
     "error": {
       "invalid_config": "Slots configuration is invalid. For more information, check the logs and the docs.",
-      "name_not_unique": "The name for code slot {slot_num} is already used by another code slot in this entry. Names must be unique.",
-      "name_required": "Code slot {slot_num} needs a name. The name identifies this user on your locks.",
+      "name_not_unique": "That name is already used by another user in this configuration. Names must be unique.",
+      "name_required": "Every user needs a name. The name identifies them on your locks.",
+      "slot_name_not_unique": "The name for code slot {slot_num} is already used by another code slot in this entry. Names must be unique.",
+      "slot_name_required": "Code slot {slot_num} needs a name. The name identifies this user on your locks.",
       "slot_out_of_range": "Lock {lock} reports only {num_slots} PIN code slots, so these slot numbers are out of range for it: {out_of_range_slots}. Renumber them to fall within 1-{num_slots}, or manage that lock from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity.",
       "slots_already_configured": "The following slots for lock {lock} are already managed by another config entry ({entry_title}) and can't be added to this configuration without being removed from the other one: {common_slots}"
     },

--- a/custom_components/lock_code_manager/translations/en.json
+++ b/custom_components/lock_code_manager/translations/en.json
@@ -4,6 +4,8 @@
       "already_configured": "Lock Code Manager config entry with same slugified name already exists.",
       "existing_codes_cancelled": "Setup cancelled. Existing codes were not modified.",
       "locks_updated": "The locks for your config entry have been updated.",
+      "occupancy_unknown": "Could not read the existing codes from {locks}, so Lock Code Manager cannot tell which code slots are free. Setting a user up now could overwrite a code already on the lock. Check the lock is reachable and try again.",
+      "too_many_users": "Lock {lock} has room for {num_slots} PIN codes, and {num_users} users were requested. Configure at most {num_slots} here, or manage the rest from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity.",
       "unknown": "An unexpected error occurred during setup."
     },
     "error": {
@@ -31,8 +33,7 @@
           "name": "Name",
           "pin": "PIN Code"
         },
-        "description": "**Configure slot {slot_num}:** A slot is active when the condition entity (if configured) is 'on'. For calendars, 'on' means an event is in progress. Supported entity types: calendar, binary_sensor, switch, schedule, input_boolean.",
-        "title": "Configure Slot {slot_num}"
+        "title": "User {user_num} of {num_users}"
       },
       "existing_codes_confirm": {
         "title": "Existing Codes Detected",
@@ -44,10 +45,9 @@
       },
       "ui": {
         "data": {
-          "num_slots": "Number of slots",
-          "start_slot": "Start from slot #"
+          "num_users": "Number of users"
         },
-        "description": "Configure slots for all codes you want on the lock. You can add and remove slots later using the integration services.",
+        "description": "How many users do you want to set up? You can add or remove users later. Lock Code Manager picks which code slot each user occupies, skipping any slot that already holds a code.",
         "title": "How Many Slots?"
       },
       "user": {

--- a/custom_components/lock_code_manager/translations/en.json
+++ b/custom_components/lock_code_manager/translations/en.json
@@ -5,7 +5,6 @@
       "existing_codes_cancelled": "Setup cancelled. Existing codes were not modified.",
       "locks_updated": "The locks for your config entry have been updated.",
       "occupancy_unknown": "Could not read the existing codes from {locks}, so Lock Code Manager cannot tell which code slots are free. Setting a user up now could overwrite a code already on the lock. Check the lock is reachable and try again.",
-      "too_many_users": "Lock {lock} has room for {num_slots} PIN codes, and {num_users} users were requested. Configure at most {num_slots} here, or manage the rest from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity.",
       "unknown": "An unexpected error occurred during setup."
     },
     "error": {
@@ -15,7 +14,8 @@
       "name_not_unique": "The name for code slot {slot_num} is already used by another code slot in this entry. Names must be unique.",
       "name_required": "Code slot {slot_num} needs a name. The name identifies this user on your locks.",
       "slot_out_of_range": "Lock {lock} reports only {num_slots} PIN code slots, so these slot numbers are out of range for it: {out_of_range_slots}. Renumber them to fall within 1-{num_slots}, or manage that lock from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity.",
-      "slots_already_configured": "The following slots for lock {lock} are already managed by another config entry ({entry_title}) and can't be added to this configuration without being removed from the other one: {common_slots}"
+      "slots_already_configured": "The following slots for lock {lock} are already managed by another config entry ({entry_title}) and can't be added to this configuration without being removed from the other one: {common_slots}",
+      "too_many_users": "Lock {lock} has {num_slots} PIN code slots and {taken} of them already hold a code, leaving room for {room} more. Set up at most {room} users here, or manage the rest from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity."
     },
     "step": {
       "choose_path": {
@@ -33,6 +33,7 @@
           "name": "Name",
           "pin": "PIN Code"
         },
+        "description": "A user is active when their condition entity (if configured) is 'on'. For calendars, 'on' means an event is in progress. Supported entity types: calendar, binary_sensor, switch, schedule, input_boolean.",
         "title": "User {user_num} of {num_users}"
       },
       "existing_codes_confirm": {
@@ -48,7 +49,7 @@
           "num_users": "Number of users"
         },
         "description": "How many users do you want to set up? You can add or remove users later. Lock Code Manager picks which code slot each user occupies, skipping any slot that already holds a code.",
-        "title": "How Many Slots?"
+        "title": "How Many Users?"
       },
       "user": {
         "data": {

--- a/custom_components/lock_code_manager/translations/en.json
+++ b/custom_components/lock_code_manager/translations/en.json
@@ -4,7 +4,6 @@
       "already_configured": "Lock Code Manager config entry with same slugified name already exists.",
       "existing_codes_cancelled": "Setup cancelled. Existing codes were not modified.",
       "locks_updated": "The locks for your config entry have been updated.",
-      "occupancy_unknown": "Could not read the existing codes from {locks}, so Lock Code Manager cannot tell which code slots are free. Setting a user up now could overwrite a code already on the lock. Check the lock is reachable and try again.",
       "unknown": "An unexpected error occurred during setup."
     },
     "error": {
@@ -13,6 +12,7 @@
       "missing_pin_if_enabled": "PIN must be set if slot is enabled.",
       "name_not_unique": "That name is already used by another user in this configuration. Names must be unique.",
       "name_required": "Every user needs a name. The name identifies them on your locks.",
+      "occupancy_unknown": "Could not read the existing codes on {locks}. Lock Code Manager will not choose slot numbers it could not check, because one of them may already hold a code. Wake the lock or check it is reachable, then try again.",
       "slot_name_not_unique": "The name for code slot {slot_num} is already used by another code slot in this entry. Names must be unique.",
       "slot_name_required": "Code slot {slot_num} needs a name. The name identifies this user on your locks.",
       "slot_out_of_range": "Lock {lock} reports only {num_slots} PIN code slots, so these slot numbers are out of range for it: {out_of_range_slots}. Renumber them to fall within 1-{num_slots}, or manage that lock from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity.",
@@ -133,7 +133,6 @@
     },
     "error": {
       "invalid_config": "Slots configuration is invalid. For more information, check the logs and the docs.",
-      "name_not_unique": "That name is already used by another user in this configuration. Names must be unique.",
       "name_required": "Every user needs a name. The name identifies them on your locks.",
       "slot_name_not_unique": "The name for code slot {slot_num} is already used by another code slot in this entry. Names must be unique.",
       "slot_name_required": "Code slot {slot_num} needs a name. The name identifies this user on your locks.",

--- a/custom_components/lock_code_manager/translations/en.json
+++ b/custom_components/lock_code_manager/translations/en.json
@@ -12,6 +12,7 @@
       "missing_pin_if_enabled": "PIN must be set if slot is enabled.",
       "name_not_unique": "That name is already used by another user in this configuration. Names must be unique.",
       "name_required": "Every user needs a name. The name identifies them on your locks.",
+      "numbers_needed_exceed_capacity": "Placing {num_users} users would need slot numbers up to {needed}, and lock {lock} has {num_slots} PIN code slots -- some of them already holding codes. Set up fewer users here, or manage the rest from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity.",
       "occupancy_unknown": "Could not read the existing codes on {locks}. Lock Code Manager will not choose slot numbers it could not check, because one of them may already hold a code. Wake the lock or check it is reachable, then try again.",
       "slot_name_not_unique": "The name for code slot {slot_num} is already used by another code slot in this entry. Names must be unique.",
       "slot_name_required": "Code slot {slot_num} needs a name. The name identifies this user on your locks.",

--- a/custom_components/lock_code_manager/translations/en.json
+++ b/custom_components/lock_code_manager/translations/en.json
@@ -17,7 +17,7 @@
       "slot_name_required": "Code slot {slot_num} needs a name. The name identifies this user on your locks.",
       "slot_out_of_range": "Lock {lock} reports only {num_slots} PIN code slots, so these slot numbers are out of range for it: {out_of_range_slots}. Renumber them to fall within 1-{num_slots}, or manage that lock from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity.",
       "slots_already_configured": "The following slots for lock {lock} are already managed by another config entry ({entry_title}) and can't be added to this configuration without being removed from the other one: {common_slots}",
-      "too_many_users": "Lock {lock} has {num_slots} PIN code slots, so {num_users} users will not fit alongside the codes already on it. Set up fewer users here, or manage the rest from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity."
+      "too_many_users": "Lock {lock} has {num_slots} PIN code slots, so {num_users} users will not fit. Set up fewer users here, or manage the rest from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity."
     },
     "step": {
       "choose_path": {

--- a/custom_components/lock_code_manager/websocket.py
+++ b/custom_components/lock_code_manager/websocket.py
@@ -524,7 +524,7 @@ def _get_slot_entity_ids(
         slot_int: _build_slot_entities(ent_reg, entry.entry_id, slot_int)
         for entry in hass.config_entries.async_entries(DOMAIN)
         if get_entry_config(entry).has_lock(lock_entity_id)
-        for slot_int in get_entry_config(entry).slots
+        for slot_int in get_entry_config(entry).slot_numbers
     }
 
 

--- a/tests/properties/test_occupancy.py
+++ b/tests/properties/test_occupancy.py
@@ -1,0 +1,120 @@
+"""
+Property-based tests for deciding which slot numbers allocation may use.
+
+The slot number is the lock's credential index on most providers, so issuing
+an occupied one overwrites a code on a real door. Two failure directions, and
+they are not symmetric:
+
+* **issuing an occupied number** overwrites somebody's credential;
+* **refusing when nothing is wrong** blocks the user from adding anybody.
+
+The first is worse, so unreadable is treated as unknown rather than free --
+but only for the locks that constrain the numbering at all.
+"""
+
+from __future__ import annotations
+
+from hypothesis import given, strategies as st
+
+from custom_components.lock_code_manager.domain.occupancy import (
+    LockOccupancy,
+    Occupancy,
+)
+
+LOCKS = st.sampled_from(["lock.front", "lock.back", "lock.side"])
+SLOTS = st.integers(min_value=1, max_value=12)
+
+
+@st.composite
+def occupancies(draw: st.DrawFn) -> Occupancy:
+    """An occupancy report across a few locks, any of which may be unreadable."""
+    reports = []
+    for lock in draw(st.lists(LOCKS, max_size=3, unique=True)):
+        follows_slot = draw(st.booleans())
+        managed = draw(st.booleans())
+        readable = draw(st.booleans())
+        reports.append(
+            LockOccupancy(
+                lock_entity_id=lock,
+                credential_index_follows_slot=follows_slot,
+                managed=managed,
+                occupied=frozenset(draw(st.sets(SLOTS, max_size=4)))
+                if readable
+                else None,
+            )
+        )
+    return Occupancy(locks=tuple(reports), claimed_by_other_entries=frozenset())
+
+
+@given(occupancy=occupancies())
+def test_only_constraining_locks_can_block_allocation(occupancy: Occupancy) -> None:
+    """A lock blocks only if Lock Code Manager writes to it by slot number.
+
+    An unsupported platform, or one that allocates its own credential index,
+    says nothing about whether slot n is free. Refusing on those would block
+    allocation forever for any setup that includes one.
+    """
+    blocking = [
+        lock
+        for lock in occupancy.locks
+        if lock.occupied is None and lock.managed and lock.credential_index_follows_slot
+    ]
+
+    # Stated in BOTH directions. The forward one alone is vacuous: an
+    # implementation that always reports occupancy as known satisfies it by
+    # never entering the branch, and that is the failure this exists to catch.
+    assert occupancy.is_known == (not blocking)
+    assert set(occupancy.unreadable) == {lock.lock_entity_id for lock in blocking}
+
+
+@given(occupancy=occupancies())
+def test_unavailable_never_includes_a_number_from_an_unconstraining_lock(
+    occupancy: Occupancy,
+) -> None:
+    """Codes on a lock we do not address by slot must not reserve a number.
+
+    Reserving them would push real users past the advertised capacity of the
+    locks that DO follow the slot number.
+    """
+    unconstraining = {
+        number
+        for lock in occupancy.locks
+        if not (lock.managed and lock.credential_index_follows_slot)
+        for number in (lock.occupied or ())
+    }
+    constraining = {
+        number
+        for lock in occupancy.locks
+        if lock.managed and lock.credential_index_follows_slot
+        for number in (lock.occupied or ())
+    }
+
+    assert not (occupancy.unavailable - constraining) & (unconstraining - constraining)
+
+
+@given(occupancy=occupancies())
+def test_every_occupied_number_on_a_constraining_lock_is_unavailable(
+    occupancy: Occupancy,
+) -> None:
+    """The direction that matters: nothing occupied is ever offered.
+
+    Issuing one writes a user's code over a credential already on the door.
+    """
+    for lock in occupancy.locks:
+        if lock.managed and lock.credential_index_follows_slot and lock.occupied:
+            assert lock.occupied <= occupancy.unavailable
+
+
+@given(occupancy=occupancies(), claimed=st.sets(SLOTS, max_size=4))
+def test_numbers_another_entry_manages_are_unavailable(
+    occupancy: Occupancy, claimed: set[int]
+) -> None:
+    """Two entries on one lock must not both manage a number.
+
+    Nothing outside the config flow enforces this, so allocation has to.
+    """
+    with_claims = Occupancy(
+        locks=occupancy.locks, claimed_by_other_entries=frozenset(claimed)
+    )
+
+    assert claimed <= with_claims.unavailable

--- a/tests/providers/test_base.py
+++ b/tests/providers/test_base.py
@@ -232,7 +232,7 @@ async def test_occupied_indices_reads_a_real_provider_end_to_end(
 
     assert not lock.managed_slots
     # 9 is real but outside the window, so it is not an answer to this question.
-    assert await lock.async_internal_get_occupied_indices(5) == frozenset({2})
+    assert await lock.async_internal_get_occupied_indices(range(1, 6)) == frozenset({2})
 
 
 async def test_occupied_indices_counts_everything_the_lock_holds(
@@ -256,7 +256,9 @@ async def test_occupied_indices_counts_everything_the_lock_holds(
     with patch.object(lock, "async_get_usercodes", AsyncMock(return_value=codes)):
         # 0 and 12 are both outside the window the caller asked about. A lock
         # numbering from zero is not one this allocates into.
-        assert await lock.async_internal_get_occupied_indices(10) == frozenset({1, 3})
+        assert await lock.async_internal_get_occupied_indices(
+            range(1, 11)
+        ) == frozenset({1, 3})
 
 
 async def test_occupied_indices_is_unknown_when_the_lock_cannot_be_read(
@@ -276,20 +278,24 @@ async def test_occupied_indices_is_unknown_when_the_lock_cannot_be_read(
         LockOperationFailed("read rejected"),
     ):
         with patch.object(lock, "async_get_usercodes", AsyncMock(side_effect=error)):
-            assert await lock.async_internal_get_occupied_indices(10) is None
+            assert await lock.async_internal_get_occupied_indices(range(1, 11)) is None
 
 
 async def test_occupied_indices_asks_only_about_the_window(
     hass: HomeAssistant,
 ) -> None:
-    """The read is scoped, so a per-index lock is not walked end to end."""
+    """The read is scoped, so a per-index lock is not walked end to end.
+
+    The caller names the indices rather than a ceiling, so one that widens
+    its search can ask only about what it has not asked about yet.
+    """
     lock = _bare_lock(hass, "test_lock_occupancy_window")
 
     read = AsyncMock(return_value={})
     with patch.object(lock, "async_get_usercodes", read):
-        await lock.async_internal_get_occupied_indices(3)
+        await lock.async_internal_get_occupied_indices(range(1, 4))
 
-    assert list(read.await_args.args[0]) == [1, 2, 3]
+    assert sorted(read.await_args.args[0]) == [1, 2, 3]
 
 
 class _PushSetupRaisesLock(MockLCMLock):
@@ -2131,3 +2137,22 @@ async def test_serialize_sequence_allows_rate_limited_inside(
         result = await lock.async_internal_set_usercode(5, "5555", "Test 5")
 
     assert result is None
+
+
+async def test_occupied_indices_asks_nothing_when_there_is_nothing_to_ask(
+    hass: HomeAssistant,
+) -> None:
+    """An empty range costs no round trip.
+
+    A caller widening its search hands over only the indices it has not
+    covered, and on the pass where that set is empty there is nothing to
+    learn -- reaching the lock would be a round trip for an answer already
+    held.
+    """
+    lock = _bare_lock(hass, "test_lock_occupancy_empty_range")
+
+    read = AsyncMock(return_value={})
+    with patch.object(lock, "async_get_usercodes", read):
+        assert await lock.async_internal_get_occupied_indices([]) == frozenset()
+
+    read.assert_not_awaited()

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -14,6 +14,7 @@ from custom_components.lock_code_manager.config_flow import (
     LockCodeManagerFlowHandler,
     _async_query_locks,
     _LockQuery,
+    _LockQuerySkipped,
 )
 from custom_components.lock_code_manager.const import (
     CONF_LOCKS,
@@ -41,6 +42,27 @@ from .common import BASE_CONFIG, LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID, MockLCMLock
 GET_ALL_CODES_PATCH = (
     "custom_components.lock_code_manager.config_flow._async_query_locks"
 )
+
+
+def _holding(*occupied: int):
+    """Patch the lock read so it answers with exactly these slots occupied.
+
+    The scope is honoured, the way a per-index provider honours it, so a test
+    that widens the window sees the wider answer.
+    """
+
+    async def _read(self, slots=None):
+        scope = self.managed_slots if slots is None else slots
+        return {
+            slot: (
+                SlotCredential.known("0000")
+                if slot in occupied
+                else SlotCredential.empty()
+            )
+            for slot in scope
+        }
+
+    return patch.object(MockLCMLock, "async_get_usercodes", _read)
 
 
 def _answers(existing: dict[str, dict[int, SlotCredential]]):
@@ -147,7 +169,7 @@ async def _init_flow_to_user_step(hass: HomeAssistant) -> str:
     return result["flow_id"]
 
 
-async def test_config_flow_ui(hass: HomeAssistant):
+async def test_config_flow_ui(hass: HomeAssistant, mock_lock_config_entry):
     """Test UI based config flow with slot number incrementing correctly."""
     flow_id = await _start_ui_config_flow(hass)
 
@@ -178,17 +200,18 @@ async def test_config_flow_ui(hass: HomeAssistant):
             "User 3": {CONF_ENABLED: True, CONF_PIN: "9012"},
             "User 4": {CONF_ENABLED: True, CONF_PIN: "3456"},
         },
-        # Numbers the user never chose: the lowest free on the lock.
+        # Numbers the user never chose: the lowest free on the lock, which
+        # already holds codes at 1 and 2.
         CONF_SLOT_ASSIGNMENT: {
-            "user 1": 1,
-            "user 2": 2,
-            "user 3": 3,
-            "user 4": 4,
+            "user 1": 3,
+            "user 2": 4,
+            "user 3": 5,
+            "user 4": 6,
         },
     }
 
 
-async def test_config_flow_ui_error(hass: HomeAssistant):
+async def test_config_flow_ui_error(hass: HomeAssistant, mock_lock_config_entry):
     """Test error in UI based config flow."""
     flow_id = await _start_ui_config_flow(hass)
 
@@ -400,7 +423,9 @@ async def test_config_flow_two_entries_same_locks(
     assert result["type"] == "create_entry"
 
 
-async def test_config_flow_ui_scheduler_entity_excluded(hass: HomeAssistant):
+async def test_config_flow_ui_scheduler_entity_excluded(
+    hass: HomeAssistant, mock_lock_config_entry
+):
     """Test that scheduler-component entities are rejected during config flow."""
     # Create a mock scheduler entity in registry
     ent_reg = er.async_get(hass)
@@ -437,7 +462,9 @@ async def test_config_flow_ui_scheduler_entity_excluded(hass: HomeAssistant):
 # --- Existing-codes confirmation step tests ---
 
 
-async def test_ui_setup_allocates_around_existing_codes(hass: HomeAssistant):
+async def test_ui_setup_allocates_around_existing_codes(
+    hass: HomeAssistant, mock_lock_config_entry
+):
     """Setup skips slots that already hold a code instead of asking about them.
 
     There is no prompt because there is nothing to overwrite: the numbers are
@@ -481,35 +508,28 @@ async def test_ui_setup_allocates_around_existing_codes(hass: HomeAssistant):
     assert result["data"][CONF_SLOT_ASSIGNMENT] == {"alice": 3, "raman": 4}
 
 
-async def test_ui_setup_refuses_when_a_lock_cannot_be_read(hass: HomeAssistant):
+async def test_ui_setup_refuses_when_a_lock_cannot_be_read(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
     """A lock that did not answer makes occupancy unknown, and setup stops.
 
-    Unreadable is not free. Issuing a number here could put a user's code over
-    a credential programmed by hand on a lock that was merely unreachable.
+    Unreadable is not free. Issuing a number here could put a user's code
+    over a credential programmed by hand on a lock that was merely
+    unreachable.
     """
+    flow_id = await _start_config_flow(hass)
+    await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
 
-    async def _unreadable(hass, dev_reg, ent_reg, lock_entity_ids):
-        return [
-            _LockQuery(
-                lock_entity_id=lock,
-                managed=True,
-                credential_index_follows_slot=True,
-                codes=None,
-            )
-            for lock in lock_entity_ids
-        ]
-
-    with patch(GET_ALL_CODES_PATCH, side_effect=_unreadable):
-        flow_id = await _init_flow_to_user_step(hass)
-        await hass.config_entries.flow.async_configure(
-            flow_id, {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
-        )
+    with patch.object(
+        MockLCMLock,
+        "async_get_usercodes",
+        AsyncMock(side_effect=LockDisconnected("asleep")),
+    ):
         result = await hass.config_entries.flow.async_configure(
-            flow_id, {"next_step_id": "ui"}
+            flow_id, {CONF_NUM_USERS: 2}
         )
 
-    # Refused on the way in to the count form, not after names and PINs have
-    # been typed -- nothing collected there could change the answer.
+    # Refused before a single name or PIN was collected.
     assert result["type"] == "abort"
     assert result["reason"] == "occupancy_unknown"
     assert LOCK_1_ENTITY_ID in result["description_placeholders"]["locks"]
@@ -580,7 +600,9 @@ async def test_yaml_existing_codes_confirm_cancel(hass: HomeAssistant):
     assert result["reason"] == "existing_codes_cancelled"
 
 
-async def test_ui_no_existing_codes_skips_confirm(hass: HomeAssistant):
+async def test_ui_no_existing_codes_skips_confirm(
+    hass: HomeAssistant, mock_lock_config_entry
+):
     """UI path: no existing codes -> skip confirm step entirely."""
     with patch(GET_ALL_CODES_PATCH, side_effect=_answers({})):
         flow_id = await _init_flow_to_user_step(hass)
@@ -1271,6 +1293,112 @@ async def test_config_flow_yaml_accepts_slot_within_capacity(
     assert result["type"] == "create_entry"
 
 
+async def test_setup_refuses_when_a_lock_has_no_provider(
+    hass: HomeAssistant, mock_lock_config_entry
+):
+    """A lock we cannot build a provider for is unread, not empty.
+
+    Lock Code Manager will still write to it once the entry loads, so
+    allocation must not issue numbers it was never able to check against it.
+    """
+    flow_id = await _start_config_flow(hass)
+    await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
+
+    with patch(
+        "custom_components.lock_code_manager.config_flow._async_build_lock_instance",
+        side_effect=_LockQuerySkipped(LOCK_1_ENTITY_ID, managed=True),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            flow_id, {CONF_NUM_USERS: 2}
+        )
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "occupancy_unknown"
+    assert LOCK_1_ENTITY_ID in result["description_placeholders"]["locks"]
+
+
+async def test_setup_ignores_a_lock_on_an_unsupported_platform(
+    hass: HomeAssistant, mock_lock_config_entry
+):
+    """A lock this integration will not write to cannot constrain numbering."""
+    flow_id = await _start_config_flow(hass)
+    await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
+
+    with patch(
+        "custom_components.lock_code_manager.config_flow._async_build_lock_instance",
+        side_effect=_LockQuerySkipped(LOCK_1_ENTITY_ID, managed=False),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            flow_id, {CONF_NUM_USERS: 2}
+        )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "code_slot"
+
+
+async def test_setup_reads_only_as_far_as_it_has_to(
+    hass: HomeAssistant, mock_lock_config_entry
+):
+    """The window starts at the number of users and widens by what is in the way.
+
+    Locks that answer one index per round trip make the width of this read
+    its cost, so a lock is never walked to its advertised capacity to place a
+    handful of users.
+    """
+    windows: list[int] = []
+
+    async def _read(self, slots=None):
+        scope = list(self.managed_slots if slots is None else slots)
+        windows.append(max(scope, default=0))
+        return {
+            slot: (
+                SlotCredential.known("0000")
+                if slot in (1, 2, 3)
+                else SlotCredential.empty()
+            )
+            for slot in scope
+        }
+
+    flow_id = await _start_config_flow(hass)
+    await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
+
+    with patch.object(MockLCMLock, "async_get_usercodes", _read):
+        result = await hass.config_entries.flow.async_configure(
+            flow_id, {CONF_NUM_USERS: 2}
+        )
+        for name in ("Raman", "Alice"):
+            result = await hass.config_entries.flow.async_configure(
+                flow_id, {CONF_NAME: name, CONF_ENABLED: True, CONF_PIN: "1111"}
+            )
+
+    assert result["type"] == "create_entry"
+    # Slots 1-3 are taken, so the two users land on 4 and 5.
+    assert result["data"][CONF_SLOT_ASSIGNMENT] == {"alice": 4, "raman": 5}
+    # Asked about 2, found 2 in the way, asked about 4, found 3 in the way,
+    # asked about 5. Never about the lock's whole capacity.
+    assert windows == [2, 4, 5]
+
+
+async def test_setup_does_not_widen_when_nothing_is_in_the_way(
+    hass: HomeAssistant, mock_lock_config_entry
+):
+    """An empty lock costs exactly one read of exactly the users asked for."""
+    windows: list[int] = []
+
+    async def _read(self, slots=None):
+        scope = list(self.managed_slots if slots is None else slots)
+        windows.append(max(scope, default=0))
+        return dict.fromkeys(scope, SlotCredential.empty())
+
+    flow_id = await _start_config_flow(hass)
+    await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
+
+    with patch.object(MockLCMLock, "async_get_usercodes", _read):
+        await hass.config_entries.flow.async_configure(flow_id, {CONF_NUM_USERS: 3})
+
+    assert windows == [3]
+
+
 async def test_config_flow_ui_rejects_more_users_than_the_lock_holds(
     hass: HomeAssistant, mock_lock_config_entry
 ):
@@ -1285,7 +1413,7 @@ async def test_config_flow_ui_rejects_more_users_than_the_lock_holds(
     probe_registered, probe_capabilities = _capacity_probe(
         return_value=_capabilities_with_slots(2)
     )
-    with probe_registered, probe_capabilities:
+    with probe_registered, probe_capabilities, _holding():
         result = await hass.config_entries.flow.async_configure(
             flow_id, {CONF_NUM_USERS: 3}
         )
@@ -1298,7 +1426,7 @@ async def test_config_flow_ui_rejects_more_users_than_the_lock_holds(
     assert result["description_placeholders"]["room"] == "2"
     assert result["description_placeholders"]["taken"] == "0"
 
-    with probe_registered, probe_capabilities:
+    with probe_registered, probe_capabilities, _holding():
         result = await hass.config_entries.flow.async_configure(
             flow_id, {CONF_NUM_USERS: 2}
         )
@@ -1315,18 +1443,13 @@ async def test_config_flow_ui_room_accounts_for_codes_already_on_the_lock(
     Reporting raw capacity would tell someone with a nearly-full lock they
     can add far more users than they can.
     """
-    existing = {LOCK_1_ENTITY_ID: {1: SlotCredential.known("1234")}}
-    with patch(GET_ALL_CODES_PATCH, side_effect=_answers(existing)):
-        flow_id = await _init_flow_to_user_step(hass)
-        await hass.config_entries.flow.async_configure(
-            flow_id, {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
-        )
+    flow_id = await _start_config_flow(hass)
     await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
 
     probe_registered, probe_capabilities = _capacity_probe(
         return_value=_capabilities_with_slots(3)
     )
-    with probe_registered, probe_capabilities:
+    with probe_registered, probe_capabilities, _holding(1):
         result = await hass.config_entries.flow.async_configure(
             flow_id, {CONF_NUM_USERS: 3}
         )
@@ -1454,7 +1577,9 @@ async def test_config_flow_capacity_check_survives_unexpected_error(
     assert "provider blew up" in caplog.text
 
 
-async def test_config_flow_ui_accepts_a_name_containing_a_pipe(hass: HomeAssistant):
+async def test_config_flow_ui_accepts_a_name_containing_a_pipe(
+    hass: HomeAssistant, mock_lock_config_entry
+):
     """A "|" in a name is ordinary text now, not a rejected character.
 
     It was rejected only while entity and device identifiers were keyed by the
@@ -1471,7 +1596,9 @@ async def test_config_flow_ui_accepts_a_name_containing_a_pipe(hass: HomeAssista
     assert not result["errors"]
 
 
-async def test_config_flow_ui_rejects_a_missing_name(hass: HomeAssistant):
+async def test_config_flow_ui_rejects_a_missing_name(
+    hass: HomeAssistant, mock_lock_config_entry
+):
     """A slot must be named, because the name is becoming the identity.
 
     Now the ONLY rule left in this branch: the separator rule that used to
@@ -1487,7 +1614,9 @@ async def test_config_flow_ui_rejects_a_missing_name(hass: HomeAssistant):
     assert result["errors"] == {CONF_NAME: "name_required"}
 
 
-async def test_config_flow_ui_rejects_duplicate_name(hass: HomeAssistant):
+async def test_config_flow_ui_rejects_duplicate_name(
+    hass: HomeAssistant, mock_lock_config_entry
+):
     """Two slots in one entry cannot share a name, ignoring case."""
     flow_id = await _start_ui_config_flow(hass)
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1375,10 +1375,12 @@ async def test_setup_reads_only_as_far_as_it_has_to(
     assert result["type"] == "create_entry"
     # Slots 1-3 are taken, so the two users land on 4 and 5.
     assert result["data"][CONF_SLOT_ASSIGNMENT] == {"alice": 4, "raman": 5}
-    # And never past what was actually read.
-    assert max(result["data"][CONF_SLOT_ASSIGNMENT].values()) <= max(
+    # Every number issued was one that was actually read -- not merely one
+    # below the highest read, which would let a gap through if the read ever
+    # stops being contiguous.
+    assert set(result["data"][CONF_SLOT_ASSIGNMENT].values()) <= {
         slot for window in windows for slot in window
-    )
+    }
     # Asked about 1-2, then only 3-4, then only 5: every index once, and
     # never about the lock's whole capacity.
     assert windows == [[1, 2], [3, 4], [5]]
@@ -1451,7 +1453,7 @@ async def test_a_refused_count_reports_only_what_it_can_stand_behind(
     strings = json.loads(
         Path("custom_components/lock_code_manager/strings.json").read_text()
     )
-    message = strings["config"]["error"]["too_many_users"]
+    message = strings["config"]["error"]["numbers_needed_exceed_capacity"]
 
     flow_id = await _start_config_flow(hass)
     await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
@@ -1465,7 +1467,7 @@ async def test_a_refused_count_reports_only_what_it_can_stand_behind(
             flow_id, {CONF_NUM_USERS: 8}
         )
 
-    assert result["errors"] == {"base": "too_many_users"}
+    assert result["errors"] == {"base": "numbers_needed_exceed_capacity"}
     supplied = result["description_placeholders"]
     assert not {
         name for name in re.findall(r"\{(\w+)\}", message) if name not in supplied
@@ -1902,7 +1904,12 @@ async def test_a_count_that_fits_can_still_need_numbers_that_do_not(
             flow_id, {CONF_NUM_USERS: 3}
         )
 
-    assert result["errors"] == {"base": "too_many_users"}
+    assert result["errors"] == {"base": "numbers_needed_exceed_capacity"}
+    # The count the user chose, and the number their last user would need.
+    # Reporting either in the other's place makes the sentence false.
+    assert result["description_placeholders"]["num_users"] == "3"
+    assert result["description_placeholders"]["needed"] == "5"
+    assert result["description_placeholders"]["num_slots"] == "4"
 
 
 async def test_choosing_the_ui_path_reads_no_lock_on_the_way_in(
@@ -1978,7 +1985,7 @@ async def test_a_nearly_full_lock_is_read_once_through(
             flow_id, {CONF_NAME: name, CONF_ENABLED: True, CONF_PIN: "1111"}
         )
     assert result["type"] == "create_entry"
-    assert max(result["data"][CONF_SLOT_ASSIGNMENT].values()) <= max(asked)
+    assert set(result["data"][CONF_SLOT_ASSIGNMENT].values()) <= set(asked)
 
 
 async def test_numbers_another_entry_manages_are_stepped_over(

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -504,12 +504,12 @@ async def test_ui_setup_refuses_when_a_lock_cannot_be_read(hass: HomeAssistant):
         await hass.config_entries.flow.async_configure(
             flow_id, {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
         )
-        await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
-        await hass.config_entries.flow.async_configure(flow_id, {CONF_NUM_USERS: 1})
         result = await hass.config_entries.flow.async_configure(
-            flow_id, {CONF_NAME: "Raman", CONF_ENABLED: True, CONF_PIN: "1111"}
+            flow_id, {"next_step_id": "ui"}
         )
 
+    # Refused on the way in to the count form, not after names and PINs have
+    # been typed -- nothing collected there could change the answer.
     assert result["type"] == "abort"
     assert result["reason"] == "occupancy_unknown"
     assert LOCK_1_ENTITY_ID in result["description_placeholders"]["locks"]
@@ -860,9 +860,11 @@ async def test_query_locks_entity_not_in_registry(hass: HomeAssistant):
 
     [query] = await _async_query_locks(hass, dev_reg, ent_reg, ["lock.does_not_exist"])
 
-    # Not a lock Lock Code Manager writes credentials to, so its contents
-    # cannot collide with anything allocation issues.
-    assert not query.managed
+    # Lock Code Manager still writes here -- the provider just could not be
+    # built right now -- so the lock has to constrain allocation, and an
+    # unread lock constrains it by making occupancy unknown.
+    assert query.managed
+    assert query.credential_index_follows_slot
     assert query.codes is None
 
 
@@ -899,9 +901,11 @@ async def test_query_locks_missing_lock_config_entry(hass: HomeAssistant):
     ):
         [query] = await _async_query_locks(hass, dev_reg, ent_reg, [LOCK_1_ENTITY_ID])
 
-    # Not a lock Lock Code Manager writes credentials to, so its contents
-    # cannot collide with anything allocation issues.
-    assert not query.managed
+    # Lock Code Manager still writes here -- the provider just could not be
+    # built right now -- so the lock has to constrain allocation, and an
+    # unread lock constrains it by making occupancy unknown.
+    assert query.managed
+    assert query.credential_index_follows_slot
     assert query.codes is None
 
 
@@ -1270,32 +1274,68 @@ async def test_config_flow_yaml_accepts_slot_within_capacity(
 async def test_config_flow_ui_rejects_more_users_than_the_lock_holds(
     hass: HomeAssistant, mock_lock_config_entry
 ):
-    """Asking for more users than the lock has slots for cannot be satisfied.
+    """A count the locks cannot hold is refused where it can still be changed.
 
-    The count is the only thing the user chose, so the refusal has to name it;
-    there is no slot range to send them back to.
+    Which users get configured does not change which numbers allocation
+    issues, so the answer is known as soon as the count is.
     """
     flow_id = await _start_config_flow(hass)
     await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
-    await hass.config_entries.flow.async_configure(flow_id, {CONF_NUM_USERS: 3})
-
-    for name in ("Raman", "Alice"):
-        await hass.config_entries.flow.async_configure(
-            flow_id, {CONF_NAME: name, CONF_ENABLED: True, CONF_PIN: "1111"}
-        )
 
     probe_registered, probe_capabilities = _capacity_probe(
         return_value=_capabilities_with_slots(2)
     )
     with probe_registered, probe_capabilities:
         result = await hass.config_entries.flow.async_configure(
-            flow_id, {CONF_NAME: "Bo", CONF_ENABLED: True, CONF_PIN: "3333"}
+            flow_id, {CONF_NUM_USERS: 3}
         )
 
-    assert result["type"] == "abort"
-    assert result["reason"] == "too_many_users"
+    # A form, not an abort: the user can lower the count and carry on.
+    assert result["type"] == "form"
+    assert result["step_id"] == "ui"
+    assert result["errors"] == {"base": "too_many_users"}
     assert result["description_placeholders"]["num_users"] == "3"
-    assert result["description_placeholders"]["num_slots"] == "2"
+    assert result["description_placeholders"]["room"] == "2"
+    assert result["description_placeholders"]["taken"] == "0"
+
+    with probe_registered, probe_capabilities:
+        result = await hass.config_entries.flow.async_configure(
+            flow_id, {CONF_NUM_USERS: 2}
+        )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "code_slot"
+
+
+async def test_config_flow_ui_room_accounts_for_codes_already_on_the_lock(
+    hass: HomeAssistant, mock_lock_config_entry
+):
+    """The room offered is capacity minus what the lock already holds.
+
+    Reporting raw capacity would tell someone with a nearly-full lock they
+    can add far more users than they can.
+    """
+    existing = {LOCK_1_ENTITY_ID: {1: SlotCredential.known("1234")}}
+    with patch(GET_ALL_CODES_PATCH, side_effect=_answers(existing)):
+        flow_id = await _init_flow_to_user_step(hass)
+        await hass.config_entries.flow.async_configure(
+            flow_id, {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
+        )
+    await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
+
+    probe_registered, probe_capabilities = _capacity_probe(
+        return_value=_capabilities_with_slots(3)
+    )
+    with probe_registered, probe_capabilities:
+        result = await hass.config_entries.flow.async_configure(
+            flow_id, {CONF_NUM_USERS: 3}
+        )
+
+    assert result["errors"] == {"base": "too_many_users"}
+    # Three slots, one already holding a code: room for two, not three.
+    assert result["description_placeholders"]["num_slots"] == "3"
+    assert result["description_placeholders"]["taken"] == "1"
+    assert result["description_placeholders"]["room"] == "2"
 
 
 async def test_config_flow_capacity_check_skipped_when_lock_unreachable(

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -12,13 +12,14 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from custom_components.lock_code_manager.config_flow import (
     LockCodeManagerFlowHandler,
-    _async_get_all_codes,
+    _async_query_locks,
+    _LockQuery,
 )
 from custom_components.lock_code_manager.const import (
     CONF_LOCKS,
-    CONF_NUM_SLOTS,
+    CONF_NUM_USERS,
     CONF_SLOTS,
-    CONF_START_SLOT,
+    CONF_USERS,
     DOMAIN,
 )
 from custom_components.lock_code_manager.domain.credentials import (
@@ -31,12 +32,37 @@ from custom_components.lock_code_manager.domain.exceptions import (
     LockDisconnected,
 )
 from custom_components.lock_code_manager.domain.models import SlotCredential
+from custom_components.lock_code_manager.domain.slot_assignment import (
+    CONF_SLOT_ASSIGNMENT,
+)
 
 from .common import BASE_CONFIG, LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID, MockLCMLock
 
 GET_ALL_CODES_PATCH = (
-    "custom_components.lock_code_manager.config_flow._async_get_all_codes"
+    "custom_components.lock_code_manager.config_flow._async_query_locks"
 )
+
+
+def _answers(existing: dict[str, dict[int, SlotCredential]]):
+    """Answer the lock query with these codes, for whichever locks are asked.
+
+    Replaces a fixture that returned one fixed mapping regardless of the
+    question. The flow now distinguishes "read, and empty" from "could not
+    read", so the stub has to answer per lock rather than in aggregate.
+    """
+
+    async def _query(hass, dev_reg, ent_reg, lock_entity_ids):
+        return [
+            _LockQuery(
+                lock_entity_id=lock,
+                managed=True,
+                credential_index_follows_slot=True,
+                codes=existing.get(lock, {}),
+            )
+            for lock in lock_entity_ids
+        ]
+
+    return _query
 
 
 @pytest.fixture(name="bypass_entry_setup_and_unload", autouse=True)
@@ -63,7 +89,7 @@ async def _start_config_flow(hass: HomeAssistant):
     assert result["step_id"] == "user"
     flow_id = result["flow_id"]
 
-    with patch(GET_ALL_CODES_PATCH, return_value={}):
+    with patch(GET_ALL_CODES_PATCH, side_effect=_answers({})):
         result = await hass.config_entries.flow.async_configure(
             flow_id, {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
         )
@@ -86,13 +112,13 @@ async def _start_ui_config_flow(hass: HomeAssistant):
     assert result["step_id"] == "ui"
 
     result = await hass.config_entries.flow.async_configure(
-        flow_id, {CONF_NUM_SLOTS: 4, CONF_START_SLOT: 1}
+        flow_id, {CONF_NUM_USERS: 4}
     )
 
     assert result["type"] == "form"
     assert result["step_id"] == "code_slot"
     assert not result["last_step"]
-    assert result["description_placeholders"]["slot_num"] == 1
+    assert result["description_placeholders"]["user_num"] == 1
 
     return flow_id
 
@@ -141,16 +167,23 @@ async def test_config_flow_ui(hass: HomeAssistant):
             assert result["type"] == "form"
             assert result["step_id"] == "code_slot"
             assert result["last_step"] == (slot_num == len(pins) - 1)
-            assert result["description_placeholders"]["slot_num"] == slot_num + 1
+            assert result["description_placeholders"]["user_num"] == slot_num + 1
 
     assert result["title"] == "test"
     assert result["data"] == {
         CONF_LOCKS: [LOCK_1_ENTITY_ID],
-        CONF_SLOTS: {
-            1: {CONF_NAME: "User 1", CONF_ENABLED: True, CONF_PIN: "1234"},
-            2: {CONF_NAME: "User 2", CONF_ENABLED: True, CONF_PIN: "5678"},
-            3: {CONF_NAME: "User 3", CONF_ENABLED: True, CONF_PIN: "9012"},
-            4: {CONF_NAME: "User 4", CONF_ENABLED: True, CONF_PIN: "3456"},
+        CONF_USERS: {
+            "User 1": {CONF_ENABLED: True, CONF_PIN: "1234"},
+            "User 2": {CONF_ENABLED: True, CONF_PIN: "5678"},
+            "User 3": {CONF_ENABLED: True, CONF_PIN: "9012"},
+            "User 4": {CONF_ENABLED: True, CONF_PIN: "3456"},
+        },
+        # Numbers the user never chose: the lowest free on the lock.
+        CONF_SLOT_ASSIGNMENT: {
+            "user 1": 1,
+            "user 2": 2,
+            "user 3": 3,
+            "user 4": 4,
         },
     }
 
@@ -404,91 +437,89 @@ async def test_config_flow_ui_scheduler_entity_excluded(hass: HomeAssistant):
 # --- Existing-codes confirmation step tests ---
 
 
-async def test_ui_existing_codes_confirm_continue(hass: HomeAssistant):
-    """UI path: existing codes detected -> confirm -> continue -> create entry."""
-    existing = {LOCK_1_ENTITY_ID: {1: SlotCredential.known("1234")}}
+async def test_ui_setup_allocates_around_existing_codes(hass: HomeAssistant):
+    """Setup skips slots that already hold a code instead of asking about them.
 
-    with patch(GET_ALL_CODES_PATCH, return_value=existing):
+    There is no prompt because there is nothing to overwrite: the numbers are
+    chosen, not requested, so an occupied one is simply not offered. The
+    confirmation the flow used to show existed because the user picked a range
+    and might have picked one already in use.
+    """
+    existing = {
+        LOCK_1_ENTITY_ID: {
+            1: SlotCredential.known("1234"),
+            2: SlotCredential.known("5678"),
+        }
+    }
+
+    with patch(GET_ALL_CODES_PATCH, side_effect=_answers(existing)):
         flow_id = await _init_flow_to_user_step(hass)
-        result = await hass.config_entries.flow.async_configure(
+        await hass.config_entries.flow.async_configure(
             flow_id, {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
         )
+        await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
+        result = await hass.config_entries.flow.async_configure(
+            flow_id, {CONF_NUM_USERS: 2}
+        )
 
-    assert result["step_id"] == "choose_path"
+        # Straight to the first user, with no confirmation in between.
+        assert result["type"] == "form"
+        assert result["step_id"] == "code_slot"
 
-    result = await hass.config_entries.flow.async_configure(
-        flow_id, {"next_step_id": "ui"}
-    )
-    assert result["step_id"] == "ui"
-
-    result = await hass.config_entries.flow.async_configure(
-        flow_id, {CONF_NUM_SLOTS: 2, CONF_START_SLOT: 1}
-    )
-
-    # Should show the confirmation menu with lock/slot details
-    assert result["type"] == "menu"
-    assert result["step_id"] == "existing_codes_confirm"
-    assert LOCK_1_ENTITY_ID in result["description_placeholders"]["details"]
-    assert "slot 1" in result["description_placeholders"]["details"]
-
-    # User acknowledges — no clearing happens, just proceeds to slot config
-    result = await hass.config_entries.flow.async_configure(
-        flow_id, {"next_step_id": "existing_codes_continue"}
-    )
-
-    assert result["type"] == "form"
-    assert result["step_id"] == "code_slot"
-    assert result["description_placeholders"]["slot_num"] == 1
-
-    # Configure slot 1
-    result = await hass.config_entries.flow.async_configure(
-        flow_id, {CONF_NAME: "User 2", CONF_ENABLED: True, CONF_PIN: "1234"}
-    )
-
-    assert result["step_id"] == "code_slot"
-
-    # Configure slot 2 -> create entry (sync manager handles reconciliation)
-    result = await hass.config_entries.flow.async_configure(
-        flow_id, {CONF_NAME: "User 3", CONF_ENABLED: True, CONF_PIN: "5678"}
-    )
+        await hass.config_entries.flow.async_configure(
+            flow_id, {CONF_NAME: "Raman", CONF_ENABLED: True, CONF_PIN: "1111"}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            flow_id, {CONF_NAME: "Alice", CONF_ENABLED: True, CONF_PIN: "2222"}
+        )
 
     assert result["type"] == "create_entry"
+    # Slots 1 and 2 are taken on the lock, so the users get 3 and 4. Which of
+    # them gets which does not follow the order they were entered: numbering
+    # is by name, so a caller passing an unordered collection cannot hand the
+    # same configuration different credential indices from one run to the next.
+    assert result["data"][CONF_SLOT_ASSIGNMENT] == {"alice": 3, "raman": 4}
 
 
-async def test_ui_existing_codes_confirm_cancel(hass: HomeAssistant):
-    """UI path: existing codes detected -> confirm -> cancel -> abort."""
-    existing = {LOCK_1_ENTITY_ID: {1: SlotCredential.known("1234")}}
+async def test_ui_setup_refuses_when_a_lock_cannot_be_read(hass: HomeAssistant):
+    """A lock that did not answer makes occupancy unknown, and setup stops.
 
-    with patch(GET_ALL_CODES_PATCH, return_value=existing):
+    Unreadable is not free. Issuing a number here could put a user's code over
+    a credential programmed by hand on a lock that was merely unreachable.
+    """
+
+    async def _unreadable(hass, dev_reg, ent_reg, lock_entity_ids):
+        return [
+            _LockQuery(
+                lock_entity_id=lock,
+                managed=True,
+                credential_index_follows_slot=True,
+                codes=None,
+            )
+            for lock in lock_entity_ids
+        ]
+
+    with patch(GET_ALL_CODES_PATCH, side_effect=_unreadable):
         flow_id = await _init_flow_to_user_step(hass)
-        result = await hass.config_entries.flow.async_configure(
+        await hass.config_entries.flow.async_configure(
             flow_id, {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
         )
-
-    result = await hass.config_entries.flow.async_configure(
-        flow_id, {"next_step_id": "ui"}
-    )
-    result = await hass.config_entries.flow.async_configure(
-        flow_id, {CONF_NUM_SLOTS: 2, CONF_START_SLOT: 1}
-    )
-
-    assert result["type"] == "menu"
-    assert result["step_id"] == "existing_codes_confirm"
-
-    # Cancel -> abort, no clear
-    result = await hass.config_entries.flow.async_configure(
-        flow_id, {"next_step_id": "existing_codes_cancel"}
-    )
+        await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
+        await hass.config_entries.flow.async_configure(flow_id, {CONF_NUM_USERS: 1})
+        result = await hass.config_entries.flow.async_configure(
+            flow_id, {CONF_NAME: "Raman", CONF_ENABLED: True, CONF_PIN: "1111"}
+        )
 
     assert result["type"] == "abort"
-    assert result["reason"] == "existing_codes_cancelled"
+    assert result["reason"] == "occupancy_unknown"
+    assert LOCK_1_ENTITY_ID in result["description_placeholders"]["locks"]
 
 
 async def test_yaml_existing_codes_confirm_continue(hass: HomeAssistant):
     """YAML path: existing codes detected -> confirm -> continue -> create entry."""
     existing = {LOCK_1_ENTITY_ID: {1: SlotCredential.known("9999")}}
 
-    with patch(GET_ALL_CODES_PATCH, return_value=existing):
+    with patch(GET_ALL_CODES_PATCH, side_effect=_answers(existing)):
         flow_id = await _init_flow_to_user_step(hass)
         result = await hass.config_entries.flow.async_configure(
             flow_id, {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
@@ -523,7 +554,7 @@ async def test_yaml_existing_codes_confirm_cancel(hass: HomeAssistant):
     """YAML path: existing codes detected -> confirm -> cancel -> abort."""
     existing = {LOCK_1_ENTITY_ID: {1: SlotCredential.known("9999")}}
 
-    with patch(GET_ALL_CODES_PATCH, return_value=existing):
+    with patch(GET_ALL_CODES_PATCH, side_effect=_answers(existing)):
         flow_id = await _init_flow_to_user_step(hass)
         result = await hass.config_entries.flow.async_configure(
             flow_id, {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
@@ -551,7 +582,7 @@ async def test_yaml_existing_codes_confirm_cancel(hass: HomeAssistant):
 
 async def test_ui_no_existing_codes_skips_confirm(hass: HomeAssistant):
     """UI path: no existing codes -> skip confirm step entirely."""
-    with patch(GET_ALL_CODES_PATCH, return_value={}):
+    with patch(GET_ALL_CODES_PATCH, side_effect=_answers({})):
         flow_id = await _init_flow_to_user_step(hass)
         result = await hass.config_entries.flow.async_configure(
             flow_id, {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
@@ -563,7 +594,7 @@ async def test_ui_no_existing_codes_skips_confirm(hass: HomeAssistant):
         flow_id, {"next_step_id": "ui"}
     )
     result = await hass.config_entries.flow.async_configure(
-        flow_id, {CONF_NUM_SLOTS: 1, CONF_START_SLOT: 1}
+        flow_id, {CONF_NUM_USERS: 1}
     )
 
     # Goes directly to code_slot, no confirm step
@@ -573,7 +604,7 @@ async def test_ui_no_existing_codes_skips_confirm(hass: HomeAssistant):
 
 async def test_yaml_no_existing_codes_skips_confirm(hass: HomeAssistant):
     """YAML path: no existing codes -> create_entry directly without confirm."""
-    with patch(GET_ALL_CODES_PATCH, return_value={}):
+    with patch(GET_ALL_CODES_PATCH, side_effect=_answers({})):
         flow_id = await _init_flow_to_user_step(hass)
         result = await hass.config_entries.flow.async_configure(
             flow_id, {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
@@ -592,8 +623,8 @@ async def test_yaml_no_existing_codes_skips_confirm(hass: HomeAssistant):
     assert result["data"][CONF_SLOTS][1][CONF_PIN] == "1234"
 
 
-async def test_ui_existing_codes_confirm_lists_multiple_slots(hass: HomeAssistant):
-    """Confirm step shows all slots with existing codes, sorted."""
+async def test_yaml_existing_codes_confirm_lists_slots_sorted(hass: HomeAssistant):
+    """The confirmation names every slot holding a code, in ascending order."""
     existing = {
         LOCK_1_ENTITY_ID: {
             3: SlotCredential.known("1234"),
@@ -601,30 +632,34 @@ async def test_ui_existing_codes_confirm_lists_multiple_slots(hass: HomeAssistan
         }
     }
 
-    with patch(GET_ALL_CODES_PATCH, return_value=existing):
+    with patch(GET_ALL_CODES_PATCH, side_effect=_answers(existing)):
         flow_id = await _init_flow_to_user_step(hass)
-        result = await hass.config_entries.flow.async_configure(
+        await hass.config_entries.flow.async_configure(
             flow_id, {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
         )
-
-    result = await hass.config_entries.flow.async_configure(
-        flow_id, {"next_step_id": "ui"}
-    )
-    result = await hass.config_entries.flow.async_configure(
-        flow_id, {CONF_NUM_SLOTS: 5, CONF_START_SLOT: 1}
-    )
+        await hass.config_entries.flow.async_configure(
+            flow_id, {"next_step_id": "yaml"}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            flow_id,
+            {
+                CONF_SLOTS: {
+                    1: {CONF_NAME: "User 1", CONF_ENABLED: True, CONF_PIN: "1111"},
+                    3: {CONF_NAME: "User 3", CONF_ENABLED: True, CONF_PIN: "3333"},
+                }
+            },
+        )
 
     assert result["type"] == "menu"
     assert result["step_id"] == "existing_codes_confirm"
-    # Slots are sorted in the placeholder
-    assert "slot 1" in result["description_placeholders"]["details"]
-    assert "slot 3" in result["description_placeholders"]["details"]
+    details = result["description_placeholders"]["details"]
+    assert details.index("slot 1") < details.index("slot 3")
 
 
 # --- _async_get_all_codes tests ---
 
 
-async def test_async_get_all_codes_exception(hass: HomeAssistant):
+async def test_query_locks_exception(hass: HomeAssistant):
     """Test _async_get_all_codes catches exception from usercodes fetch."""
     mock_instance = MagicMock()
     mock_instance.async_internal_get_usercodes = AsyncMock(
@@ -649,13 +684,16 @@ async def test_async_get_all_codes_exception(hass: HomeAssistant):
             return_value=MockConfigEntry(domain="zwave_js"),
         ),
     ):
-        result = await _async_get_all_codes(hass, dev_reg, ent_reg, [LOCK_1_ENTITY_ID])
+        [query] = await _async_query_locks(hass, dev_reg, ent_reg, [LOCK_1_ENTITY_ID])
 
     # Exception should be caught; result should be empty
-    assert result == {}
+    # The read FAILED. Reporting it as empty would let allocation issue a
+    # number this lock may already hold a credential at.
+    assert query.codes is None
+    assert query.managed
 
 
-async def test_async_get_all_codes_provider_failure_logs_warning(
+async def test_query_locks_provider_failure_logs_warning(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ):
     """
@@ -690,9 +728,12 @@ async def test_async_get_all_codes_provider_failure_logs_warning(
         ),
         caplog.at_level("WARNING"),
     ):
-        result = await _async_get_all_codes(hass, dev_reg, ent_reg, [LOCK_1_ENTITY_ID])
+        [query] = await _async_query_locks(hass, dev_reg, ent_reg, [LOCK_1_ENTITY_ID])
 
-    assert result == {}
+    # The read FAILED. Reporting it as empty would let allocation issue a
+    # number this lock may already hold a credential at.
+    assert query.codes is None
+    assert query.managed
     # Surfaced at WARNING (not DEBUG): failure should be visible in logs
     assert any(
         record.levelname == "WARNING" and LOCK_1_ENTITY_ID in record.message
@@ -700,7 +741,7 @@ async def test_async_get_all_codes_provider_failure_logs_warning(
     )
 
 
-async def test_async_get_all_codes_bare_base_error_logs_warning(
+async def test_query_locks_bare_base_error_logs_warning(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ):
     """
@@ -735,9 +776,12 @@ async def test_async_get_all_codes_bare_base_error_logs_warning(
         ),
         caplog.at_level("WARNING"),
     ):
-        result = await _async_get_all_codes(hass, dev_reg, ent_reg, [LOCK_1_ENTITY_ID])
+        [query] = await _async_query_locks(hass, dev_reg, ent_reg, [LOCK_1_ENTITY_ID])
 
-    assert result == {}
+    # The read FAILED. Reporting it as empty would let allocation issue a
+    # number this lock may already hold a credential at.
+    assert query.codes is None
+    assert query.managed
     # Should be a clean WARNING (no traceback), since this is a known
     # failure mode — not the generic Exception arm
     warnings = [r for r in caplog.records if r.levelname == "WARNING"]
@@ -747,9 +791,9 @@ async def test_async_get_all_codes_bare_base_error_logs_warning(
     assert all(r.exc_info is None for r in warnings)
 
 
-async def test_async_get_all_codes_returns_all_codes(hass: HomeAssistant):
+async def test_query_locks_returns_all_codes(hass: HomeAssistant):
     """
-    Test _async_get_all_codes returns every slot the lock reports.
+    Test _async_query_locks returns every slot the lock reports.
 
     Filtering empty slots is the caller's responsibility, so this function
     must not drop them.
@@ -797,29 +841,32 @@ async def test_async_get_all_codes_returns_all_codes(hass: HomeAssistant):
             return_value=MockConfigEntry(domain="zwave_js"),
         ),
     ):
-        result = await _async_get_all_codes(hass, dev_reg, ent_reg, [LOCK_1_ENTITY_ID])
+        [query] = await _async_query_locks(hass, dev_reg, ent_reg, [LOCK_1_ENTITY_ID])
 
-    # _async_get_all_codes returns ALL codes — including empty slots.
-    # Callers (e.g. _slots_with_existing_codes) filter as needed.
-    assert LOCK_1_ENTITY_ID in result
-    assert result[LOCK_1_ENTITY_ID] == {
+    # Every slot the lock reports, including empty ones: filtering is the
+    # caller's job, and an empty slot is a slot allocation may use.
+    assert query.lock_entity_id == LOCK_1_ENTITY_ID
+    assert query.codes == {
         1: SlotCredential.known("1234"),
         3: SlotCredential.known("9999"),
         4: SlotCredential.empty(),
     }
 
 
-async def test_async_get_all_codes_entity_not_in_registry(hass: HomeAssistant):
+async def test_query_locks_entity_not_in_registry(hass: HomeAssistant):
     """Test _async_get_all_codes skips locks not in the entity registry."""
     ent_reg = er.async_get(hass)
     dev_reg = dr.async_get(hass)
 
-    result = await _async_get_all_codes(hass, dev_reg, ent_reg, ["lock.does_not_exist"])
+    [query] = await _async_query_locks(hass, dev_reg, ent_reg, ["lock.does_not_exist"])
 
-    assert result == {}
+    # Not a lock Lock Code Manager writes credentials to, so its contents
+    # cannot collide with anything allocation issues.
+    assert not query.managed
+    assert query.codes is None
 
 
-async def test_async_get_all_codes_unsupported_platform(hass: HomeAssistant):
+async def test_query_locks_unsupported_platform(hass: HomeAssistant):
     """Test _async_get_all_codes skips locks on unsupported platforms."""
     ent_reg = er.async_get(hass)
     ent_reg.async_get_or_create(
@@ -827,12 +874,15 @@ async def test_async_get_all_codes_unsupported_platform(hass: HomeAssistant):
     )
     dev_reg = dr.async_get(hass)
 
-    result = await _async_get_all_codes(hass, dev_reg, ent_reg, [LOCK_1_ENTITY_ID])
+    [query] = await _async_query_locks(hass, dev_reg, ent_reg, [LOCK_1_ENTITY_ID])
 
-    assert result == {}
+    # Not a lock Lock Code Manager writes credentials to, so its contents
+    # cannot collide with anything allocation issues.
+    assert not query.managed
+    assert query.codes is None
 
 
-async def test_async_get_all_codes_missing_lock_config_entry(hass: HomeAssistant):
+async def test_query_locks_missing_lock_config_entry(hass: HomeAssistant):
     """Test _async_get_all_codes skips locks whose config entry is missing."""
     ent_reg = er.async_get(hass)
     ent_reg.async_get_or_create(
@@ -847,44 +897,52 @@ async def test_async_get_all_codes_missing_lock_config_entry(hass: HomeAssistant
         ),
         patch.object(hass.config_entries, "async_get_entry", return_value=None),
     ):
-        result = await _async_get_all_codes(hass, dev_reg, ent_reg, [LOCK_1_ENTITY_ID])
+        [query] = await _async_query_locks(hass, dev_reg, ent_reg, [LOCK_1_ENTITY_ID])
 
-    assert result == {}
+    # Not a lock Lock Code Manager writes credentials to, so its contents
+    # cannot collide with anything allocation issues.
+    assert not query.managed
+    assert query.codes is None
 
 
 async def test_existing_codes_detected_across_multiple_locks(hass: HomeAssistant):
-    """Test that existing codes are detected across multiple locks without clearing."""
-    # Locks: one without an instance (skipped), one OK, one that fails,
-    # one whose slot 1 is reported as EMPTY (must not be cleared), and one
-    # that doesn't have slot 1 at all (must not be cleared)
+    """One lock holding a code at the requested slot is enough to prompt.
+
+    The other lock answers, and answers "empty" -- which is a real answer, not
+    a missing one, and must not be reported as an existing code.
+    """
     existing = {
-        "lock.no_instance": {1: SlotCredential.known("1111")},
-        "lock.ok": {1: SlotCredential.known("2222")},
-        "lock.fails": {1: SlotCredential.known("3333")},
-        "lock.empty_slot": {1: SlotCredential.empty()},
-        "lock.different_slot": {2: SlotCredential.known("4444")},
+        LOCK_1_ENTITY_ID: {1: SlotCredential.empty()},
+        LOCK_2_ENTITY_ID: {1: SlotCredential.known("2222")},
     }
-    with patch(GET_ALL_CODES_PATCH, return_value=existing):
+    with patch(GET_ALL_CODES_PATCH, side_effect=_answers(existing)):
         flow_id = await _init_flow_to_user_step(hass)
+        await hass.config_entries.flow.async_configure(
+            flow_id,
+            {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID]},
+        )
+        await hass.config_entries.flow.async_configure(
+            flow_id, {"next_step_id": "yaml"}
+        )
         result = await hass.config_entries.flow.async_configure(
-            flow_id, {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
+            flow_id,
+            {
+                CONF_SLOTS: {
+                    1: {CONF_NAME: "User 1", CONF_ENABLED: True, CONF_PIN: "5678"}
+                }
+            },
         )
 
-    result = await hass.config_entries.flow.async_configure(
-        flow_id, {"next_step_id": "yaml"}
-    )
-    result = await hass.config_entries.flow.async_configure(
-        flow_id,
-        {CONF_SLOTS: {1: {CONF_NAME: "User 1", CONF_ENABLED: True, CONF_PIN: "5678"}}},
-    )
-
-    # Confirm step shown because slot 1 has existing codes on some locks
     assert result["step_id"] == "existing_codes_confirm"
+    details = result["description_placeholders"]["details"]
+    assert LOCK_2_ENTITY_ID in details
+    assert LOCK_1_ENTITY_ID not in details
+
     result = await hass.config_entries.flow.async_configure(
         flow_id, {"next_step_id": "existing_codes_continue"}
     )
 
-    # No clearing happens — sync manager handles reconciliation
+    # Nothing is cleared -- the sync manager reconciles from here.
     assert result["type"] == "create_entry"
 
 
@@ -959,7 +1017,7 @@ async def test_options_flow_added_pair_no_existing_code_persists(hass: HomeAssis
     # Adding slot 2; lock has nothing in slot 2 (only slot 1)
     with patch(
         GET_ALL_CODES_PATCH,
-        return_value={LOCK_1_ENTITY_ID: {1: SlotCredential.known("1234")}},
+        side_effect=_answers({LOCK_1_ENTITY_ID: {1: SlotCredential.known("1234")}}),
     ):
         result = await hass.config_entries.options.async_configure(
             flow_id,
@@ -985,12 +1043,14 @@ async def test_options_flow_added_pair_with_existing_code_confirm(
     # in slot 1 — slot 1 is NOT in added_pairs so it must not be cleared)
     with patch(
         GET_ALL_CODES_PATCH,
-        return_value={
-            LOCK_1_ENTITY_ID: {
-                1: SlotCredential.known("1234"),
-                2: SlotCredential.known("9999"),
+        side_effect=_answers(
+            {
+                LOCK_1_ENTITY_ID: {
+                    1: SlotCredential.known("1234"),
+                    2: SlotCredential.known("9999"),
+                }
             }
-        },
+        ),
     ):
         result = await hass.config_entries.options.async_configure(
             flow_id,
@@ -1027,7 +1087,7 @@ async def test_options_flow_added_lock_with_existing_code_confirm(
     # code in slot 1. The mixin should detect this and prompt.
     with patch(
         GET_ALL_CODES_PATCH,
-        return_value={LOCK_2_ENTITY_ID: {1: SlotCredential.known("5555")}},
+        side_effect=_answers({LOCK_2_ENTITY_ID: {1: SlotCredential.known("5555")}}),
     ):
         result = await hass.config_entries.options.async_configure(
             flow_id,
@@ -1054,7 +1114,7 @@ async def test_options_flow_existing_codes_cancel_aborts(hass: HomeAssistant):
 
     with patch(
         GET_ALL_CODES_PATCH,
-        return_value={LOCK_1_ENTITY_ID: {2: SlotCredential.known("9999")}},
+        side_effect=_answers({LOCK_1_ENTITY_ID: {2: SlotCredential.known("9999")}}),
     ):
         result = await hass.config_entries.options.async_configure(
             flow_id,
@@ -1083,7 +1143,7 @@ async def test_options_flow_added_pair_empty_code_persists(hass: HomeAssistant):
 
     with patch(
         GET_ALL_CODES_PATCH,
-        return_value={LOCK_1_ENTITY_ID: {2: SlotCredential.empty()}},
+        side_effect=_answers({LOCK_1_ENTITY_ID: {2: SlotCredential.empty()}}),
     ):
         result = await hass.config_entries.options.async_configure(
             flow_id,
@@ -1207,28 +1267,35 @@ async def test_config_flow_yaml_accepts_slot_within_capacity(
     assert result["type"] == "create_entry"
 
 
-async def test_config_flow_ui_rejects_slot_range_beyond_lock_capacity(
+async def test_config_flow_ui_rejects_more_users_than_the_lock_holds(
     hass: HomeAssistant, mock_lock_config_entry
 ):
-    """The UI path bounds start+count against the lock the same way YAML does."""
+    """Asking for more users than the lock has slots for cannot be satisfied.
+
+    The count is the only thing the user chose, so the refusal has to name it;
+    there is no slot range to send them back to.
+    """
     flow_id = await _start_config_flow(hass)
-    result = await hass.config_entries.flow.async_configure(
-        flow_id, {"next_step_id": "ui"}
-    )
-    assert result["step_id"] == "ui"
+    await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
+    await hass.config_entries.flow.async_configure(flow_id, {CONF_NUM_USERS: 3})
+
+    for name in ("Raman", "Alice"):
+        await hass.config_entries.flow.async_configure(
+            flow_id, {CONF_NAME: name, CONF_ENABLED: True, CONF_PIN: "1111"}
+        )
 
     probe_registered, probe_capabilities = _capacity_probe(
-        return_value=_capabilities_with_slots(10)
+        return_value=_capabilities_with_slots(2)
     )
     with probe_registered, probe_capabilities:
         result = await hass.config_entries.flow.async_configure(
-            flow_id, {CONF_START_SLOT: 8, CONF_NUM_SLOTS: 5}
+            flow_id, {CONF_NAME: "Bo", CONF_ENABLED: True, CONF_PIN: "3333"}
         )
 
-    assert result["type"] == "form"
-    assert result["step_id"] == "ui"
-    assert result["errors"] == {"base": "slot_out_of_range"}
-    assert result["description_placeholders"]["out_of_range_slots"] == "11, 12"
+    assert result["type"] == "abort"
+    assert result["reason"] == "too_many_users"
+    assert result["description_placeholders"]["num_users"] == "3"
+    assert result["description_placeholders"]["num_slots"] == "2"
 
 
 async def test_config_flow_capacity_check_skipped_when_lock_unreachable(

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -78,12 +78,7 @@ def _answers(existing: dict[str, dict[int, SlotCredential]]):
 
     async def _query(hass, dev_reg, ent_reg, lock_entity_ids):
         return [
-            _LockQuery(
-                lock_entity_id=lock,
-                managed=True,
-                credential_index_follows_slot=True,
-                codes=existing.get(lock, {}),
-            )
+            _LockQuery(lock_entity_id=lock, codes=existing.get(lock, {}))
             for lock in lock_entity_ids
         ]
 
@@ -533,8 +528,10 @@ async def test_ui_setup_refuses_when_a_lock_cannot_be_read(
         )
 
     # Refused before a single name or PIN was collected.
-    assert result["type"] == "abort"
-    assert result["reason"] == "occupancy_unknown"
+    # A form, not an abort: a lock that is merely asleep must not end setup.
+    assert result["type"] == "form"
+    assert result["step_id"] == "ui"
+    assert result["errors"] == {"base": "occupancy_unknown"}
     assert LOCK_1_ENTITY_ID in result["description_placeholders"]["locks"]
 
 
@@ -555,10 +552,15 @@ async def test_yaml_existing_codes_confirm_continue(hass: HomeAssistant):
     )
     assert result["step_id"] == "yaml"
 
-    result = await hass.config_entries.flow.async_configure(
-        flow_id,
-        {CONF_SLOTS: {1: {CONF_NAME: "User 1", CONF_ENABLED: True, CONF_PIN: "1234"}}},
-    )
+    with patch(GET_ALL_CODES_PATCH, side_effect=_answers(existing)):
+        result = await hass.config_entries.flow.async_configure(
+            flow_id,
+            {
+                CONF_SLOTS: {
+                    1: {CONF_NAME: "User 1", CONF_ENABLED: True, CONF_PIN: "1234"}
+                }
+            },
+        )
 
     assert result["type"] == "menu"
     assert result["step_id"] == "existing_codes_confirm"
@@ -586,10 +588,15 @@ async def test_yaml_existing_codes_confirm_cancel(hass: HomeAssistant):
     result = await hass.config_entries.flow.async_configure(
         flow_id, {"next_step_id": "yaml"}
     )
-    result = await hass.config_entries.flow.async_configure(
-        flow_id,
-        {CONF_SLOTS: {1: {CONF_NAME: "User 1", CONF_ENABLED: True, CONF_PIN: "1234"}}},
-    )
+    with patch(GET_ALL_CODES_PATCH, side_effect=_answers(existing)):
+        result = await hass.config_entries.flow.async_configure(
+            flow_id,
+            {
+                CONF_SLOTS: {
+                    1: {CONF_NAME: "User 1", CONF_ENABLED: True, CONF_PIN: "1234"}
+                }
+            },
+        )
 
     assert result["type"] == "menu"
     assert result["step_id"] == "existing_codes_confirm"
@@ -715,7 +722,6 @@ async def test_query_locks_exception(hass: HomeAssistant):
     # The read FAILED. Reporting it as empty would let allocation issue a
     # number this lock may already hold a credential at.
     assert query.codes is None
-    assert query.managed
 
 
 async def test_query_locks_provider_failure_logs_warning(
@@ -758,7 +764,6 @@ async def test_query_locks_provider_failure_logs_warning(
     # The read FAILED. Reporting it as empty would let allocation issue a
     # number this lock may already hold a credential at.
     assert query.codes is None
-    assert query.managed
     # Surfaced at WARNING (not DEBUG): failure should be visible in logs
     assert any(
         record.levelname == "WARNING" and LOCK_1_ENTITY_ID in record.message
@@ -806,7 +811,6 @@ async def test_query_locks_bare_base_error_logs_warning(
     # The read FAILED. Reporting it as empty would let allocation issue a
     # number this lock may already hold a credential at.
     assert query.codes is None
-    assert query.managed
     # Should be a clean WARNING (no traceback), since this is a known
     # failure mode — not the generic Exception arm
     warnings = [r for r in caplog.records if r.levelname == "WARNING"]
@@ -885,11 +889,8 @@ async def test_query_locks_entity_not_in_registry(hass: HomeAssistant):
 
     [query] = await _async_query_locks(hass, dev_reg, ent_reg, ["lock.does_not_exist"])
 
-    # Lock Code Manager still writes here -- the provider just could not be
-    # built right now -- so the lock has to constrain allocation, and an
-    # unread lock constrains it by making occupancy unknown.
-    assert query.managed
-    assert query.credential_index_follows_slot
+    # Nothing to show for a lock that could not be read. Allocation asks the
+    # locks itself, so this says nothing about which numbers are free.
     assert query.codes is None
 
 
@@ -903,9 +904,7 @@ async def test_query_locks_unsupported_platform(hass: HomeAssistant):
 
     [query] = await _async_query_locks(hass, dev_reg, ent_reg, [LOCK_1_ENTITY_ID])
 
-    # Not a lock Lock Code Manager writes credentials to, so its contents
-    # cannot collide with anything allocation issues.
-    assert not query.managed
+    # Nothing to show for a lock this integration does not write to.
     assert query.codes is None
 
 
@@ -926,11 +925,8 @@ async def test_query_locks_missing_lock_config_entry(hass: HomeAssistant):
     ):
         [query] = await _async_query_locks(hass, dev_reg, ent_reg, [LOCK_1_ENTITY_ID])
 
-    # Lock Code Manager still writes here -- the provider just could not be
-    # built right now -- so the lock has to constrain allocation, and an
-    # unread lock constrains it by making occupancy unknown.
-    assert query.managed
-    assert query.credential_index_follows_slot
+    # Nothing to show for a lock that could not be read. Allocation asks the
+    # locks itself, so this says nothing about which numbers are free.
     assert query.codes is None
 
 
@@ -1315,8 +1311,10 @@ async def test_setup_refuses_when_a_lock_has_no_provider(
             flow_id, {CONF_NUM_USERS: 2}
         )
 
-    assert result["type"] == "abort"
-    assert result["reason"] == "occupancy_unknown"
+    # A form, not an abort: a lock that is merely asleep must not end setup.
+    assert result["type"] == "form"
+    assert result["step_id"] == "ui"
+    assert result["errors"] == {"base": "occupancy_unknown"}
     assert LOCK_1_ENTITY_ID in result["description_placeholders"]["locks"]
 
 
@@ -1348,11 +1346,11 @@ async def test_setup_reads_only_as_far_as_it_has_to(
     its cost, so a lock is never walked to its advertised capacity to place a
     handful of users.
     """
-    windows: list[int] = []
+    windows: list[list[int]] = []
 
     async def _read(self, slots=None):
-        scope = list(self.managed_slots if slots is None else slots)
-        windows.append(max(scope, default=0))
+        scope = sorted(self.managed_slots if slots is None else slots)
+        windows.append(scope)
         return {
             slot: (
                 SlotCredential.known("0000")
@@ -1377,20 +1375,20 @@ async def test_setup_reads_only_as_far_as_it_has_to(
     assert result["type"] == "create_entry"
     # Slots 1-3 are taken, so the two users land on 4 and 5.
     assert result["data"][CONF_SLOT_ASSIGNMENT] == {"alice": 4, "raman": 5}
-    # Asked about 2, found 2 in the way, asked about 4, found 3 in the way,
-    # asked about 5. Never about the lock's whole capacity.
-    assert windows == [2, 4, 5]
+    # Asked about 1-2, then only 3-4, then only 5: every index once, and
+    # never about the lock's whole capacity.
+    assert windows == [[1, 2], [3, 4], [5]]
 
 
 async def test_setup_does_not_widen_when_nothing_is_in_the_way(
     hass: HomeAssistant, mock_lock_config_entry
 ):
     """An empty lock costs exactly one read of exactly the users asked for."""
-    windows: list[int] = []
+    windows: list[list[int]] = []
 
     async def _read(self, slots=None):
-        scope = list(self.managed_slots if slots is None else slots)
-        windows.append(max(scope, default=0))
+        scope = sorted(self.managed_slots if slots is None else slots)
+        windows.append(scope)
         return dict.fromkeys(scope, SlotCredential.empty())
 
     flow_id = await _start_config_flow(hass)
@@ -1399,7 +1397,7 @@ async def test_setup_does_not_widen_when_nothing_is_in_the_way(
     with patch.object(MockLCMLock, "async_get_usercodes", _read):
         await hass.config_entries.flow.async_configure(flow_id, {CONF_NUM_USERS: 3})
 
-    assert windows == [3]
+    assert windows == [[1, 2, 3]]
 
 
 async def test_config_flow_ui_rejects_more_users_than_the_lock_holds(
@@ -1871,8 +1869,10 @@ async def test_a_lock_that_fails_unexpectedly_is_unknown_not_empty(
             flow_id, {CONF_NUM_USERS: 2}
         )
 
-    assert result["type"] == "abort"
-    assert result["reason"] == "occupancy_unknown"
+    # A form, not an abort: a lock that is merely asleep must not end setup.
+    assert result["type"] == "form"
+    assert result["step_id"] == "ui"
+    assert result["errors"] == {"base": "occupancy_unknown"}
     assert LOCK_1_ENTITY_ID in result["description_placeholders"]["locks"]
 
 
@@ -1899,3 +1899,122 @@ async def test_a_count_that_fits_can_still_need_numbers_that_do_not(
         )
 
     assert result["errors"] == {"base": "too_many_users"}
+
+
+async def test_choosing_the_ui_path_reads_no_lock_on_the_way_in(
+    hass: HomeAssistant, mock_lock_config_entry
+):
+    """Only the path that needs a full read pays for one.
+
+    Picking locks used to read every one of them up front, for the benefit of
+    a confirmation only the YAML path shows. The path that chooses numbers
+    itself reads what it needs, when it knows how much of the lock that is.
+    """
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    flow_id = result["flow_id"]
+
+    with patch(GET_ALL_CODES_PATCH, side_effect=_answers({})) as full_read:
+        result = await hass.config_entries.flow.async_configure(
+            flow_id, {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
+        )
+        assert result["step_id"] == "choose_path"
+
+        await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
+        with _holding():
+            result = await hass.config_entries.flow.async_configure(
+                flow_id, {CONF_NUM_USERS: 1}
+            )
+
+    assert result["step_id"] == "code_slot"
+    assert full_read.call_count == 0
+
+
+async def test_a_nearly_full_lock_is_read_once_through(
+    hass: HomeAssistant, mock_lock_config_entry
+):
+    """No index is asked about twice, however many passes it takes.
+
+    Widening from the count re-reading everything each pass costs a lock
+    holding codes low down several times its own capacity to place a couple
+    of users -- on the providers that answer one index per round trip, that
+    is the cost this whole approach exists to avoid.
+    """
+    asked: list[int] = []
+    occupied = set(range(1, 30))
+
+    async def _read(self, slots=None):
+        scope = sorted(self.managed_slots if slots is None else slots)
+        asked.extend(scope)
+        return {
+            slot: (
+                SlotCredential.known("0000")
+                if slot in occupied
+                else SlotCredential.empty()
+            )
+            for slot in scope
+        }
+
+    flow_id = await _start_config_flow(hass)
+    await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
+
+    with patch.object(MockLCMLock, "async_get_usercodes", _read):
+        result = await hass.config_entries.flow.async_configure(
+            flow_id, {CONF_NUM_USERS: 2}
+        )
+
+    assert result["step_id"] == "code_slot"
+    # The users land on 30 and 31, so 31 indices are read -- each exactly once.
+    assert sorted(asked) == list(range(1, 32))
+    assert len(asked) == len(set(asked)), "an index was read more than once"
+
+
+async def test_numbers_another_entry_manages_are_stepped_over(
+    hass: HomeAssistant, mock_lock_config_entry, lock_code_manager_config_entry
+):
+    """A slot another entry holds on the same lock is not handed out twice.
+
+    This replaced a loud refusal (`slots_already_configured`) with quietly
+    routing around it, so it is the whole of what stops two entries writing
+    the same credential index -- and the case that matters is a neighbour
+    holding a LOW number the new users have to step over.
+    """
+    flow_id = await _start_config_flow(hass)
+    await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
+
+    # The existing entry manages slots 1 and 2 on this lock; the lock itself
+    # holds nothing, so only the neighbour's claim can push the users up.
+    with _holding():
+        await hass.config_entries.flow.async_configure(flow_id, {CONF_NUM_USERS: 2})
+        for name in ("Raman", "Alice"):
+            result = await hass.config_entries.flow.async_configure(
+                flow_id, {CONF_NAME: name, CONF_ENABLED: True, CONF_PIN: "1111"}
+            )
+
+    assert result["type"] == "create_entry"
+    assert result["data"][CONF_SLOT_ASSIGNMENT] == {"alice": 3, "raman": 4}
+
+
+async def test_a_blank_yaml_name_names_the_slot_it_came_from(
+    hass: HomeAssistant, mock_lock_config_entry
+):
+    """The YAML path can say which slot failed, and its message does."""
+    strings = json.loads(
+        Path("custom_components/lock_code_manager/strings.json").read_text()
+    )
+    flow_id = await _start_yaml_config_flow(hass)
+
+    result = await hass.config_entries.flow.async_configure(
+        flow_id,
+        {CONF_SLOTS: {4: {CONF_NAME: "   ", CONF_ENABLED: True, CONF_PIN: "1234"}}},
+    )
+
+    assert result["errors"] == {"base": "slot_name_required"}
+    assert result["description_placeholders"]["slot_num"] == "4"
+    message = strings["config"]["error"]["slot_name_required"]
+    assert not {
+        name
+        for name in re.findall(r"\{(\w+)\}", message)
+        if name not in result["description_placeholders"]
+    }

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,5 +1,8 @@
 """Config flow tests."""
 
+import json
+from pathlib import Path
+import re
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import pytest
@@ -1423,8 +1426,7 @@ async def test_config_flow_ui_rejects_more_users_than_the_lock_holds(
     assert result["step_id"] == "ui"
     assert result["errors"] == {"base": "too_many_users"}
     assert result["description_placeholders"]["num_users"] == "3"
-    assert result["description_placeholders"]["room"] == "2"
-    assert result["description_placeholders"]["taken"] == "0"
+    assert result["description_placeholders"]["num_slots"] == "2"
 
     with probe_registered, probe_capabilities, _holding():
         result = await hass.config_entries.flow.async_configure(
@@ -1435,30 +1437,39 @@ async def test_config_flow_ui_rejects_more_users_than_the_lock_holds(
     assert result["step_id"] == "code_slot"
 
 
-async def test_config_flow_ui_room_accounts_for_codes_already_on_the_lock(
+async def test_a_refused_count_reports_only_what_it_can_stand_behind(
     hass: HomeAssistant, mock_lock_config_entry
 ):
-    """The room offered is capacity minus what the lock already holds.
+    """The refusal states the capacity and the count, and promises no maximum.
 
-    Reporting raw capacity would tell someone with a nearly-full lock they
-    can add far more users than they can.
+    It cannot promise one: occupancy is known only as far as the window that
+    was read, so any "you may have N" computed from the lock's full capacity
+    can be too high -- and the user who follows it is refused again.
     """
+    strings = json.loads(
+        Path("custom_components/lock_code_manager/strings.json").read_text()
+    )
+    message = strings["config"]["error"]["too_many_users"]
+
     flow_id = await _start_config_flow(hass)
     await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
 
     probe_registered, probe_capabilities = _capacity_probe(
-        return_value=_capabilities_with_slots(3)
+        return_value=_capabilities_with_slots(10)
     )
-    with probe_registered, probe_capabilities, _holding(1):
+    # Nine of the ten slots are taken, well past the window the count asks for.
+    with probe_registered, probe_capabilities, _holding(*range(1, 10)):
         result = await hass.config_entries.flow.async_configure(
-            flow_id, {CONF_NUM_USERS: 3}
+            flow_id, {CONF_NUM_USERS: 8}
         )
 
     assert result["errors"] == {"base": "too_many_users"}
-    # Three slots, one already holding a code: room for two, not three.
-    assert result["description_placeholders"]["num_slots"] == "3"
-    assert result["description_placeholders"]["taken"] == "1"
-    assert result["description_placeholders"]["room"] == "2"
+    supplied = result["description_placeholders"]
+    assert not {
+        name for name in re.findall(r"\{(\w+)\}", message) if name not in supplied
+    }
+    # No count is offered, so there is none to be wrong about.
+    assert "room" not in message and "room" not in supplied
 
 
 async def test_config_flow_capacity_check_skipped_when_lock_unreachable(
@@ -1642,7 +1653,7 @@ async def test_config_flow_ui_rejects_duplicate_name(
                 1: {CONF_NAME: "Raman", CONF_ENABLED: True, CONF_PIN: "1234"},
                 2: {CONF_NAME: " raman ", CONF_ENABLED: True, CONF_PIN: "5678"},
             },
-            "name_not_unique",
+            "slot_name_not_unique",
         ),
     ],
 )
@@ -1681,3 +1692,210 @@ async def test_config_flow_yaml_missing_name_says_so(
 
     assert result["type"] == "form"
     assert result["errors"] == {"base": "name_required"}
+
+
+async def test_every_name_error_supplies_what_its_message_asks_for(
+    hass: HomeAssistant, mock_lock_config_entry
+):
+    """A message that names a placeholder must be given one.
+
+    Home Assistant renders these through IntlMessageFormat, which raises on a
+    missing argument -- so the user sees a translation error where the
+    explanation should be. The user-facing paths have no slot number to give,
+    which is why their wording must not ask for one.
+    """
+    strings = json.loads(
+        Path("custom_components/lock_code_manager/strings.json").read_text()
+    )
+
+    flow_id = await _start_config_flow(hass)
+    await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
+    with _holding():
+        await hass.config_entries.flow.async_configure(flow_id, {CONF_NUM_USERS: 2})
+
+    for user_input in (
+        {CONF_NAME: "", CONF_ENABLED: True, CONF_PIN: "1111"},
+        {CONF_NAME: "Raman", CONF_ENABLED: True, CONF_PIN: "1111"},
+        {CONF_NAME: "raman ", CONF_ENABLED: True, CONF_PIN: "2222"},
+    ):
+        with _holding():
+            result = await hass.config_entries.flow.async_configure(flow_id, user_input)
+        for key in (result.get("errors") or {}).values():
+            message = strings["config"]["error"][key]
+            supplied = result.get("description_placeholders") or {}
+            missing = {
+                name
+                for name in re.findall(r"\{(\w+)\}", message)
+                if name not in supplied
+            }
+            assert not missing, f"{key} renders {missing} with nothing to fill them"
+
+
+async def test_an_impossible_count_is_refused_without_asking_a_lock(
+    hass: HomeAssistant, mock_lock_config_entry
+):
+    """A count no lock could hold must not be read for first.
+
+    The window starts at the number of users, so a mistyped 500 would
+    otherwise be 500 round trips on a lock that answers one index at a time
+    -- each one holding the operation lock -- before the flow says the lock
+    has three slots.
+    """
+    reads: list[int] = []
+
+    async def _read(self, slots=None):
+        scope = list(self.managed_slots if slots is None else slots)
+        reads.append(max(scope, default=0))
+        return dict.fromkeys(scope, SlotCredential.empty())
+
+    flow_id = await _start_config_flow(hass)
+    await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
+
+    probe_registered, probe_capabilities = _capacity_probe(
+        return_value=_capabilities_with_slots(3)
+    )
+    with (
+        probe_registered,
+        probe_capabilities,
+        patch.object(MockLCMLock, "async_get_usercodes", _read),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            flow_id, {CONF_NUM_USERS: 500}
+        )
+
+    assert result["errors"] == {"base": "too_many_users"}
+    assert reads == [], "the lock was read before the count was refused"
+
+
+async def test_claims_above_the_window_do_not_widen_the_read(
+    hass: HomeAssistant, mock_lock_config_entry
+):
+    """Numbers another entry holds far above the window cost nothing to read.
+
+    Occupancy is counted within the window, not across everything known, so
+    claims the window never reaches cannot push it wider. Counting them would
+    make a lock with a high-numbered neighbour entry read far past what
+    placing these users needs.
+    """
+    windows: list[int] = []
+
+    async def _read(self, slots=None):
+        scope = list(self.managed_slots if slots is None else slots)
+        windows.append(max(scope, default=0))
+        return dict.fromkeys(scope, SlotCredential.empty())
+
+    flow_id = await _start_config_flow(hass)
+    await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
+
+    with (
+        patch(
+            "custom_components.lock_code_manager.config_flow.get_managed_slots",
+            return_value=set(range(90, 100)),
+        ),
+        patch.object(MockLCMLock, "async_get_usercodes", _read),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            flow_id, {CONF_NUM_USERS: 3}
+        )
+
+    assert result["step_id"] == "code_slot"
+    assert windows == [3], "another entry's distant claims widened the read"
+
+
+async def test_a_lock_that_allocates_its_own_index_is_not_asked(
+    hass: HomeAssistant, mock_lock_config_entry
+):
+    """Occupancy is not read from a lock whose contents cannot constrain it.
+
+    Where the lock picks its own credential index, what it holds says nothing
+    about which slot number is free -- so asking spends a round trip, or one
+    per index on some providers, on an answer nothing reads.
+    """
+    reads: list[int] = []
+
+    async def _read(self, slots=None):
+        scope = list(self.managed_slots if slots is None else slots)
+        reads.append(max(scope, default=0))
+        return dict.fromkeys(scope, SlotCredential.empty())
+
+    flow_id = await _start_config_flow(hass)
+    await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
+
+    with (
+        patch.object(
+            MockLCMLock,
+            "credential_index_follows_slot",
+            new_callable=PropertyMock,
+            return_value=False,
+        ),
+        patch.object(MockLCMLock, "async_get_usercodes", _read),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            flow_id, {CONF_NUM_USERS: 2}
+        )
+
+    assert result["step_id"] == "code_slot"
+    assert reads == [], "a lock that cannot constrain the numbering was read"
+
+
+@pytest.mark.parametrize(
+    ("target", "boom"),
+    [
+        ("_async_build_lock_instance", RuntimeError("provider blew up")),
+        ("async_get_usercodes", TimeoutError("node asleep")),
+    ],
+)
+async def test_a_lock_that_fails_unexpectedly_is_unknown_not_empty(
+    hass: HomeAssistant, mock_lock_config_entry, target: str, boom: Exception
+):
+    """Any failure to answer has to read as unknown, not as an empty lock.
+
+    Only errors this integration defines are promised; a provider can still
+    raise something else. Letting that escape kills the flow, and the one
+    reading it must never become "no numbers are taken".
+    """
+    flow_id = await _start_config_flow(hass)
+    await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
+
+    if target == "_async_build_lock_instance":
+        patcher = patch(
+            "custom_components.lock_code_manager.config_flow"
+            "._async_build_lock_instance",
+            side_effect=boom,
+        )
+    else:
+        patcher = patch.object(MockLCMLock, target, AsyncMock(side_effect=boom))
+
+    with patcher:
+        result = await hass.config_entries.flow.async_configure(
+            flow_id, {CONF_NUM_USERS: 2}
+        )
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "occupancy_unknown"
+    assert LOCK_1_ENTITY_ID in result["description_placeholders"]["locks"]
+
+
+async def test_a_count_that_fits_can_still_need_numbers_that_do_not(
+    hass: HomeAssistant, mock_lock_config_entry
+):
+    """Codes already on the lock push the last user past the capacity.
+
+    Three users fit in four slots, so the bare count is accepted. Widening
+    around the two codes already there needs a fifth number, and that is
+    where it is refused.
+    """
+    probe_registered, probe_capabilities = _capacity_probe(
+        return_value=_capabilities_with_slots(4)
+    )
+    flow_id = await _start_config_flow(hass)
+    await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
+
+    # Three users fit in four slots; slots 1 and 2 are taken, so they would
+    # land on 3, 4 and 5 -- and 5 does not exist.
+    with probe_registered, probe_capabilities, _holding(1, 2):
+        result = await hass.config_entries.flow.async_configure(
+            flow_id, {CONF_NUM_USERS: 3}
+        )
+
+    assert result["errors"] == {"base": "too_many_users"}

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1375,6 +1375,10 @@ async def test_setup_reads_only_as_far_as_it_has_to(
     assert result["type"] == "create_entry"
     # Slots 1-3 are taken, so the two users land on 4 and 5.
     assert result["data"][CONF_SLOT_ASSIGNMENT] == {"alice": 4, "raman": 5}
+    # And never past what was actually read.
+    assert max(result["data"][CONF_SLOT_ASSIGNMENT].values()) <= max(
+        slot for window in windows for slot in window
+    )
     # Asked about 1-2, then only 3-4, then only 5: every index once, and
     # never about the lock's whole capacity.
     assert windows == [[1, 2], [3, 4], [5]]
@@ -1969,6 +1973,13 @@ async def test_a_nearly_full_lock_is_read_once_through(
     assert sorted(asked) == list(range(1, 32))
     assert len(asked) == len(set(asked)), "an index was read more than once"
 
+    for name in ("Raman", "Alice"):
+        result = await hass.config_entries.flow.async_configure(
+            flow_id, {CONF_NAME: name, CONF_ENABLED: True, CONF_PIN: "1111"}
+        )
+    assert result["type"] == "create_entry"
+    assert max(result["data"][CONF_SLOT_ASSIGNMENT].values()) <= max(asked)
+
 
 async def test_numbers_another_entry_manages_are_stepped_over(
     hass: HomeAssistant, mock_lock_config_entry, lock_code_manager_config_entry
@@ -2018,3 +2029,55 @@ async def test_a_blank_yaml_name_names_the_slot_it_came_from(
         for name in re.findall(r"\{(\w+)\}", message)
         if name not in result["description_placeholders"]
     }
+
+
+async def test_an_empty_lock_numbers_users_from_one(
+    hass: HomeAssistant, mock_lock_config_entry
+):
+    """With nothing in the way, the users take the lowest numbers there are.
+
+    Every other assignment test has codes or a neighbouring entry holding the
+    low numbers, so none of them would notice allocation starting from
+    somewhere other than 1 -- and starting higher hands out numbers no lock
+    was ever read for.
+    """
+    flow_id = await _start_config_flow(hass)
+    await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
+
+    with _holding():
+        await hass.config_entries.flow.async_configure(flow_id, {CONF_NUM_USERS: 3})
+        for name in ("Raman", "Alice", "Wren"):
+            result = await hass.config_entries.flow.async_configure(
+                flow_id, {CONF_NAME: name, CONF_ENABLED: True, CONF_PIN: "1111"}
+            )
+
+    assert result["type"] == "create_entry"
+    assert sorted(result["data"][CONF_SLOT_ASSIGNMENT].values()) == [1, 2, 3]
+
+
+async def test_a_refused_count_comes_back_in_the_box(
+    hass: HomeAssistant, mock_lock_config_entry
+):
+    """The form returns holding what was refused, not its default.
+
+    Otherwise the user who asked for eight is handed the default back and has
+    to work out what they typed before they can adjust it.
+    """
+    flow_id = await _start_config_flow(hass)
+    await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
+
+    probe_registered, probe_capabilities = _capacity_probe(
+        return_value=_capabilities_with_slots(2)
+    )
+    with probe_registered, probe_capabilities, _holding():
+        result = await hass.config_entries.flow.async_configure(
+            flow_id, {CONF_NUM_USERS: 8}
+        )
+
+    assert result["errors"] == {"base": "too_many_users"}
+    suggested = [
+        key.description["suggested_value"]
+        for key in result["data_schema"].schema
+        if key == CONF_NUM_USERS and key.description
+    ]
+    assert suggested == [8]


### PR DESCRIPTION
## Proposed change

The setup flow stops asking which slot numbers to use and picks them.

Version 3 makes the user's name the identity and the slot number internal
bookkeeping. The UI setup path had not caught up: it still asked for a start
slot and a slot count, which is the one place a user was required to think
about credential indices in order to add a person. It now asks **how many
users** there are, collects them by name, and allocates the numbers itself.

```
before                              after
──────                              ─────
Start slot:  [ 1 ]                   How many users? [ 2 ]
Slots:       [ 4 ]                   → Raman  PIN ****
                                     → Alice  PIN ****
```

### How the numbers get chosen

Every configured lock is read first. Allocation takes the lowest numbers that

* no lock already holds a credential at,
* and no other Lock Code Manager entry manages.

Only locks that address credentials **by** slot number constrain the choice
(`credential_index_follows_slot`). Reserving a number because a Matter lock
happens to hold something at that index would push real users past the
capacity of the locks that do follow the slot number.

A lock that does not answer is **not** treated as empty. Issuing a number
against an unread lock could overwrite a credential programmed by hand, so
setup aborts with `occupancy_unknown` naming the locks that stayed silent.
That distinction is the reason for the new `domain/occupancy.py` seam — the
lock query previously collapsed "read, and empty" and "could not read" into
the same empty mapping.

`SlotAssignment.reconcile` gets its first production caller here.


### How the numbers get read

Allocation consumes the occupancy read from #1434, and reads a **window**
rather than a lock. It starts at the number of users asked for and widens
only by what turned out to be in the way:

```
2 users, slots 1-3 already taken

  ask about 1..2   -> 2 in the way, 0 free
  ask about 1..4   -> 3 in the way, 1 free
  ask about 1..5   -> 3 in the way, 2 free   -> users land on 4 and 5
```

Three reads, not 250. That matters because ZHA and Zigbee2MQTT cost one
device round trip per index and hold the operation lock for the whole read,
so a lock walked to its advertised capacity blocks its own poll and every
set and clear behind it.

**There is no ceiling constant.** The window is bounded by demand from below
and by the lock's advertised capacity from above -- both real numbers.
Widening stops when the numbers it would need are past what a lock can hold,
which is the same refusal as asking for too many users, because on a full
lock that is what it is.

### Behaviour changes worth calling out

**The existing-codes confirmation no longer appears during setup.** It
existed because the user picked a range and might have picked a slot already
in use; an occupied number is now simply never offered, so there is nothing
to confirm. The gate still runs for the YAML path and for adding a lock to an
existing entry, where codes can still turn up at numbers already assigned.

**Capacity refusal on the UI path aborts with `too_many_users`**, not the
YAML path's `slot_out_of_range`. The latter was defined only as a form error
— so on a path that aborts, Home Assistant would have rendered the raw key —
and its text tells the user to renumber slots they never chose.

**Which user gets which number does not follow entry order.** Numbering is by
name, so an unordered collection of users cannot hand the same configuration
different credential indices from one run to the next. The numbers are not
user-visible, so the ordering is not either.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- Part of the v3 release; targets `v3`, not `main`.
- **Stacked on #1434**, which adds the occupancy read this consumes. Review
  or merge that first; this branch contains its commits until it lands.
- No wall-clock deadline was added to the read. With demand-driven widening
  the window is small unless the lock is nearly full, and a full lock is
  refused by the capacity check instead.
- Follows #1432, which keyed the configuration and the internal model by user.
- Four config-flow tests changed meaning rather than being deleted: the three
  that asserted the setup-time existing-codes prompt now assert that
  allocation routed around the occupied numbers, and the slot-range capacity
  test now covers asking for more users than the lock can hold. One of them
  had been asking about locks the flow never queried — it passed only because
  the old stub answered with a fixed mapping regardless of the question.
- 100% coverage held; full suite green under `HYPOTHESIS_PROFILE=ci`.
