### PR TITLE
feat: read what a lock holds, not just what we manage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ entities.
 - `akuvox.py`: Akuvox intercom/lock implementation
 - `zigbee2mqtt.py`: Zigbee2MQTT lock implementation (via MQTT)
 - `virtual.py`: Virtual lock implementation for testing
-- Each provider implements: `async_get_users()`, `async_set_usercode()`, `async_clear_usercode()`,
+- Each provider implements: `async_get_users()`, `async_set_credential()`, `async_delete_credential()`,
   `async_is_integration_connected()`, `async_hard_refresh_codes()`
 - Providers listen for lock-specific events and translate them to LCM events via `async_fire_code_slot_event()`
 - `BaseLock` provides `managed_slots` property (aggregates slots across all config entries for the lock)
@@ -106,7 +106,9 @@ entities.
 2. `async_update_listener()` creates coordinator and provider instances for each lock
 3. Lock provider sets up listeners for lock-specific events (e.g., Z-Wave JS notification events)
 4. Coordinator polls provider's `async_get_usercodes()` to keep state in sync (or receives push updates)
-5. When slot config changes (name, PIN, enabled), entities call provider's `async_set_usercode()` or `async_clear_usercode()`
+5. When slot config changes (name, PIN, enabled), sync calls
+   `BaseLock.async_set_usercode()` / `async_clear_usercode()`, which drive the
+   provider's credential primitives
 6. Provider fires `EVENT_LOCK_STATE_CHANGED` events when locks are operated with PINs
 
 ### Sync State Machine (`sync.py`)
@@ -359,10 +361,15 @@ with a comment citing the contract. Never silence one by rerunning.
        otherwise walks the lock's entire advertised capacity, one round trip at
        a time, holding the operation lock throughout.
      - The result may exceed the scope; callers bound it themselves.
-   - `async_set_usercode()`: program a code to a slot
-   - `async_clear_usercode()`: remove code from slot. Returns whether anything
-     actually changed — a clear that found nothing to clear is not evidence
-     the slot is empty.
+   - `async_set_credential()`: write one credential to the lock
+   - `async_delete_credential()`: remove one credential. Returns whether
+     anything actually changed — a delete that found nothing to delete is not
+     evidence the slot is empty.
+
+   `async_set_usercode()` / `async_clear_usercode()` are `BaseLock`
+   orchestration on top of these, not provider methods: they own the
+   create-the-user-first lifecycle and the readable-PIN checks. Do not
+   override them.
 4. Getting `SlotCredential` right is the whole job of a read. Three states, and
    the wrong one is a defect, not an inaccuracy:
    - `known(pin)` — the lock holds this code **and is accepting it**. Sync
@@ -413,31 +420,35 @@ For providers where the underlying integration's value cache updates asynchronou
 push notifications), implement optimistic updates to prevent sync loops:
 
 ```python
-async def async_set_usercode(self, code_slot: int, usercode: str, ...) -> bool:
+async def async_set_credential(self, ref: CredentialRef, value: str, ...) -> WriteResult:
     # ... perform the set operation ...
-    await self._call_service_to_set_code(code_slot, usercode)
+    await self._call_service_to_set_code(ref.slot, value)
 
-    # Optimistic update: command succeeded, update coordinator immediately
-    if self.coordinator:
-        self.coordinator.push_update({code_slot: usercode})
-    return True
+    # Optimistic update: the command succeeded, so tell the coordinator now
+    # rather than waiting for a cache that updates later.
+    self._push_credential_update(
+        ref.slot, SlotCredential.known(value), optimistic=True
+    )
+    return WriteResult(changed=True)
 
-async def async_clear_usercode(self, code_slot: int) -> bool:
+async def async_delete_credential(self, ref: CredentialRef) -> bool:
     # ... perform the clear operation ...
-    await self._call_service_to_clear_code(code_slot)
+    await self._call_service_to_clear_code(ref.slot)
 
-    # Optimistic update
-    if self.coordinator:
-        self.coordinator.push_update({code_slot: ""})
+    self._push_credential_update(ref.slot, SlotCredential.empty(), optimistic=True)
     return True
 ```
+
+Push `SlotCredential` values, never raw strings — every consumer calls
+`.is_present` / `.matches` on them. `_push_credential_update` is the helper that
+wraps `coordinator.push_update` correctly.
 
 **When needed:** The Z-Wave command is acknowledged by the lock (via Supervision CC), but the JS value
 cache updates later via push notification. Without optimistic updates, the coordinator refresh reads
 stale cache data, sees a mismatch, and triggers repeated sync attempts.
 
-**When NOT needed:** Providers with synchronous caches (like Virtual) don't need this - `get_usercodes()`
-returns the updated value immediately after set/clear.
+**When NOT needed:** Providers with synchronous caches (like Virtual) don't need this - their next
+read returns the updated value immediately after set/clear.
 
 ## Important Constraints
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ entities.
 - `akuvox.py`: Akuvox intercom/lock implementation
 - `zigbee2mqtt.py`: Zigbee2MQTT lock implementation (via MQTT)
 - `virtual.py`: Virtual lock implementation for testing
-- Each provider implements: `async_get_usercodes()`, `async_set_usercode()`, `async_clear_usercode()`,
+- Each provider implements: `async_get_users()`, `async_set_usercode()`, `async_clear_usercode()`,
   `async_is_integration_connected()`, `async_hard_refresh_codes()`
 - Providers listen for lock-specific events and translate them to LCM events via `async_fire_code_slot_event()`
 - `BaseLock` provides `managed_slots` property (aggregates slots across all config entries for the lock)
@@ -348,17 +348,46 @@ with a comment citing the contract. Never silence one by rerunning.
    - `async_is_integration_connected()`: check if integration is connected. Raises
      `LockCodeManagerError` by default if `lock_config_entry` is None — providers
      without a config entry (e.g., virtual) must override.
-   - `async_get_usercodes()`: return dict of slot→code mappings
+   - `async_get_users(slots=None)`: read the lock's users and their credentials.
+     `BaseLock` projects these to the slot→credential mapping the rest of the
+     integration uses, so most providers implement this rather than
+     `async_get_usercodes()`.
+     - `slots` names which credential indices to answer about; `None` means the
+       slots this integration manages. A provider that reads the whole lock in
+       one call may ignore it. **A provider that must ask the lock about one
+       index at a time MUST honour it** — a caller widening the question
+       otherwise walks the lock's entire advertised capacity, one round trip at
+       a time, holding the operation lock throughout.
+     - The result may exceed the scope; callers bound it themselves.
    - `async_set_usercode()`: program a code to a slot
-   - `async_clear_usercode()`: remove code from slot
-4. Optionally override `async_is_device_available()` to return `False` when the physical
+   - `async_clear_usercode()`: remove code from slot. Returns whether anything
+     actually changed — a clear that found nothing to clear is not evidence
+     the slot is empty.
+4. Getting `SlotCredential` right is the whole job of a read. Three states, and
+   the wrong one is a defect, not an inaccuracy:
+   - `known(pin)` — the lock holds this code **and is accepting it**. Sync
+     compares it against the configured PIN, so a code the lock is refusing
+     must not be reported this way: the slot would read in sync while the door
+     stays shut.
+   - `empty()` — **confirmed cleared**. Only an explicit "nothing here" from
+     the lock earns it. Sync treats it as proof a clear landed, and slot
+     allocation treats the index as free to hand out, so guessing here
+     overwrites a real credential on a real door.
+   - `unreadable()` — something is there and its value cannot be trusted: a
+     write-only code, a failed read, a status this provider cannot interpret,
+     a slot the lock reports as disabled. This is the safe answer whenever the
+     lock has not plainly said "free" or "here is the code I am accepting".
+
+   When in doubt, `unreadable()`. It costs a user one slot number; the other
+   two mistakes cost them the code on their door.
+5. Optionally override `async_is_device_available()` to return `False` when the physical
    device is unresponsive (default returns `True`). Operations are gated on both
    integration connectivity and device availability.
-5. Override `async_setup()` to register event listeners
-6. Call `async_fire_code_slot_event()` when lock events indicate PIN usage
-7. Add tests in `tests/providers/<provider>/test_<provider>.py`
-8. Use `self.managed_slots` (property) to get managed slot numbers
-9. Use `self.async_call_service()` for HA service calls — it wraps `HomeAssistantError`
+6. Override `async_setup()` to register event listeners
+7. Call `async_fire_code_slot_event()` when lock events indicate PIN usage
+8. Add tests in `tests/providers/<provider>/test_<provider>.py`
+9. Use `self.managed_slots` (property) to get managed slot numbers
+10. Use `self.async_call_service()` for HA service calls — it wraps `HomeAssistantError`
    as `LockDisconnected` automatically
 
 ### Optional Provider Properties

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -1800,11 +1800,14 @@ class BaseLock:
         ``user_from_slot``.
 
         ``slots`` names which credential indices to report on; ``None``
-        means the slots this integration manages. Providers that read the
-        whole lock in one call may ignore it -- the projection bounds the
-        answer. Providers that must ask the lock about one index at a time
-        MUST honour it, or a caller widening the question walks the lock's
-        entire advertised capacity one round trip at a time.
+        means the slots this integration manages. Providers that must ask
+        the lock about one index at a time MUST honour it, or a caller
+        widening the question walks the lock's entire advertised capacity
+        one round trip at a time. Providers that read the whole lock in one
+        call may ignore it, because the result is allowed to EXCEED the
+        scope -- the projection seeds the scope but overlays everything the
+        provider reports, so an unmanaged occupied slot stays visible on the
+        default path. A caller that needs the answer bounded must bound it.
 
         A wide scope is the caller's to justify. The whole read is one
         rate-limited operation, so on a per-index provider it holds the

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -8,7 +8,7 @@ See ARCHITECTURE.md for the provider interface contract.
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Collection
 import contextlib
 from dataclasses import dataclass, field, replace
 from datetime import timedelta
@@ -1339,13 +1339,16 @@ class BaseLock:
         return bool(changed)
 
     async def _project_users_to_slots(
-        self, credential_type: CredentialType
+        self,
+        credential_type: CredentialType,
+        slots: Collection[int] | None = None,
     ) -> dict[int, SlotCredential]:
         """
         Project the lock's users to a slot -> ``SlotCredential`` map.
 
         Every managed slot is present even when empty: the projection
-        starts from ``managed_slots`` mapped to ``SlotCredential.empty()``
+        starts from ``slots`` -- or ``managed_slots`` when the caller names
+        none -- mapped to ``SlotCredential.empty()``
         and then overlays the credentials of ``credential_type`` read via
         ``async_get_users``. This preserves the slot-keyed contract the
         coordinator, sync manager, and slot entities depend on -- a
@@ -1371,17 +1374,20 @@ class BaseLock:
         (do users configure "PIN slots 1-10" and "password slots 1-5"
         separately, or is each slot polymorphic?).
         """
-        codes = {slot: SlotCredential.empty() for slot in self.managed_slots}
+        scope = self.managed_slots if slots is None else slots
+        codes = {slot: SlotCredential.empty() for slot in scope}
         codes.update(
             {
                 credential.slot: credential.state
-                for user in await self.async_get_users()
+                for user in await self.async_get_users(slots)
                 for credential in user.credentials_of_type(credential_type)
             }
         )
         return codes
 
-    async def async_get_usercodes(self) -> dict[int, SlotCredential]:
+    async def async_get_usercodes(
+        self, slots: Collection[int] | None = None
+    ) -> dict[int, SlotCredential]:
         """
         Return the slot -> ``SlotCredential`` map for Personal Identification Numbers.
 
@@ -1389,8 +1395,15 @@ class BaseLock:
         ``_project_users_to_slots``; preserved as a stable name because
         the coordinator, sync manager, and slot entities are all
         Personal Identification Number-scoped today.
+
+        ``slots`` widens the read past the slots this integration manages,
+        for callers that need to know what the lock holds rather than what
+        this integration put there. Everything read-repairing happens on
+        this side of the seam, so a caller asking a wider question gets the
+        repairs too -- which is why occupancy is derived from here and not
+        read separately.
         """
-        return await self._project_users_to_slots(CredentialType.PIN)
+        return await self._project_users_to_slots(CredentialType.PIN, slots)
 
     @final
     async def _get_cached_capabilities(self) -> LockCapabilities:
@@ -1777,7 +1790,7 @@ class BaseLock:
             "Override to delete a credential from the lock.",
         )
 
-    async def async_get_users(self) -> list[User]:
+    async def async_get_users(self, slots: Collection[int] | None = None) -> list[User]:
         """
         Read every user and their credentials from the lock.
 
@@ -1785,35 +1798,23 @@ class BaseLock:
         providers map their integration's user list; slot-only providers
         project each occupied slot to a single-credential user via
         ``user_from_slot``.
+
+        ``slots`` names which credential indices to report on; ``None``
+        means the slots this integration manages. Providers that read the
+        whole lock in one call may ignore it -- the projection bounds the
+        answer. Providers that must ask the lock about one index at a time
+        MUST honour it, or a caller widening the question walks the lock's
+        entire advertised capacity one round trip at a time.
+
+        A wide scope is the caller's to justify. The whole read is one
+        rate-limited operation, so on a per-index provider it holds the
+        operation lock for every round trip it makes -- blocking the poll
+        and any set or clear behind it for as long as that takes.
         """
         self._raise_not_implemented(
             "async_get_users",
             "Override to read users and credentials from the lock.",
         )
-
-    async def async_get_occupied_indices(self, limit: int) -> frozenset[int] | None:
-        """
-        Return which Personal Identification Number indices in 1..limit are taken.
-
-        Reports what is on the DEVICE, whoever put it there. That is what
-        separates this from ``async_get_users``, which is deliberately scoped
-        to the users Lock Code Manager manages because it also decides where
-        writes land. A code programmed by hand occupies an index just as
-        firmly as one this integration wrote, so allocation needs the wider
-        view or it will hand a new user somebody else's index.
-
-        ``limit`` bounds the work. Locks that can only be asked about one
-        index at a time would otherwise have to walk their entire advertised
-        capacity to report a handful of numbers; a caller that finds the
-        window too full to satisfy it asks again with a wider one.
-
-        ``None`` means the lock could not say, and callers must treat it as
-        unknown rather than empty -- issuing an index against a lock that
-        never answered is how a real credential gets overwritten. The base
-        returns ``None`` so a provider that cannot answer refuses by default
-        rather than by omission.
-        """
-        return None
 
     async def async_get_capabilities(self) -> LockCapabilities:
         """
@@ -1837,14 +1838,32 @@ class BaseLock:
         self, limit: int
     ) -> frozenset[int] | None:
         """
-        Rate-limited wrapper around async_get_occupied_indices().
+        Return which slot numbers in 1..limit this lock holds, or None.
 
-        A failed read becomes ``None`` rather than an exception: unknown is
-        already a value this returns, and every caller has to handle it.
+        These are slot numbers, not device credential indices. The two
+        coincide on every provider where allocation consults this, because
+        it only consults locks whose credential index IS the slot number
+        (``credential_index_follows_slot``). Where they diverge -- Matter,
+        which allocates its own index -- the number here is the Lock Code
+        Manager slot recovered from the user's tag, and allocation knows not
+        to treat it as a device index.
+
+        Derived from ``async_get_usercodes`` rather than read separately, so
+        that whatever a provider does to make its read honest -- Z-Wave's
+        User Code CC occupancy overlay, most of all -- applies here too. A
+        second read path would have to repeat every one of those repairs, and
+        the one it missed would report an occupied slot as free.
+
+        An index whose value could not be read still counts as occupied: it
+        holds something, and over-reserving costs a user a slot number, while
+        under-reserving costs them the code on their door.
+
+        ``None`` means the lock could not be read at all, which callers must
+        treat as unknown rather than free.
         """
         try:
-            return await self._execute_rate_limited(
-                "get", partial(self.async_get_occupied_indices, limit)
+            codes = await self._execute_rate_limited(
+                "get", partial(self.async_get_usercodes, range(1, limit + 1))
             )
         except LockCodeManagerError as err:
             _LOGGER.debug(
@@ -1853,6 +1872,11 @@ class BaseLock:
                 err,
             )
             return None
+        return frozenset(
+            slot
+            for slot, credential in codes.items()
+            if credential.is_present and 1 <= slot <= limit
+        )
 
     @final
     async def async_call_service(

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -1346,7 +1346,7 @@ class BaseLock:
         """
         Project the lock's users to a slot -> ``SlotCredential`` map.
 
-        Every managed slot is present even when empty: the projection
+        Every slot in scope is present even when empty: the projection
         starts from ``slots`` -- or ``managed_slots`` when the caller names
         none -- mapped to ``SlotCredential.empty()``
         and then overlays the credentials of ``credential_type`` read via
@@ -1396,9 +1396,11 @@ class BaseLock:
         the coordinator, sync manager, and slot entities are all
         Personal Identification Number-scoped today.
 
-        ``slots`` widens the read past the slots this integration manages,
-        for callers that need to know what the lock holds rather than what
-        this integration put there. Everything read-repairing happens on
+        ``slots`` replaces the set of slots this integration manages, for
+        callers asking what the lock holds rather than what this integration
+        put there. It can be wider or narrower, so a scoped result is not
+        the coordinator's contract and must not be handed to it: a managed
+        slot missing from a narrow read reads as unavailable, not empty. Everything read-repairing happens on
         this side of the seam, so a caller asking a wider question gets the
         repairs too -- which is why occupancy is derived from here and not
         read separately.

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -12,6 +12,7 @@ from collections.abc import Awaitable, Callable
 import contextlib
 from dataclasses import dataclass, field, replace
 from datetime import timedelta
+from functools import partial
 import logging
 import time
 from typing import Any, Literal, NoReturn, final
@@ -1790,6 +1791,30 @@ class BaseLock:
             "Override to read users and credentials from the lock.",
         )
 
+    async def async_get_occupied_indices(self, limit: int) -> frozenset[int] | None:
+        """
+        Return which Personal Identification Number indices in 1..limit are taken.
+
+        Reports what is on the DEVICE, whoever put it there. That is what
+        separates this from ``async_get_users``, which is deliberately scoped
+        to the users Lock Code Manager manages because it also decides where
+        writes land. A code programmed by hand occupies an index just as
+        firmly as one this integration wrote, so allocation needs the wider
+        view or it will hand a new user somebody else's index.
+
+        ``limit`` bounds the work. Locks that can only be asked about one
+        index at a time would otherwise have to walk their entire advertised
+        capacity to report a handful of numbers; a caller that finds the
+        window too full to satisfy it asks again with a wider one.
+
+        ``None`` means the lock could not say, and callers must treat it as
+        unknown rather than empty -- issuing an index against a lock that
+        never answered is how a real credential gets overwritten. The base
+        returns ``None`` so a provider that cannot answer refuses by default
+        rather than by omission.
+        """
+        return None
+
     async def async_get_capabilities(self) -> LockCapabilities:
         """
         Report the lock's user/credential capabilities.
@@ -1806,6 +1831,28 @@ class BaseLock:
     async def async_internal_get_usercodes(self) -> dict[int, SlotCredential]:
         """Rate-limited wrapper around async_get_usercodes()."""
         return await self._execute_rate_limited("get", self.async_get_usercodes)
+
+    @final
+    async def async_internal_get_occupied_indices(
+        self, limit: int
+    ) -> frozenset[int] | None:
+        """
+        Rate-limited wrapper around async_get_occupied_indices().
+
+        A failed read becomes ``None`` rather than an exception: unknown is
+        already a value this returns, and every caller has to handle it.
+        """
+        try:
+            return await self._execute_rate_limited(
+                "get", partial(self.async_get_occupied_indices, limit)
+            )
+        except LockCodeManagerError as err:
+            _LOGGER.debug(
+                "Could not read occupied indices from %s: %s",
+                self.lock.entity_id,
+                err,
+            )
+            return None
 
     @final
     async def async_call_service(

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -1846,10 +1846,11 @@ class BaseLock:
         These are slot numbers, not device credential indices. The two
         coincide on every provider where allocation consults this, because
         it only consults locks whose credential index IS the slot number
-        (``credential_index_follows_slot``). Where they diverge -- Matter,
-        which allocates its own index -- the number here is the Lock Code
-        Manager slot recovered from the user's tag, and allocation knows not
-        to treat it as a device index.
+        (``credential_index_follows_slot``). Matter is the exception both
+        ways: it allocates its own index, so allocation does not consult it,
+        and the number reported here is the Lock Code Manager slot from the
+        user's tag -- or, for a user this integration never tagged, the raw
+        Matter credential index standing in for one.
 
         Derived from ``async_get_usercodes`` rather than read separately, so
         that whatever a provider does to make its read honest -- Z-Wave's

--- a/custom_components/lock_code_manager/providers/akuvox.py
+++ b/custom_components/lock_code_manager/providers/akuvox.py
@@ -124,15 +124,20 @@ class AkuvoxLock(BaseLock):
                 f"Malformed list_users entity response from {entity_id}: "
                 f"expected dict, got {type(entity_response).__name__}"
             )
-        # A response with no user list at all is a shape this does not
+        # A response with no usable user list is a shape this does not
         # understand, not a device with no users. Returning an empty list
         # would say "every slot is free", which is the answer that gets a
-        # real credential overwritten.
-        if "users" not in entity_response:
+        # real credential overwritten. The type is checked as well as the
+        # key: a wrongly typed value would otherwise surface as a bare
+        # TypeError from the caller's loop, past every handler that knows
+        # what to do with this integration's own errors.
+        users = entity_response.get("users")
+        if not isinstance(users, list):
             raise LockCodeManagerProviderError(
-                f"Malformed list_users entity response from {entity_id}: no 'users' key"
+                f"Malformed list_users entity response from {entity_id}: "
+                f"expected a list of users, got {type(users).__name__}"
             )
-        return entity_response["users"]
+        return users
 
     async def _async_add_user(self, name: str, pin: str) -> None:
         """Add a new user with the given name and PIN."""

--- a/custom_components/lock_code_manager/providers/akuvox.py
+++ b/custom_components/lock_code_manager/providers/akuvox.py
@@ -14,6 +14,7 @@ services (``list_users``, ``add_user``, ``modify_user``, ``delete_user``).
 
 from __future__ import annotations
 
+from collections.abc import Collection
 from dataclasses import dataclass, field
 from datetime import timedelta
 from typing import Any, Literal
@@ -123,7 +124,15 @@ class AkuvoxLock(BaseLock):
                 f"Malformed list_users entity response from {entity_id}: "
                 f"expected dict, got {type(entity_response).__name__}"
             )
-        return entity_response.get("users", [])
+        # A response with no user list at all is a shape this does not
+        # understand, not a device with no users. Returning an empty list
+        # would say "every slot is free", which is the answer that gets a
+        # real credential overwritten.
+        if "users" not in entity_response:
+            raise LockCodeManagerProviderError(
+                f"Malformed list_users entity response from {entity_id}: no 'users' key"
+            )
+        return entity_response["users"]
 
     async def _async_add_user(self, name: str, pin: str) -> None:
         """Add a new user with the given name and PIN."""
@@ -290,30 +299,7 @@ class AkuvoxLock(BaseLock):
                 "will be retried on reconnect"
             ) from first_disconnect
 
-    async def async_get_occupied_indices(self, limit: int) -> frozenset[int] | None:
-        """
-        Report the slot numbers this lock's tagged users claim.
-
-        An Akuvox user is addressed by its own identifier, not by a slot
-        number -- the slot number lives in the user's NAME, put there by this
-        integration. So an untagged user occupies no slot number and cannot
-        collide with one allocation issues; what it consumes is one of the
-        lock's finite user entries.
-
-        Reading the tags still matters: a tag left behind by a configuration
-        that has since been removed claims a slot number nothing else knows
-        about.
-        """
-        users = await self._async_list_users()
-        return frozenset(
-            slot_num
-            for user in users
-            if _is_local_user(user)
-            and (slot_num := _parse_tag(user.get("name", ""))[0]) is not None
-            and slot_num <= limit
-        )
-
-    async def async_get_users(self) -> list[User]:
+    async def async_get_users(self, slots: Collection[int] | None = None) -> list[User]:
         """
         Return users by reading tagged local users from the Akuvox device.
 
@@ -324,7 +310,7 @@ class AkuvoxLock(BaseLock):
         Personal Identification Numbers are readable on Akuvox, so occupied
         slots report the actual value.
         """
-        managed_slots = self.managed_slots
+        managed_slots = self.managed_slots if slots is None else set(slots)
         if not managed_slots:
             return []
 

--- a/custom_components/lock_code_manager/providers/akuvox.py
+++ b/custom_components/lock_code_manager/providers/akuvox.py
@@ -290,6 +290,29 @@ class AkuvoxLock(BaseLock):
                 "will be retried on reconnect"
             ) from first_disconnect
 
+    async def async_get_occupied_indices(self, limit: int) -> frozenset[int] | None:
+        """
+        Report the slot numbers this lock's tagged users claim.
+
+        An Akuvox user is addressed by its own identifier, not by a slot
+        number -- the slot number lives in the user's NAME, put there by this
+        integration. So an untagged user occupies no slot number and cannot
+        collide with one allocation issues; what it consumes is one of the
+        lock's finite user entries.
+
+        Reading the tags still matters: a tag left behind by a configuration
+        that has since been removed claims a slot number nothing else knows
+        about.
+        """
+        users = await self._async_list_users()
+        return frozenset(
+            slot_num
+            for user in users
+            if _is_local_user(user)
+            and (slot_num := _parse_tag(user.get("name", ""))[0]) is not None
+            and slot_num <= limit
+        )
+
     async def async_get_users(self) -> list[User]:
         """
         Return users by reading tagged local users from the Akuvox device.

--- a/custom_components/lock_code_manager/providers/matter.py
+++ b/custom_components/lock_code_manager/providers/matter.py
@@ -10,6 +10,7 @@ and occupancy updates (LockUserChange).
 
 from __future__ import annotations
 
+from collections.abc import Collection
 from dataclasses import dataclass
 from datetime import timedelta
 from typing import Any, Literal
@@ -453,13 +454,20 @@ class MatterLock(BaseLock):
         )
         return lock_data.get("users", [])
 
-    async def async_get_users(self) -> list[User]:
+    async def async_get_users(self, slots: Collection[int] | None = None) -> list[User]:
         """
         Read every user and their Personal Identification Number credentials from the lock.
 
         Matter PINs are write-only: each occupied credential slot is projected to
         SlotCredential.unreadable(). Non-PIN credentials (for example RFID) are
         filtered out because the coordinator and sync manager only manage PIN slots.
+
+        ``slots`` is ignored: this reads every user on the device in one
+        call. What comes back is keyed by Lock Code Manager slot, recovered
+        from each user's tag -- not by Matter credential index, which the
+        lock allocates itself. Allocation knows not to read anything into a
+        Matter index for that reason (``credential_index_follows_slot``),
+        but the slots reported here are still real claims on a number.
 
         Credential.slot is the LCM slot, NOT the Matter credential index.
         The LCM slot is recovered from the owning user's ``lcm:<slot>:`` tag;

--- a/custom_components/lock_code_manager/providers/matter.py
+++ b/custom_components/lock_code_manager/providers/matter.py
@@ -463,8 +463,9 @@ class MatterLock(BaseLock):
         filtered out because the coordinator and sync manager only manage PIN slots.
 
         ``slots`` is ignored: this reads every user on the device in one
-        call. What comes back is keyed by Lock Code Manager slot, recovered
-        from each user's tag -- not by Matter credential index, which the
+        call, so the answer may name slots outside the scope. What comes
+        back is keyed by Lock Code Manager slot, recovered from each user's
+        tag -- not by Matter credential index, which the
         lock allocates itself. Allocation knows not to read anything into a
         Matter index for that reason (``credential_index_follows_slot``),
         but the slots reported here are still real claims on a number.

--- a/custom_components/lock_code_manager/providers/schlage.py
+++ b/custom_components/lock_code_manager/providers/schlage.py
@@ -19,6 +19,7 @@ service returns masked PINs (``****``), so occupied slots report
 
 from __future__ import annotations
 
+from collections.abc import Collection
 import contextlib
 from dataclasses import dataclass, field
 from datetime import timedelta
@@ -293,30 +294,7 @@ class SchlageLock(BaseLock):
                 "will be retried on reconnect"
             ) from first_disconnect
 
-    async def async_get_occupied_indices(self, limit: int) -> frozenset[int] | None:
-        """
-        Report the slot numbers this lock's tagged codes claim.
-
-        A Schlage code is addressed by its own identifier, not by a slot
-        number -- the slot number lives in the code's NAME, put there by this
-        integration. So an untagged code, however it was programmed, occupies
-        no slot number and cannot collide with one allocation issues. What it
-        does consume is one of the lock's finite code entries, which is a
-        matter of capacity rather than of which index is free.
-
-        Reading the tags still matters: a tag left behind by a configuration
-        that has since been removed claims a slot number nothing else knows
-        about.
-        """
-        codes = await self._async_get_codes()
-        return frozenset(
-            slot_num
-            for code_data in codes.values()
-            if (slot_num := _parse_tag(code_data.get("name", ""))[0]) is not None
-            and slot_num <= limit
-        )
-
-    async def async_get_users(self) -> list[User]:
+    async def async_get_users(self, slots: Collection[int] | None = None) -> list[User]:
         """
         Return users by reading all tagged codes from the Schlage lock.
 
@@ -327,7 +305,7 @@ class SchlageLock(BaseLock):
         fall within the managed set are returned. Auto-tagging of unmanaged
         codes is handled separately by ``_async_tag_unmanaged_codes()``.
         """
-        managed_slots = self.managed_slots
+        managed_slots = self.managed_slots if slots is None else set(slots)
         if not managed_slots:
             return []
 

--- a/custom_components/lock_code_manager/providers/schlage.py
+++ b/custom_components/lock_code_manager/providers/schlage.py
@@ -293,6 +293,29 @@ class SchlageLock(BaseLock):
                 "will be retried on reconnect"
             ) from first_disconnect
 
+    async def async_get_occupied_indices(self, limit: int) -> frozenset[int] | None:
+        """
+        Report the slot numbers this lock's tagged codes claim.
+
+        A Schlage code is addressed by its own identifier, not by a slot
+        number -- the slot number lives in the code's NAME, put there by this
+        integration. So an untagged code, however it was programmed, occupies
+        no slot number and cannot collide with one allocation issues. What it
+        does consume is one of the lock's finite code entries, which is a
+        matter of capacity rather than of which index is free.
+
+        Reading the tags still matters: a tag left behind by a configuration
+        that has since been removed claims a slot number nothing else knows
+        about.
+        """
+        codes = await self._async_get_codes()
+        return frozenset(
+            slot_num
+            for code_data in codes.values()
+            if (slot_num := _parse_tag(code_data.get("name", ""))[0]) is not None
+            and slot_num <= limit
+        )
+
     async def async_get_users(self) -> list[User]:
         """
         Return users by reading all tagged codes from the Schlage lock.

--- a/custom_components/lock_code_manager/providers/virtual.py
+++ b/custom_components/lock_code_manager/providers/virtual.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Collection
 from dataclasses import dataclass, field
 import logging
 from typing import Literal, TypedDict
@@ -105,15 +106,7 @@ class VirtualLock(BaseLock):
         self._data.pop(slot_key)
         return True
 
-    async def async_get_occupied_indices(self, limit: int) -> frozenset[int] | None:
-        """Report every stored slot, managed by this entry or not."""
-        return frozenset(
-            slot_num
-            for key in self._data
-            if (slot_num := parse_slot_num(key)) is not None and slot_num <= limit
-        )
-
-    async def async_get_users(self) -> list[User]:
+    async def async_get_users(self, slots: Collection[int] | None = None) -> list[User]:
         """
         Return users by reading all stored and managed slots.
 
@@ -123,7 +116,7 @@ class VirtualLock(BaseLock):
         like the lock-reset config flow step can detect codes not managed
         by Lock Code Manager.
         """
-        managed_slots = self.managed_slots
+        managed_slots = self.managed_slots if slots is None else set(slots)
         stored_slots = set()
         for k in self._data:
             slot_num = parse_slot_num(k)

--- a/custom_components/lock_code_manager/providers/virtual.py
+++ b/custom_components/lock_code_manager/providers/virtual.py
@@ -105,6 +105,14 @@ class VirtualLock(BaseLock):
         self._data.pop(slot_key)
         return True
 
+    async def async_get_occupied_indices(self, limit: int) -> frozenset[int] | None:
+        """Report every stored slot, managed by this entry or not."""
+        return frozenset(
+            slot_num
+            for key in self._data
+            if (slot_num := parse_slot_num(key)) is not None and slot_num <= limit
+        )
+
     async def async_get_users(self) -> list[User]:
         """
         Return users by reading all stored and managed slots.

--- a/custom_components/lock_code_manager/providers/zha.py
+++ b/custom_components/lock_code_manager/providers/zha.py
@@ -346,11 +346,13 @@ class ZHALock(BaseLock):
         cluster answers a single index per round trip, so ``slots`` bounds
         the work and must be honoured.
 
-        Anything the lock will not put a value to -- a failed read, a
-        response shape this cannot parse, an enabled slot whose code the
-        lock withholds -- is ``unreadable``, never ``empty``. ``empty``
-        means confirmed cleared, and confirming that wrongly makes sync
-        reprogram a slot that already holds a code.
+        ``empty`` means confirmed cleared, and only the ``AVAILABLE`` status
+        says that. Everything else the lock will not put a readable value to
+        -- a failed read, a response shape this cannot parse, a slot whose
+        code the lock withholds, a slot the ZCL calls ``DISABLED`` (occupied
+        but not currently accepted) -- is ``unreadable``. Confirming a clear
+        wrongly makes sync reprogram a slot that already holds a code, and
+        tells allocation an occupied credential index is free.
         """
         cluster = await self._get_connected_cluster()
         scope = self.managed_slots if slots is None else slots
@@ -387,10 +389,17 @@ class ZHALock(BaseLock):
                     slot_num,
                 )
                 slot_states[slot_num] = SlotCredential.unreadable()
-            elif parsed[0] != DoorLock.UserStatus.Enabled:
+                continue
+
+            user_status, pin_code = parsed
+            # AVAILABLE is the only status that means the slot holds nothing.
+            # DISABLED is the ZCL's occupied-but-inactive: there is a code
+            # there, the lock just will not accept it right now. NOT_SUPPORTED
+            # is not a free slot either -- a write to it fails.
+            if user_status == DoorLock.UserStatus.Available:
                 slot_states[slot_num] = SlotCredential.empty()
-            elif parsed[1]:
-                slot_states[slot_num] = SlotCredential.known(parsed[1])
+            elif pin_code:
+                slot_states[slot_num] = SlotCredential.known(pin_code)
             else:
                 slot_states[slot_num] = SlotCredential.unreadable()
         return [user_from_slot(slot, state) for slot, state in slot_states.items()]

--- a/custom_components/lock_code_manager/providers/zha.py
+++ b/custom_components/lock_code_manager/providers/zha.py
@@ -10,6 +10,7 @@ polling.
 
 from __future__ import annotations
 
+from collections.abc import Collection
 from dataclasses import dataclass, field
 from datetime import timedelta
 import logging
@@ -337,22 +338,27 @@ class ZHALock(BaseLock):
         self._push_credential_update(code_slot, SlotCredential.empty())
         return True
 
-    async def async_get_users(self) -> list[User]:
+    async def async_get_users(self, slots: Collection[int] | None = None) -> list[User]:
         """
-        Read Personal Identification Number codes from all managed slots.
+        Read Personal Identification Number codes one index at a time.
 
-        Returns a user per slot via the one-slot-one-user projection.
-        Known codes surface as occupied users; failed reads produce
-        unreadable credentials so the coordinator does not treat a
-        transient cluster error as a confirmed-empty slot.
+        Returns a user per slot via the one-slot-one-user projection. The
+        cluster answers a single index per round trip, so ``slots`` bounds
+        the work and must be honoured.
+
+        Anything the lock will not put a value to -- a failed read, a
+        response shape this cannot parse, an enabled slot whose code the
+        lock withholds -- is ``unreadable``, never ``empty``. ``empty``
+        means confirmed cleared, and confirming that wrongly makes sync
+        reprogram a slot that already holds a code.
         """
         cluster = await self._get_connected_cluster()
-        managed = self.managed_slots
-        if not managed:
+        scope = self.managed_slots if slots is None else slots
+        if not scope:
             return []
 
         slot_states: dict[int, SlotCredential] = {}
-        for slot_num in managed:
+        for slot_num in scope:
             try:
                 result = await cluster.get_pin_code(slot_num)
                 _LOGGER.debug(
@@ -361,11 +367,7 @@ class ZHALock(BaseLock):
                     slot_num,
                     result,
                 )
-                user_status, pin_code = self._parse_pin_response(result)
-                if user_status == DoorLock.UserStatus.Enabled and pin_code:
-                    slot_states[slot_num] = SlotCredential.known(pin_code)
-                else:
-                    slot_states[slot_num] = SlotCredential.empty()
+                parsed = self._parse_pin_response(result)
             except LockDisconnected:
                 raise
             except Exception:
@@ -376,41 +378,22 @@ class ZHALock(BaseLock):
                     exc_info=True,
                 )
                 slot_states[slot_num] = SlotCredential.unreadable()
-        return [user_from_slot(slot, state) for slot, state in slot_states.items()]
+                continue
 
-    async def async_get_occupied_indices(self, limit: int) -> frozenset[int] | None:
-        """
-        Ask the lock about each index in turn, up to ``limit``.
-
-        The cluster answers one index per round trip, which is why the
-        caller bounds the range instead of the whole advertised capacity
-        being walked.
-
-        A single index that cannot be read makes the whole answer unknown.
-        Returning the rest would understate what is occupied, and an
-        understated answer is the one that overwrites a code.
-        """
-        cluster = await self._get_connected_cluster()
-        occupied: set[int] = set()
-        for slot_num in range(1, limit + 1):
-            try:
-                result = await cluster.get_pin_code(slot_num)
-                user_status, _pin_code = self._parse_pin_response(result)
-            except Exception:
+            if parsed is None:
                 _LOGGER.debug(
-                    "Lock %s: could not read slot %s, so occupancy is unknown",
+                    "Lock %s: unrecognized get_pin_code response for slot %s",
                     self.lock.entity_id,
                     slot_num,
-                    exc_info=True,
                 )
-                return None
-            # Enabled is enough. A lock that will not hand back the code
-            # still has one in that slot, and requiring the value would
-            # report a write-only slot as free -- the understatement that
-            # overwrites a credential.
-            if user_status == DoorLock.UserStatus.Enabled:
-                occupied.add(slot_num)
-        return frozenset(occupied)
+                slot_states[slot_num] = SlotCredential.unreadable()
+            elif parsed[0] != DoorLock.UserStatus.Enabled:
+                slot_states[slot_num] = SlotCredential.empty()
+            elif parsed[1]:
+                slot_states[slot_num] = SlotCredential.known(parsed[1])
+            else:
+                slot_states[slot_num] = SlotCredential.unreadable()
+        return [user_from_slot(slot, state) for slot, state in slot_states.items()]
 
     async def async_hard_refresh_codes(self) -> dict[int, SlotCredential]:
         """Re-read all codes from the lock (no cache to invalidate)."""
@@ -419,8 +402,14 @@ class ZHALock(BaseLock):
     # -- Response parsing ----------------------------------------------------
 
     @staticmethod
-    def _parse_pin_response(result: Any) -> tuple[int, str]:
-        """Extract (user_status, pin_code) from a get_pin_code response."""
+    def _parse_pin_response(result: Any) -> tuple[int, str] | None:
+        """
+        Extract (user_status, pin_code) from a get_pin_code response.
+
+        ``None`` for a shape this does not recognize. Reporting such a
+        response as ``Available`` would answer "this slot is free" from a
+        reply that was never understood.
+        """
         if hasattr(result, "user_status"):
             pin = getattr(result, "code", "") or ""
             if isinstance(pin, bytes):
@@ -431,7 +420,7 @@ class ZHALock(BaseLock):
             if isinstance(pin, bytes):
                 pin = pin.decode("utf-8", errors="ignore")
             return result[1], str(pin) if pin else ""
-        return DoorLock.UserStatus.Available, ""
+        return None
 
     # -- Push updates --------------------------------------------------------
 

--- a/custom_components/lock_code_manager/providers/zha.py
+++ b/custom_components/lock_code_manager/providers/zha.py
@@ -378,6 +378,40 @@ class ZHALock(BaseLock):
                 slot_states[slot_num] = SlotCredential.unreadable()
         return [user_from_slot(slot, state) for slot, state in slot_states.items()]
 
+    async def async_get_occupied_indices(self, limit: int) -> frozenset[int] | None:
+        """
+        Ask the lock about each index in turn, up to ``limit``.
+
+        The cluster answers one index per round trip, which is why the
+        caller bounds the range instead of the whole advertised capacity
+        being walked.
+
+        A single index that cannot be read makes the whole answer unknown.
+        Returning the rest would understate what is occupied, and an
+        understated answer is the one that overwrites a code.
+        """
+        cluster = await self._get_connected_cluster()
+        occupied: set[int] = set()
+        for slot_num in range(1, limit + 1):
+            try:
+                result = await cluster.get_pin_code(slot_num)
+                user_status, _pin_code = self._parse_pin_response(result)
+            except Exception:
+                _LOGGER.debug(
+                    "Lock %s: could not read slot %s, so occupancy is unknown",
+                    self.lock.entity_id,
+                    slot_num,
+                    exc_info=True,
+                )
+                return None
+            # Enabled is enough. A lock that will not hand back the code
+            # still has one in that slot, and requiring the value would
+            # report a write-only slot as free -- the understatement that
+            # overwrites a credential.
+            if user_status == DoorLock.UserStatus.Enabled:
+                occupied.add(slot_num)
+        return frozenset(occupied)
+
     async def async_hard_refresh_codes(self) -> dict[int, SlotCredential]:
         """Re-read all codes from the lock (no cache to invalidate)."""
         return await self.async_get_usercodes()

--- a/custom_components/lock_code_manager/providers/zha.py
+++ b/custom_components/lock_code_manager/providers/zha.py
@@ -346,13 +346,16 @@ class ZHALock(BaseLock):
         cluster answers a single index per round trip, so ``slots`` bounds
         the work and must be honoured.
 
-        ``empty`` means confirmed cleared, and only the ``AVAILABLE`` status
-        says that. Everything else the lock will not put a readable value to
-        -- a failed read, a response shape this cannot parse, a slot whose
-        code the lock withholds, a slot the ZCL calls ``DISABLED`` (occupied
-        but not currently accepted) -- is ``unreadable``. Confirming a clear
-        wrongly makes sync reprogram a slot that already holds a code, and
-        tells allocation an occupied credential index is free.
+        ``empty`` means confirmed cleared, and ``AVAILABLE`` is the only
+        status that says so. ``known`` means the lock is accepting this code,
+        which only ``ENABLED`` says. Every other answer -- another status, a
+        failed read, a response shape this cannot parse -- is ``unreadable``:
+        something is there and its value cannot be trusted.
+
+        Both directions matter. Reporting a clear that did not happen makes
+        sync reprogram a slot that already holds a code and tells allocation
+        an occupied index is free; reporting a value the lock is not
+        honouring makes a code that will not open the door read as in sync.
         """
         cluster = await self._get_connected_cluster()
         scope = self.managed_slots if slots is None else slots
@@ -392,13 +395,16 @@ class ZHALock(BaseLock):
                 continue
 
             user_status, pin_code = parsed
-            # AVAILABLE is the only status that means the slot holds nothing.
-            # DISABLED is the ZCL's occupied-but-inactive: there is a code
-            # there, the lock just will not accept it right now. NOT_SUPPORTED
-            # is not a free slot either -- a write to it fails.
+            # AVAILABLE is the only status that leaves this index free to
+            # write to, and ENABLED the only one whose code the lock says it
+            # is currently accepting. Everything between them is reported as
+            # holding something whose value cannot be trusted: claiming a
+            # value the lock is not honouring would read as in sync while the
+            # code does not open the door, and claiming the index is empty
+            # would hand it to allocation.
             if user_status == DoorLock.UserStatus.Available:
                 slot_states[slot_num] = SlotCredential.empty()
-            elif pin_code:
+            elif user_status == DoorLock.UserStatus.Enabled and pin_code:
                 slot_states[slot_num] = SlotCredential.known(pin_code)
             else:
                 slot_states[slot_num] = SlotCredential.unreadable()

--- a/custom_components/lock_code_manager/providers/zigbee2mqtt.py
+++ b/custom_components/lock_code_manager/providers/zigbee2mqtt.py
@@ -372,18 +372,25 @@ class Zigbee2MQTTLock(BaseLock):
                 if not future.done():
                     user_enabled = pin_code_data.get("user_enabled", False)
                     pin_code = pin_code_data.get("pin_code")
-                    if not _mqtt_payload_pin_has_code_value(pin_code):
-                        # No value came back. This reply carries no status to
-                        # tell an empty slot from a withheld code, so the
-                        # answer stays what it has always been.
-                        future.set_result(SlotCredential.empty())
-                    elif user_enabled:
-                        future.set_result(SlotCredential.known(str(pin_code)))
-                    else:
-                        # A code is plainly here; the lock is just not
-                        # accepting it. Discarding the reply as empty would
-                        # hand the index to allocation.
+                    if _mqtt_payload_pin_has_code_value(pin_code):
+                        # A code is plainly here. Whether the lock is
+                        # currently accepting it decides only whether the
+                        # value can be compared, not whether the index is
+                        # taken.
+                        future.set_result(
+                            SlotCredential.known(str(pin_code))
+                            if user_enabled
+                            else SlotCredential.unreadable()
+                        )
+                    elif user_enabled and "pin_code" not in pin_code_data:
+                        # Enabled, and the code withheld rather than reported
+                        # -- ``expose_pin`` off. The same state the users
+                        # object reports, and the same answer it gives.
                         future.set_result(SlotCredential.unreadable())
+                    else:
+                        # Either the lock says nothing is enabled here, or it
+                        # answered the code explicitly with nothing.
+                        future.set_result(SlotCredential.empty())
 
     async def _async_ensure_device_subscription(self) -> None:
         """Subscribe to the Z2M device topic; idempotent and drift-aware."""

--- a/custom_components/lock_code_manager/providers/zigbee2mqtt.py
+++ b/custom_components/lock_code_manager/providers/zigbee2mqtt.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Collection
 from dataclasses import dataclass, field
 from datetime import timedelta
 import json
@@ -624,9 +625,9 @@ class Zigbee2MQTTLock(BaseLock):
         self._push_credential_update(code_slot, SlotCredential.empty())
         return True
 
-    async def async_get_users(self) -> list[User]:
+    async def async_get_users(self, slots: Collection[int] | None = None) -> list[User]:
         """
-        Read Personal Identification Number codes from all managed slots.
+        Read Personal Identification Number codes one index at a time.
 
         Queries Zigbee2MQTT one slot at a time over MQTT so the bridge can
         respond to each GET before the next. Transient publish/timeout/read
@@ -660,29 +661,26 @@ class Zigbee2MQTTLock(BaseLock):
         if not get_topic:
             raise LockDisconnected("Could not determine MQTT topic")
 
-        # Get configured code slots for this lock (any LCM entry that includes this lock).
-        code_slots = self.managed_slots
+        # One request per index, so the caller's scope bounds the work.
+        code_slots = self.managed_slots if slots is None else slots
 
         if not code_slots:
             return []
 
         slot_states = {
             slot_num: await self._async_read_slot(slot_num, get_topic)
-            or SlotCredential.unreadable()
             for slot_num in sorted(code_slots)
         }
         return [user_from_slot(slot, state) for slot, state in slot_states.items()]
 
-    async def _async_read_slot(
-        self, slot_num: int, get_topic: str
-    ) -> SlotCredential | None:
+    async def _async_read_slot(self, slot_num: int, get_topic: str) -> SlotCredential:
         """
         Ask the lock for one slot and wait for the answer.
 
-        Returns ``None`` when the lock did not answer at all. That is a
-        different thing from ``SlotCredential.unreadable()``, which says the
-        slot holds a code whose value is write-only -- callers that must not
-        confuse "no answer" with "occupied" need the two kept apart.
+        A publish failure, a timeout, or an unusable reply all produce
+        ``unreadable`` rather than ``empty``: sync must not take a transient
+        MQTT problem for a confirmed-empty slot and storm reprogramming once
+        MQTT recovers.
 
         Slots are queried one at a time so Zigbee2MQTT and the firmware can
         answer each GET before the next. A parallel gather with per-slot
@@ -709,7 +707,7 @@ class Zigbee2MQTTLock(BaseLock):
                 err,
             )
             self._pending_codes.pop(slot_num, None)
-            return None
+            return SlotCredential.unreadable()
 
         try:
             result = await asyncio.wait_for(future, timeout=10.0)
@@ -719,7 +717,7 @@ class Zigbee2MQTTLock(BaseLock):
                 self.lock.entity_id,
                 slot_num,
             )
-            credential = None
+            credential = SlotCredential.unreadable()
         except Exception as err:
             # Broad catch is intentional: the future is resolved by the MQTT
             # callback, and any exception from resolution (InvalidStateError,
@@ -731,39 +729,12 @@ class Zigbee2MQTTLock(BaseLock):
                 slot_num,
                 err,
             )
-            credential = None
+            credential = SlotCredential.unreadable()
         else:
             credential = result
         finally:
             self._pending_codes.pop(slot_num, None)
         return credential
-
-    async def async_get_occupied_indices(self, limit: int) -> frozenset[int] | None:
-        """
-        Ask the lock about each index in turn, up to ``limit``.
-
-        Zigbee2MQTT answers one index per request, which is why the caller
-        bounds the range rather than the whole advertised capacity being
-        walked.
-
-        A single index that cannot be read makes the whole answer unknown.
-        Returning the rest would understate what is occupied, and an
-        understated answer is the one that overwrites a code.
-        """
-        if not await self.async_is_integration_connected():
-            return None
-        get_topic = self._get_topic("get")
-        if not get_topic:
-            return None
-
-        occupied: set[int] = set()
-        for slot_num in range(1, limit + 1):
-            credential = await self._async_read_slot(slot_num, get_topic)
-            if credential is None:
-                return None
-            if credential.is_present:
-                occupied.add(slot_num)
-        return frozenset(occupied)
 
     async def async_hard_refresh_codes(self) -> dict[int, SlotCredential]:
         """Perform hard refresh and return all codes."""

--- a/custom_components/lock_code_manager/providers/zigbee2mqtt.py
+++ b/custom_components/lock_code_manager/providers/zigbee2mqtt.py
@@ -687,11 +687,6 @@ class Zigbee2MQTTLock(BaseLock):
         timeouts can fail an entire refresh and leave the coordinator with no
         data, which makes sync skip every slot (see
         ``SlotSyncManager._resolve_credential_snapshot``).
-
-        Publish, timeout and read failures all produce an unreadable
-        credential rather than an empty one, so sync does not take a
-        transient MQTT problem for a confirmed-empty slot and storm
-        reprogramming once MQTT recovers.
         """
         loop = asyncio.get_running_loop()
         future = loop.create_future()

--- a/custom_components/lock_code_manager/providers/zigbee2mqtt.py
+++ b/custom_components/lock_code_manager/providers/zigbee2mqtt.py
@@ -666,60 +666,104 @@ class Zigbee2MQTTLock(BaseLock):
         if not code_slots:
             return []
 
-        loop = asyncio.get_running_loop()
-        slot_states: dict[int, SlotCredential] = {}
-
-        # Query one slot at a time so Zigbee2MQTT / firmware can answer each GET before
-        # the next. Parallel gather + per-slot timeouts can fail the entire refresh and
-        # leave coordinator.data empty -- sync then skips every slot (see
-        # SlotSyncManager._resolve_credential_snapshot).
-        # Transient publish/timeout/read failures use the unreadable credential so sync
-        # does not treat the slot as confirmed-empty and storm reprogramming after MQTT
-        # recovery.
-        for slot_num in sorted(code_slots):
-            future = loop.create_future()
-            self._pending_codes[slot_num] = future
-            payload = json.dumps({"pin_code": {"user": slot_num}})
-            try:
-                await async_publish(self.hass, get_topic, payload)
-            except (HomeAssistantError, OSError) as err:
-                LOGGER.debug(
-                    "MQTT publish failed for PIN get %s slot %s: %s",
-                    self.lock.entity_id,
-                    slot_num,
-                    err,
-                )
-                slot_states[slot_num] = SlotCredential.unreadable()
-                self._pending_codes.pop(slot_num, None)
-                continue
-
-            try:
-                result = await asyncio.wait_for(future, timeout=10.0)
-            except TimeoutError:
-                LOGGER.debug(
-                    "Timeout waiting for PIN code response for %s slot %s",
-                    self.lock.entity_id,
-                    slot_num,
-                )
-                slot_states[slot_num] = SlotCredential.unreadable()
-            except Exception as err:
-                # Broad catch is intentional: the future is resolved by the MQTT
-                # callback, and any exception from resolution (InvalidStateError,
-                # data processing errors) should not crash the entire refresh.
-                # CancelledError is BaseException in Python 3.11+ and propagates.
-                LOGGER.warning(
-                    "Unexpected error getting PIN for %s slot %s: %s",
-                    self.lock.entity_id,
-                    slot_num,
-                    err,
-                )
-                slot_states[slot_num] = SlotCredential.unreadable()
-            else:
-                slot_states[slot_num] = result
-            finally:
-                self._pending_codes.pop(slot_num, None)
-
+        slot_states = {
+            slot_num: await self._async_read_slot(slot_num, get_topic)
+            or SlotCredential.unreadable()
+            for slot_num in sorted(code_slots)
+        }
         return [user_from_slot(slot, state) for slot, state in slot_states.items()]
+
+    async def _async_read_slot(
+        self, slot_num: int, get_topic: str
+    ) -> SlotCredential | None:
+        """
+        Ask the lock for one slot and wait for the answer.
+
+        Returns ``None`` when the lock did not answer at all. That is a
+        different thing from ``SlotCredential.unreadable()``, which says the
+        slot holds a code whose value is write-only -- callers that must not
+        confuse "no answer" with "occupied" need the two kept apart.
+
+        Slots are queried one at a time so Zigbee2MQTT and the firmware can
+        answer each GET before the next. A parallel gather with per-slot
+        timeouts can fail an entire refresh and leave the coordinator with no
+        data, which makes sync skip every slot (see
+        ``SlotSyncManager._resolve_credential_snapshot``).
+
+        Publish, timeout and read failures all produce an unreadable
+        credential rather than an empty one, so sync does not take a
+        transient MQTT problem for a confirmed-empty slot and storm
+        reprogramming once MQTT recovers.
+        """
+        loop = asyncio.get_running_loop()
+        future = loop.create_future()
+        self._pending_codes[slot_num] = future
+        payload = json.dumps({"pin_code": {"user": slot_num}})
+        try:
+            await async_publish(self.hass, get_topic, payload)
+        except (HomeAssistantError, OSError) as err:
+            LOGGER.debug(
+                "MQTT publish failed for PIN get %s slot %s: %s",
+                self.lock.entity_id,
+                slot_num,
+                err,
+            )
+            self._pending_codes.pop(slot_num, None)
+            return None
+
+        try:
+            result = await asyncio.wait_for(future, timeout=10.0)
+        except TimeoutError:
+            LOGGER.debug(
+                "Timeout waiting for PIN code response for %s slot %s",
+                self.lock.entity_id,
+                slot_num,
+            )
+            credential = None
+        except Exception as err:
+            # Broad catch is intentional: the future is resolved by the MQTT
+            # callback, and any exception from resolution (InvalidStateError,
+            # data processing errors) should not crash the entire refresh.
+            # CancelledError is BaseException in Python 3.11+ and propagates.
+            LOGGER.warning(
+                "Unexpected error getting PIN for %s slot %s: %s",
+                self.lock.entity_id,
+                slot_num,
+                err,
+            )
+            credential = None
+        else:
+            credential = result
+        finally:
+            self._pending_codes.pop(slot_num, None)
+        return credential
+
+    async def async_get_occupied_indices(self, limit: int) -> frozenset[int] | None:
+        """
+        Ask the lock about each index in turn, up to ``limit``.
+
+        Zigbee2MQTT answers one index per request, which is why the caller
+        bounds the range rather than the whole advertised capacity being
+        walked.
+
+        A single index that cannot be read makes the whole answer unknown.
+        Returning the rest would understate what is occupied, and an
+        understated answer is the one that overwrites a code.
+        """
+        if not await self.async_is_integration_connected():
+            return None
+        get_topic = self._get_topic("get")
+        if not get_topic:
+            return None
+
+        occupied: set[int] = set()
+        for slot_num in range(1, limit + 1):
+            credential = await self._async_read_slot(slot_num, get_topic)
+            if credential is None:
+                return None
+            if credential.is_present:
+                occupied.add(slot_num)
+        return frozenset(occupied)
 
     async def async_hard_refresh_codes(self) -> dict[int, SlotCredential]:
         """Perform hard refresh and return all codes."""

--- a/custom_components/lock_code_manager/providers/zigbee2mqtt.py
+++ b/custom_components/lock_code_manager/providers/zigbee2mqtt.py
@@ -87,8 +87,11 @@ def _project_z2m_user_state(user_info: dict[str, Any]) -> SlotCredential:
     - The one exception: an explicit ``pin_code: null`` on an enabled user
       means the broker exposes the field and the device reports no code,
       so that projects to empty.
-    - Unrecognized statuses (``not_supported_*``) project to unreadable,
-      not empty, for the same reprogramming-storm reason.
+    - ``available`` is the only status that means the slot holds nothing.
+      ``disabled`` is a user the lock is refusing, and unrecognized statuses
+      (``not_supported_*``) say nothing at all, so both project to
+      unreadable for the same reprogramming-storm reason -- and so that
+      allocation does not read either as a free credential index.
     """
     status = user_info.get("status")
     pin_raw = user_info.get("pin_code")
@@ -98,8 +101,11 @@ def _project_z2m_user_state(user_info: dict[str, Any]) -> SlotCredential:
         if "pin_code" in user_info:
             return SlotCredential.empty()
         return SlotCredential.unreadable()
-    if status in ("available", "disabled"):
+    if status == "available":
         return SlotCredential.empty()
+    # ``disabled`` is a user the lock is holding and not accepting, not a
+    # free slot. Reporting it empty tells allocation the index is available
+    # and tells sync the slot is confirmed cleared.
     return SlotCredential.unreadable()
 
 
@@ -366,10 +372,18 @@ class Zigbee2MQTTLock(BaseLock):
                 if not future.done():
                     user_enabled = pin_code_data.get("user_enabled", False)
                     pin_code = pin_code_data.get("pin_code")
-                    if user_enabled and _mqtt_payload_pin_has_code_value(pin_code):
+                    if not _mqtt_payload_pin_has_code_value(pin_code):
+                        # No value came back. This reply carries no status to
+                        # tell an empty slot from a withheld code, so the
+                        # answer stays what it has always been.
+                        future.set_result(SlotCredential.empty())
+                    elif user_enabled:
                         future.set_result(SlotCredential.known(str(pin_code)))
                     else:
-                        future.set_result(SlotCredential.empty())
+                        # A code is plainly here; the lock is just not
+                        # accepting it. Discarding the reply as empty would
+                        # hand the index to allocation.
+                        future.set_result(SlotCredential.unreadable())
 
     async def _async_ensure_device_subscription(self) -> None:
         """Subscribe to the Z2M device topic; idempotent and drift-aware."""

--- a/custom_components/lock_code_manager/providers/zwave_js.py
+++ b/custom_components/lock_code_manager/providers/zwave_js.py
@@ -8,7 +8,7 @@ provider's role in the data flow.
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Collection
 from dataclasses import dataclass, field
 from datetime import timedelta
 import logging
@@ -259,21 +259,7 @@ class ZWaveJSLock(BaseLock):
             return SlotCredential.unreadable()
         return SlotCredential.known(code)
 
-    async def async_get_occupied_indices(self, limit: int) -> frozenset[int] | None:
-        """
-        Report occupancy from the node read, which already covers every user.
-
-        ``async_get_users`` is not scoped to the slots Lock Code Manager
-        manages here, so a code programmed by hand is already in the answer.
-        """
-        return frozenset(
-            credential.slot
-            for user in await self.async_get_users()
-            for credential in user.pin_credentials
-            if credential.is_present and credential.slot <= limit
-        )
-
-    async def async_get_users(self) -> list[User]:
+    async def async_get_users(self, slots: Collection[int] | None = None) -> list[User]:
         """
         Read every user and all of their credentials from the lock.
 
@@ -287,6 +273,10 @@ class ZWaveJSLock(BaseLock):
         extra read. Z-Wave credential types with no domain equivalent
         (BLE, UWB, DESFIRE, unspecified/eye/hand biometrics) are
         dropped.
+
+        ``slots`` is ignored: the node read covers every user in one call,
+        so narrowing the question would save nothing. The projection bounds
+        the answer.
 
         Uses the unified ``access_control`` API which dispatches to UC
         or U3C internally per node-zwave-js v15.24.3+. A User Code CC
@@ -330,7 +320,9 @@ class ZWaveJSLock(BaseLock):
             )
         return list(users_by_id.values())
 
-    async def async_get_usercodes(self) -> dict[int, SlotCredential]:
+    async def async_get_usercodes(
+        self, slots: Collection[int] | None = None
+    ) -> dict[int, SlotCredential]:
         """
         Project to slots, then rescue occupied slots the unified read left valueless.
 
@@ -340,7 +332,7 @@ class ZWaveJSLock(BaseLock):
         from the value database must not redirect which user a write
         targets. Read-repair belongs to the read.
         """
-        codes = await super().async_get_usercodes()
+        codes = await super().async_get_usercodes(slots)
         return self._overlay_uc_occupancy(codes)
 
     def _overlay_uc_occupancy(

--- a/custom_components/lock_code_manager/providers/zwave_js.py
+++ b/custom_components/lock_code_manager/providers/zwave_js.py
@@ -275,8 +275,8 @@ class ZWaveJSLock(BaseLock):
         dropped.
 
         ``slots`` is ignored: the node read covers every user in one call,
-        so narrowing the question would save nothing. The projection bounds
-        the answer.
+        so narrowing the question would save nothing. The answer may
+        therefore name slots outside the scope, which callers filter.
 
         Uses the unified ``access_control`` API which dispatches to UC
         or U3C internally per node-zwave-js v15.24.3+. A User Code CC

--- a/custom_components/lock_code_manager/providers/zwave_js.py
+++ b/custom_components/lock_code_manager/providers/zwave_js.py
@@ -259,6 +259,20 @@ class ZWaveJSLock(BaseLock):
             return SlotCredential.unreadable()
         return SlotCredential.known(code)
 
+    async def async_get_occupied_indices(self, limit: int) -> frozenset[int] | None:
+        """
+        Report occupancy from the node read, which already covers every user.
+
+        ``async_get_users`` is not scoped to the slots Lock Code Manager
+        manages here, so a code programmed by hand is already in the answer.
+        """
+        return frozenset(
+            credential.slot
+            for user in await self.async_get_users()
+            for credential in user.pin_credentials
+            if credential.is_present and credential.slot <= limit
+        )
+
     async def async_get_users(self) -> list[User]:
         """
         Read every user and all of their credentials from the lock.

--- a/tests/common.py
+++ b/tests/common.py
@@ -206,9 +206,12 @@ class MockLCMLock(BaseLock):
         codes.update({slot: SlotCredential.unreadable() for slot in self.write_only})
         if slots is None:
             return codes
-        # Answer about exactly what was asked, the way a real lock does: a slot
-        # in the scope that holds nothing is empty, not absent.
-        return {slot: codes.get(slot, SlotCredential.empty()) for slot in slots}
+        # Mirrors the base projection, including the part that matters: a slot
+        # in the scope that holds nothing is empty, and a slot the lock holds
+        # OUTSIDE the scope is still reported. Answering with exactly the
+        # scope would model the one shape where a caller's own bounds check
+        # is a no-op.
+        return {**dict.fromkeys(slots, SlotCredential.empty()), **codes}
 
 
 @dataclass(repr=False, eq=False)

--- a/tests/common.py
+++ b/tests/common.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from collections.abc import Collection
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Literal
@@ -195,13 +196,19 @@ class MockLCMLock(BaseLock):
         self.service_calls["clear_usercode"].append((code_slot,))
         return True
 
-    async def async_get_usercodes(self) -> dict[int, SlotCredential]:
+    async def async_get_usercodes(
+        self, slots: Collection[int] | None = None
+    ) -> dict[int, SlotCredential]:
         """Return dictionary of code slots and usercodes."""
         snapshot = self.codes.copy()
         self.service_calls["get_usercodes"].append(snapshot)
         codes = {slot: SlotCredential.known(pin) for slot, pin in snapshot.items()}
         codes.update({slot: SlotCredential.unreadable() for slot in self.write_only})
-        return codes
+        if slots is None:
+            return codes
+        # Answer about exactly what was asked, the way a real lock does: a slot
+        # in the scope that holds nothing is empty, not absent.
+        return {slot: codes.get(slot, SlotCredential.empty()) for slot in slots}
 
 
 @dataclass(repr=False, eq=False)

--- a/tests/providers/akuvox/test_provider.py
+++ b/tests/providers/akuvox/test_provider.py
@@ -1048,7 +1048,9 @@ async def test_occupied_indices_sees_tags_no_entry_manages(
     with patch.object(akuvox_lock, "_async_list_users", AsyncMock(return_value=users)):
         # The untagged user claims no slot: an Akuvox user is addressed by its
         # own identifier, not by a slot number.
-        assert await akuvox_lock.async_get_occupied_indices(10) == frozenset({1, 7})
+        codes = await akuvox_lock.async_get_usercodes(range(1, 11))
+    assert codes[1].is_present
+    assert codes[7].is_present
 
 
 async def test_occupied_indices_ignores_users_from_elsewhere(
@@ -1060,4 +1062,23 @@ async def test_occupied_indices_ignores_users_from_elsewhere(
         {"name": "lcm:4:FromCloud", "source_type": "9", "private_pin": "5678"},
     ]
     with patch.object(akuvox_lock, "_async_list_users", AsyncMock(return_value=users)):
-        assert await akuvox_lock.async_get_occupied_indices(10) == frozenset({1})
+        codes = await akuvox_lock.async_get_usercodes(range(1, 11))
+    assert codes[1].is_present
+    assert codes[4].is_empty
+
+
+async def test_list_users_without_a_user_list_is_an_error(
+    akuvox_lock: AkuvoxLock,
+) -> None:
+    """A response carrying no user list is a shape we do not understand.
+
+    Reading it as a device with no users would report every slot as free,
+    which is the answer that gets a real credential overwritten.
+    """
+    with (
+        patch.object(
+            akuvox_lock, "async_call_service", AsyncMock(return_value={"ok": True})
+        ),
+        pytest.raises(LockCodeManagerError, match="no 'users' key"),
+    ):
+        await akuvox_lock._async_list_users()

--- a/tests/providers/akuvox/test_provider.py
+++ b/tests/providers/akuvox/test_provider.py
@@ -1034,3 +1034,30 @@ class TestBaseOrchestration:
         codes = await akuvox_lock.async_get_usercodes()
         assert codes[1] is SlotCredential.empty()
         assert codes[2] is SlotCredential.empty()
+
+
+async def test_occupied_indices_sees_tags_no_entry_manages(
+    akuvox_lock: AkuvoxLock,
+) -> None:
+    """A tag left behind by a removed configuration still claims its number."""
+    users = [
+        {"name": "lcm:1:Raman", "source_type": "1", "private_pin": "1234"},
+        {"name": "lcm:7:Departed", "source_type": "1", "private_pin": "5678"},
+        {"name": "Cleaner", "source_type": "1", "private_pin": "9999"},
+    ]
+    with patch.object(akuvox_lock, "_async_list_users", AsyncMock(return_value=users)):
+        # The untagged user claims no slot: an Akuvox user is addressed by its
+        # own identifier, not by a slot number.
+        assert await akuvox_lock.async_get_occupied_indices(10) == frozenset({1, 7})
+
+
+async def test_occupied_indices_ignores_users_from_elsewhere(
+    akuvox_lock: AkuvoxLock,
+) -> None:
+    """Only users created on the device itself are the device's own."""
+    users = [
+        {"name": "lcm:1:Raman", "source_type": "1", "private_pin": "1234"},
+        {"name": "lcm:4:FromCloud", "source_type": "9", "private_pin": "5678"},
+    ]
+    with patch.object(akuvox_lock, "_async_list_users", AsyncMock(return_value=users)):
+        assert await akuvox_lock.async_get_occupied_indices(10) == frozenset({1})

--- a/tests/providers/akuvox/test_provider.py
+++ b/tests/providers/akuvox/test_provider.py
@@ -1067,9 +1067,11 @@ async def test_occupied_indices_ignores_users_from_elsewhere(
     assert codes[4].is_empty
 
 
-@pytest.mark.parametrize("users", [None, {"1": "a"}, "nope"])
+@pytest.mark.parametrize(
+    "response", [{}, {"users": None}, {"users": {"1": "a"}}, {"users": "nope"}]
+)
 async def test_list_users_without_a_usable_user_list_is_an_error(
-    akuvox_lock: AkuvoxLock, users: object
+    akuvox_lock: AkuvoxLock, response: dict
 ) -> None:
     """A response carrying no usable user list is a shape we do not understand.
 
@@ -1082,7 +1084,7 @@ async def test_list_users_without_a_usable_user_list_is_an_error(
         patch.object(
             akuvox_lock,
             "async_call_service",
-            AsyncMock(return_value={"users": users}),
+            AsyncMock(return_value=response),
         ),
         pytest.raises(LockCodeManagerError, match="expected a list of users"),
     ):

--- a/tests/providers/akuvox/test_provider.py
+++ b/tests/providers/akuvox/test_provider.py
@@ -1067,18 +1067,23 @@ async def test_occupied_indices_ignores_users_from_elsewhere(
     assert codes[4].is_empty
 
 
-async def test_list_users_without_a_user_list_is_an_error(
-    akuvox_lock: AkuvoxLock,
+@pytest.mark.parametrize("users", [None, {"1": "a"}, "nope"])
+async def test_list_users_without_a_usable_user_list_is_an_error(
+    akuvox_lock: AkuvoxLock, users: object
 ) -> None:
-    """A response carrying no user list is a shape we do not understand.
+    """A response carrying no usable user list is a shape we do not understand.
 
     Reading it as a device with no users would report every slot as free,
-    which is the answer that gets a real credential overwritten.
+    which is the answer that gets a real credential overwritten. A wrongly
+    typed value has to raise for the same reason -- and has to raise the
+    integration's own error, or it escapes every handler as a bare TypeError.
     """
     with (
         patch.object(
-            akuvox_lock, "async_call_service", AsyncMock(return_value={"ok": True})
+            akuvox_lock,
+            "async_call_service",
+            AsyncMock(return_value={"users": users}),
         ),
-        pytest.raises(LockCodeManagerError, match="no 'users' key"),
+        pytest.raises(LockCodeManagerError, match="expected a list of users"),
     ):
         await akuvox_lock._async_list_users()

--- a/tests/providers/matter/test_provider.py
+++ b/tests/providers/matter/test_provider.py
@@ -2024,6 +2024,36 @@ class TestGetUsers:
         cred = users[0].credentials[0]
         assert cred.slot == 5
 
+    async def test_scoped_read_surfaces_a_user_created_on_the_keypad(
+        self, hass: HomeAssistant, matter_lock: MatterLock
+    ) -> None:
+        """A wide scope still reports users this integration never wrote.
+
+        Matter is the one provider where the slot number is not the device's
+        credential index, so what comes back is the Lock Code Manager slot --
+        recovered from the tag, or the credential index itself for an
+        untagged user, which is exactly what a code added on the keypad looks
+        like. Allocation knows not to read a device index into that; it still
+        must not hand the number out twice.
+        """
+        mock_get_lock_users = AsyncMock(
+            return_value={
+                "max_users": 10,
+                "users": [
+                    {
+                        "user_index": 1,
+                        "user_name": "Added at the door",
+                        "credentials": [{"type": "pin", "index": 4}],
+                    },
+                ],
+            }
+        )
+        with patch(f"{_PROVIDER_MODULE}.get_lock_users", mock_get_lock_users):
+            codes = await matter_lock.async_get_usercodes(range(1, 6))
+
+        assert codes[4].is_present
+        assert codes[1].is_empty
+
     async def test_get_users_non_pin_credentials_excluded(
         self, hass: HomeAssistant, matter_lock: MatterLock
     ) -> None:

--- a/tests/providers/schlage/test_provider.py
+++ b/tests/providers/schlage/test_provider.py
@@ -1086,7 +1086,9 @@ async def test_occupied_indices_sees_tags_no_entry_manages(
 
     # Slot 7 is tagged but unmanaged; the untagged code claims no slot at all,
     # because a Schlage code is addressed by its own identifier.
-    assert await schlage_lock.async_get_occupied_indices(10) == frozenset({1, 7})
+    codes = await schlage_lock.async_get_usercodes(range(1, 11))
+    assert codes[1].is_present
+    assert codes[7].is_present
 
 
 async def test_occupied_indices_respects_the_limit(
@@ -1105,4 +1107,6 @@ async def test_occupied_indices_respects_the_limit(
         hass, SCHLAGE_DOMAIN, "get_codes", AsyncMock(return_value=mock_response)
     )
 
-    assert await schlage_lock.async_get_occupied_indices(5) == frozenset({1})
+    codes = await schlage_lock.async_get_usercodes(range(1, 6))
+    assert codes[1].is_present
+    assert 9 not in codes

--- a/tests/providers/schlage/test_provider.py
+++ b/tests/providers/schlage/test_provider.py
@@ -1061,3 +1061,48 @@ async def test_base_orchestration_clear(
     codes = await schlage_lock.async_get_usercodes()
     assert codes[1] is SlotCredential.empty()
     assert codes[2] is SlotCredential.empty()
+
+
+async def test_occupied_indices_sees_tags_no_entry_manages(
+    hass: HomeAssistant,
+    schlage_lock: SchlageLock,
+    simple_lcm_config_entry: MockConfigEntry,
+) -> None:
+    """A tag left behind by a removed configuration still claims its number.
+
+    Nothing else knows about it: the slot is not in any entry's managed set,
+    so allocation would happily issue it and land on the orphaned code.
+    """
+    mock_response = {
+        LOCK_ENTITY_ID: {
+            "code-a": {"name": "lcm:1:Raman", "code": "1234"},
+            "code-b": {"name": "lcm:7:Departed", "code": "5678"},
+            "code-c": {"name": "Cleaner", "code": "9999"},
+        }
+    }
+    register_mock_service(
+        hass, SCHLAGE_DOMAIN, "get_codes", AsyncMock(return_value=mock_response)
+    )
+
+    # Slot 7 is tagged but unmanaged; the untagged code claims no slot at all,
+    # because a Schlage code is addressed by its own identifier.
+    assert await schlage_lock.async_get_occupied_indices(10) == frozenset({1, 7})
+
+
+async def test_occupied_indices_respects_the_limit(
+    hass: HomeAssistant,
+    schlage_lock: SchlageLock,
+    simple_lcm_config_entry: MockConfigEntry,
+) -> None:
+    """Numbers beyond the window the caller asked about are not reported."""
+    mock_response = {
+        LOCK_ENTITY_ID: {
+            "code-a": {"name": "lcm:1:Raman", "code": "1234"},
+            "code-b": {"name": "lcm:9:Far", "code": "5678"},
+        }
+    }
+    register_mock_service(
+        hass, SCHLAGE_DOMAIN, "get_codes", AsyncMock(return_value=mock_response)
+    )
+
+    assert await schlage_lock.async_get_occupied_indices(5) == frozenset({1})

--- a/tests/providers/test_base.py
+++ b/tests/providers/test_base.py
@@ -184,6 +184,22 @@ def _bare_lock(hass: HomeAssistant, unique_id: str) -> MockLCMLock:
     return MockLCMLock(hass, dr.async_get(hass), entity_reg, config_entry, lock_entity)
 
 
+async def test_occupied_indices_reads_a_real_provider_end_to_end(
+    hass: HomeAssistant,
+) -> None:
+    """The derivation runs against a provider read, not a stubbed one.
+
+    Every other test here patches ``async_get_usercodes``, which proves the
+    filtering and nothing about the seam it sits on. This one drives a
+    provider that implements the scope, so a signature that cannot accept it
+    fails here rather than in whatever lands next.
+    """
+    lock = _bare_lock(hass, "test_lock_occupancy_end_to_end")
+    lock.codes = {2: "1234", 9: "5678"}
+
+    assert await lock.async_internal_get_occupied_indices(5) == frozenset({2})
+
+
 async def test_occupied_indices_counts_everything_the_lock_holds(
     hass: HomeAssistant,
 ) -> None:

--- a/tests/providers/test_base.py
+++ b/tests/providers/test_base.py
@@ -36,6 +36,7 @@ from custom_components.lock_code_manager.domain.credentials import (
 )
 from custom_components.lock_code_manager.domain.exceptions import (
     DuplicateCodeError,
+    LockCodeManagerProviderError,
     LockDisconnected,
     LockOperationFailed,
     ProviderNotImplementedError,
@@ -246,28 +247,36 @@ async def test_occupied_indices_counts_everything_the_lock_holds(
     lock = _bare_lock(hass, "test_lock_occupancy_derivation")
 
     codes = {
+        0: SlotCredential.known("0000"),
         1: SlotCredential.known("1234"),
         2: SlotCredential.empty(),
         3: SlotCredential.unreadable(),
         12: SlotCredential.known("9999"),
     }
     with patch.object(lock, "async_get_usercodes", AsyncMock(return_value=codes)):
-        # 12 is outside the window the caller asked about.
+        # 0 and 12 are both outside the window the caller asked about. A lock
+        # numbering from zero is not one this allocates into.
         assert await lock.async_internal_get_occupied_indices(10) == frozenset({1, 3})
 
 
 async def test_occupied_indices_is_unknown_when_the_lock_cannot_be_read(
     hass: HomeAssistant,
 ) -> None:
-    """A lock that cannot be reached reports unknown, never empty."""
+    """A lock that cannot be read reports unknown, never empty.
+
+    Every failure this integration raises has to land here. One that escapes
+    reaches a caller with no answer at all, where the safe reading -- refuse
+    -- is the one it cannot make.
+    """
     lock = _bare_lock(hass, "test_lock_occupancy_error")
 
-    with patch.object(
-        lock,
-        "async_get_usercodes",
-        AsyncMock(side_effect=LockDisconnected("asleep")),
+    for error in (
+        LockDisconnected("asleep"),
+        LockCodeManagerProviderError("malformed response"),
+        LockOperationFailed("read rejected"),
     ):
-        assert await lock.async_internal_get_occupied_indices(10) is None
+        with patch.object(lock, "async_get_usercodes", AsyncMock(side_effect=error)):
+            assert await lock.async_internal_get_occupied_indices(10) is None
 
 
 async def test_occupied_indices_asks_only_about_the_window(

--- a/tests/providers/test_base.py
+++ b/tests/providers/test_base.py
@@ -1,6 +1,7 @@
 """Test base class."""
 
 import asyncio
+from collections.abc import Collection
 from datetime import datetime, timedelta
 import logging
 import time
@@ -173,15 +174,43 @@ async def test_describe_link_health_defaults_to_none(hass: HomeAssistant) -> Non
     assert lock.describe_link_health() is None
 
 
-def _bare_lock(hass: HomeAssistant, unique_id: str) -> MockLCMLock:
-    """Build a reachable lock whose read can be stubbed."""
+def _lock_args(hass: HomeAssistant, unique_id: str) -> tuple:
+    """Build the positional arguments every provider is constructed with."""
     entity_reg = er.async_get(hass)
     config_entry = MockConfigEntry(domain=DOMAIN)
     config_entry.add_to_hass(hass)
     lock_entity = entity_reg.async_get_or_create(
         "lock", "test", unique_id, config_entry=config_entry
     )
-    return MockLCMLock(hass, dr.async_get(hass), entity_reg, config_entry, lock_entity)
+    return (hass, dr.async_get(hass), entity_reg, config_entry, lock_entity)
+
+
+def _bare_lock(hass: HomeAssistant, unique_id: str) -> MockLCMLock:
+    """Build a reachable lock whose read can be stubbed."""
+    return MockLCMLock(*_lock_args(hass, unique_id))
+
+
+class _ScopedReadLock(MockLCMLock):
+    """A lock that can only answer about the indices it was asked about.
+
+    The shape of ZHA and Zigbee2MQTT, which cost one device round trip per
+    index. For these the scope is not an optimization -- a read that loses it
+    answers a different question entirely.
+    """
+
+    async def async_get_usercodes(
+        self, slots: Collection[int] | None = None
+    ) -> dict[int, SlotCredential]:
+        """Answer about exactly the scope, and nothing else."""
+        scope = self.managed_slots if slots is None else slots
+        return {
+            slot: (
+                SlotCredential.known(self.codes[slot])
+                if slot in self.codes
+                else SlotCredential.empty()
+            )
+            for slot in scope
+        }
 
 
 async def test_occupied_indices_reads_a_real_provider_end_to_end(
@@ -190,13 +219,18 @@ async def test_occupied_indices_reads_a_real_provider_end_to_end(
     """The derivation runs against a provider read, not a stubbed one.
 
     Every other test here patches ``async_get_usercodes``, which proves the
-    filtering and nothing about the seam it sits on. This one drives a
-    provider that implements the scope, so a signature that cannot accept it
-    fails here rather than in whatever lands next.
+    filtering and nothing about the seam under it. This drives a provider
+    that can only answer about the indices it was given, so a derivation that
+    dropped the scope would ask about the slots this entry manages -- none --
+    and report an empty lock.
     """
-    lock = _bare_lock(hass, "test_lock_occupancy_end_to_end")
+    lock = _ScopedReadLock(
+        *_lock_args(hass, "test_lock_occupancy_end_to_end"),
+    )
     lock.codes = {2: "1234", 9: "5678"}
 
+    assert not lock.managed_slots
+    # 9 is real but outside the window, so it is not an answer to this question.
     assert await lock.async_internal_get_occupied_indices(5) == frozenset({2})
 
 

--- a/tests/providers/test_base.py
+++ b/tests/providers/test_base.py
@@ -173,49 +173,64 @@ async def test_describe_link_health_defaults_to_none(hass: HomeAssistant) -> Non
     assert lock.describe_link_health() is None
 
 
-async def test_occupied_indices_defaults_to_unknown(hass: HomeAssistant) -> None:
-    """A provider that cannot report occupancy refuses by default.
-
-    Returning an empty set instead would make every unimplemented provider
-    look like an empty lock, and allocation would issue indices over codes it
-    never asked about.
-    """
+def _bare_lock(hass: HomeAssistant, unique_id: str) -> MockLCMLock:
+    """Build a reachable lock whose read can be stubbed."""
     entity_reg = er.async_get(hass)
     config_entry = MockConfigEntry(domain=DOMAIN)
     config_entry.add_to_hass(hass)
     lock_entity = entity_reg.async_get_or_create(
-        "lock",
-        "test",
-        "test_lock_occupancy_default",
-        config_entry=config_entry,
+        "lock", "test", unique_id, config_entry=config_entry
     )
-    lock = BaseLock(hass, dr.async_get(hass), entity_reg, config_entry, lock_entity)
-
-    assert await lock.async_get_occupied_indices(10) is None
-    assert await lock.async_internal_get_occupied_indices(10) is None
+    return MockLCMLock(hass, dr.async_get(hass), entity_reg, config_entry, lock_entity)
 
 
-async def test_internal_occupied_indices_turns_a_failed_read_into_unknown(
+async def test_occupied_indices_counts_everything_the_lock_holds(
     hass: HomeAssistant,
 ) -> None:
-    """A provider error is unknown, which callers already have to handle."""
-    entity_reg = er.async_get(hass)
-    config_entry = MockConfigEntry(domain=DOMAIN)
-    config_entry.add_to_hass(hass)
-    lock_entity = entity_reg.async_get_or_create(
-        "lock",
-        "test",
-        "test_lock_occupancy_error",
-        config_entry=config_entry,
-    )
-    lock = BaseLock(hass, dr.async_get(hass), entity_reg, config_entry, lock_entity)
+    """Occupancy is derived from the read, so every repair the read does counts.
+
+    An index whose value could not be read still holds something. Reserving
+    it costs a user a slot number; handing it out costs them the code on
+    their door.
+    """
+    lock = _bare_lock(hass, "test_lock_occupancy_derivation")
+
+    codes = {
+        1: SlotCredential.known("1234"),
+        2: SlotCredential.empty(),
+        3: SlotCredential.unreadable(),
+        12: SlotCredential.known("9999"),
+    }
+    with patch.object(lock, "async_get_usercodes", AsyncMock(return_value=codes)):
+        # 12 is outside the window the caller asked about.
+        assert await lock.async_internal_get_occupied_indices(10) == frozenset({1, 3})
+
+
+async def test_occupied_indices_is_unknown_when_the_lock_cannot_be_read(
+    hass: HomeAssistant,
+) -> None:
+    """A lock that cannot be reached reports unknown, never empty."""
+    lock = _bare_lock(hass, "test_lock_occupancy_error")
 
     with patch.object(
         lock,
-        "async_get_occupied_indices",
+        "async_get_usercodes",
         AsyncMock(side_effect=LockDisconnected("asleep")),
     ):
         assert await lock.async_internal_get_occupied_indices(10) is None
+
+
+async def test_occupied_indices_asks_only_about_the_window(
+    hass: HomeAssistant,
+) -> None:
+    """The read is scoped, so a per-index lock is not walked end to end."""
+    lock = _bare_lock(hass, "test_lock_occupancy_window")
+
+    read = AsyncMock(return_value={})
+    with patch.object(lock, "async_get_usercodes", read):
+        await lock.async_internal_get_occupied_indices(3)
+
+    assert list(read.await_args.args[0]) == [1, 2, 3]
 
 
 class _PushSetupRaisesLock(MockLCMLock):

--- a/tests/providers/test_base.py
+++ b/tests/providers/test_base.py
@@ -173,6 +173,51 @@ async def test_describe_link_health_defaults_to_none(hass: HomeAssistant) -> Non
     assert lock.describe_link_health() is None
 
 
+async def test_occupied_indices_defaults_to_unknown(hass: HomeAssistant) -> None:
+    """A provider that cannot report occupancy refuses by default.
+
+    Returning an empty set instead would make every unimplemented provider
+    look like an empty lock, and allocation would issue indices over codes it
+    never asked about.
+    """
+    entity_reg = er.async_get(hass)
+    config_entry = MockConfigEntry(domain=DOMAIN)
+    config_entry.add_to_hass(hass)
+    lock_entity = entity_reg.async_get_or_create(
+        "lock",
+        "test",
+        "test_lock_occupancy_default",
+        config_entry=config_entry,
+    )
+    lock = BaseLock(hass, dr.async_get(hass), entity_reg, config_entry, lock_entity)
+
+    assert await lock.async_get_occupied_indices(10) is None
+    assert await lock.async_internal_get_occupied_indices(10) is None
+
+
+async def test_internal_occupied_indices_turns_a_failed_read_into_unknown(
+    hass: HomeAssistant,
+) -> None:
+    """A provider error is unknown, which callers already have to handle."""
+    entity_reg = er.async_get(hass)
+    config_entry = MockConfigEntry(domain=DOMAIN)
+    config_entry.add_to_hass(hass)
+    lock_entity = entity_reg.async_get_or_create(
+        "lock",
+        "test",
+        "test_lock_occupancy_error",
+        config_entry=config_entry,
+    )
+    lock = BaseLock(hass, dr.async_get(hass), entity_reg, config_entry, lock_entity)
+
+    with patch.object(
+        lock,
+        "async_get_occupied_indices",
+        AsyncMock(side_effect=LockDisconnected("asleep")),
+    ):
+        assert await lock.async_internal_get_occupied_indices(10) is None
+
+
 class _PushSetupRaisesLock(MockLCMLock):
     """Mock lock whose setup_push_subscription raises a configurable error."""
 

--- a/tests/providers/test_seam.py
+++ b/tests/providers/test_seam.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Collection
 from dataclasses import replace
 from typing import Literal
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -105,7 +106,7 @@ class _NativeStubLock(BaseLock):
         user.credentials = []
         return True
 
-    async def async_get_users(self) -> list[User]:
+    async def async_get_users(self, slots: Collection[int] | None = None) -> list[User]:
         return list(self._users.values())
 
     async def async_get_capabilities(self) -> LockCapabilities:
@@ -155,7 +156,7 @@ class _DegenerateStubLock(BaseLock):
         self.calls.append(("delete_credential", ref.user_id, ref.slot))
         return self._slots.pop(ref.slot, None) is not None
 
-    async def async_get_users(self) -> list[User]:
+    async def async_get_users(self, slots: Collection[int] | None = None) -> list[User]:
         return [user_from_slot(slot, state) for slot, state in self._slots.items()]
 
 

--- a/tests/providers/virtual/test_provider.py
+++ b/tests/providers/virtual/test_provider.py
@@ -303,4 +303,5 @@ async def test_occupied_indices_reports_stored_slots(virtual_lock: VirtualLock) 
     virtual_lock._data["3"] = {"code": "1234", "name": "programmed by hand"}
     virtual_lock._data["11"] = {"code": "5678", "name": "beyond the window"}
 
-    assert await virtual_lock.async_get_occupied_indices(10) == frozenset({3})
+    codes = await virtual_lock.async_get_usercodes(range(1, 11))
+    assert codes[3].is_present

--- a/tests/providers/virtual/test_provider.py
+++ b/tests/providers/virtual/test_provider.py
@@ -305,3 +305,6 @@ async def test_occupied_indices_reports_stored_slots(virtual_lock: VirtualLock) 
 
     codes = await virtual_lock.async_get_usercodes(range(1, 11))
     assert codes[3].is_present
+    # Stored slots outside the scope are reported too -- the projection seeds
+    # the scope but never drops what the lock actually holds.
+    assert codes[11].is_present

--- a/tests/providers/virtual/test_provider.py
+++ b/tests/providers/virtual/test_provider.py
@@ -296,3 +296,11 @@ async def test_get_users_returns_user_objects(virtual_lock_with_slots: VirtualLo
     assert user_1.user_id == expected.user_id
     assert user_1.active == expected.active
     assert user_1.pin_credentials[0].state == expected.pin_credentials[0].state
+
+
+async def test_occupied_indices_reports_stored_slots(virtual_lock: VirtualLock) -> None:
+    """The store is the device, so everything in it holds its number."""
+    virtual_lock._data["3"] = {"code": "1234", "name": "programmed by hand"}
+    virtual_lock._data["11"] = {"code": "5678", "name": "beyond the window"}
+
+    assert await virtual_lock.async_get_occupied_indices(10) == frozenset({3})

--- a/tests/providers/zha/test_provider.py
+++ b/tests/providers/zha/test_provider.py
@@ -876,3 +876,99 @@ async def test_programming_event_unparseable_with_coordinator_triggers_refresh(
     await hass.async_block_till_done()
 
     zha_lock.coordinator.async_request_refresh.assert_called_once()
+
+
+async def test_occupied_indices_sees_slots_no_entry_manages(
+    hass: HomeAssistant,
+    zha_lock: ZHALock,
+    simple_lcm_config_entry: MockConfigEntry,
+) -> None:
+    """Occupancy reports codes this integration did not put there.
+
+    ``async_get_users`` is scoped to the slots Lock Code Manager manages
+    because it also decides where writes land. Allocation needs the wider
+    view: a code programmed by hand holds its index just as firmly, and
+    issuing that index to a new user would overwrite it.
+    """
+    cluster = zha_lock._get_door_lock_cluster()
+    assert cluster is not None
+
+    async def mock_get_pin_code(slot_num):
+        # Slot 4 is outside anything this entry manages.
+        if slot_num == 4:
+            return type(
+                "Response",
+                (),
+                {"user_status": DoorLock.UserStatus.Enabled, "code": "9999"},
+            )()
+        return type(
+            "Response",
+            (),
+            {"user_status": DoorLock.UserStatus.Available, "code": ""},
+        )()
+
+    cluster.get_pin_code = AsyncMock(side_effect=mock_get_pin_code)
+
+    assert await zha_lock.async_get_occupied_indices(5) == frozenset({4})
+    # The managed-slot read cannot see it, which is why occupancy is separate.
+    assert 4 not in await zha_lock.async_get_usercodes()
+
+
+async def test_occupied_indices_stops_at_the_limit(
+    hass: HomeAssistant,
+    zha_lock: ZHALock,
+    simple_lcm_config_entry: MockConfigEntry,
+) -> None:
+    """The bound is what keeps a per-index lock from being walked end to end."""
+    cluster = zha_lock._get_door_lock_cluster()
+    assert cluster is not None
+    cluster.get_pin_code = AsyncMock(
+        return_value=type(
+            "Response", (), {"user_status": DoorLock.UserStatus.Available, "code": ""}
+        )()
+    )
+
+    assert await zha_lock.async_get_occupied_indices(3) == frozenset()
+    assert cluster.get_pin_code.await_count == 3
+
+
+async def test_occupied_indices_unknown_when_one_index_fails(
+    hass: HomeAssistant,
+    zha_lock: ZHALock,
+    simple_lcm_config_entry: MockConfigEntry,
+) -> None:
+    """One unreadable index makes the whole answer unknown, not partial.
+
+    A partial answer understates what is occupied, and an understated answer
+    is the one that overwrites a code.
+    """
+    cluster = zha_lock._get_door_lock_cluster()
+    assert cluster is not None
+
+    async def mock_get_pin_code(slot_num):
+        if slot_num == 2:
+            raise OSError("radio dropped")
+        return type(
+            "Response", (), {"user_status": DoorLock.UserStatus.Available, "code": ""}
+        )()
+
+    cluster.get_pin_code = AsyncMock(side_effect=mock_get_pin_code)
+
+    assert await zha_lock.async_get_occupied_indices(3) is None
+
+
+async def test_occupied_indices_counts_a_write_only_slot(
+    hass: HomeAssistant,
+    zha_lock: ZHALock,
+    simple_lcm_config_entry: MockConfigEntry,
+) -> None:
+    """An enabled slot is occupied even when the lock will not return its code."""
+    cluster = zha_lock._get_door_lock_cluster()
+    assert cluster is not None
+    cluster.get_pin_code = AsyncMock(
+        return_value=type(
+            "Response", (), {"user_status": DoorLock.UserStatus.Enabled, "code": ""}
+        )()
+    )
+
+    assert await zha_lock.async_get_occupied_indices(2) == frozenset({1, 2})

--- a/tests/providers/zha/test_provider.py
+++ b/tests/providers/zha/test_provider.py
@@ -1004,3 +1004,56 @@ async def test_unparseable_response_is_unreadable_not_empty(
 
     assert codes[1] is SlotCredential.unreadable()
     assert codes[2] is SlotCredential.unreadable()
+
+
+@pytest.mark.parametrize(
+    ("user_status", "code"),
+    [
+        (DoorLock.UserStatus.Disabled, "1234"),
+        (DoorLock.UserStatus.Disabled, ""),
+        (DoorLock.UserStatus.Not_Supported, ""),
+    ],
+)
+async def test_only_available_means_the_slot_is_free(
+    hass: HomeAssistant,
+    zha_lock: ZHALock,
+    simple_lcm_config_entry: MockConfigEntry,
+    user_status: int,
+    code: str,
+) -> None:
+    """DISABLED holds a code the lock is refusing, not an empty slot.
+
+    The ZCL has four statuses and only AVAILABLE means nothing is there.
+    Reading DISABLED as cleared tells sync to reprogram a slot that already
+    holds a code, and tells allocation the index is free to hand out.
+    """
+    cluster = zha_lock._get_door_lock_cluster()
+    assert cluster is not None
+    cluster.get_pin_code = AsyncMock(
+        return_value=type("Response", (), {"user_status": user_status, "code": code})()
+    )
+
+    codes = await zha_lock.async_get_usercodes(range(1, 3))
+
+    assert codes[1].is_present
+    assert codes[2].is_present
+
+
+async def test_available_is_an_empty_slot(
+    hass: HomeAssistant,
+    zha_lock: ZHALock,
+    simple_lcm_config_entry: MockConfigEntry,
+) -> None:
+    """The one status that does mean cleared still reads as cleared."""
+    cluster = zha_lock._get_door_lock_cluster()
+    assert cluster is not None
+    cluster.get_pin_code = AsyncMock(
+        return_value=type(
+            "Response", (), {"user_status": DoorLock.UserStatus.Available, "code": ""}
+        )()
+    )
+
+    codes = await zha_lock.async_get_usercodes(range(1, 3))
+
+    assert codes[1].is_empty
+    assert codes[2].is_empty

--- a/tests/providers/zha/test_provider.py
+++ b/tests/providers/zha/test_provider.py
@@ -1021,11 +1021,12 @@ async def test_only_available_means_the_slot_is_free(
     user_status: int,
     code: str,
 ) -> None:
-    """DISABLED holds a code the lock is refusing, not an empty slot.
+    """AVAILABLE is the only status that leaves an index free to write to.
 
-    The ZCL has four statuses and only AVAILABLE means nothing is there.
-    Reading DISABLED as cleared tells sync to reprogram a slot that already
-    holds a code, and tells allocation the index is free to hand out.
+    Reading any of the others as cleared tells sync to reprogram the slot and
+    tells allocation to hand the index out. What each of them means beyond
+    "not free" is something this credential model cannot express, so they are
+    reported alike.
     """
     cluster = zha_lock._get_door_lock_cluster()
     assert cluster is not None
@@ -1037,6 +1038,10 @@ async def test_only_available_means_the_slot_is_free(
 
     assert codes[1].is_present
     assert codes[2].is_present
+    # And never as a value sync can compare: a code the lock is not
+    # accepting would otherwise read as in sync while the door stays shut.
+    assert not codes[1].is_readable
+    assert not codes[2].is_readable
 
 
 async def test_available_is_an_empty_slot(

--- a/tests/providers/zha/test_provider.py
+++ b/tests/providers/zha/test_provider.py
@@ -936,15 +936,16 @@ async def test_occupied_indices_stops_at_the_limit(
     assert cluster.get_pin_code.await_count == 3
 
 
-async def test_occupied_indices_unknown_when_one_index_fails(
+async def test_a_failed_index_is_unreadable_not_empty(
     hass: HomeAssistant,
     zha_lock: ZHALock,
     simple_lcm_config_entry: MockConfigEntry,
 ) -> None:
-    """One unreadable index makes the whole answer unknown, not partial.
+    """An index the lock did not answer about is not an empty index.
 
-    A partial answer understates what is occupied, and an understated answer
-    is the one that overwrites a code.
+    Calling it empty understates what the lock holds, and an understated
+    answer is the one that overwrites a code. Only a read that fails outright
+    makes occupancy unknown; a single index does not.
     """
     cluster = zha_lock._get_door_lock_cluster()
     assert cluster is not None

--- a/tests/providers/zha/test_provider.py
+++ b/tests/providers/zha/test_provider.py
@@ -558,10 +558,12 @@ def test_parse_pin_response_list_bytes() -> None:
 
 
 def test_parse_pin_response_unknown_format() -> None:
-    """Test parsing unknown response format returns Available/empty."""
-    status, pin = ZHALock._parse_pin_response("unexpected")
-    assert status == DoorLock.UserStatus.Available
-    assert pin == ""
+    """An unrecognized response is not an answer.
+
+    Reporting it as ``Available`` would say "this slot is free" on the
+    strength of a reply that was never understood.
+    """
+    assert ZHALock._parse_pin_response("unexpected") is None
 
 
 # ---------------------------------------------------------------------------
@@ -909,8 +911,9 @@ async def test_occupied_indices_sees_slots_no_entry_manages(
 
     cluster.get_pin_code = AsyncMock(side_effect=mock_get_pin_code)
 
-    assert await zha_lock.async_get_occupied_indices(5) == frozenset({4})
-    # The managed-slot read cannot see it, which is why occupancy is separate.
+    codes = await zha_lock.async_get_usercodes(range(1, 6))
+    assert codes[4].is_present
+    # The default scope cannot see it, which is what the scope argument is for.
     assert 4 not in await zha_lock.async_get_usercodes()
 
 
@@ -928,7 +931,8 @@ async def test_occupied_indices_stops_at_the_limit(
         )()
     )
 
-    assert await zha_lock.async_get_occupied_indices(3) == frozenset()
+    codes = await zha_lock.async_get_usercodes(range(1, 4))
+    assert all(credential.is_empty for credential in codes.values())
     assert cluster.get_pin_code.await_count == 3
 
 
@@ -954,7 +958,11 @@ async def test_occupied_indices_unknown_when_one_index_fails(
 
     cluster.get_pin_code = AsyncMock(side_effect=mock_get_pin_code)
 
-    assert await zha_lock.async_get_occupied_indices(3) is None
+    codes = await zha_lock.async_get_usercodes(range(1, 4))
+    # Unreadable, not empty: the index holds something we could not read, and
+    # calling that empty is what lets a real credential be overwritten.
+    assert codes[2] is SlotCredential.unreadable()
+    assert codes[1].is_empty and codes[3].is_empty
 
 
 async def test_occupied_indices_counts_a_write_only_slot(
@@ -971,4 +979,27 @@ async def test_occupied_indices_counts_a_write_only_slot(
         )()
     )
 
-    assert await zha_lock.async_get_occupied_indices(2) == frozenset({1, 2})
+    codes = await zha_lock.async_get_usercodes(range(1, 3))
+    assert codes[1] is SlotCredential.unreadable()
+    assert codes[2] is SlotCredential.unreadable()
+
+
+async def test_unparseable_response_is_unreadable_not_empty(
+    hass: HomeAssistant,
+    zha_lock: ZHALock,
+    simple_lcm_config_entry: MockConfigEntry,
+) -> None:
+    """A reply we cannot parse is not an answer that the slot is free.
+
+    Calling it empty would tell sync the slot is confirmed cleared, and tell
+    allocation the index is available -- both from a response nothing
+    understood.
+    """
+    cluster = zha_lock._get_door_lock_cluster()
+    assert cluster is not None
+    cluster.get_pin_code = AsyncMock(return_value="unexpected shape")
+
+    codes = await zha_lock.async_get_usercodes(range(1, 3))
+
+    assert codes[1] is SlotCredential.unreadable()
+    assert codes[2] is SlotCredential.unreadable()

--- a/tests/providers/zigbee2mqtt/test_e2e.py
+++ b/tests/providers/zigbee2mqtt/test_e2e.py
@@ -122,14 +122,20 @@ class TestPushUpdatesViaMqtt:
         assert z2m_lock.coordinator.data.get(pin_address(2)) == SlotCredential.known(
             "2222"
         )
-        assert z2m_lock.coordinator.data.get(pin_address(3)) is SlotCredential.empty()
+        assert (
+            z2m_lock.coordinator.data.get(pin_address(3)) is SlotCredential.unreadable()
+        )
 
-    async def test_disabled_slot_maps_to_empty(
+    async def test_disabled_slot_is_occupied_not_empty(
         self,
         hass: HomeAssistant,
         z2m_lock,
     ) -> None:
-        """A disabled user slot is reported as SlotCredential.empty()."""
+        """A disabled user is one the lock is holding and refusing.
+
+        Reporting it empty tells sync the slot is confirmed cleared and tells
+        allocation the credential index is free to hand out.
+        """
         _fire_device_payload(
             hass,
             {"users": {"5": {"status": "disabled"}}},
@@ -137,7 +143,24 @@ class TestPushUpdatesViaMqtt:
         await hass.async_block_till_done()
         await hass.async_block_till_done()
 
-        assert z2m_lock.coordinator.data.get(pin_address(5)) is SlotCredential.empty()
+        credential = z2m_lock.coordinator.data.get(pin_address(5))
+        assert credential.is_present
+        assert not credential.is_readable
+
+    async def test_available_slot_is_empty(
+        self,
+        hass: HomeAssistant,
+        z2m_lock,
+    ) -> None:
+        """``available`` is the one status that does mean nothing is there."""
+        _fire_device_payload(
+            hass,
+            {"users": {"6": {"status": "available"}}},
+        )
+        await hass.async_block_till_done()
+        await hass.async_block_till_done()
+
+        assert z2m_lock.coordinator.data.get(pin_address(6)) is SlotCredential.empty()
 
 
 class TestSetAndClearUsercodes:

--- a/tests/providers/zigbee2mqtt/test_payload.py
+++ b/tests/providers/zigbee2mqtt/test_payload.py
@@ -140,7 +140,11 @@ async def test_pin_code_get_disabled_or_empty_pin_sets_future_empty() -> None:
     lock._process_z2m_device_payload(
         {"pin_code": {"user": 7, "user_enabled": False, "pin_code": "1234"}}
     )
-    assert fut_disabled.done() and fut_disabled.result() == SlotCredential.empty()
+    # The reply carries the code: the slot is occupied, the lock is simply
+    # not accepting it. Discarding that as empty frees the index for
+    # allocation and tells sync the slot is confirmed cleared.
+    assert fut_disabled.done()
+    assert fut_disabled.result() is SlotCredential.unreadable()
 
     fut_empty = loop.create_future()
     lock._pending_codes[8] = fut_empty

--- a/tests/providers/zigbee2mqtt/test_payload.py
+++ b/tests/providers/zigbee2mqtt/test_payload.py
@@ -405,3 +405,29 @@ def test_pin_code_boolean_user_does_not_resolve_slot_one() -> None:
     )
     fut.set_result.assert_not_called()
     assert 1 in lock._pending_codes
+
+
+async def test_pin_code_get_enabled_without_a_code_is_withheld_not_empty() -> None:
+    """An enabled slot whose code the broker hides still holds a code.
+
+    ``expose_pin`` off omits the field entirely. Reading that as empty tells
+    sync the slot is confirmed cleared and hands the index to allocation --
+    the answer the users object already refuses to give for this same state.
+    """
+    loop = asyncio.get_running_loop()
+    lock = _minimal_lock()
+
+    withheld = loop.create_future()
+    lock._pending_codes[11] = withheld
+    lock._process_z2m_device_payload({"pin_code": {"user": 11, "user_enabled": True}})
+    assert withheld.done()
+    assert withheld.result() is SlotCredential.unreadable()
+
+    # An explicit "no code" from an enabled user is still an answer.
+    explicit = loop.create_future()
+    lock._pending_codes[12] = explicit
+    lock._process_z2m_device_payload(
+        {"pin_code": {"user": 12, "user_enabled": True, "pin_code": None}}
+    )
+    assert explicit.done()
+    assert explicit.result() is SlotCredential.empty()

--- a/tests/providers/zigbee2mqtt/test_provider.py
+++ b/tests/providers/zigbee2mqtt/test_provider.py
@@ -802,6 +802,52 @@ class TestAsyncSetClearHardRefresh:
         assert refresh == direct == {12: SlotCredential.known("ABC")}
 
 
+class TestScopedRead:
+    """A caller-named scope drives the real per-index read, not a stub."""
+
+    async def test_a_timeout_outside_the_managed_slots_is_still_unreadable(
+        self,
+        hass: HomeAssistant,
+        zigbee2mqtt_lock_connected: Zigbee2MQTTLock,
+    ) -> None:
+        """The scope reaches slots no entry manages, and its failures behave.
+
+        Driving the real read rather than a stubbed one is the point: nothing
+        else proves that a slot the lock never answers about comes back
+        unreadable, and an empty answer there is what lets allocation hand out
+        an occupied index.
+        """
+        real_wait_for = asyncio.wait_for
+
+        async def fast_pin_timeout(
+            awaitable: object, timeout: float | None = None
+        ) -> object:
+            return await real_wait_for(awaitable, timeout=0.001)
+
+        lock = zigbee2mqtt_lock_connected
+
+        with (
+            patch(
+                "custom_components.lock_code_manager.providers._base.get_managed_slots",
+                return_value=set(),
+            ),
+            patch(
+                "custom_components.lock_code_manager.providers.zigbee2mqtt.async_publish",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "custom_components.lock_code_manager.providers.zigbee2mqtt.asyncio.wait_for",
+                side_effect=fast_pin_timeout,
+            ),
+        ):
+            # Nothing is managed, so the default read would ask about nothing.
+            assert await lock.async_get_usercodes() == {}
+            codes = await lock.async_get_usercodes(range(1, 3))
+
+        assert codes[1] is SlotCredential.unreadable()
+        assert codes[2] is SlotCredential.unreadable()
+
+
 class TestOccupiedIndices:
     """Occupancy reads span the lock, not just the slots this entry manages."""
 
@@ -829,7 +875,9 @@ class TestOccupiedIndices:
             patch.object(lock, "_get_topic", return_value="topic/get"),
             patch.object(lock, "_async_read_slot", side_effect=_read),
         ):
-            assert await lock.async_get_occupied_indices(5) == frozenset({4, 5})
+            codes = await lock.async_get_usercodes(range(1, 6))
+            assert codes[4].is_present
+            assert codes[5] is SlotCredential.unreadable()
 
     async def test_stops_at_the_limit(
         self, zigbee2mqtt_lock_connected: Zigbee2MQTTLock
@@ -845,18 +893,21 @@ class TestOccupiedIndices:
             patch.object(lock, "_get_topic", return_value="topic/get"),
             patch.object(lock, "_async_read_slot", read),
         ):
-            assert await lock.async_get_occupied_indices(3) == frozenset()
+            codes = await lock.async_get_usercodes(range(1, 4))
+            assert all(credential.is_empty for credential in codes.values())
 
         assert read.await_count == 3
 
-    async def test_unknown_when_one_index_goes_unanswered(
+    async def test_an_unanswered_index_is_not_reported_empty(
         self, zigbee2mqtt_lock_connected: Zigbee2MQTTLock
     ) -> None:
-        """A partial answer understates occupancy, which is what overwrites codes."""
+        """Calling an unanswered index empty is what overwrites codes."""
         lock = zigbee2mqtt_lock_connected
 
-        async def _read(slot_num: int, get_topic: str) -> SlotCredential | None:
-            return None if slot_num == 2 else SlotCredential.empty()
+        async def _read(slot_num: int, get_topic: str) -> SlotCredential:
+            return (
+                SlotCredential.unreadable() if slot_num == 2 else SlotCredential.empty()
+            )
 
         with (
             patch.object(
@@ -865,27 +916,41 @@ class TestOccupiedIndices:
             patch.object(lock, "_get_topic", return_value="topic/get"),
             patch.object(lock, "_async_read_slot", side_effect=_read),
         ):
-            assert await lock.async_get_occupied_indices(3) is None
+            codes = await lock.async_get_usercodes(range(1, 4))
+            assert codes[2] is SlotCredential.unreadable()
+            assert codes[1].is_empty and codes[3].is_empty
 
-    async def test_unknown_when_disconnected(
+    async def test_raises_when_disconnected_rather_than_answering_empty(
         self, zigbee2mqtt_lock_connected: Zigbee2MQTTLock
     ) -> None:
-        """A lock that cannot be reached reports unknown, never empty."""
-        lock = zigbee2mqtt_lock_connected
-        with patch.object(
-            lock, "async_is_integration_connected", new=AsyncMock(return_value=False)
-        ):
-            assert await lock.async_get_occupied_indices(3) is None
+        """A lock that cannot be reached must not answer at all.
 
-    async def test_unknown_without_a_get_topic(
+        Raising is what makes occupancy read as unknown; answering with
+        nothing would read as an empty lock.
+        """
+        lock = zigbee2mqtt_lock_connected
+        with (
+            patch.object(
+                lock,
+                "async_is_integration_connected",
+                new=AsyncMock(return_value=False),
+            ),
+            pytest.raises(LockDisconnected),
+        ):
+            await lock.async_get_usercodes(range(1, 4))
+
+    async def test_raises_without_a_get_topic(
         self, zigbee2mqtt_lock_connected: Zigbee2MQTTLock
     ) -> None:
         """No topic means no question can be asked, which is not an empty lock."""
         lock = zigbee2mqtt_lock_connected
         with (
             patch.object(
-                lock, "async_is_integration_connected", new=AsyncMock(return_value=True)
+                lock,
+                "async_is_integration_connected",
+                new=AsyncMock(return_value=True),
             ),
             patch.object(lock, "_get_topic", return_value=None),
+            pytest.raises(LockDisconnected),
         ):
-            assert await lock.async_get_occupied_indices(3) is None
+            await lock.async_get_usercodes(range(1, 4))

--- a/tests/providers/zigbee2mqtt/test_provider.py
+++ b/tests/providers/zigbee2mqtt/test_provider.py
@@ -800,3 +800,92 @@ class TestAsyncSetClearHardRefresh:
             direct = await lock.async_get_usercodes()
 
         assert refresh == direct == {12: SlotCredential.known("ABC")}
+
+
+class TestOccupiedIndices:
+    """Occupancy reads span the lock, not just the slots this entry manages."""
+
+    async def test_sees_slots_no_entry_manages(
+        self, zigbee2mqtt_lock_connected: Zigbee2MQTTLock
+    ) -> None:
+        """A code programmed by hand holds its index and must be reported.
+
+        A write-only code counts as occupied: the value cannot be read, but
+        the index plainly is taken.
+        """
+        lock = zigbee2mqtt_lock_connected
+
+        async def _read(slot_num: int, get_topic: str) -> SlotCredential | None:
+            if slot_num == 4:
+                return SlotCredential.known("9999")
+            if slot_num == 5:
+                return SlotCredential.unreadable()
+            return SlotCredential.empty()
+
+        with (
+            patch.object(
+                lock, "async_is_integration_connected", new=AsyncMock(return_value=True)
+            ),
+            patch.object(lock, "_get_topic", return_value="topic/get"),
+            patch.object(lock, "_async_read_slot", side_effect=_read),
+        ):
+            assert await lock.async_get_occupied_indices(5) == frozenset({4, 5})
+
+    async def test_stops_at_the_limit(
+        self, zigbee2mqtt_lock_connected: Zigbee2MQTTLock
+    ) -> None:
+        """The bound is what keeps a per-index lock from being walked end to end."""
+        lock = zigbee2mqtt_lock_connected
+        read = AsyncMock(return_value=SlotCredential.empty())
+
+        with (
+            patch.object(
+                lock, "async_is_integration_connected", new=AsyncMock(return_value=True)
+            ),
+            patch.object(lock, "_get_topic", return_value="topic/get"),
+            patch.object(lock, "_async_read_slot", read),
+        ):
+            assert await lock.async_get_occupied_indices(3) == frozenset()
+
+        assert read.await_count == 3
+
+    async def test_unknown_when_one_index_goes_unanswered(
+        self, zigbee2mqtt_lock_connected: Zigbee2MQTTLock
+    ) -> None:
+        """A partial answer understates occupancy, which is what overwrites codes."""
+        lock = zigbee2mqtt_lock_connected
+
+        async def _read(slot_num: int, get_topic: str) -> SlotCredential | None:
+            return None if slot_num == 2 else SlotCredential.empty()
+
+        with (
+            patch.object(
+                lock, "async_is_integration_connected", new=AsyncMock(return_value=True)
+            ),
+            patch.object(lock, "_get_topic", return_value="topic/get"),
+            patch.object(lock, "_async_read_slot", side_effect=_read),
+        ):
+            assert await lock.async_get_occupied_indices(3) is None
+
+    async def test_unknown_when_disconnected(
+        self, zigbee2mqtt_lock_connected: Zigbee2MQTTLock
+    ) -> None:
+        """A lock that cannot be reached reports unknown, never empty."""
+        lock = zigbee2mqtt_lock_connected
+        with patch.object(
+            lock, "async_is_integration_connected", new=AsyncMock(return_value=False)
+        ):
+            assert await lock.async_get_occupied_indices(3) is None
+
+    async def test_unknown_without_a_get_topic(
+        self, zigbee2mqtt_lock_connected: Zigbee2MQTTLock
+    ) -> None:
+        """No topic means no question can be asked, which is not an empty lock."""
+        lock = zigbee2mqtt_lock_connected
+        with (
+            patch.object(
+                lock, "async_is_integration_connected", new=AsyncMock(return_value=True)
+            ),
+            patch.object(lock, "_get_topic", return_value=None),
+        ):
+            assert await lock.async_get_occupied_indices(3) is None

--- a/tests/providers/zwave_js/test_provider.py
+++ b/tests/providers/zwave_js/test_provider.py
@@ -36,6 +36,7 @@ from custom_components.lock_code_manager.domain.credentials import (
     SetUserResult,
     User,
     WriteResult,
+    credential_from_slot,
 )
 from custom_components.lock_code_manager.domain.exceptions import (
     CodeRejectedError,
@@ -2143,3 +2144,44 @@ async def test_reconcile_read_unexpected_error_does_not_replace_typed_error(
             name=None,
             source="sync",
         )
+
+
+async def test_occupied_indices_covers_users_no_entry_manages(
+    zwave_js_lock: ZWaveJSLock,
+) -> None:
+    """The node read already spans the whole lock, so occupancy comes free.
+
+    This is the property the scoped providers lack: nothing here filters to
+    the slots Lock Code Manager manages, so a code programmed by hand is
+    already in the answer.
+    """
+    users = [
+        User(
+            user_id=2,
+            credentials=[
+                credential_from_slot(2, SlotCredential.known("1111")),
+            ],
+        ),
+        User(
+            user_id=8,
+            credentials=[
+                credential_from_slot(8, SlotCredential.known("2222")),
+            ],
+        ),
+    ]
+    with patch.object(zwave_js_lock, "async_get_users", AsyncMock(return_value=users)):
+        assert await zwave_js_lock.async_get_occupied_indices(5) == frozenset({2})
+
+
+async def test_occupied_indices_ignores_empty_credentials(
+    zwave_js_lock: ZWaveJSLock,
+) -> None:
+    """A slot the lock reports as empty is free, not occupied."""
+    users = [
+        User(user_id=1, credentials=[credential_from_slot(1, SlotCredential.empty())]),
+        User(
+            user_id=2, credentials=[credential_from_slot(2, SlotCredential.known("1"))]
+        ),
+    ]
+    with patch.object(zwave_js_lock, "async_get_users", AsyncMock(return_value=users)):
+        assert await zwave_js_lock.async_get_occupied_indices(5) == frozenset({2})

--- a/tests/providers/zwave_js/test_provider.py
+++ b/tests/providers/zwave_js/test_provider.py
@@ -2146,42 +2146,50 @@ async def test_reconcile_read_unexpected_error_does_not_replace_typed_error(
         )
 
 
-async def test_occupied_indices_covers_users_no_entry_manages(
+async def test_scoped_read_covers_users_no_entry_manages(
     zwave_js_lock: ZWaveJSLock,
 ) -> None:
-    """The node read already spans the whole lock, so occupancy comes free.
+    """The node read spans the whole lock, so a wider scope costs nothing.
 
-    This is the property the scoped providers lack: nothing here filters to
-    the slots Lock Code Manager manages, so a code programmed by hand is
+    This is the property the per-index providers lack: nothing here filters
+    to the slots Lock Code Manager manages, so a code programmed by hand is
     already in the answer.
     """
     users = [
         User(
             user_id=2,
-            credentials=[
-                credential_from_slot(2, SlotCredential.known("1111")),
-            ],
+            credentials=[credential_from_slot(2, SlotCredential.known("1111"))],
         ),
         User(
             user_id=8,
-            credentials=[
-                credential_from_slot(8, SlotCredential.known("2222")),
-            ],
+            credentials=[credential_from_slot(8, SlotCredential.known("2222"))],
         ),
     ]
     with patch.object(zwave_js_lock, "async_get_users", AsyncMock(return_value=users)):
-        assert await zwave_js_lock.async_get_occupied_indices(5) == frozenset({2})
+        codes = await zwave_js_lock.async_get_usercodes(range(1, 6))
+
+    # Slot 8 is outside anything this entry manages, and the read still saw it.
+    assert codes[2].is_present
+    assert codes[8].is_present
 
 
-async def test_occupied_indices_ignores_empty_credentials(
+async def test_scoped_read_keeps_the_user_code_occupancy_repair(
     zwave_js_lock: ZWaveJSLock,
 ) -> None:
-    """A slot the lock reports as empty is free, not occupied."""
-    users = [
-        User(user_id=1, credentials=[credential_from_slot(1, SlotCredential.empty())]),
-        User(
-            user_id=2, credentials=[credential_from_slot(2, SlotCredential.known("1"))]
-        ),
-    ]
-    with patch.object(zwave_js_lock, "async_get_users", AsyncMock(return_value=users)):
-        assert await zwave_js_lock.async_get_occupied_indices(5) == frozenset({2})
+    """A wider read still gets the repair that makes the narrow read honest.
+
+    On User Code CC locks the unified read drops a slot the lock reports as
+    occupied but whose code it withholds (issue #1397), which is why
+    ``_overlay_uc_occupancy`` exists. Occupancy is derived from this read, so
+    sourcing it from anywhere the repair does not reach would report an
+    occupied slot as free -- the one mistake that overwrites a real
+    credential.
+    """
+    with patch.object(zwave_js_lock, "async_get_users", AsyncMock(return_value=[])):
+        codes = await zwave_js_lock.async_get_usercodes(range(1, 6))
+
+    occupied = {slot for slot, credential in codes.items() if credential.is_present}
+    # The unified read returned nothing, so anything present here came from
+    # the value database via the repair.
+    assert occupied
+    assert all(codes[slot] is SlotCredential.unreadable() for slot in occupied)


### PR DESCRIPTION
## Proposed change

Allocation needs to know which slot numbers a lock already holds, so that
choosing slot numbers (the follow-up PR) never issues one over a code someone
programmed by hand. The read it had could not tell it.

### The gap

`async_get_users` is scoped to `managed_slots` — the slots existing Lock Code
Manager entries claim on that lock — because it also decides where writes
land. That scoping is right for writing and wrong for allocating.

During a first-time config flow no entry claims anything yet, so the set is
empty and **ZHA, Zigbee2MQTT, Schlage and Akuvox report nothing at all**. An
empty answer is indistinguishable from an empty lock. The same hole reappears
when adding a lock to an existing entry: the read covers the slots already
claimed and nothing else.

### One read, with a scope — not a second read

The first version of this PR added `async_get_occupied_indices` alongside the
existing read. Review killed that design with a concrete failure: on a
User Code CC lock the separate read reported **no occupied slots while the
projection reported two**. It sourced from `async_get_users`, which is exactly
the read node-zwave-js leaves blind when a lock reports a slot occupied but
withholds its code — the defect `_overlay_uc_occupancy` exists to repair, and
it repairs the *projection*, not the user list.

That is the general shape of the problem: **a second read path has to repeat
every repair the first one does, and the one it misses reports an occupied
slot as free.** So there is no second read path.

- `async_get_users(slots)` and `async_get_usercodes(slots)` take an optional
  scope. `None` still means "the slots this integration manages".
- Occupancy is one derivation in `BaseLock` over the projection those already
  produce, so every read-repair applies to it for free.
- Providers have **no** occupancy override at all.
- **Polling is unchanged** — the coordinator still passes no scope. Widening
  the poll was never on the table: ZHA and Zigbee2MQTT cost one round trip per
  index, so a whole-lock read every minute is 30–250 round trips on a battery
  lock.

An index whose value could not be read counts as **occupied**. Over-reserving
costs a user a slot number; under-reserving costs them the code on their door.
That also removes any need to signal "no answer" separately.

### Understatements fixed along the way

Each would have reported an occupied index as free:

- **ZHA had drifted into two answers for one question** — which is what the
  split invited. The managed read called an `Enabled` slot with no readable
  code `empty()` (confirmed cleared, so sync reprograms over it) while the
  occupancy read called the same slot occupied. One loop now, `unreadable()`
  in both roles, matching what Zigbee2MQTT and zwave_js already did.
- **`_parse_pin_response` answered `Available`** for any response shape it
  could not parse — "this slot is free", from a reply nothing understood. Now
  it returns `None`, which the caller maps to `unreadable()`.
- **Akuvox read a response carrying no user list as a device with no users.**
  It now raises.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- Part of the v3 release; targets `v3`, not `main`.
- Nothing consumes the occupancy derivation yet — #1433 rebases onto this and
  wires it into the config flow.
- Correction to an earlier claim in this PR: untagged codes on Schlage and
  Akuvox were described as unable to collide with an allocated number, since
  the slot lives in the code's name. That was wrong — `_async_run_tag_pass`
  *adopts* untagged codes into managed slots, so allocation can issue a number
  the tag pass then attaches to a real credential, which sync overwrites. The
  behaviour predates this PR; the reasoning was mine and it was wrong.
- 100% coverage held; full suite green under `HYPOTHESIS_PROFILE=ci`.
