### PR TITLE
fix: restore @callback, and let the mock lock be another integration's

### DIFF
--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -867,11 +867,11 @@ def _async_reclaim_entities_from_foreign_devices(
     entities are moved to the slot device they belong to and the emptied copy
     is removed here.
 
-    Runs before the platforms are set up, so an entity that is disabled or
-    whose slot has since been removed -- neither of which is ever re-added --
-    is moved rather than deleted along with the copy it is sitting on. It also
-    runs before the orphaned-slot sweep, which then collects any slot device
-    this recreates for a slot that is no longer configured.
+    Runs before the platforms are set up, so a disabled entity -- which no
+    platform re-adds -- is moved rather than deleted along with the copy it
+    is sitting on. It also runs before the orphaned-slot sweep, so an entity
+    whose slot is no longer configured lands on that slot's device and is
+    removed with it, instead of the sweep leaving a device behind.
     """
     dev_reg = dr.async_get(hass)
     ent_reg = er.async_get(hass)
@@ -915,6 +915,7 @@ def _async_reclaim_entities_from_foreign_devices(
         dev_reg.async_remove_device(device.id)
 
 
+@callback
 def _async_prune_orphaned_slot_devices(
     hass: HomeAssistant, config_entry: LockCodeManagerConfigEntry
 ) -> None:

--- a/custom_components/lock_code_manager/entity.py
+++ b/custom_components/lock_code_manager/entity.py
@@ -75,7 +75,6 @@ class BaseLockCodeManagerEntity(Entity):
         self.ent_reg = ent_reg
 
         self._attr_translation_key = key
-        self._attr_translation_placeholders = {"slot_num": str(slot_num)}
 
         self._attr_device_info = build_slot_device_info(config_entry, slot_num)
 
@@ -338,10 +337,7 @@ class BaseLockCodeManagerCodeSlotPerLockEntity(BaseLockCodeManagerEntity):
         # The lock therefore has to be named by the ENTITY. Sitting on the
         # slot device, one per lock, the slot number alone would name every
         # one of them the same thing.
-        self._attr_translation_placeholders = {
-            "slot_num": str(slot_num),
-            "lock_name": lock.display_name,
-        }
+        self._attr_translation_placeholders = {"lock_name": lock.display_name}
 
         self._attr_unique_id = build_slot_unique_id(
             self.base_unique_id, slot_num, self.key, lock.lock.entity_id

--- a/tests/common.py
+++ b/tests/common.py
@@ -98,6 +98,9 @@ def _per_lock_entity_id(
     return entity_id
 
 
+# The integration the mock lock entities belong to.
+LOCK_DEVICE_DOMAIN = "test"
+
 SLOT_1_ACTIVE_ENTITY = "binary_sensor.mock_title_code_slot_1_active"
 SLOT_1_ENABLED_ENTITY = "switch.mock_title_code_slot_1_enabled"
 SLOT_1_EVENT_ENTITY = "event.mock_title_code_slot_1"
@@ -229,8 +232,13 @@ class MockLockEntity(LockEntity):
         self._attr_unique_id = slugify(name)
         self._attr_is_locked = False
         self._attr_has_entity_name = False
+        # The mock lock's device belongs to the mock lock's integration, not
+        # to Lock Code Manager. Using Lock Code Manager's domain here would
+        # make the device read as one of ours, and the sweep that moves
+        # entities off other integrations' devices would never be exercised
+        # against the shape it exists for.
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, f"lock.{slugify(name)}")}, name=name
+            identifiers={(LOCK_DEVICE_DOMAIN, f"lock.{slugify(name)}")}, name=name
         )
         super().__init__()
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -66,6 +66,7 @@ from .common import (
     BASE_CONFIG,
     LOCK_1_ENTITY_ID,
     LOCK_2_ENTITY_ID,
+    LOCK_DEVICE_DOMAIN,
     SLOT_1_IN_SYNC_ENTITY,
     MockLCMLock,
     in_sync_entity_id,
@@ -107,7 +108,7 @@ async def test_entry_setup_and_unload(
     ent_reg = er.async_get(hass)
 
     for entity_id in (LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID):
-        device = dev_reg.async_get_device({(DOMAIN, entity_id)})
+        device = dev_reg.async_get_device({(LOCK_DEVICE_DOMAIN, entity_id)})
         assert device
         assert device.config_entries == {mock_lock_entry_id}
         # Nothing of ours sits on the lock's own device. A device belongs to
@@ -247,7 +248,7 @@ async def test_entry_setup_and_unload(
 
     # LOCK_2 was removed from the LCM config entry; its device keeps its own
     # config entry and no longer has any LCM entities linked to it.
-    device = dev_reg.async_get_device({(DOMAIN, LOCK_2_ENTITY_ID)})
+    device = dev_reg.async_get_device({(LOCK_DEVICE_DOMAIN, LOCK_2_ENTITY_ID)})
     assert device
     assert device.config_entries == {mock_lock_entry_id}
     assert not [
@@ -1971,7 +1972,7 @@ async def test_setup_leaves_devices_of_other_integrations_alone(
     dev_reg = dr.async_get(hass)
     ent_reg = er.async_get(hass)
 
-    lock_device = dev_reg.async_get_device({(DOMAIN, LOCK_1_ENTITY_ID)})
+    lock_device = dev_reg.async_get_device({(LOCK_DEVICE_DOMAIN, LOCK_1_ENTITY_ID)})
     assert lock_device
     before = {
         entry.entity_id
@@ -2173,5 +2174,52 @@ async def test_reclaim_does_not_resurrect_a_device_for_an_unconfigured_slot(
         is None
     )
     assert dev_reg.async_get(split.id) is None
+
+    await hass.config_entries.async_unload(entry_id)
+
+
+async def test_reclaim_moves_an_entity_off_the_lock_integrations_device(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """The repair this exists for: an entity sitting on the lock's own device.
+
+    That is the state entities were left in before the device model changed --
+    attached to a device owned by the lock's integration, which Lock Code
+    Manager cannot display. It is the common case, and the one the mock lock
+    could not represent while its device carried this integration's domain.
+    """
+    dev_reg = dr.async_get(hass)
+    ent_reg = er.async_get(hass)
+
+    lock_device = dev_reg.async_get_device({(LOCK_DEVICE_DOMAIN, LOCK_1_ENTITY_ID)})
+    assert lock_device
+    assert lock_device.config_entries != {DOMAIN}
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data=BASE_CONFIG, unique_id="On The Lock Device"
+    )
+    config_entry.add_to_hass(hass)
+    entry_id = config_entry.entry_id
+
+    # Disabled so no platform re-homes it, isolating the sweep's own work.
+    stranded = ent_reg.async_get_or_create(
+        "binary_sensor",
+        DOMAIN,
+        f"{entry_id}|1|{ATTR_IN_SYNC}|{LOCK_1_ENTITY_ID}",
+        config_entry=config_entry,
+        device_id=lock_device.id,
+        disabled_by=er.RegistryEntryDisabler.USER,
+    )
+
+    await hass.config_entries.async_setup(entry_id)
+    await hass.async_block_till_done()
+
+    slot_device = dev_reg.async_get_device(
+        {(DOMAIN, build_slot_device_identifier(entry_id, 1))}
+    )
+    assert slot_device
+    assert ent_reg.async_get(stranded.entity_id).device_id == slot_device.id
+    # The lock's own device is another integration's and must survive.
+    assert dev_reg.async_get(lock_device.id) is not None
 
     await hass.config_entries.async_unload(entry_id)


### PR DESCRIPTION
## Proposed change

Follow-ups from the review of #1435, which found these after it merged.

### The mock lock was pretending to be us

`MockLCMLock`'s device carried **Lock Code Manager's own identifier domain**,
so `_is_ours` returned True for it and the reclaim sweep would never move an
entity off it.

That is precisely the shape the sweep exists for. Before the device model
changed, every per-lock entity sat on the lock integration's device — and no
test could reach that state, because in the harness the lock's device looked
like one of ours. `test_setup_leaves_devices_of_other_integrations_alone` was
passing for two wrong reasons at once.

The mock lock's device now belongs to the mock lock's integration, and a test
covers an entity actually being brought home from it. `_is_ours` is pinned in
both directions now — inverting it either way fails three tests, where before
only one direction was caught.

### A decorator moved

Inserting `_async_reclaim_entities_from_foreign_devices` put it between
`@callback` and the function that decorator belonged to, so
`_async_prune_orphaned_slot_devices` lost it. Neither function is ever handed
to `async_run_hass_job`, so the runtime effect is zero — but the decorator
moved rather than being added, and that should not stand.

### Two smaller things

- The reclaim docstring said an entity whose slot was removed is "moved rather
  than deleted". It **is** deleted: it lands on that slot's device and the
  orphan sweep takes both. That is correct, and the next sentence already
  described it — the earlier claim just contradicted it.
- Entities stopped supplying a `slot_num` translation placeholder. No entity
  name template has referenced it since the per-lock rename; the issue and
  config-flow strings that use `{slot_num}` supply their own.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- Follows #1435. No user-visible behaviour change: the decorator was inert,
  the placeholder was unused, and the rest is test fidelity.
- 100% coverage held; full suite green under `HYPOTHESIS_PROFILE=ci`.
