### PR TITLE
fix: keep Lock Code Manager's entities on Lock Code Manager's devices

### DIFF
--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -595,8 +595,8 @@ async def async_setup_entry(
         name=config_entry.title,
         serial_number=entry_id,
     )
-    _async_prune_orphaned_slot_devices(hass, config_entry)
     _async_reclaim_entities_from_foreign_devices(hass, config_entry)
+    _async_prune_orphaned_slot_devices(hass, config_entry)
 
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
 
@@ -867,10 +867,11 @@ def _async_reclaim_entities_from_foreign_devices(
     entities are moved to the slot device they belong to and the emptied copy
     is removed here.
 
-    Runs before the platforms are set up, so a slot's device is created if it
-    does not exist yet rather than assumed -- an entity that is disabled, or
-    whose slot has since been removed, is never re-added and would otherwise
-    keep pointing at a device this is trying to delete.
+    Runs before the platforms are set up, so an entity that is disabled or
+    whose slot has since been removed -- neither of which is ever re-added --
+    is moved rather than deleted along with the copy it is sitting on. It also
+    runs before the orphaned-slot sweep, which then collects any slot device
+    this recreates for a slot that is no longer configured.
     """
     dev_reg = dr.async_get(hass)
     ent_reg = er.async_get(hass)

--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -84,6 +84,7 @@ from .domain.config import (
     EntryConfig,
     build_slot_device_identifier,
     parse_slot_device_identifier,
+    parse_slot_unique_id,
 )
 from .domain.exceptions import LockDisconnected, LockOperationFailed
 from .domain.locks import async_create_lock_instance, get_locks_from_targets
@@ -111,6 +112,7 @@ from .domain.util import (
     deobfuscate_pins,
     per_lock_issue_id,
 )
+from .entity import build_slot_device_info
 from .providers import BaseLock
 from .websocket import async_setup as async_websocket_setup
 
@@ -594,6 +596,7 @@ async def async_setup_entry(
         serial_number=entry_id,
     )
     _async_prune_orphaned_slot_devices(hass, config_entry)
+    _async_reclaim_entities_from_foreign_devices(hass, config_entry)
 
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
 
@@ -847,6 +850,70 @@ def _async_remove_slot_devices(
 
 
 @callback
+def _async_reclaim_entities_from_foreign_devices(
+    hass: HomeAssistant, config_entry: LockCodeManagerConfigEntry
+) -> None:
+    """
+    Move this entry's entities onto its own devices, and drop what is left.
+
+    Before Home Assistant 2026.8 the per-lock entities were attached to the
+    lock's own device by reusing that device's identifiers, which also added
+    this entry to it. 2026.8 restricts a device to one config entry and split
+    every such device in two, leaving a Lock Code Manager-owned copy of the
+    lock holding those entities.
+
+    The copy cannot age out on its own: ``dr.async_cleanup`` keeps any device
+    referencing a live config entry, whether or not anything is on it. So the
+    entities are moved to the slot device they belong to and the emptied copy
+    is removed here.
+
+    Runs before the platforms are set up, so a slot's device is created if it
+    does not exist yet rather than assumed -- an entity that is disabled, or
+    whose slot has since been removed, is never re-added and would otherwise
+    keep pointing at a device this is trying to delete.
+    """
+    dev_reg = dr.async_get(hass)
+    ent_reg = er.async_get(hass)
+    entry_id = config_entry.entry_id
+
+    def _is_ours(device: dr.DeviceEntry) -> bool:
+        return any(domain == DOMAIN for domain, _ in device.identifiers)
+
+    for entity in er.async_entries_for_config_entry(ent_reg, entry_id):
+        if entity.device_id is None:
+            continue
+        device = dev_reg.async_get(entity.device_id)
+        if device is None or _is_ours(device):
+            continue
+        slot_num = parse_slot_unique_id(entry_id, entity.unique_id)
+        if slot_num is None:
+            continue
+        slot_device = dev_reg.async_get_or_create(
+            config_entry_id=entry_id,
+            **build_slot_device_info(config_entry, slot_num),
+        )
+        _LOGGER.debug(
+            "%s (%s): Moving %s onto its slot device",
+            entry_id,
+            config_entry.title,
+            entity.entity_id,
+        )
+        ent_reg.async_update_entity(entity.entity_id, device_id=slot_device.id)
+
+    for device in dr.async_entries_for_config_entry(dev_reg, entry_id):
+        if _is_ours(device) or er.async_entries_for_device(
+            ent_reg, device.id, include_disabled_entities=True
+        ):
+            continue
+        _LOGGER.debug(
+            "%s (%s): Removing copy of device %s left by the 2026.8 device split",
+            entry_id,
+            config_entry.title,
+            device.name,
+        )
+        dev_reg.async_remove_device(device.id)
+
+
 def _async_prune_orphaned_slot_devices(
     hass: HomeAssistant, config_entry: LockCodeManagerConfigEntry
 ) -> None:

--- a/custom_components/lock_code_manager/domain/config.py
+++ b/custom_components/lock_code_manager/domain/config.py
@@ -348,3 +348,27 @@ def parse_slot_device_identifier(entry_id: str, identifier: str) -> int | None:
     except ValueError:
         return None
     return slot_num if str(slot_num) == suffix else None
+
+
+def parse_slot_unique_id(entry_id: str, unique_id: str) -> int | None:
+    """
+    Recover the slot number from a slot entity's unique ID, else ``None``.
+
+    Reads what :func:`build_slot_unique_id` writes, in both its shapes: the
+    key and any trailing lock entity ID are ignored, so a per-lock entity
+    resolves to the same slot as the shared entities beside it.
+
+    Applies the same round-trip check as
+    :func:`parse_slot_device_identifier`, for the same reason -- a looser
+    parse claims slot numbers the builder would never emit, and this decides
+    which device an entity is moved to.
+    """
+    prefix = f"{entry_id}|"
+    if not unique_id.startswith(prefix):
+        return None
+    suffix = unique_id.removeprefix(prefix).split("|", 1)[0]
+    try:
+        slot_num = int(suffix)
+    except ValueError:
+        return None
+    return slot_num if str(slot_num) == suffix else None

--- a/custom_components/lock_code_manager/entity.py
+++ b/custom_components/lock_code_manager/entity.py
@@ -340,9 +340,7 @@ class BaseLockCodeManagerCodeSlotPerLockEntity(BaseLockCodeManagerEntity):
         # one of them the same thing.
         self._attr_translation_placeholders = {
             "slot_num": str(slot_num),
-            "lock_name": lock.lock.name
-            or lock.lock.original_name
-            or lock.lock.entity_id,
+            "lock_name": lock.display_name,
         }
 
         self._attr_unique_id = build_slot_unique_id(

--- a/custom_components/lock_code_manager/entity.py
+++ b/custom_components/lock_code_manager/entity.py
@@ -37,6 +37,19 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
+def build_slot_device_info(config_entry: ConfigEntry, slot_num: int) -> DeviceInfo:
+    """Describe the device that carries every entity for one code slot."""
+    return DeviceInfo(
+        identifiers={
+            (DOMAIN, build_slot_device_identifier(config_entry.entry_id, slot_num))
+        },
+        name=f"{config_entry.title} Code slot {slot_num}",
+        manufacturer="Lock Code Manager",
+        model="Code Slot",
+        via_device=(DOMAIN, config_entry.entry_id),
+    )
+
+
 class BaseLockCodeManagerEntity(Entity):
     """Base Lock Code Manager Entity."""
 
@@ -62,17 +75,9 @@ class BaseLockCodeManagerEntity(Entity):
         self.ent_reg = ent_reg
 
         self._attr_translation_key = key
-        self._attr_translation_placeholders = {"slot_num": slot_num}
+        self._attr_translation_placeholders = {"slot_num": str(slot_num)}
 
-        self._attr_device_info = DeviceInfo(
-            identifiers={
-                (DOMAIN, build_slot_device_identifier(self.entry_id, slot_num))
-            },
-            name=f"{config_entry.title} Code slot {slot_num}",
-            manufacturer="Lock Code Manager",
-            model="Code Slot",
-            via_device=(DOMAIN, self.entry_id),
-        )
+        self._attr_device_info = build_slot_device_info(config_entry, slot_num)
 
         self._attr_unique_id = build_slot_unique_id(self.base_unique_id, slot_num, key)
         self._attr_extra_state_attributes: dict[str, int | list[str]] = {
@@ -323,18 +328,22 @@ class BaseLockCodeManagerCodeSlotPerLockEntity(BaseLockCodeManagerEntity):
             self, hass, ent_reg, config_entry, slot_num, key
         )
         self.lock = lock
-        if lock.device_entry:
-            # Link this entity to the lock's own device. Since HA 2026.8 a
-            # device belongs to a single config entry, so a helper
-            # integration must not reuse another integration's device
-            # identifiers/connections in ``device_info`` (which added LCM's
-            # config entry to that device and now forks a duplicate device
-            # instead). Setting ``device_entry`` links the entity to the
-            # existing device without claiming ownership of it; the entity
-            # platform honors a pre-set ``device_entry`` when ``device_info``
-            # is not provided.
-            self._attr_device_info = None
-            self.device_entry = lock.device_entry
+        # Deliberately keeps the slot device the base assigned rather than
+        # attaching to the lock's own device. Since HA 2026.8 a device belongs
+        # to exactly one config entry, so anything Lock Code Manager puts on
+        # another integration's device either forks a duplicate of it or, if
+        # attached without claiming it, leaves this entity somewhere its own
+        # integration cannot show it.
+        #
+        # The lock therefore has to be named by the ENTITY. Sitting on the
+        # slot device, one per lock, the slot number alone would name every
+        # one of them the same thing.
+        self._attr_translation_placeholders = {
+            "slot_num": str(slot_num),
+            "lock_name": lock.lock.name
+            or lock.lock.original_name
+            or lock.lock.entity_id,
+        }
 
         self._attr_unique_id = build_slot_unique_id(
             self.base_unique_id, slot_num, self.key, lock.lock.entity_id

--- a/custom_components/lock_code_manager/strings.json
+++ b/custom_components/lock_code_manager/strings.json
@@ -78,7 +78,7 @@
         "name": "Active"
       },
       "in_sync": {
-        "name": "Code slot {slot_num} in sync",
+        "name": "{lock_name} in sync",
         "state_attributes": {
           "sync_status": {
             "state": {
@@ -104,7 +104,7 @@
     },
     "sensor": {
       "code": {
-        "name": "Code slot {slot_num}"
+        "name": "{lock_name} code"
       }
     },
     "switch": {

--- a/custom_components/lock_code_manager/translations/en.json
+++ b/custom_components/lock_code_manager/translations/en.json
@@ -78,7 +78,7 @@
         "name": "Active"
       },
       "in_sync": {
-        "name": "Code slot {slot_num} in sync",
+        "name": "{lock_name} in sync",
         "state_attributes": {
           "sync_status": {
             "state": {
@@ -104,7 +104,7 @@
     },
     "sensor": {
       "code": {
-        "name": "Code slot {slot_num}"
+        "name": "{lock_name} code"
       }
     },
     "switch": {

--- a/tests/common.py
+++ b/tests/common.py
@@ -10,6 +10,7 @@ from typing import Literal
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
 from homeassistant.components.calendar import CalendarEntity, CalendarEvent
 from homeassistant.components.lock import LockEntity
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ENABLED, CONF_ENTITY_ID, CONF_NAME, CONF_PIN
 from homeassistant.core import HomeAssistant, callback
@@ -18,6 +19,7 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.util import slugify
 
 from custom_components.lock_code_manager.const import (
+    ATTR_CODE,
     ATTR_IN_SYNC,
     CONF_LOCKS,
     CONF_SLOTS,
@@ -47,6 +49,18 @@ BASE_CONFIG = {
 }
 
 
+def code_entity_id(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    slot_num: int,
+    lock_entity_id: str = LOCK_1_ENTITY_ID,
+) -> str:
+    """Return the code sensor for one slot on one lock."""
+    return _per_lock_entity_id(
+        hass, SENSOR_DOMAIN, config_entry, slot_num, ATTR_CODE, lock_entity_id
+    )
+
+
 def in_sync_entity_id(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
@@ -61,14 +75,26 @@ def in_sync_entity_id(
     test ties that test to both -- and a test that renames either then looks
     for an entity that was never going to exist.
     """
-    entity_id = er.async_get(hass).async_get_entity_id(
-        BINARY_SENSOR_DOMAIN,
-        DOMAIN,
-        build_slot_unique_id(
-            config_entry.entry_id, slot_num, ATTR_IN_SYNC, lock_entity_id
-        ),
+    return _per_lock_entity_id(
+        hass, BINARY_SENSOR_DOMAIN, config_entry, slot_num, ATTR_IN_SYNC, lock_entity_id
     )
-    assert entity_id, f"No in-sync entity for slot {slot_num} on {lock_entity_id}"
+
+
+def _per_lock_entity_id(
+    hass: HomeAssistant,
+    platform: str,
+    config_entry: ConfigEntry,
+    slot_num: int,
+    key: str,
+    lock_entity_id: str,
+) -> str:
+    """Resolve a per-lock entity by unique ID."""
+    entity_id = er.async_get(hass).async_get_entity_id(
+        platform,
+        DOMAIN,
+        build_slot_unique_id(config_entry.entry_id, slot_num, key, lock_entity_id),
+    )
+    assert entity_id, f"No {key} entity for slot {slot_num} on {lock_entity_id}"
     return entity_id
 
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -7,18 +7,23 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Literal
 
+from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
 from homeassistant.components.calendar import CalendarEntity, CalendarEvent
 from homeassistant.components.lock import LockEntity
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ENABLED, CONF_ENTITY_ID, CONF_NAME, CONF_PIN
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.util import slugify
 
 from custom_components.lock_code_manager.const import (
+    ATTR_IN_SYNC,
     CONF_LOCKS,
     CONF_SLOTS,
     DOMAIN,
 )
+from custom_components.lock_code_manager.domain.config import build_slot_unique_id
 from custom_components.lock_code_manager.domain.credentials import WriteResult
 from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers import BaseLock
@@ -41,18 +46,44 @@ BASE_CONFIG = {
     },
 }
 
+
+def in_sync_entity_id(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    slot_num: int,
+    lock_entity_id: str = LOCK_1_ENTITY_ID,
+) -> str:
+    """
+    Return the in-sync entity for one slot on one lock.
+
+    Looked up by unique ID rather than spelled out. The entity ID is derived
+    from the config entry's title and the lock's name, so writing it into a
+    test ties that test to both -- and a test that renames either then looks
+    for an entity that was never going to exist.
+    """
+    entity_id = er.async_get(hass).async_get_entity_id(
+        BINARY_SENSOR_DOMAIN,
+        DOMAIN,
+        build_slot_unique_id(
+            config_entry.entry_id, slot_num, ATTR_IN_SYNC, lock_entity_id
+        ),
+    )
+    assert entity_id, f"No in-sync entity for slot {slot_num} on {lock_entity_id}"
+    return entity_id
+
+
 SLOT_1_ACTIVE_ENTITY = "binary_sensor.mock_title_code_slot_1_active"
 SLOT_1_ENABLED_ENTITY = "switch.mock_title_code_slot_1_enabled"
 SLOT_1_EVENT_ENTITY = "event.mock_title_code_slot_1"
 SLOT_1_PIN_ENTITY = "text.mock_title_code_slot_1_pin"
-SLOT_1_IN_SYNC_ENTITY = "binary_sensor.test_1_code_slot_1_in_sync"
+SLOT_1_IN_SYNC_ENTITY = "binary_sensor.mock_title_code_slot_1_test_1_in_sync"
 
 SLOT_2_ENABLED_ENTITY = "switch.mock_title_code_slot_2_enabled"
 SLOT_2_ACTIVE_ENTITY = "binary_sensor.mock_title_code_slot_2_active"
 SLOT_2_EVENT_ENTITY = "event.mock_title_code_slot_2"
 SLOT_2_PIN_ENTITY = "text.mock_title_code_slot_2_pin"
 SLOT_2_NAME_ENTITY = "text.mock_title_code_slot_2_name"
-SLOT_2_IN_SYNC_ENTITY = "binary_sensor.test_1_code_slot_2_in_sync"
+SLOT_2_IN_SYNC_ENTITY = "binary_sensor.mock_title_code_slot_2_test_1_in_sync"
 
 
 @dataclass(repr=False, eq=False)

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -61,8 +61,10 @@ from .common import (
     SLOT_1_PIN_ENTITY,
     SLOT_2_ACTIVE_ENTITY,
     SLOT_2_ENABLED_ENTITY,
+    SLOT_2_IN_SYNC_ENTITY,
     SLOT_2_PIN_ENTITY,
     MockLCMLock,
+    in_sync_entity_id,
 )
 from .conftest import (
     async_advance_time,
@@ -199,7 +201,7 @@ async def test_startup_no_code_flapping_when_synced(
     await hass.async_block_till_done()
 
     # Get the in-sync binary sensor for lock 1, slot 2
-    in_sync_entity = "binary_sensor.test_1_code_slot_2_in_sync"
+    in_sync_entity = SLOT_2_IN_SYNC_ENTITY
 
     # Verify the entity exists
     state = hass.states.get(in_sync_entity)
@@ -257,7 +259,7 @@ async def test_startup_detects_out_of_sync_code(
     await hass.async_block_till_done()
 
     # Get the in-sync binary sensor
-    in_sync_entity = "binary_sensor.test_1_code_slot_1_in_sync"
+    in_sync_entity = in_sync_entity_id(hass, config_entry, 1)
 
     # Verify the entity exists
     state = hass.states.get(in_sync_entity)
@@ -324,8 +326,8 @@ async def test_startup_out_of_sync_slots_sync_once(
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    in_sync_slot_1 = "binary_sensor.test_1_code_slot_1_in_sync"
-    in_sync_slot_2 = "binary_sensor.test_1_code_slot_2_in_sync"
+    in_sync_slot_1 = in_sync_entity_id(hass, config_entry, 1)
+    in_sync_slot_2 = in_sync_entity_id(hass, config_entry, 2)
 
     assert hass.states.get(in_sync_slot_1)
     assert hass.states.get(in_sync_slot_2)
@@ -386,7 +388,7 @@ async def test_startup_waits_for_valid_active_state(
 
     # Get the entity IDs
     active_entity_id = "binary_sensor.test_lcm_code_slot_1_active"
-    in_sync_entity = "binary_sensor.test_1_code_slot_1_in_sync"
+    in_sync_entity = in_sync_entity_id(hass, config_entry, 1)
 
     # Verify entities exist
     assert hass.states.get(active_entity_id), (
@@ -688,7 +690,7 @@ async def test_coordinator_update_triggers_sync_on_external_change(
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    in_sync_entity = "binary_sensor.test_1_code_slot_1_in_sync"
+    in_sync_entity = in_sync_entity_id(hass, config_entry, 1)
     await async_initial_tick(hass, in_sync_entity)
 
     # Verify initial state - should be in sync
@@ -1178,7 +1180,7 @@ async def test_coordinator_poll_detects_external_change_and_syncs(
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    in_sync_entity = "binary_sensor.test_1_code_slot_1_in_sync"
+    in_sync_entity = in_sync_entity_id(hass, config_entry, 1)
     await async_initial_tick(hass, in_sync_entity)
 
     # Verify initial state is in sync
@@ -1241,7 +1243,7 @@ async def test_push_update_triggers_sync_state_change_on_binary_sensor(
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    in_sync_entity = "binary_sensor.test_1_code_slot_1_in_sync"
+    in_sync_entity = in_sync_entity_id(hass, config_entry, 1)
     await async_initial_tick(hass, in_sync_entity)
 
     state = hass.states.get(in_sync_entity)
@@ -1311,8 +1313,8 @@ async def test_slot_suspension_isolated_from_other_slots(
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    in_sync_slot_1 = "binary_sensor.test_1_code_slot_1_in_sync"
-    in_sync_slot_2 = "binary_sensor.test_1_code_slot_2_in_sync"
+    in_sync_slot_1 = in_sync_entity_id(hass, config_entry, 1)
+    in_sync_slot_2 = in_sync_entity_id(hass, config_entry, 2)
     await async_initial_tick(hass, in_sync_slot_1)
     await async_initial_tick(hass, in_sync_slot_2)
 
@@ -1364,7 +1366,7 @@ async def test_drift_check_detects_external_change_and_triggers_sync(
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    in_sync_entity = "binary_sensor.test_1_code_slot_1_in_sync"
+    in_sync_entity = in_sync_entity_id(hass, config_entry, 1)
     await async_initial_tick(hass, in_sync_entity)
 
     state = hass.states.get(in_sync_entity)
@@ -1455,7 +1457,7 @@ async def test_async_advance_time_drains_background_tick_chain(
     ):
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
-        in_sync_entity = "binary_sensor.test_1_code_slot_1_in_sync"
+        in_sync_entity = in_sync_entity_id(hass, config_entry, 1)
         await async_initial_tick(hass, in_sync_entity)
 
         lock_provider = config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
@@ -1508,7 +1510,7 @@ async def test_sync_manager_handles_code_sensor_unknown_state_on_startup(
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    in_sync_entity = "binary_sensor.test_1_code_slot_1_in_sync"
+    in_sync_entity = in_sync_entity_id(hass, config_entry, 1)
     entity_obj = get_in_sync_entity_obj(hass, in_sync_entity)
     mgr = entity_obj._sync_manager
 
@@ -1640,7 +1642,7 @@ async def test_sync_manager_stop_during_active_sync_does_not_raise(
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    in_sync_entity = "binary_sensor.test_1_code_slot_1_in_sync"
+    in_sync_entity = in_sync_entity_id(hass, config_entry, 1)
     await async_initial_tick(hass, in_sync_entity)
 
     lock_provider = config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
@@ -1869,8 +1871,8 @@ async def test_multiple_slots_sync_sequentially_not_concurrently(
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    in_sync_slot_1 = "binary_sensor.test_1_code_slot_1_in_sync"
-    in_sync_slot_2 = "binary_sensor.test_1_code_slot_2_in_sync"
+    in_sync_slot_1 = in_sync_entity_id(hass, config_entry, 1)
+    in_sync_slot_2 = in_sync_entity_id(hass, config_entry, 2)
     await async_initial_tick(hass, in_sync_slot_1)
     await async_initial_tick(hass, in_sync_slot_2)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -17,6 +17,7 @@ from custom_components.lock_code_manager.domain.config import (
     build_slot_device_identifier,
     build_slot_unique_id,
     parse_slot_device_identifier,
+    parse_slot_unique_id,
 )
 from custom_components.lock_code_manager.domain.queries import get_entry_config
 
@@ -660,3 +661,28 @@ def test_build_slot_unique_id_variants_never_collide() -> None:
     per_lock = build_slot_unique_id("abc123", 4, "code", "lock.front_door")
     assert standard != per_lock
     assert per_lock.startswith(f"{standard}|")
+
+
+@pytest.mark.parametrize("slot_num", [1, 10, 250, -1])
+@pytest.mark.parametrize("lock_entity_id", [None, "lock.front_door"])
+def test_slot_unique_id_round_trips(slot_num: int, lock_entity_id: str | None) -> None:
+    """Both shapes of unique ID resolve to the slot they were built for.
+
+    A per-lock entity has to land on the same slot device as the shared
+    entities beside it; parsing only the shared shape would leave exactly the
+    entities this moves stranded.
+    """
+    unique_id = build_slot_unique_id("abc123", slot_num, "in_sync", lock_entity_id)
+    assert parse_slot_unique_id("abc123", unique_id) == slot_num
+
+
+def test_parse_slot_unique_id_rejects_what_it_did_not_build() -> None:
+    """Anything that is not this entry's slot entity resolves to nothing."""
+    # Another entry's entity.
+    assert parse_slot_unique_id("abc123", "def456|1|in_sync") is None
+    # Not a slot number.
+    assert parse_slot_unique_id("abc123", "abc123|name|in_sync") is None
+    assert parse_slot_unique_id("abc123", "abc123||in_sync") is None
+    # Aliases of a number that the builder would never emit.
+    assert parse_slot_unique_id("abc123", "abc123|+1|in_sync") is None
+    assert parse_slot_unique_id("abc123", "abc123|1_0|in_sync") is None

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -50,6 +50,9 @@ from custom_components.lock_code_manager.const import (
     SERVICE_HARD_REFRESH_USERCODES,
     STRATEGY_PATH,
 )
+from custom_components.lock_code_manager.domain.config import (
+    build_slot_device_identifier,
+)
 from custom_components.lock_code_manager.domain.exceptions import (
     LockDisconnected,
 )
@@ -105,18 +108,29 @@ async def test_entry_setup_and_unload(
     for entity_id in (LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID):
         device = dev_reg.async_get_device({(DOMAIN, entity_id)})
         assert device
-        # LCM links its per-lock entities to the lock's own device but no
-        # longer adds its config entry to it -- a device belongs to a single
-        # config entry as of HA 2026.8.
         assert device.config_entries == {mock_lock_entry_id}
-        lcm_device_entities = {
-            entry.unique_id
+        # Nothing of ours sits on the lock's own device. A device belongs to
+        # one config entry as of HA 2026.8, so an entity parked on another
+        # integration's device is one this integration cannot show.
+        assert not [
+            entry
             for entry in er.async_entries_for_device(ent_reg, device.id)
             if entry.config_entry_id == lcm_entry_id
-        }
-        assert lcm_device_entities == {
+        ]
+
+    # The per-lock entities live on the slot device beside the shared ones.
+    for slot in range(1, 3):
+        slot_device = dev_reg.async_get_device(
+            {(DOMAIN, build_slot_device_identifier(lcm_entry_id, slot))}
+        )
+        assert slot_device
+        assert slot_device.config_entries == {lcm_entry_id}
+        assert {
+            entry.unique_id
+            for entry in er.async_entries_for_device(ent_reg, slot_device.id)
+        } >= {
             f"{lcm_entry_id}|{slot}|{key}|{entity_id}"
-            for slot in range(1, 3)
+            for entity_id in (LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID)
             for key in (ATTR_CODE, ATTR_IN_SYNC)
         }
 
@@ -1276,7 +1290,7 @@ async def test_two_entries_same_lock_share_suspension_and_recovery(
     )
 
     # Get entry B's in-sync entity for slot 3 on lock 1
-    entry_b_in_sync_entity = "binary_sensor.test_1_code_slot_3_in_sync"
+    entry_b_in_sync_entity = "binary_sensor.entry_b_code_slot_3_test_1_in_sync"
 
     # Ensure slot 3 exists in coordinator data so sync manager can resolve state.
     # The mock lock only starts with slots 1 and 2, so push slot 3 data.
@@ -1885,3 +1899,144 @@ async def test_pairs_removed_skips_untracked_lock_and_logs_release_failure(
     assert LOCK_1_ENTITY_ID in caplog.text
 
     await hass.config_entries.async_unload(entry.entry_id)
+
+
+async def test_setup_reclaims_entities_left_on_a_split_device(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """Entities parked on a copy of the lock's device are brought home.
+
+    HA 2026.8 restricted a device to one config entry and split every device
+    that had two, leaving a Lock Code Manager-owned copy of the lock holding
+    the per-lock entities. Setup moves them onto their slot device and drops
+    the emptied copy, which nothing else will: ``dr.async_cleanup`` keeps any
+    device that references a live config entry, occupied or not.
+    """
+    dev_reg = dr.async_get(hass)
+    ent_reg = er.async_get(hass)
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data=BASE_CONFIG, unique_id="Split Device"
+    )
+    config_entry.add_to_hass(hass)
+    entry_id = config_entry.entry_id
+
+    # The copy the split left behind: our config entry, the lock's identifiers.
+    split = dev_reg.async_get_or_create(
+        config_entry_id=entry_id,
+        identifiers={("test", "lock_1_serial")},
+        name="Test 1",
+    )
+    stranded = ent_reg.async_get_or_create(
+        "binary_sensor",
+        DOMAIN,
+        f"{entry_id}|1|{ATTR_IN_SYNC}|{LOCK_1_ENTITY_ID}",
+        config_entry=config_entry,
+        device_id=split.id,
+    )
+
+    await hass.config_entries.async_setup(entry_id)
+    await hass.async_block_till_done()
+
+    slot_device = dev_reg.async_get_device(
+        {(DOMAIN, build_slot_device_identifier(entry_id, 1))}
+    )
+    assert slot_device
+    assert ent_reg.async_get(stranded.entity_id).device_id == slot_device.id
+    assert dev_reg.async_get(split.id) is None
+
+    await hass.config_entries.async_unload(entry_id)
+
+
+async def test_setup_leaves_devices_of_other_integrations_alone(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """The sweep only touches devices this entry owns.
+
+    The lock's real device is owned by the lock's integration and holds its
+    entities; removing it, or moving anything off it, would be this
+    integration reaching into another's registry.
+    """
+    dev_reg = dr.async_get(hass)
+    ent_reg = er.async_get(hass)
+
+    lock_device = dev_reg.async_get_device({(DOMAIN, LOCK_1_ENTITY_ID)})
+    assert lock_device
+    before = {
+        entry.entity_id
+        for entry in er.async_entries_for_device(ent_reg, lock_device.id)
+    }
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data=BASE_CONFIG, unique_id="Leaves Others Alone"
+    )
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert dev_reg.async_get(lock_device.id) is not None
+    assert {
+        entry.entity_id
+        for entry in er.async_entries_for_device(ent_reg, lock_device.id)
+    } == before
+
+    await hass.config_entries.async_unload(config_entry.entry_id)
+
+
+async def test_reclaim_skips_entities_it_has_no_slot_device_for(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """The sweep moves slot entities and nothing else.
+
+    An entity with no device, one already on a Lock Code Manager device, and
+    one whose unique ID names no slot are all left exactly where they are --
+    the last of those names no slot device to be moved to.
+    """
+    dev_reg = dr.async_get(hass)
+    ent_reg = er.async_get(hass)
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data=BASE_CONFIG, unique_id="Skips Non Slot Entities"
+    )
+    config_entry.add_to_hass(hass)
+    entry_id = config_entry.entry_id
+
+    foreign = dev_reg.async_get_or_create(
+        config_entry_id=entry_id,
+        identifiers={("test", "some_other_serial")},
+        name="Test 1",
+    )
+    ours = dev_reg.async_get_or_create(
+        config_entry_id=entry_id,
+        identifiers={(DOMAIN, build_slot_device_identifier(entry_id, 1))},
+        name="Already home",
+    )
+    no_device = ent_reg.async_get_or_create(
+        "binary_sensor", DOMAIN, f"{entry_id}|no_device", config_entry=config_entry
+    )
+    settled = ent_reg.async_get_or_create(
+        "binary_sensor",
+        DOMAIN,
+        f"{entry_id}|1|{ATTR_IN_SYNC}|{LOCK_2_ENTITY_ID}",
+        config_entry=config_entry,
+        device_id=ours.id,
+    )
+    unparseable = ent_reg.async_get_or_create(
+        "binary_sensor",
+        DOMAIN,
+        f"{entry_id}|not_a_slot|{ATTR_IN_SYNC}",
+        config_entry=config_entry,
+        device_id=foreign.id,
+    )
+
+    await hass.config_entries.async_setup(entry_id)
+    await hass.async_block_till_done()
+
+    assert ent_reg.async_get(no_device.entity_id).device_id is None
+    # Already on one of our devices, so the sweep has nothing to do for it.
+    assert ent_reg.async_get(settled.entity_id).device_id == ours.id
+    # Still on the foreign device, which therefore survives the removal pass.
+    assert ent_reg.async_get(unparseable.entity_id).device_id == foreign.id
+    assert dev_reg.async_get(foreign.id) is not None
+
+    await hass.config_entries.async_unload(entry_id)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -68,6 +68,7 @@ from .common import (
     LOCK_2_ENTITY_ID,
     SLOT_1_IN_SYNC_ENTITY,
     MockLCMLock,
+    in_sync_entity_id,
 )
 from .conftest import (
     async_initial_tick,
@@ -125,13 +126,23 @@ async def test_entry_setup_and_unload(
         )
         assert slot_device
         assert slot_device.config_entries == {lcm_entry_id}
+        # Exact, so anything unexpected landing here is caught too.
         assert {
             entry.unique_id
             for entry in er.async_entries_for_device(ent_reg, slot_device.id)
-        } >= {
+        } == {
             f"{lcm_entry_id}|{slot}|{key}|{entity_id}"
             for entity_id in (LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID)
             for key in (ATTR_CODE, ATTR_IN_SYNC)
+        } | {
+            f"{lcm_entry_id}|{slot}|{key}"
+            for key in (
+                CONF_ENABLED,
+                CONF_NAME,
+                CONF_PIN,
+                ATTR_ACTIVE,
+                EVENT_PIN_USED,
+            )
         }
 
     unique_ids = set()
@@ -1290,7 +1301,7 @@ async def test_two_entries_same_lock_share_suspension_and_recovery(
     )
 
     # Get entry B's in-sync entity for slot 3 on lock 1
-    entry_b_in_sync_entity = "binary_sensor.entry_b_code_slot_3_test_1_in_sync"
+    entry_b_in_sync_entity = in_sync_entity_id(hass, entry_b, 3)
 
     # Ensure slot 3 exists in coordinator data so sync manager can resolve state.
     # The mock lock only starts with slots 1 and 2, so push slot 3 data.
@@ -2038,5 +2049,129 @@ async def test_reclaim_skips_entities_it_has_no_slot_device_for(
     # Still on the foreign device, which therefore survives the removal pass.
     assert ent_reg.async_get(unparseable.entity_id).device_id == foreign.id
     assert dev_reg.async_get(foreign.id) is not None
+
+    await hass.config_entries.async_unload(entry_id)
+
+
+async def test_reclaim_leaves_our_own_empty_devices_alone(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """Devices of ours that hold nothing are not copies to be cleaned up.
+
+    The entry's own device carries no entities by design -- it exists so the
+    slot devices have a parent -- which makes it a perfect match for the
+    removal pass. Only the check that it is one of ours keeps it.
+    """
+    dev_reg = dr.async_get(hass)
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data=BASE_CONFIG, unique_id="Keeps Own Devices"
+    )
+    config_entry.add_to_hass(hass)
+    entry_id = config_entry.entry_id
+
+    await hass.config_entries.async_setup(entry_id)
+    await hass.async_block_till_done()
+
+    hub = dev_reg.async_get_device({(DOMAIN, entry_id)})
+    assert hub
+    assert not er.async_entries_for_device(
+        er.async_get(hass), hub.id, include_disabled_entities=True
+    )
+
+    # A second setup runs the sweep against a registry that already has it.
+    await hass.config_entries.async_reload(entry_id)
+    await hass.async_block_till_done()
+
+    assert dev_reg.async_get_device({(DOMAIN, entry_id)}) is not None
+
+    await hass.config_entries.async_unload(entry_id)
+
+
+async def test_reclaim_moves_a_disabled_entity_rather_than_deleting_it(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """A disabled entity is never re-added by a platform, so it must be moved.
+
+    Removing the copy first and letting the platforms sort it out would take
+    this entity with it, along with whatever the user had customised on it.
+    """
+    dev_reg = dr.async_get(hass)
+    ent_reg = er.async_get(hass)
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data=BASE_CONFIG, unique_id="Disabled Entity"
+    )
+    config_entry.add_to_hass(hass)
+    entry_id = config_entry.entry_id
+
+    split = dev_reg.async_get_or_create(
+        config_entry_id=entry_id,
+        identifiers={("test", "lock_1_serial")},
+        name="Test 1",
+    )
+    disabled = ent_reg.async_get_or_create(
+        "binary_sensor",
+        DOMAIN,
+        f"{entry_id}|1|{ATTR_IN_SYNC}|{LOCK_1_ENTITY_ID}",
+        config_entry=config_entry,
+        device_id=split.id,
+        disabled_by=er.RegistryEntryDisabler.USER,
+    )
+
+    await hass.config_entries.async_setup(entry_id)
+    await hass.async_block_till_done()
+
+    survivor = ent_reg.async_get(disabled.entity_id)
+    assert survivor is not None
+    assert survivor.disabled_by is er.RegistryEntryDisabler.USER
+    slot_device = dev_reg.async_get_device(
+        {(DOMAIN, build_slot_device_identifier(entry_id, 1))}
+    )
+    assert slot_device and survivor.device_id == slot_device.id
+    assert dev_reg.async_get(split.id) is None
+
+    await hass.config_entries.async_unload(entry_id)
+
+
+async def test_reclaim_does_not_resurrect_a_device_for_an_unconfigured_slot(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """Moving an entity must not recreate a slot device the sweep then drops.
+
+    The entity's slot is no longer configured, so its device is orphaned. If
+    the move ran after the orphan sweep, that device would be recreated and
+    left behind as a phantom until the next reload.
+    """
+    dev_reg = dr.async_get(hass)
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data=BASE_CONFIG, unique_id="Unconfigured Slot"
+    )
+    config_entry.add_to_hass(hass)
+    entry_id = config_entry.entry_id
+
+    split = dev_reg.async_get_or_create(
+        config_entry_id=entry_id,
+        identifiers={("test", "lock_1_serial")},
+        name="Test 1",
+    )
+    er.async_get(hass).async_get_or_create(
+        "binary_sensor",
+        DOMAIN,
+        f"{entry_id}|9|{ATTR_IN_SYNC}|{LOCK_1_ENTITY_ID}",
+        config_entry=config_entry,
+        device_id=split.id,
+    )
+
+    await hass.config_entries.async_setup(entry_id)
+    await hass.async_block_till_done()
+
+    # Slot 9 is not configured, so neither device may survive.
+    assert (
+        dev_reg.async_get_device({(DOMAIN, build_slot_device_identifier(entry_id, 9))})
+        is None
+    )
+    assert dev_reg.async_get(split.id) is None
 
     await hass.config_entries.async_unload(entry_id)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -22,10 +22,10 @@ async def test_sensor_entity(
 ):
     """Test sensor entity shows lock code values."""
     for code_slot, pin in ((1, "1234"), (2, "5678")):
-        state = hass.states.get(f"sensor.test_1_code_slot_{code_slot}")
+        state = hass.states.get(f"sensor.mock_title_code_slot_{code_slot}_test_1_code")
         assert state
         assert state.state == pin
-        state = hass.states.get(f"sensor.test_2_code_slot_{code_slot}")
+        state = hass.states.get(f"sensor.mock_title_code_slot_{code_slot}_test_2_code")
         assert state
         assert state.state == pin
 
@@ -43,21 +43,21 @@ async def test_sensor_native_value_with_slot_code(
     # Empty credential -> sensor shows empty string
     coordinator.async_set_updated_data({pin_address(1): SlotCredential.empty()})
     await hass.async_block_till_done()
-    state = hass.states.get("sensor.test_1_code_slot_1")
+    state = hass.states.get("sensor.mock_title_code_slot_1_test_1_code")
     assert state is not None
     assert state.state == ""
 
     # Unreadable credential -> sensor resolves to expected PIN from config
     coordinator.async_set_updated_data({pin_address(1): SlotCredential.unreadable()})
     await hass.async_block_till_done()
-    state = hass.states.get("sensor.test_1_code_slot_1")
+    state = hass.states.get("sensor.mock_title_code_slot_1_test_1_code")
     assert state is not None
     assert state.state == "1234"
 
     # Known credential -> sensor shows the code
     coordinator.async_set_updated_data({pin_address(1): SlotCredential.known("5678")})
     await hass.async_block_till_done()
-    state = hass.states.get("sensor.test_1_code_slot_1")
+    state = hass.states.get("sensor.mock_title_code_slot_1_test_1_code")
     assert state is not None
     assert state.state == "5678"
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -10,7 +10,7 @@ from custom_components.lock_code_manager.domain.locks import async_create_lock_i
 from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers import BaseLock
 
-from .common import LOCK_1_ENTITY_ID
+from .common import LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID, code_entity_id
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -22,10 +22,16 @@ async def test_sensor_entity(
 ):
     """Test sensor entity shows lock code values."""
     for code_slot, pin in ((1, "1234"), (2, "5678")):
-        state = hass.states.get(f"sensor.mock_title_code_slot_{code_slot}_test_1_code")
+        state = hass.states.get(
+            code_entity_id(hass, lock_code_manager_config_entry, code_slot)
+        )
         assert state
         assert state.state == pin
-        state = hass.states.get(f"sensor.mock_title_code_slot_{code_slot}_test_2_code")
+        state = hass.states.get(
+            code_entity_id(
+                hass, lock_code_manager_config_entry, code_slot, LOCK_2_ENTITY_ID
+            )
+        )
         assert state
         assert state.state == pin
 
@@ -43,21 +49,21 @@ async def test_sensor_native_value_with_slot_code(
     # Empty credential -> sensor shows empty string
     coordinator.async_set_updated_data({pin_address(1): SlotCredential.empty()})
     await hass.async_block_till_done()
-    state = hass.states.get("sensor.mock_title_code_slot_1_test_1_code")
+    state = hass.states.get(code_entity_id(hass, lock_code_manager_config_entry, 1))
     assert state is not None
     assert state.state == ""
 
     # Unreadable credential -> sensor resolves to expected PIN from config
     coordinator.async_set_updated_data({pin_address(1): SlotCredential.unreadable()})
     await hass.async_block_till_done()
-    state = hass.states.get("sensor.mock_title_code_slot_1_test_1_code")
+    state = hass.states.get(code_entity_id(hass, lock_code_manager_config_entry, 1))
     assert state is not None
     assert state.state == "1234"
 
     # Known credential -> sensor shows the code
     coordinator.async_set_updated_data({pin_address(1): SlotCredential.known("5678")})
     await hass.async_block_till_done()
-    state = hass.states.get("sensor.mock_title_code_slot_1_test_1_code")
+    state = hass.states.get(code_entity_id(hass, lock_code_manager_config_entry, 1))
     assert state is not None
     assert state.state == "5678"
 


### PR DESCRIPTION
## Proposed change

Lock Code Manager's per-lock entities were living on the lock's own device.
They now live on the code-slot device beside the shared entities for the same
slot, and setup repairs the registries of anyone who already upgraded.

### What actually happened

Before HA 2026.8, the per-lock entities were attached to the lock's device by
reusing that device's identifiers in `device_info`. That had a side effect:
it added this config entry to the lock's device, which is why the lock used
to appear under Lock Code Manager.

**2026.8 restricts a device to exactly one config entry.** Its registry
migration splits every device that had two into one device per entry — each
keeping a *copy* of the identifiers — and then "entities are moved to the
matching split device when the registries are loaded"
(`homeassistant/helpers/device_registry.py:830-836`). So the upgrade left an
LCM-owned copy of every lock, holding the per-lock entities.

#1379 then stopped claiming the lock's device and set `device_entry`
directly. That is correct as far as it goes — the entities are attached and
working, which is why #1418 reports everything functioning — but it put them
on a device this integration does not own and cannot display, and it left the
copy behind.

**The copy never ages out.** `async_cleanup` removes a device only when it is
referenced by neither entities nor a live config entry
(`device_registry.py:3277-3282`), and the copy references ours. Verified
directly: creating an LCM-owned device with a lock integration's identifiers
yields a second, distinct device that survives `async_cleanup` with nothing on
it.

### The change

- Per-lock entities keep the slot device the base class already assigns.
  Nothing of ours sits on another integration's device.
- Setup moves any entity of ours found on a device we do not own onto its slot
  device, then removes a copy left holding nothing. It runs **before** the
  platforms are set up, deliberately: an entity that is disabled, or whose
  slot has since been removed, is never re-added by a platform and would
  otherwise be deleted along with the device instead of moved.
- Devices belonging to other integrations are never touched — the sweep only
  considers devices this config entry owns.

### One user-visible rename

On the slot device there is one of these entities per lock, so "Code slot 1 in
sync" named every lock's entity identically. The lock moved into the entity
name:

| | before | after |
|---|---|---|
| binary sensor | Front Door **Code slot 1 in sync** | Code slot 1 **Front Door in sync** |
| sensor | Front Door **Code slot 1** | Code slot 1 **Front Door code** |

**Existing entity IDs do not change** — the registry keeps the ID it first
assigned, so automations and dashboards are unaffected. Only newly created
entities get IDs derived from the new device and name.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #1418
- Note for the release notes: the lock itself cannot be shown under Lock Code
  Manager again. `add_config_entry_id` is deprecated in 2026.8 and, per its own
  docstring, "on its own it does nothing" — the only mechanism that ever put
  the lock there is the one that now forks a duplicate.
- Tests: the migration is covered in both directions (moved and left alone),
  and verified to fail when the sweep is removed. Tests no longer spell out
  per-lock entity IDs, which depended on the config entry title and the lock's
  name; they resolve them by unique ID instead.
- 100% coverage held; full suite green under `HYPOTHESIS_PROFILE=ci`.
