### PR TITLE
fix: stop reclearing a slot the lock will not report on

### DIFF
--- a/custom_components/lock_code_manager/domain/sync.py
+++ b/custom_components/lock_code_manager/domain/sync.py
@@ -230,14 +230,6 @@ class SlotSyncManager:
         # masked/write-only slot on every restart.
         self._last_set_pin: str | None = None
 
-        # Whether the last write to this slot was a clear. Read only when the
-        # lock reports the slot occupied but withholds its contents, where it
-        # is the only evidence the clear landed. In memory only, and False on
-        # restart, so an unreadable slot is cleared once more after a restart
-        # rather than assumed -- matching what ``_last_set_pin`` does on the
-        # set side, and for the same reason.
-        self._cleared_slot: bool = False
-
         # Slot-level circuit breaker: trips when a code repeatedly fails to
         # converge within the window, suspending just this lock and slot.
         # Only ``_async_tick_impl`` mutates the breaker; external callbacks
@@ -496,12 +488,13 @@ class SlotSyncManager:
                 return True
             if not credential.is_readable:
                 # The lock says the slot holds something but will not say
-                # what, so it can neither confirm nor deny the clear. Trust
-                # the clear already issued -- the same trade the set path
-                # above makes with ``_last_set_pin``. Without it the slot is
-                # never in sync, and every tick issues another clear at a
-                # lock that has already done as it was asked.
-                return self._cleared_slot
+                # what, so it can neither confirm nor deny the clear. The
+                # clear already issued is the only evidence there is -- the
+                # same trade the set path above makes with ``_last_set_pin``.
+                # Without it the slot is never in sync, and every tick issues
+                # another clear at a lock that has already done as it was
+                # asked.
+                return self._lock.last_write_was_clear(self._slot_num)
             return False
         # Code sensor entity returns "" for empty credential.
         return snapshot.code_state == ""
@@ -526,12 +519,10 @@ class SlotSyncManager:
                 source="sync",
             )
             self._last_set_pin = snapshot.credential_state
-            self._cleared_slot = False
             _LOGGER.debug("%s: Set usercode", self._log_prefix)
             return True
         await self._lock.async_internal_clear_usercode(self._slot_num, source="sync")
         self._last_set_pin = None
-        self._cleared_slot = True
         _LOGGER.debug("%s: Cleared usercode", self._log_prefix)
         return False
 

--- a/custom_components/lock_code_manager/domain/sync.py
+++ b/custom_components/lock_code_manager/domain/sync.py
@@ -230,6 +230,14 @@ class SlotSyncManager:
         # masked/write-only slot on every restart.
         self._last_set_pin: str | None = None
 
+        # Whether the last write to this slot was a clear. Read only when the
+        # lock reports the slot occupied but withholds its contents, where it
+        # is the only evidence the clear landed. In memory only, and False on
+        # restart, so an unreadable slot is cleared once more after a restart
+        # rather than assumed -- matching what ``_last_set_pin`` does on the
+        # set side, and for the same reason.
+        self._cleared_slot: bool = False
+
         # Slot-level circuit breaker: trips when a code repeatedly fails to
         # converge within the window, suspending just this lock and slot.
         # Only ``_async_tick_impl`` mutates the breaker; external callbacks
@@ -484,7 +492,17 @@ class SlotSyncManager:
             return snapshot.credential_state == snapshot.code_state
         # active_state == STATE_OFF: slot should be cleared
         if credential is not None:
-            return credential.is_empty
+            if credential.is_empty:
+                return True
+            if not credential.is_readable:
+                # The lock says the slot holds something but will not say
+                # what, so it can neither confirm nor deny the clear. Trust
+                # the clear already issued -- the same trade the set path
+                # above makes with ``_last_set_pin``. Without it the slot is
+                # never in sync, and every tick issues another clear at a
+                # lock that has already done as it was asked.
+                return self._cleared_slot
+            return False
         # Code sensor entity returns "" for empty credential.
         return snapshot.code_state == ""
 
@@ -508,10 +526,12 @@ class SlotSyncManager:
                 source="sync",
             )
             self._last_set_pin = snapshot.credential_state
+            self._cleared_slot = False
             _LOGGER.debug("%s: Set usercode", self._log_prefix)
             return True
         await self._lock.async_internal_clear_usercode(self._slot_num, source="sync")
         self._last_set_pin = None
+        self._cleared_slot = True
         _LOGGER.debug("%s: Cleared usercode", self._log_prefix)
         return False
 

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -225,6 +225,9 @@ class BaseLock:
     _setup_running: bool = field(default=False, init=False)
     _lcm_config_entry: ConfigEntry | None = field(default=None, init=False)
     _rejected_code_slots: set[int] = field(default_factory=set, init=False)
+    # Slots whose most recent write from this integration was a clear that
+    # changed something. See ``last_write_was_clear``.
+    _cleared_slots: set[int] = field(default_factory=set, init=False)
     # Slots with an outstanding optimistic (ambiguous-but-treated-as-completed)
     # write awaiting confirmation, mapped to (believed_pin, monotonic_deadline).
     # A confirmation -- a push event or a hard-refresh read observing the slot
@@ -1165,6 +1168,11 @@ class BaseLock:
         source: Literal["sync", "direct"] = "direct",
     ) -> None:
         """Set a usercode on a code slot."""
+        # Discarded BEFORE the write: a set that raises may still have landed
+        # -- the verification read is what times out -- and a slot still
+        # remembered as cleared would be reported cleared while it holds a
+        # working code.
+        self._cleared_slots.discard(code_slot)
         LOGGER.debug(
             "Setting usercode on %s slot %s (pin=%s, source=%s)",
             self.lock.entity_id,
@@ -1297,8 +1305,14 @@ class BaseLock:
         self,
         code_slot: int,
         source: Literal["sync", "direct"] = "direct",
-    ) -> None:
-        """Clear a usercode on a code slot."""
+    ) -> bool:
+        """
+        Clear a usercode on a code slot.
+
+        Returns whether the provider actually changed anything. A clear that
+        found nothing to clear has told the caller nothing about what the
+        slot holds.
+        """
         LOGGER.debug(
             "Clearing usercode on %s slot %s (source=%s)",
             self.lock.entity_id,
@@ -1312,8 +1326,16 @@ class BaseLock:
         changed = await self._execute_rate_limited(
             "clear", self.async_clear_usercode, code_slot
         )
+        # Only a clear that changed something is evidence about the slot. A
+        # provider that found nothing to clear has said nothing about what is
+        # there.
+        if changed:
+            self._cleared_slots.add(code_slot)
+        else:
+            self._cleared_slots.discard(code_slot)
         if changed and self.coordinator and not self.supports_push:
             await self.coordinator.async_request_refresh()
+        return bool(changed)
 
     async def _project_users_to_slots(
         self, credential_type: CredentialType
@@ -1835,6 +1857,22 @@ class BaseLock:
             ) from err
 
     @final
+    @final
+    def last_write_was_clear(self, code_slot: int) -> bool:
+        """
+        Return whether the last write this integration made here was a clear.
+
+        The only evidence a clear landed on a lock that reports a slot
+        occupied without saying what it holds. Kept on the provider rather
+        than in the sync manager because every write funnels through here,
+        including the ones a service call makes directly -- a memory the sync
+        manager kept could not see those and would go stale.
+
+        In memory only, so a restart forgets and the slot is cleared once
+        more rather than assumed.
+        """
+        return code_slot in self._cleared_slots
+
     @property
     def managed_slots(self) -> set[int]:
         """Return slot numbers managed by any Lock Code Manager config entry that includes this lock."""

--- a/tests/common.py
+++ b/tests/common.py
@@ -126,6 +126,11 @@ class MockLCMLock(BaseLock):
         self._device_available = True
         self._hard_refresh_interval: timedelta | None = None
         self.codes: dict[int, str] = {1: "1234", 2: "5678"}
+        # Slots this lock reports as occupied without giving up the value,
+        # the way a lock with masked Personal Identification Numbers does.
+        # Reported regardless of ``codes``, so a slot keeps reading occupied
+        # after a clear -- which is the state a clear can never confirm.
+        self.write_only: set[int] = set()
         self.service_calls: defaultdict[str, list] = defaultdict(list)
 
     @property
@@ -193,7 +198,9 @@ class MockLCMLock(BaseLock):
         """Return dictionary of code slots and usercodes."""
         snapshot = self.codes.copy()
         self.service_calls["get_usercodes"].append(snapshot)
-        return {slot: SlotCredential.known(pin) for slot, pin in snapshot.items()}
+        codes = {slot: SlotCredential.known(pin) for slot, pin in snapshot.items()}
+        codes.update({slot: SlotCredential.unreadable() for slot in self.write_only})
+        return codes
 
 
 @dataclass(repr=False, eq=False)

--- a/tests/properties/test_in_sync.py
+++ b/tests/properties/test_in_sync.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
-from hypothesis import assume, given, strategies as st
+from hypothesis import given, strategies as st
 
 from homeassistant.const import STATE_OFF, STATE_ON
 
@@ -43,7 +43,7 @@ def _manager(
     manager._address = pin_address(1)
     manager._coordinator = SimpleNamespace(is_verified=lambda address: verified)
     manager._last_set_pin = last_set_pin
-    manager._cleared_slot = cleared_slot
+    manager._lock = SimpleNamespace(last_write_was_clear=lambda slot: cleared_slot)
     return manager
 
 
@@ -109,7 +109,7 @@ def test_inactive_slot_syncs_iff_the_lock_shows_no_code_it_can_report(
     A lock that reports the slot occupied but withholds its contents can
     neither confirm nor deny a clear, so the clear already issued is the only
     evidence there is. Everything else is unchanged: a readable code means
-    work to do, and an empty slot is done.
+    work to do whatever was cleared before, and an empty slot is done.
     """
     manager = _manager(
         verified=True, last_set_pin=last_set_pin, cleared_slot=cleared_slot
@@ -131,25 +131,3 @@ def test_inactive_slot_syncs_iff_the_lock_shows_no_code_it_can_report(
     else:
         expected = cleared_slot
     assert manager.calculate_in_sync(state) is expected
-
-
-@given(snapshot=SLOT_STATES, last_set_pin=LAST_SET)
-def test_inactive_slot_with_a_readable_code_is_never_in_sync(
-    snapshot: CredentialSyncState, last_set_pin: str | None
-) -> None:
-    """No memory of a clear can make a code the lock still reports acceptable.
-
-    The clear-was-issued evidence must not leak into the case where the lock
-    tells us plainly that a code is there.
-    """
-    assume(snapshot.coordinator_credential is not None)
-    assume(snapshot.coordinator_credential.is_readable)
-    manager = _manager(verified=True, last_set_pin=last_set_pin, cleared_slot=True)
-    state = CredentialSyncState(
-        STATE_OFF,
-        snapshot.credential_state,
-        snapshot.name_state,
-        snapshot.code_state,
-        snapshot.coordinator_credential,
-    )
-    assert manager.calculate_in_sync(state) is False

--- a/tests/properties/test_in_sync.py
+++ b/tests/properties/test_in_sync.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
-from hypothesis import given, strategies as st
+from hypothesis import assume, given, strategies as st
 
 from homeassistant.const import STATE_OFF, STATE_ON
 
@@ -33,7 +33,9 @@ SLOT_STATES = st.builds(
 )
 
 
-def _manager(*, verified: bool, last_set_pin: str | None) -> SlotSyncManager:
+def _manager(
+    *, verified: bool, last_set_pin: str | None, cleared_slot: bool = False
+) -> SlotSyncManager:
     # __new__ skips the heavyweight __init__ (hass, registries, entities);
     # calculate_in_sync only touches these four attributes.
     manager = SlotSyncManager.__new__(SlotSyncManager)
@@ -41,6 +43,7 @@ def _manager(*, verified: bool, last_set_pin: str | None) -> SlotSyncManager:
     manager._address = pin_address(1)
     manager._coordinator = SimpleNamespace(is_verified=lambda address: verified)
     manager._last_set_pin = last_set_pin
+    manager._cleared_slot = cleared_slot
     return manager
 
 
@@ -97,12 +100,20 @@ def test_active_without_coordinator_data_falls_back_to_code_sensor(
     assert manager.calculate_in_sync(state) is (pin == code)
 
 
-@given(snapshot=SLOT_STATES, last_set_pin=LAST_SET)
-def test_inactive_slot_syncs_iff_lock_side_empty(
-    snapshot: CredentialSyncState, last_set_pin: str | None
+@given(snapshot=SLOT_STATES, last_set_pin=LAST_SET, cleared_slot=st.booleans())
+def test_inactive_slot_syncs_iff_the_lock_shows_no_code_it_can_report(
+    snapshot: CredentialSyncState, last_set_pin: str | None, cleared_slot: bool
 ) -> None:
-    """Inactive slot: in sync exactly when the lock side shows no code."""
-    manager = _manager(verified=True, last_set_pin=last_set_pin)
+    """Inactive slot: in sync exactly when no code the lock can report remains.
+
+    A lock that reports the slot occupied but withholds its contents can
+    neither confirm nor deny a clear, so the clear already issued is the only
+    evidence there is. Everything else is unchanged: a readable code means
+    work to do, and an empty slot is done.
+    """
+    manager = _manager(
+        verified=True, last_set_pin=last_set_pin, cleared_slot=cleared_slot
+    )
     state = CredentialSyncState(
         STATE_OFF,
         snapshot.credential_state,
@@ -111,5 +122,34 @@ def test_inactive_slot_syncs_iff_lock_side_empty(
         snapshot.coordinator_credential,
     )
     credential = state.coordinator_credential
-    expected = credential.is_empty if credential is not None else state.code_state == ""
+    if credential is None:
+        expected = state.code_state == ""
+    elif credential.is_empty:
+        expected = True
+    elif credential.is_readable:
+        expected = False
+    else:
+        expected = cleared_slot
     assert manager.calculate_in_sync(state) is expected
+
+
+@given(snapshot=SLOT_STATES, last_set_pin=LAST_SET)
+def test_inactive_slot_with_a_readable_code_is_never_in_sync(
+    snapshot: CredentialSyncState, last_set_pin: str | None
+) -> None:
+    """No memory of a clear can make a code the lock still reports acceptable.
+
+    The clear-was-issued evidence must not leak into the case where the lock
+    tells us plainly that a code is there.
+    """
+    assume(snapshot.coordinator_credential is not None)
+    assume(snapshot.coordinator_credential.is_readable)
+    manager = _manager(verified=True, last_set_pin=last_set_pin, cleared_slot=True)
+    state = CredentialSyncState(
+        STATE_OFF,
+        snapshot.credential_state,
+        snapshot.name_state,
+        snapshot.code_state,
+        snapshot.coordinator_credential,
+    )
+    assert manager.calculate_in_sync(state) is False

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -2227,3 +2227,48 @@ async def test_add_standard_entity_for_slot_without_coordinator_logs_warning(
         if "|99|" in entry.unique_id
     ]
     assert slot_99_entities
+
+
+async def test_a_lock_that_withholds_its_contents_is_cleared_once(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """A disabled slot the lock will not report on must not be cleared forever.
+
+    Some locks answer "occupied" without returning the code -- masked PINs on
+    Z-Wave, an enabled status with no value on Zigbee. The clear lands, but
+    the read can never confirm it, so the slot reads out of sync on every
+    tick and each tick issues another clear at a lock that has already done
+    as it was asked.
+    """
+    await async_initial_tick(hass, SLOT_1_IN_SYNC_ENTITY)
+
+    lock_provider = lock_code_manager_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
+    coordinator = lock_provider.coordinator
+    assert coordinator is not None
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_OFF,
+        target={ATTR_ENTITY_ID: SLOT_1_ENABLED_ENTITY},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    lock_provider.service_calls["clear_usercode"].clear()
+
+    await async_trigger_sync_tick(hass, SLOT_1_IN_SYNC_ENTITY)
+    assert len(lock_provider.service_calls.get("clear_usercode", [])) == 1
+
+    # The lock keeps reporting the slot occupied, without saying what it holds.
+    for _ in range(3):
+        coordinator.async_set_updated_data(
+            {pin_address(1): SlotCredential.unreadable()}
+        )
+        await hass.async_block_till_done()
+        await async_trigger_sync_tick(hass, SLOT_1_IN_SYNC_ENTITY)
+
+    assert len(lock_provider.service_calls.get("clear_usercode", [])) == 1, (
+        "The clear was reissued on every tick"
+    )
+    assert hass.states.get(SLOT_1_IN_SYNC_ENTITY).state == STATE_ON

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -33,10 +33,14 @@ from homeassistant.helpers.update_coordinator import UpdateFailed
 from homeassistant.util import dt as dt_util
 
 from custom_components.lock_code_manager.const import (
+    ATTR_CODE_SLOT,
+    ATTR_LOCK_ENTITY_ID,
+    ATTR_USERCODE,
     CONF_LOCKS,
     CONF_SLOTS,
     DOMAIN,
     MAX_SYNC_ATTEMPTS,
+    SERVICE_SET_USERCODE,
     SYNC_ATTEMPT_WINDOW,
     TICK_INTERVAL,
 )
@@ -47,6 +51,7 @@ from custom_components.lock_code_manager.domain.credentials import pin_address
 from custom_components.lock_code_manager.domain.exceptions import (
     DuplicateCodeError,
     LockCodeManagerError,
+    LockOperationFailed,
 )
 from custom_components.lock_code_manager.domain.locks import async_create_lock_instance
 from custom_components.lock_code_manager.domain.models import SlotCredential, SyncState
@@ -2241,12 +2246,167 @@ async def test_a_lock_that_withholds_its_contents_is_cleared_once(
     the read can never confirm it, so the slot reads out of sync on every
     tick and each tick issues another clear at a lock that has already done
     as it was asked.
+
+    Counted at the provider boundary, not on the mock's own bookkeeping: the
+    mock records nothing for a clear that finds no code, which is exactly
+    what every clear after the first one looks like.
     """
     await async_initial_tick(hass, SLOT_1_IN_SYNC_ENTITY)
 
     lock_provider = lock_code_manager_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
     coordinator = lock_provider.coordinator
     assert coordinator is not None
+
+    # From here the lock reports slot 1 occupied and will not say what it
+    # holds -- including after the clear lands.
+    lock_provider.write_only = {1}
+
+    with patch.object(
+        lock_provider,
+        "async_internal_clear_usercode",
+        wraps=lock_provider.async_internal_clear_usercode,
+    ) as clears:
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_OFF,
+            target={ATTR_ENTITY_ID: SLOT_1_ENABLED_ENTITY},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+        for _ in range(4):
+            await coordinator.async_refresh()
+            await hass.async_block_till_done()
+            await async_trigger_sync_tick(hass, SLOT_1_IN_SYNC_ENTITY)
+
+    assert clears.await_count == 1, (
+        f"The clear was reissued on every tick ({clears.await_count} times)"
+    )
+    assert hass.states.get(SLOT_1_IN_SYNC_ENTITY).state == STATE_ON
+
+
+async def test_a_set_that_lands_but_raises_still_invalidates_the_clear(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """A failed set may have landed, so it must not leave a clear standing.
+
+    Issue #1397's mode is exactly this: the write reaches the lock and the
+    verification read times out. If the memory of an earlier clear survived
+    that, disabling the slot again would report it cleared while a working
+    code sits on the door -- and no clear would ever be issued.
+    """
+    await async_initial_tick(hass, SLOT_1_IN_SYNC_ENTITY)
+
+    lock_provider = lock_code_manager_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
+    coordinator = lock_provider.coordinator
+    assert coordinator is not None
+    # The real initial value, not one a test handed it.
+    assert lock_provider.last_write_was_clear(1) is False
+
+    lock_provider.write_only = {1}
+
+    async def _turn(service: str) -> None:
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            service,
+            target={ATTR_ENTITY_ID: SLOT_1_ENABLED_ENTITY},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        await coordinator.async_refresh()
+        await hass.async_block_till_done()
+        await async_trigger_sync_tick(hass, SLOT_1_IN_SYNC_ENTITY)
+
+    await _turn(SERVICE_TURN_OFF)
+    assert lock_provider.last_write_was_clear(1) is True
+
+    # The provider primitive fails, so the write funnel still runs -- which is
+    # where the memory of the clear has to be discarded. Patching the funnel
+    # itself would skip the very line under test.
+    with patch.object(
+        lock_provider,
+        "async_set_usercode",
+        AsyncMock(side_effect=LockOperationFailed("verification read timed out")),
+    ):
+        await _turn(SERVICE_TURN_ON)
+
+    # The set may have landed, so the earlier clear is no longer evidence.
+    assert lock_provider.last_write_was_clear(1) is False
+
+    with patch.object(
+        lock_provider,
+        "async_internal_clear_usercode",
+        wraps=lock_provider.async_internal_clear_usercode,
+    ) as clears:
+        await _turn(SERVICE_TURN_OFF)
+
+    assert clears.await_count == 1, "The slot was reported cleared without a clear"
+
+
+async def test_a_clear_that_changed_nothing_is_not_evidence(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """Only a clear that actually changed something may settle the slot.
+
+    A provider that found nothing to clear -- no user owns the credential,
+    say -- has said nothing about what the slot holds. Treating the call as
+    proof would report a slot cleared that this integration was never able
+    to touch. Staying out of sync is the honest answer: the clear keeps being
+    attempted and the user can see it never lands.
+    """
+    await async_initial_tick(hass, SLOT_1_IN_SYNC_ENTITY)
+
+    lock_provider = lock_code_manager_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
+    coordinator = lock_provider.coordinator
+    assert coordinator is not None
+
+    # The lock reports the slot occupied, but there is nothing here to clear.
+    lock_provider.codes.pop(1, None)
+    lock_provider.write_only = {1}
+
+    with patch.object(
+        lock_provider,
+        "async_internal_clear_usercode",
+        wraps=lock_provider.async_internal_clear_usercode,
+    ) as clears:
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_OFF,
+            target={ATTR_ENTITY_ID: SLOT_1_ENABLED_ENTITY},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+        for _ in range(2):
+            await coordinator.async_refresh()
+            await hass.async_block_till_done()
+            await async_trigger_sync_tick(hass, SLOT_1_IN_SYNC_ENTITY)
+
+    assert clears.await_count > 1, "A no-op clear was taken as proof the slot is clear"
+    assert hass.states.get(SLOT_1_IN_SYNC_ENTITY).state == STATE_OFF
+
+
+async def test_a_code_written_by_service_invalidates_the_clear(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """A write from anywhere invalidates the clear, not just one sync issued.
+
+    The set_usercode service goes straight to the provider, so a memory kept
+    by the sync manager could never see it. On a lock that masks its codes
+    the slot would keep reporting cleared while the service's code sat there.
+    """
+    await async_initial_tick(hass, SLOT_1_IN_SYNC_ENTITY)
+
+    lock_provider = lock_code_manager_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
+    coordinator = lock_provider.coordinator
+    assert coordinator is not None
+    lock_provider.write_only = {1}
 
     await hass.services.async_call(
         SWITCH_DOMAIN,
@@ -2255,20 +2415,19 @@ async def test_a_lock_that_withholds_its_contents_is_cleared_once(
         blocking=True,
     )
     await hass.async_block_till_done()
-    lock_provider.service_calls["clear_usercode"].clear()
-
     await async_trigger_sync_tick(hass, SLOT_1_IN_SYNC_ENTITY)
-    assert len(lock_provider.service_calls.get("clear_usercode", [])) == 1
+    assert lock_provider.last_write_was_clear(1) is True
 
-    # The lock keeps reporting the slot occupied, without saying what it holds.
-    for _ in range(3):
-        coordinator.async_set_updated_data(
-            {pin_address(1): SlotCredential.unreadable()}
-        )
-        await hass.async_block_till_done()
-        await async_trigger_sync_tick(hass, SLOT_1_IN_SYNC_ENTITY)
-
-    assert len(lock_provider.service_calls.get("clear_usercode", [])) == 1, (
-        "The clear was reissued on every tick"
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_USERCODE,
+        {
+            ATTR_LOCK_ENTITY_ID: LOCK_1_ENTITY_ID,
+            ATTR_CODE_SLOT: 1,
+            ATTR_USERCODE: "9999",
+        },
+        blocking=True,
     )
-    assert hass.states.get(SLOT_1_IN_SYNC_ENTITY).state == STATE_ON
+    await hass.async_block_till_done()
+
+    assert lock_provider.last_write_was_clear(1) is False

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -71,11 +71,16 @@ def _slot(
 
 
 def _manager(
-    last_set_pin: str | None = None, *, verified: bool = True, slot_num: int = 1
+    last_set_pin: str | None = None,
+    *,
+    verified: bool = True,
+    slot_num: int = 1,
+    cleared_slot: bool = False,
 ) -> SlotSyncManager:
     """Build a mock SlotSyncManager with _last_set_pin and a verified coordinator."""
     mgr = MagicMock(spec=SlotSyncManager)
     mgr._last_set_pin = last_set_pin
+    mgr._cleared_slot = cleared_slot
     mgr._slot_num = slot_num
     mgr._address = pin_address(slot_num)
     mgr._coordinator = MagicMock()
@@ -199,7 +204,7 @@ class TestCalculateInSync:
                     "coordinator_credential": SlotCredential.unreadable(),
                 },
                 False,
-                id="inactive-unknown-code",
+                id="inactive-unknown-code-never-cleared",
             ),
             pytest.param(
                 None,
@@ -232,6 +237,22 @@ class TestCalculateInSync:
             _manager(last_set_pin=last_set_pin).calculate_in_sync(_slot(**slot_kwargs))
             is expected
         )
+
+    def test_inactive_unknown_code_is_in_sync_once_cleared(self) -> None:
+        """A lock that withholds its contents cannot confirm or deny a clear.
+
+        Without this the slot is never in sync, so every tick issues another
+        clear at a lock that already did as it was asked -- forever.
+        """
+        slot = _slot(
+            active=STATE_OFF, coordinator_credential=SlotCredential.unreadable()
+        )
+        assert _manager(cleared_slot=True).calculate_in_sync(slot) is True
+
+    def test_a_readable_code_still_needs_clearing_after_a_clear(self) -> None:
+        """Remembering the clear must not excuse a code the lock still reports."""
+        slot = _slot(active=STATE_OFF, coordinator_credential="1234")
+        assert _manager(cleared_slot=True).calculate_in_sync(slot) is False
 
     def test_unverified_slot_is_never_in_sync(self) -> None:
         """An unverified slot is not in sync even when the value would match.

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -80,7 +80,8 @@ def _manager(
     """Build a mock SlotSyncManager with _last_set_pin and a verified coordinator."""
     mgr = MagicMock(spec=SlotSyncManager)
     mgr._last_set_pin = last_set_pin
-    mgr._cleared_slot = cleared_slot
+    mgr._lock = MagicMock()
+    mgr._lock.last_write_was_clear.return_value = cleared_slot
     mgr._slot_num = slot_num
     mgr._address = pin_address(slot_num)
     mgr._coordinator = MagicMock()


### PR DESCRIPTION
## Proposed change

A disabled slot on a lock that will not report its contents was cleared on
**every tick, forever**.

Some locks answer "this slot is occupied" without returning the code. Masked
PINs on Z-Wave project to `unreadable` (`zwave_js.py:254`), and so does an
`enabled` status carrying no PIN value on Zigbee2MQTT
(`zigbee2mqtt.py:94-99`). For an inactive slot, `calculate_in_sync` returned
`credential.is_empty` — and `unreadable` is not empty, so:

```
tick → not in sync → clear → lock still reports "occupied, value withheld"
     → not in sync → clear → …
```

The clear lands. The read can never confirm it. The circuit breaker never
catches it either, because `record_failure()` is only charged `if was_set`
(`sync.py:984`) and a clear returns False. So it runs indefinitely — repeated
radio traffic to what is often a battery lock, and a sync state that never
settles.

### The fix

An inactive slot is in sync when the lock reports nothing readable **and** a
clear has been issued since the last set.

That is the same trade the *active* path already makes: when a slot's code is
write-only, it trusts `_last_set_pin` rather than demanding a readback. This
adds the missing symmetric memory for the clear side. It is in-process only,
for the same stated reason — after a restart the slot is cleared once more
rather than assumed, costing one clear per unreadable slot per restart.

A code the lock *does* report still needs clearing. The memory of a clear must
not excuse a credential the lock is actively telling us about.

### Tests

- A full-stack test disables a slot, has the lock keep answering `unreadable`,
  and asserts **one** clear across four ticks. Reverting the fix fails it.
- The property "an inactive slot is in sync exactly when the lock side is
  empty" stated the old contract, so it now states the three cases
  separately — empty, readable, and withheld.
- A second property pins that no memory of a clear makes a readable code
  acceptable, so the new evidence cannot leak into the case where the lock
  answers plainly.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- Found while reviewing the v3 occupancy work: a ZHA change there would have
  widened the trigger to any firmware that leaves a cleared slot reporting
  `Enabled`. The bug itself predates that and affects Z-Wave and Zigbee2MQTT
  users today, which is why it targets `main` rather than `v3`.
- 100% coverage held; full suite green under `HYPOTHESIS_PROFILE=ci`.
