### PR TITLE
refactor: first consolidation pass over the v3 diff

### DIFF
--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -132,17 +132,16 @@ async def _async_check_slot_capacity(
     """
     Reject slot numbers no lock in the set could ever hold.
 
-    Only locks whose credential index IS the slot number are checked (see
-    ``BaseLock.credential_index_follows_slot``) -- Matter allocates its own
-    index, so a slot number above its credential count is perfectly legal
-    there. Catching this at configuration time is what issue #1398 asked
-    for: the write would otherwise fail forever on the device with nothing
-    but a connectivity warning to show for it.
+    Only locks whose credential index IS the slot number are checked
+    (``BaseLock.credential_index_follows_slot``) -- Matter allocates its own
+    index, so a slot number above its credential count is legal there.
+    Catching it here spares the user a write that fails forever on the device
+    with nothing but a connectivity warning to show for it.
 
-    A lock that cannot be queried is skipped rather than blocking the flow.
-    Capabilities need the lock awake, and a battery lock that happens to be
-    asleep must not make the config flow unusable; the same check runs again
-    at write time, where it can suspend the affected slot precisely.
+    A lock that cannot be queried is skipped rather than blocking the flow:
+    capabilities need the lock awake, and a sleeping battery lock must not
+    make the config flow unusable. The same check runs at write time, where
+    it can suspend the affected slot precisely.
     """
     dev_reg = dr.async_get(hass)
     ent_reg = er.async_get(hass)
@@ -202,28 +201,21 @@ async def _async_validate_slots_yaml(
         parsed_slots = CODE_SLOTS_SCHEMA(raw_slots)
     except vol.Invalid as err:
         _LOGGER.error("Invalid YAML: %s", err)
-        # A missing name is now the most likely reason a previously-valid
-        # slots block fails, so name it rather than sending the user to the
-        # logs for the one error we can predict.
-        #
-        # Match on the error PATH, not the rendered text. CONF_NAME is
-        # "name", which is a substring of any key containing it
-        # ("friendly_name", "username"), so a text match reports an
-        # unrelated schema failure as a missing name -- sending the user to
-        # exactly the logs this branch exists to avoid.
+        # Match on the error PATH, not the rendered text: CONF_NAME is
+        # "name", a substring of any key containing it ("friendly_name",
+        # "username"), so a text match would report an unrelated schema
+        # failure as a missing name.
         if CONF_NAME in getattr(err, "path", []):
             return None, {"base": "name_required"}, {}
         return None, {"base": "invalid_config"}, {}
 
-    # The single-slot flow checks one name at a time; these paths submit the
-    # whole set, so the set has to be checked together.
+    # These paths submit the whole set at once, so names are checked together
+    # rather than one at a time as the single-slot flow does.
     if problem := validate_slot_names(parsed_slots):
         slot_num, error = problem
-        # This is the one path that knows which slot failed, so it uses the
-        # messages that name one. Everywhere else the user is looking at a
-        # single user and there is no slot number to give -- the shared
-        # messages must not ask for one, or they render as a translation
-        # error instead of an explanation.
+        # The only path that knows WHICH slot failed, so it uses the messages
+        # that name one. The shared messages must not ask for a slot number
+        # they cannot be given, or they render as a translation error.
         return None, {"base": _SLOT_NAME_ERRORS[error]}, {"slot_num": slot_num}
 
     errors, placeholders = _check_common_slots(hass, locks, parsed_slots, config_entry)
@@ -516,13 +508,11 @@ class LockCodeManagerFlowHandler(
                 locks.append(
                     LockOccupancy(
                         lock_entity_id=lock_entity_id,
-                        # A lock this integration writes to constrains the
-                        # numbering, and without a provider there is no way
-                        # to ask whether it addresses credentials by slot
-                        # number -- so assume it does, which is the
-                        # assumption that refuses rather than guesses. A lock
-                        # on an unsupported platform is written to by nobody
-                        # and constrains nothing.
+                        # With no provider there is no way to ask whether this
+                        # lock addresses credentials by slot number, so assume
+                        # it does -- the assumption that refuses rather than
+                        # guesses. An unmanaged lock constrains nothing either
+                        # way.
                         credential_index_follows_slot=skipped.managed,
                         managed=skipped.managed,
                         occupied=None,
@@ -643,9 +633,7 @@ class LockCodeManagerFlowHandler(
                     continue
                 # None is a lock with no opinion, not a lock with no slots.
                 # Only a real answer earns a name, because the name is what
-                # the refusal blames -- and blaming a lock for a limit it
-                # never reported sends the user to re-interview it over a
-                # number it never said.
+                # the refusal blames.
                 if (bound := await lock_instance.async_get_max_slot()) is not None:
                     limits[lock_entity_id] = bound
             except Exception:
@@ -669,29 +657,19 @@ class LockCodeManagerFlowHandler(
         Find numbers for ``num_users``, reading only as far as it has to.
 
         Locks that answer one index per round trip make the width of this
-        read the cost of it, so it starts at the number of users and widens
-        only by what turned out to be in the way -- and each pass asks only
-        about the numbers no earlier pass covered. Every index is read at
-        most once, so placing a handful of users never costs more round trips
-        than the highest number they land on.
+        read its cost, so the window starts at the number of users and widens
+        only by what turned out to be in the way, each pass asking only about
+        numbers no earlier pass covered. Every index is read at most once.
 
-        Widening stops when the numbers it would need are past what a lock
-        can hold, which is the same refusal as asking for too many users --
-        because on a full lock that is what it is.
-
-        It also stops on its own. Each pass either finds enough free numbers
-        or discovers strictly more occupied ones than the pass before -- a
-        pass that discovered no more would have found the window big enough,
-        since the window is exactly the count plus what was in the way -- and
-        the locks hold finitely many credentials.
-
-        The count itself is checked before the first read: one no lock could
-        ever hold is refused without asking a lock about it, rather than
-        after a round trip per user.
+        Terminating is not an accident: each pass either finds enough free
+        numbers or discovers strictly MORE occupied ones than the pass
+        before -- a pass discovering no more would have found the window big
+        enough, the window being exactly the count plus what was in the way --
+        and the locks hold finitely many credentials.
 
         Returns the numbers allocation must avoid, verified across a window
-        wide enough to hold everyone. The users themselves are numbered from
-        it later, once they have names.
+        wide enough to hold everyone. The users are numbered from it later,
+        once they have names.
         """
         errors, placeholders = await _async_check_slot_capacity(
             self.hass, self.data[CONF_LOCKS], [num_users]
@@ -705,18 +683,17 @@ class LockCodeManagerFlowHandler(
 
         max_slot, limiting_lock = await self._async_max_slot()
         if num_users > max_slot:
-            # Checked before the first read, not only before each widening:
-            # a count that already exceeds the range walks past the end of
-            # the lock on the way in, and on a lock that reads past-end as
-            # free it would be handed every one of those numbers.
+            # Before the first read, not just before each widening: a count
+            # past the range walks off the end of the lock on the way in, and
+            # a lock reading past-end as free would hand back all of it.
             return None, *self._too_far(num_users, max_slot, limiting_lock)
 
         unavailable: set[int] = set()
         read_up_to = 0
         window = num_users
         while True:
-            # Only the part nobody has asked about yet. Re-reading from one
-            # every pass would cost a nearly-full lock several times its own
+            # Only the part nobody has asked about yet; re-reading from one
+            # each pass would cost a nearly-full lock several times its own
             # capacity to place a couple of users.
             occupancy = await self._async_read_occupancy(
                 range(read_up_to + 1, window + 1)
@@ -742,12 +719,9 @@ class LockCodeManagerFlowHandler(
                 self.hass, self.data[CONF_LOCKS], [wider]
             )
             if errors:
-                # A different statement from the count being too large: the
-                # count fits the lock, and the numbers it would have to reach
-                # around what is already there do not. Saying "N users will
-                # not fit" of a count the lock could hold reads as a bug, and
-                # sends the user to re-interview a lock whose interview is
-                # fine.
+                # Distinct from the count being too large: the count fits,
+                # and the numbers needed to reach around what is already
+                # there do not.
                 return (
                     None,
                     {"base": "numbers_needed_exceed_capacity"},

--- a/custom_components/lock_code_manager/const.py
+++ b/custom_components/lock_code_manager/const.py
@@ -134,19 +134,13 @@ DEFAULT_NUM_USERS = 3
 # How far a search for free slot numbers goes when no lock will say where its
 # own range ends.
 #
-# 255 because that is the largest value a one-byte user identifier can carry,
-# and the older credential command classes address users with one -- so no
-# lock reached through them has a slot number above it to find. Where the slot
-# number is this integration's own tag rather than an index on the lock
-# (Schlage, Akuvox, virtual) there is no device range at all, and this stands
-# in as the point past which nobody is configuring more users.
+# 255 is the largest value a one-byte user identifier can carry, and the older
+# credential command classes address users with one. Where the slot number is
+# this integration's own tag rather than an index on the lock (Schlage,
+# Akuvox, virtual) there is no device range at all and this stands in.
 #
-# A search policy, not a property of any lock, which is why it lives here and
-# not on the provider: a provider that cannot say answers None, and the caller
-# decides what to do about it.
-#
-# It bounds only the SEARCH. A number a user already holds above it keeps
-# working, and a lock that reports a larger range is believed up to it.
+# Bounds only the SEARCH: a number a user already holds above it keeps
+# working, and a lock reporting a larger range is believed up to it.
 MAX_SEARCHED_SLOT = 255
 
 PLATFORM_MAP = {

--- a/custom_components/lock_code_manager/domain/config.py
+++ b/custom_components/lock_code_manager/domain/config.py
@@ -15,7 +15,7 @@ from .names import normalize_name
 from .slot_assignment import (
     CONF_SLOT_ASSIGNMENT,
     SlotAssignment,
-    _identity,
+    identity,
     users_from_slots,
 )
 
@@ -144,7 +144,7 @@ class EntryConfig:
             users = {}
             for name, user in raw_users.items():
                 normalized = normalize_name(name)
-                if any(_identity(seen) == _identity(normalized) for seen in users):
+                if any(identity(seen) == identity(normalized) for seen in users):
                     continue
                 users[normalized] = dict(user)
             assignment = SlotAssignment.from_mapping(mapping)
@@ -229,7 +229,7 @@ class EntryConfig:
         slot number.
         """
         stored = next(
-            (known for known in self.users if _identity(known) == _identity(old)), None
+            (known for known in self.users if identity(known) == identity(old)), None
         )
         if stored is None:
             return self
@@ -238,7 +238,7 @@ class EntryConfig:
         # deleting one and freeing their slot. Refused here rather than relying
         # on the callers that validate it.
         if any(
-            _identity(known) == _identity(renamed) and known != stored
+            identity(known) == identity(renamed) and known != stored
             for known in self.users
         ):
             return self
@@ -249,7 +249,7 @@ class EntryConfig:
         # user holding no slot would be issued one here. A rename moves a
         # number, it never issues one.
         moved = {
-            (_identity(renamed) if name == _identity(stored) else name): slot
+            (identity(renamed) if name == identity(stored) else name): slot
             for name, slot in self.assignment.slots.items()
         }
         return EntryConfig(
@@ -275,7 +275,7 @@ class EntryConfig:
         if key == CONF_NAME:
             return self.with_user_renamed(name, value)
         stored = next(
-            (known for known in self.users if _identity(known) == _identity(name)), None
+            (known for known in self.users if identity(known) == identity(name)), None
         )
         if stored is None:
             return self
@@ -293,7 +293,7 @@ class EntryConfig:
     def with_user_field_removed(self, name: str, key: str) -> EntryConfig:
         """Return a copy with one user's field removed; a no-op if absent."""
         stored = next(
-            (known for known in self.users if _identity(known) == _identity(name)), None
+            (known for known in self.users if identity(known) == identity(name)), None
         )
         if stored is None or key not in self.users[stored]:
             return self

--- a/custom_components/lock_code_manager/domain/config.py
+++ b/custom_components/lock_code_manager/domain/config.py
@@ -50,11 +50,9 @@ class EntryConfig:
     locks: tuple[str, ...]
     users: Mapping[str, Mapping[str, Any]]
     assignment: SlotAssignment
-    # Every other top-level key in the entry, carried through verbatim.
-    #
-    # No default: to_dict() feeds async_update_entry directly, so a field that
-    # could be omitted at a construction site would erase whatever it holds on
-    # the next write.
+    # Every other top-level key in the entry, carried through verbatim. No
+    # default: to_dict() feeds async_update_entry directly, so a field that
+    # could be omitted at a construction site would erase what it holds.
     extra: Mapping[str, Any]
     # Derived once at construction: the instance is immutable and cached, and
     # the slot view is read per entry per lock on some paths.
@@ -94,10 +92,9 @@ class EntryConfig:
         sides: setup moves it from data into options and the listener moves it
         back, so either side may hold it.
         """
-        # ONE side holds the configuration and is read whole, options first.
-        # Taking the shape keys independently would let an entry carry both
-        # shapes at once, and reading a mix of them silently discards whichever
-        # one loses.
+        # ONE side holds the configuration and is read whole, options first:
+        # taking the shape keys independently would let an entry carry both
+        # shapes and silently discard whichever lost.
         config_side: Mapping[str, Any] = next(
             (
                 side
@@ -111,10 +108,8 @@ class EntryConfig:
             **{k: v for k, v in entry.options.items() if k not in _CONFIG_KEYS},
             CONF_LOCKS: entry.options.get(CONF_LOCKS, entry.data.get(CONF_LOCKS, [])),
         }
-        # The assignment comes from the SAME side as the users it numbers. A
-        # user-keyed side always carries its own, and a slot-keyed one derives
-        # it from the slot keys; taking it from the other side could pair
-        # users with numbering that predates them.
+        # The assignment comes from the SAME side as the users it numbers, or
+        # it could pair users with numbering that predates them.
         for key in (CONF_USERS, CONF_SLOTS, CONF_SLOT_ASSIGNMENT):
             if key in config_side:
                 merged[key] = config_side[key]
@@ -125,27 +120,28 @@ class EntryConfig:
         """
         Build EntryConfig from a raw config mapping.
 
-        Accepts the pre-version-3 slot-keyed shape as input only, converted
-        by :func:`.slot_assignment.users_from_slots`. Nothing writes that
-        shape any more.
+        Accepts the slot-keyed shape as INPUT, converted on the way in. The
+        YAML and options flows still submit it; nothing stores it. That
+        conversion goes when those flows stop producing it.
         """
         raw_users = mapping.get(CONF_USERS)
         if raw_users is None:
-            # Slot-keyed input, converted by the migration's own function so
-            # the two cannot disagree. One-directional: nothing writes this
-            # shape. Goes when the config flow stops producing it.
+            # Converted by the migration's own function so the two cannot
+            # disagree about what a slot-keyed entry means.
             converted, assignment, _ = users_from_slots(mapping.get(CONF_SLOTS) or {})
             users = dict(converted)
         else:
             # Two keys reducing to one identity keep the FIRST. Both
             # surviving would put them on one slot while the name lookups
-            # disagreed about which of them holds it, so a display would show
-            # one user and a write would land on the other.
+            # disagreed about which holds it, so a display would show one user
+            # and a write would land on the other.
             users = {}
+            seen: set[str] = set()
             for name, user in raw_users.items():
                 normalized = normalize_name(name)
-                if any(identity(seen) == identity(normalized) for seen in users):
+                if (key := identity(normalized)) in seen:
                     continue
+                seen.add(key)
                 users[normalized] = dict(user)
             assignment = SlotAssignment.from_mapping(mapping)
         return cls(
@@ -235,8 +231,7 @@ class EntryConfig:
             return self
         renamed = normalize_name(new)
         # Renaming onto somebody else would collapse two users into one key,
-        # deleting one and freeing their slot. Refused here rather than relying
-        # on the callers that validate it.
+        # deleting one and freeing their slot.
         if any(
             identity(known) == identity(renamed) and known != stored
             for known in self.users
@@ -246,8 +241,7 @@ class EntryConfig:
             (renamed if k == stored else k): dict(v) for k, v in self.users.items()
         }
         # Re-keyed directly rather than through reconcile, which allocates: a
-        # user holding no slot would be issued one here. A rename moves a
-        # number, it never issues one.
+        # rename moves a number, it never issues one.
         moved = {
             (identity(renamed) if name == identity(stored) else name): slot
             for name, slot in self.assignment.slots.items()

--- a/custom_components/lock_code_manager/domain/names.py
+++ b/custom_components/lock_code_manager/domain/names.py
@@ -1,10 +1,8 @@
 """
 User-name rules for Lock Code Manager slots.
 
-A slot's name is on its way to becoming the identity Lock Code Manager keys
-on -- the config entry will store a mapping of named users rather than one of
-slot numbers, and lock users will be tagged ``lcm:{name}``. That only works if
-every name is present and unique within its entry.
+The name is the identity the configuration is keyed on, so it has to be
+present and unique within its entry.
 
 This module is the single place those rules live, so the config flow
 (validating new input) and the migration (repairing existing data) cannot
@@ -29,6 +27,18 @@ def normalize_name(name: str | None) -> str:
     Code Manager would treat them as distinct users.
     """
     return (name or "").strip()
+
+
+def identity(name: str | None) -> str:
+    """
+    Return the form a user is recognized by.
+
+    Whitespace normalized and casefolded, so ``Bob`` and ``BOB `` are one
+    person everywhere. Comparing any other way lets the same user hold two
+    credential indices, and makes a case-only rename read as a deletion plus
+    an addition.
+    """
+    return normalize_name(name).casefold()
 
 
 def name_error(name: str | None) -> str | None:
@@ -56,11 +66,11 @@ def deduplicate(name: str, taken: Iterable[str]) -> str:
     because two users differing only in case would be indistinguishable in
     the frontend and would collide once slugified into an entity identifier.
     """
-    lowered = {existing.casefold() for existing in taken}
-    if name.casefold() not in lowered:
+    lowered = {identity(existing) for existing in taken}
+    if identity(name) not in lowered:
         return name
     suffix = 2
-    while f"{name} {suffix}".casefold() in lowered:
+    while identity(f"{name} {suffix}") in lowered:
         suffix += 1
     return f"{name} {suffix}"
 
@@ -99,8 +109,8 @@ def normalize_slot_names(
     needs_repair: set[Any] = set()
     for slot_num in ordered:
         name = slots[slot_num].get(CONF_NAME)
-        if name_error(name) is None and normalize_name(name).casefold() not in {
-            existing.casefold() for existing in reserved
+        if name_error(name) is None and identity(name) not in {
+            identity(existing) for existing in reserved
         }:
             reserved.append(normalize_name(name))
         else:
@@ -150,7 +160,7 @@ def validate_slot_names(
         name = slots[slot_num].get(CONF_NAME)
         if error := name_error(name):
             return str(slot_num), error
-        key = normalize_name(name).casefold()
+        key = identity(name)
         if key in seen:
             return str(slot_num), "name_not_unique"
         seen[key] = str(slot_num)

--- a/custom_components/lock_code_manager/domain/occupancy.py
+++ b/custom_components/lock_code_manager/domain/occupancy.py
@@ -50,9 +50,7 @@ class Occupancy:
     @property
     def is_known(self) -> bool:
         """Return whether every lock that constrains allocation could be read."""
-        return not any(
-            lock.occupied is None and lock.constrains_allocation for lock in self.locks
-        )
+        return not self.unreadable
 
     @property
     def unreadable(self) -> tuple[str, ...]:

--- a/custom_components/lock_code_manager/domain/slot_assignment.py
+++ b/custom_components/lock_code_manager/domain/slot_assignment.py
@@ -1,24 +1,22 @@
 """
 Which slot number each user occupies.
 
-The slot number stops being configuration in version 3 and becomes internal
-bookkeeping. It still exists, because on most providers it IS the lock's
-credential index -- ``credential_index_follows_slot`` -- so it is bounded by
-the lock's advertised capacity and must be reusable when a user is deleted.
+The number is internal bookkeeping, not configuration, but on most providers
+it IS the lock's credential index (``credential_index_follows_slot``). That
+bounds it by the lock's advertised capacity, which is why numbers are reused
+on deletion rather than issued monotonically -- monotonic ones would
+eventually exceed every lock.
 
-That boundedness is why numbers are reused rather than issued monotonically:
-one that is never reused would eventually exceed every lock's capacity.
-Deleting a user and creating another does hand the newcomer the departed
-user's slot, entity identifiers, and history, which matches what the physical
-credential slot is doing.
+Reuse hands a newcomer the departed user's number, entity identifiers and
+history, matching what the physical credential slot does.
 
-Entity and device identifiers keep keying on this number, so a rename moves
-nothing in either registry.
+Entity and device identifiers key on this number, so a rename moves nothing
+in either registry.
 
-Users are identified the way :mod:`.names` identifies them: whitespace
-normalized, compared case-insensitively. Storing a name in any other form
-would let it match on one path and miss on another, and missing means looking
-like a different user and being renumbered onto a different credential index.
+Users are identified as :mod:`.names` identifies them: whitespace normalized,
+compared case-insensitively. Any other stored form can match on one path and
+miss on another, and a miss reads as a different user and renumbers them onto
+a different credential index.
 """
 
 from __future__ import annotations
@@ -30,24 +28,9 @@ from typing import Any
 
 from homeassistant.const import CONF_NAME
 
-from .names import normalize_name, normalize_slot_names
+from .names import identity, normalize_slot_names
 
 CONF_SLOT_ASSIGNMENT = "slot_assignment"
-
-_EMPTY_ASSIGNMENT: Mapping[str, int] = MappingProxyType({})
-
-
-def _identity(name: str) -> str:
-    """
-    Return the form a user is recognized by.
-
-    Matches ``names.deduplicate`` and ``names.validate_slot_names``, which
-    both casefold. Comparing case-sensitively here would let ``Bob`` and
-    ``BOB`` hold two credential indices for someone the rest of the system
-    treats as one person, and would make a case-only rename read as a
-    deletion plus an addition.
-    """
-    return normalize_name(name).casefold()
 
 
 @dataclass(frozen=True, slots=True)
@@ -60,40 +43,32 @@ class SlotAssignment:
         """
         Put the mapping into its canonical form, then freeze it.
 
-        Names are reduced to their identity form and slot numbers coerced to
-        ``int``. Doing it here makes both invariants of the TYPE rather than of
-        whichever factory built it, so a caller constructing directly from
-        stored data cannot introduce a string key that compares unequal to an
-        int one.
+        Canonicalizing here makes identity-form names and ``int`` numbers
+        invariants of the type rather than of whichever factory built it, so
+        constructing directly from stored data cannot introduce a string key
+        that compares unequal to an int one.
 
-        Two keys reducing to one identity keeps the LOWER slot. That case
-        means the stored bookkeeping was already inconsistent; raising would
-        make the entry unloadable, which is worse than picking
-        deterministically, and the lower number is the one likelier to
-        predate the corruption.
+        Two keys reducing to one identity keep the LOWER number: the stored
+        bookkeeping was already inconsistent, and picking deterministically
+        beats making the entry unloadable.
         """
         canonical: dict[str, int] = {}
         for name, slot in self.slots.items():
             try:
                 number = int(slot)
             except TypeError, ValueError:
-                # Unusable stored value. Dropping costs this user their slot,
-                # which reconcile then reissues; raising would take the whole
-                # entry down, and corrupt bookkeeping is exactly what the
-                # coercion above exists to survive.
+                # Dropping costs this user their number, which reconcile
+                # reissues; raising would take the whole entry down.
                 continue
-            key = _identity(str(name))
+            key = identity(str(name))
             canonical[key] = min(canonical.get(key, number), number)
 
-        # No two users on one number, as an invariant of the TYPE. Reachable
-        # only from bookkeeping that was already inconsistent, but both users
-        # would otherwise write over each other on the lock every sync, and
-        # nothing else in the system repairs it.
+        # No two users on one number: they would otherwise overwrite each
+        # other on the lock every sync, and nothing else repairs it.
         #
-        # The loser is DROPPED rather than renumbered here, because this has
-        # no idea what the entry's start slot is -- reissuing from 1 could put
-        # them below it, on a code programmed by hand. reconcile knows, and
-        # gives them a number that respects it.
+        # The loser is dropped rather than renumbered because this type cannot
+        # see the entry's start slot, so reissuing from 1 could land on a code
+        # programmed by hand. reconcile knows the start and respects it.
         deduped: dict[str, int] = {}
         held: set[int] = set()
         for key in sorted(canonical):
@@ -117,25 +92,21 @@ class SlotAssignment:
     @classmethod
     def empty(cls) -> SlotAssignment:
         """Return the assignment for an entry with no users."""
-        return cls(slots=_EMPTY_ASSIGNMENT)
+        return cls(slots={})
 
     @classmethod
     def from_mapping(cls, mapping: Mapping[str, Any]) -> SlotAssignment:
         """
         Read the assignment out of an entry's stored bookkeeping.
 
-        Takes ONE mapping deliberately. Configuration is read options-first
-        and falls back to data (``EntryConfig.from_entry``), but the
-        assignment must be read from the same side the users came from, or a
-        stale copy renumbers everyone on the next start. Consumers pass the
-        already-merged mapping rather than an entry, so there is no second
-        precedence rule here to get out of step with the first.
+        Takes the already-merged mapping rather than an entry so there is no
+        second options-before-data precedence rule to drift from the one in
+        ``EntryConfig.from_entry``. The assignment has to come from the same
+        side the users did, or a stale copy renumbers everyone on next start.
         """
         stored = mapping.get(CONF_SLOT_ASSIGNMENT)
-        # Anything that is not a mapping carries nothing worth keeping, and
-        # reconcile rebuilds the assignment from the configured users anyway.
-        # Raising here would abort entry setup over hand-edited storage, which
-        # is the same threat model the coercions below exist for.
+        # Non-mapping storage carries nothing worth keeping and reconcile
+        # rebuilds from the configured users; raising would abort setup.
         return cls(slots=stored if isinstance(stored, Mapping) else {})
 
     def to_dict(self) -> dict[str, Any]:
@@ -144,7 +115,7 @@ class SlotAssignment:
 
     def slot(self, name: str) -> int | None:
         """Return the slot ``name`` occupies, or None if they hold none."""
-        return self.slots.get(_identity(name))
+        return self.slots.get(identity(name))
 
     def reconcile(
         self,
@@ -157,65 +128,43 @@ class SlotAssignment:
         """
         Return the assignment covering exactly ``names``, applying ``renames``.
 
-        ONE operation rather than a rename step followed by an allocation
-        step. Splitting them put the order in the caller's hands, and the
-        order is the whole difficulty: a rename is indistinguishable from a
-        deletion plus an addition unless you already know who survives.
-        Getting that sequence wrong produced a high-severity defect in three
-        consecutive review rounds -- users deleted, users renumbered onto
-        another user's credential index -- so the sequence is gone rather
-        than documented.
+        Renaming and allocating are ONE operation because their order is the
+        whole difficulty: a rename is indistinguishable from a deletion plus
+        an addition unless you already know who survives. ``names`` -- the
+        full set of users in the NEW configuration -- is what resolves it. A
+        rename target absent from ``names`` is departing; one present names
+        the renamed user.
 
-        ``names`` is the full set of users in the NEW configuration, which is
-        what resolves the ambiguity: a rename target that is not in ``names``
-        is departing, and one that is names the renamed user.
-
-        Users keep their slot through a rename and through anyone else's
+        Users keep their number through a rename and through anyone else's
         arrival or departure. New users take the lowest free number at or
-        above ``start``, skipping ``unavailable``.
+        above ``start``, skipping ``unavailable``. ``start`` is required so a
+        caller decides where issuing begins rather than inheriting a default.
 
-        ``start`` is required, not defaulted, so a caller has to decide where
-        issuing begins rather than inheriting a default that happens to be
-        safe today.
+        Tenure outranks both constraints: a user already holding a number
+        keeps it even when ``start`` rises above it or ``unavailable`` grows
+        to include it, because moving somebody rewrites their credential on
+        every lock and orphans their entities.
 
-        A user already holding a slot keeps it even when ``start`` rises
-        above it or ``unavailable`` comes to include it: both constrain
-        ALLOCATION, not tenure. Moving somebody rewrites their credential on
-        every lock and orphans their entities, which is worse than the entry
-        holding a number it would not choose today.
-
-        That trade is clean for ``start`` and NOT clean for ``unavailable``.
-        A tenured user on a number another entry owns means two entries
-        writing one credential index, which nothing here can repair -- this
-        type cannot see the other entry. It is left standing because the
-        alternative is renumbering somebody without being asked, and because
-        ``config_flow._check_common_slots`` is what prevents the overlap
-        arising in the first place. If a consumer ever needs the conflict
-        surfaced rather than absorbed, that belongs at the seam that knows
-        about other entries, not here.
+        For ``unavailable`` that leaves a real conflict standing -- two
+        entries writing one credential index -- which this type cannot repair
+        because it cannot see the other entry. ``config_flow`` prevents the
+        overlap arising; surfacing it instead belongs at that seam.
 
         Returns ``self`` when nothing differs, so callers can use identity to
         decide whether a write is needed.
         """
-        wanted = list(dict.fromkeys(_identity(name) for name in names))
+        wanted = list(dict.fromkeys(identity(name) for name in names))
         surviving = set(wanted)
 
-        # A move is honoured only when the source holds a slot AND the target
-        # is among the survivors; a rename whose target is absent contradicts
-        # the name set and is ignored.
+        # Reduce to identity form BEFORE resolving, or two keys meaning the
+        # same user (``Alice`` and ``alice ``) each take a turn: the later
+        # overwrites the earlier while the earlier's target stays claimed,
+        # refusing a third user's legitimate rename onto it.
         #
-        # Two sources renaming onto one target is likewise contradictory.
-        # Resolved in sorted order so the same input always gives the same
-        # answer regardless of mapping iteration order.
-        # Reduce to identity form FIRST. Iterating the raw mapping let two
-        # keys that mean the same user (``Alice`` and ``alice ``) each take a
-        # turn: the later overwrote the earlier while the earlier's target
-        # stayed claimed, so a third user's legitimate rename onto that target
-        # was refused and they were renumbered. It also made the answer depend
-        # on the mapping's insertion order.
+        # Sorted throughout so the answer never depends on mapping order.
         wanted_moves: dict[str, str] = {}
-        for old in sorted(renames or {}, key=lambda key: (_identity(key), str(key))):
-            wanted_moves.setdefault(_identity(old), _identity((renames or {})[old]))
+        for old in sorted(renames or {}, key=lambda key: (identity(key), str(key))):
+            wanted_moves.setdefault(identity(old), identity((renames or {})[old]))
 
         honoured: dict[str, str] = {}
         claimed: set[str] = set()
@@ -242,10 +191,9 @@ class SlotAssignment:
         carried = {**kept, **renamed}
         taken = set(carried.values()) | set(unavailable)
         candidate = start
-        # Sorted so the answer does not depend on how the caller ordered
-        # ``names``. The signature accepts any iterable, and a set or
-        # ``dict.keys()`` from an unordered source would otherwise give the
-        # same configuration different credential indices from run to run.
+        # Sorted because the signature accepts any iterable: an unordered one
+        # would give the same configuration different credential indices from
+        # run to run.
         for name in sorted(name for name in wanted if name not in carried):
             while candidate in taken:
                 candidate += 1
@@ -263,22 +211,20 @@ def users_from_slots(
     """
     Convert slot-keyed configuration into name-keyed users plus an assignment.
 
-    The version 3 migration in one function, kept pure so the properties that
-    matter -- nothing lost, nobody renumbered -- can be stated over it
-    directly rather than through a config entry. Also returns the slots whose
-    name the repair changed, so the migration can report them.
+    Pure, so the properties that matter -- nothing lost, nobody renumbered --
+    can be stated over it directly rather than through a config entry. Also
+    returns the slots whose name the repair changed, for the migration to
+    report.
 
-    Repairs the names ITSELF rather than documenting that callers must. The
-    name becomes the mapping key here, so two slots sharing one would collapse
-    into a single user -- losing a user and their code, and renumbering the
-    survivor -- and a slot with no name at all would raise mid-migration. Both
-    are reachable from a version 2 entry, where the name is optional. A
-    precondition is not good enough on a migration with no rollback.
+    Repairs names itself rather than requiring callers to. The name becomes
+    the mapping key here, so a duplicate would collapse two slots into one
+    user and a missing one would raise mid-migration -- both reachable from
+    stored data, and a migration with no rollback cannot rely on a
+    precondition.
 
-    Slot keys are coerced to ``int``. The on-disk JSON form is ``str``, so a
-    migration reading stored data hands strings straight in; a string here
-    survives into the assignment, where ``candidate in taken`` compares an int
-    against it, misses, and issues a slot that is already occupied.
+    Slot keys are coerced to ``int`` because the on-disk JSON form is ``str``,
+    and a string surviving into the assignment misses ``candidate in taken``
+    and issues an already-occupied number.
     """
     repaired, renamed = normalize_slot_names(slots)
     users: dict[str, dict[str, Any]] = {}

--- a/custom_components/lock_code_manager/providers/zha.py
+++ b/custom_components/lock_code_manager/providers/zha.py
@@ -396,13 +396,11 @@ class ZHALock(BaseLock):
                 continue
 
             user_status, pin_code = parsed
-            # AVAILABLE is the only status that leaves this index free to
-            # write to, and ENABLED the only one whose code the lock says it
-            # is currently accepting. Everything between them is reported as
-            # holding something whose value cannot be trusted: claiming a
-            # value the lock is not honouring would read as in sync while the
-            # code does not open the door, and claiming the index is empty
-            # would hand it to allocation.
+            # Available is the only status leaving this index free to write
+            # to, Enabled the only one whose code the lock says it accepts.
+            # Everything else holds something untrustworthy: claiming its
+            # value would read as in sync while the code does not open the
+            # door, and claiming it empty would hand it to allocation.
             if user_status == DoorLock.UserStatus.Available:
                 slot_states[slot_num] = SlotCredential.empty()
             elif user_status == DoorLock.UserStatus.Enabled and pin_code:

--- a/tests/properties/test_slot_assignment.py
+++ b/tests/properties/test_slot_assignment.py
@@ -21,11 +21,13 @@ from hypothesis import assume, given, strategies as st
 
 from homeassistant.const import CONF_ENABLED, CONF_NAME, CONF_PIN
 
-from custom_components.lock_code_manager.domain.names import normalize_slot_names
+from custom_components.lock_code_manager.domain.names import (
+    identity,
+    normalize_slot_names,
+)
 from custom_components.lock_code_manager.domain.slot_assignment import (
     CONF_SLOT_ASSIGNMENT,
     SlotAssignment,
-    _identity,
     users_from_slots,
 )
 
@@ -156,7 +158,7 @@ def test_a_surviving_user_is_never_renumbered(
     assignment = SlotAssignment.empty()
     for configured in history:
         after = _reconcile(assignment, configured, start=start)
-        for name in set(assignment.slots) & {_identity(n) for n in configured}:
+        for name in set(assignment.slots) & {identity(n) for n in configured}:
             assert after.slot(name) == assignment.slot(name)
         assignment = after
 
@@ -179,7 +181,7 @@ def test_every_configured_user_holds_a_slot(
     assignment = SlotAssignment.empty()
     for configured in history:
         assignment = _reconcile(assignment, configured, start=start)
-        assert {_identity(n) for n in configured} == set(assignment.slots)
+        assert {identity(n) for n in configured} == set(assignment.slots)
 
 
 NEWCOMERS = st.lists(st.sampled_from(["Zoe", "Yan", "Xavier"]), max_size=2).map(
@@ -212,8 +214,8 @@ def test_renaming_keeps_the_users_slot(
     reorders two users' credential indices on a real lock.
     """
     before = _reconcile(SlotAssignment.empty(), names, start=start)
-    moves = {old: new for old, new in renames.items() if _identity(old) in before.slots}
-    assume(len({_identity(v) for v in moves.values()}) == len(moves))
+    moves = {old: new for old, new in renames.items() if identity(old) in before.slots}
+    assume(len({identity(v) for v in moves.values()}) == len(moves))
 
     after_names = data.draw(
         st.permutations([moves.get(n, n) for n in names] + newcomers)
@@ -234,8 +236,8 @@ def test_renaming_does_not_depend_on_insertion_order(
 ) -> None:
     """The same edit gives the same answer whatever order the mapping holds."""
     before = _reconcile(SlotAssignment.empty(), names, start=start)
-    moves = {old: new for old, new in renames.items() if _identity(old) in before.slots}
-    assume(len({_identity(v) for v in moves.values()}) == len(moves))
+    moves = {old: new for old, new in renames.items() if identity(old) in before.slots}
+    assume(len({identity(v) for v in moves.values()}) == len(moves))
     after_names = [moves.get(n, n) for n in names]
 
     flipped = SlotAssignment(slots=dict(reversed(list(before.slots.items()))))
@@ -426,7 +428,7 @@ def test_a_rename_to_somebody_absent_leaves_the_source_alone(
     absent = {
         old: new
         for old, new in renames.items()
-        if _identity(new) not in {_identity(n) for n in names}
+        if identity(new) not in {identity(n) for n in names}
     }
 
     after = before.reconcile(names, start=start, renames=absent)
@@ -448,7 +450,7 @@ def test_a_double_booked_slot_is_repaired(slots: dict[str, int], start: int) -> 
 
     numbers = list(reconciled.slots.values())
     assert len(numbers) == len(set(numbers))
-    assert set(reconciled.slots) == {_identity(n) for n in slots}
+    assert set(reconciled.slots) == {identity(n) for n in slots}
 
 
 def test_a_collapsed_identity_keeps_the_lower_slot() -> None:

--- a/tests/properties/test_user_migration.py
+++ b/tests/properties/test_user_migration.py
@@ -27,10 +27,10 @@ from custom_components.lock_code_manager.const import (
     CONF_USERS,
 )
 from custom_components.lock_code_manager.domain.config import EntryConfig
+from custom_components.lock_code_manager.domain.names import identity
 from custom_components.lock_code_manager.domain.slot_assignment import (
     CONF_SLOT_ASSIGNMENT,
     SlotAssignment,
-    _identity,
 )
 from custom_components.lock_code_manager.domain.user_migration import (
     migrate_to_users,
@@ -159,7 +159,7 @@ def test_user_keys_keep_the_name_as_displayed(entry: dict) -> None:
 
     for name in migrated[CONF_USERS]:
         assert name == name.strip()
-    folded = [_identity(name) for name in migrated[CONF_USERS]]
+    folded = [identity(name) for name in migrated[CONF_USERS]]
     assert len(folded) == len(set(folded))
 
 


### PR DESCRIPTION
## Summary

First consolidation pass over what v3 added, ahead of the pre-main review. No behavior change — the full suite passes at every commit.

Two things came out of it, and the second is the reason a pass like this is worth doing:

**Comments that narrate how the code got here.** `_async_allocate_for` carried a 28-line docstring for a 50-line function, most of it arguing with review objections rather than describing behavior. `SlotAssignment.reconcile` documented that a bug appeared "in three consecutive review rounds" — that belongs in a commit message. What survives is the part not evident from the code: why the search window widens as it does, why it terminates, and which statuses leave a credential index writable.

**Duplication that building in stages hid.** "The form a user is recognized by" existed in three modules spelled three ways — open-coded twice inside `names`, duplicated as a private `_identity` in `slot_assignment`, and imported across a module boundary as a private name by `config` and by two test modules. It is a naming rule, so it now lives in `names` as `identity`. Similarly `Occupancy.is_known` and `.unreadable` expressed one predicate twice, and `_EMPTY_ASSIGNMENT` existed only to be handed to `empty()` while `__post_init__` rebuilt the mapping regardless.

Each individual reach was locally reasonable, which is why per-PR correctness review does not catch this class of thing.

## One factual fix

`EntryConfig.from_mapping`'s docstring claimed nothing writes the slot-keyed shape any more, while a comment eight lines below said it goes when the config flow stops producing it. The comment was right — the YAML and options flows still submit that shape (`config_flow.py:882`, `:1045`) and it is converted on the way in. Nothing *stores* it, which is the distinction the docstring was reaching for.

Also drops an O(n²) rescan in the same function in favor of a set of identities.

## Testing

`pytest tests/` — 1688 passed, 3 skipped, run after each commit. `prek` clean.