### PR TITLE
feat: name a slot's device after the user who holds it

### DIFF
--- a/blueprints/automation/lock_code_manager/calendar_pin_setter.yaml
+++ b/blueprints/automation/lock_code_manager/calendar_pin_setter.yaml
@@ -127,9 +127,11 @@ actions:
         {{ state_attr(calendar_entity, 'all_day') | default(false, true) }}
       slot_number: !input slot_number
       pin_entity: >
-        {{ _all_entities
-           | select('match', 'text\\..*_code_slot_' ~ slot_number ~ '_pin')
-           | first | default('') }}
+        {{ expand(_all_entities)
+           | selectattr('attributes.slot_field', 'defined')
+           | selectattr('attributes.slot_field', 'eq', 'pin')
+           | selectattr('attributes.code_slot', 'eq', slot_number | int)
+           | map(attribute='entity_id') | first | default('') }}
       pin_value: !input pin_template
   - choose:
       - conditions:

--- a/blueprints/template/lock_code_manager/calendar_condition.yaml
+++ b/blueprints/template/lock_code_manager/calendar_condition.yaml
@@ -116,15 +116,19 @@ variables:
     {{ state_attr(calendar_entity, 'all_day') | default(false, true) }}
   slot_number: !input slot_number
   _name_entity: >
-    {{ _all_entities
-       | select('match', 'text\\..*_code_slot_' ~ slot_number ~ '_name')
-       | first | default('') }}
+    {{ expand(_all_entities)
+       | selectattr('attributes.slot_field', 'defined')
+       | selectattr('attributes.slot_field', 'eq', 'name')
+       | selectattr('attributes.code_slot', 'eq', slot_number | int)
+       | map(attribute='entity_id') | first | default('') }}
   name_state: >
     {{ states(_name_entity) if _name_entity else '' }}
   _event_entity: >
-    {{ _all_entities
-       | select('match', 'event\\..*_code_slot_' ~ slot_number ~ '_pin_used')
-       | first | default('') }}
+    {{ expand(_all_entities)
+       | selectattr('attributes.slot_field', 'defined')
+       | selectattr('attributes.slot_field', 'eq', 'pin_used')
+       | selectattr('attributes.code_slot', 'eq', slot_number | int)
+       | map(attribute='entity_id') | first | default('') }}
   lock_entity_ids: >
     {{ state_attr(_event_entity, 'event_types') | default([]) }}
   _condition_result: !input condition_template

--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -944,6 +944,32 @@ def _async_reclaim_entities_from_foreign_devices(
 
 
 @callback
+def _async_rename_slot_devices(
+    hass: HomeAssistant, config_entry: LockCodeManagerConfigEntry
+) -> None:
+    """
+    Point each slot's device at the name of whoever holds it now.
+
+    DeviceInfo only names a device as it is created, so a rename would
+    otherwise leave the old name standing until the entity was rebuilt. It
+    runs before the update listener's entity work because the rename that
+    matters most -- the name text entity -- writes to data with empty options
+    and returns before any of that.
+
+    ``name_by_user`` is untouched, so a device the user renamed themselves
+    keeps their name.
+    """
+    dev_reg = dr.async_get(hass)
+    entry_id = config_entry.entry_id
+    config = get_entry_config(config_entry)
+    for slot_num, name in ((num, config.name_for(num)) for num in config.slot_numbers):
+        identifier = build_slot_device_identifier(entry_id, slot_num)
+        device = dev_reg.async_get_device(identifiers={(DOMAIN, identifier)})
+        if device is not None and name and device.name != name:
+            dev_reg.async_update_device(device.id, name=name)
+
+
+@callback
 def _async_prune_orphaned_slot_devices(
     hass: HomeAssistant, config_entry: LockCodeManagerConfigEntry
 ) -> None:
@@ -1126,6 +1152,8 @@ async def async_update_listener(
     # same way.
     for coordinator in runtime_data.slot_coordinators.values():
         coordinator.notify_config_changed()
+
+    _async_rename_slot_devices(hass, config_entry)
 
     # No need to do entity creation/removal work if there are no options
     # because that only happens at the end of this function (data + empty

--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -231,7 +231,28 @@ async def async_migrate_entry(
                 config_entry.entry_id,
                 config_entry.title,
                 len(re_slugged),
-                ", ".join(sorted(re_slugged)),
+                ", ".join(f"{was} -> {now}" for was, now in sorted(re_slugged)),
+            )
+            # Home Assistant repoints recorder history on a rename, but nothing
+            # rewrites an entity id stored inside an automation or script --
+            # only the frontend's own rename dialog offers that, and this did
+            # not go through it. Automations built from the Slot Usage Limiter
+            # and Slot Usage Notifier blueprints hold these ids directly, so
+            # the user is given the mapping rather than left to find it.
+            async_create_issue(
+                hass,
+                DOMAIN,
+                f"entity_ids_renamed_{config_entry.entry_id}",
+                is_fixable=True,
+                is_persistent=True,
+                severity=IssueSeverity.WARNING,
+                translation_key="entity_ids_renamed",
+                translation_placeholders={
+                    "entry_title": config_entry.title,
+                    "renames": "\n".join(
+                        f"- `{was}` is now `{now}`" for was, now in sorted(re_slugged)
+                    ),
+                },
             )
         if renamed:
             _LOGGER.info(
@@ -956,7 +977,7 @@ def _async_reclaim_entities_from_foreign_devices(
 @callback
 def _async_rename_slot_entity_ids(
     hass: HomeAssistant, config_entry: LockCodeManagerConfigEntry
-) -> list[str]:
+) -> list[tuple[str, str]]:
     """
     Re-slug every entity ID onto the name of whoever holds the slot.
 
@@ -976,7 +997,7 @@ def _async_rename_slot_entity_ids(
     ent_reg = er.async_get(hass)
     entry_id = config_entry.entry_id
     config = EntryConfig.from_entry(config_entry)
-    renamed: list[str] = []
+    renamed: list[tuple[str, str]] = []
     for entity in er.async_entries_for_config_entry(ent_reg, entry_id):
         slot_num = parse_slot_unique_id(entry_id, entity.unique_id)
         if slot_num is None or not (name := config.name_for(slot_num)):
@@ -992,7 +1013,7 @@ def _async_rename_slot_entity_ids(
         if new_entity_id == entity.entity_id:
             continue
         ent_reg.async_update_entity(entity.entity_id, new_entity_id=new_entity_id)
-        renamed.append(f"{entity.entity_id} -> {new_entity_id}")
+        renamed.append((entity.entity_id, new_entity_id))
     return renamed
 
 

--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -55,6 +55,7 @@ from homeassistant.helpers.issue_registry import (
     async_create_issue,
     async_delete_issue,
 )
+from homeassistant.util import slugify
 
 from .const import (
     ATTR_CODE_SLOT,
@@ -215,14 +216,23 @@ async def async_migrate_entry(
         # configuration by that name and demote the slot number to internal
         # bookkeeping.
         #
-        # No registry writes happen here. Entity and device identifiers keep
-        # the slot number, so there is nothing to move.
+        # IDENTIFIERS do not move -- unique IDs keep the slot number, so no
+        # entity loses its registry entry, its settings or its history. Only
+        # the entity IDs are re-slugged, below, once the names are known.
         new_data, renamed_in_data = migrate_to_users(config_entry.data)
         new_options, renamed_in_options = migrate_to_users(config_entry.options)
         renamed = set(renamed_in_data) | set(renamed_in_options)
         hass.config_entries.async_update_entry(
             config_entry, data=new_data, options=new_options, version=4
         )
+        if re_slugged := _async_rename_slot_entity_ids(hass, config_entry):
+            _LOGGER.info(
+                "%s (%s): renamed %d entity id(s) onto their user's name: %s",
+                config_entry.entry_id,
+                config_entry.title,
+                len(re_slugged),
+                ", ".join(sorted(re_slugged)),
+            )
         if renamed:
             _LOGGER.info(
                 "%s (%s): named %d previously-unnamed or conflicting slot(s): %s. "
@@ -941,6 +951,49 @@ def _async_reclaim_entities_from_foreign_devices(
             device.name,
         )
         dev_reg.async_remove_device(device.id)
+
+
+@callback
+def _async_rename_slot_entity_ids(
+    hass: HomeAssistant, config_entry: LockCodeManagerConfigEntry
+) -> list[str]:
+    """
+    Re-slug every entity ID onto the name of whoever holds the slot.
+
+    Home Assistant only derives an entity ID when the entity is first
+    registered, so without this an upgraded install would keep slot-shaped
+    IDs forever while a fresh one got name-shaped ones. Recorder history and
+    long-term statistics follow the rename: the registry emits
+    ``old_entity_id`` and ``recorder.entity_registry`` repoints them.
+
+    The device-slug PREFIX is swapped rather than the whole ID rebuilt,
+    because the rest of the ID comes from the entity's own name, which is
+    translated -- an install created in another language does not spell its
+    suffixes the way this code would. An entity whose ID does not start with
+    the prefix this integration would have generated is left alone, since
+    there is no way to tell which part of it was the prefix.
+    """
+    ent_reg = er.async_get(hass)
+    entry_id = config_entry.entry_id
+    config = EntryConfig.from_entry(config_entry)
+    renamed: list[str] = []
+    for entity in er.async_entries_for_config_entry(ent_reg, entry_id):
+        slot_num = parse_slot_unique_id(entry_id, entity.unique_id)
+        if slot_num is None or not (name := config.name_for(slot_num)):
+            continue
+        old_prefix = slugify(f"{config_entry.title} Code slot {slot_num}")
+        domain, object_id = entity.entity_id.split(".", 1)
+        if object_id != old_prefix and not object_id.startswith(f"{old_prefix}_"):
+            continue
+        suffix = object_id.removeprefix(old_prefix)
+        new_entity_id = ent_reg.async_generate_entity_id(
+            domain, f"{slugify(name)}{suffix}", current_entity_id=entity.entity_id
+        )
+        if new_entity_id == entity.entity_id:
+            continue
+        ent_reg.async_update_entity(entity.entity_id, new_entity_id=new_entity_id)
+        renamed.append(f"{entity.entity_id} -> {new_entity_id}")
+    return renamed
 
 
 @callback

--- a/custom_components/lock_code_manager/const.py
+++ b/custom_components/lock_code_manager/const.py
@@ -26,6 +26,10 @@ ATTR_TEXT = "text"
 
 
 ATTR_CODE_SLOT = "code_slot"
+# Which property of the slot an entity represents ("pin", "name", "enabled").
+# Published so a template can find an entity without matching on its ID, whose
+# shape depends on the user's name and on the language it was created in.
+ATTR_SLOT_FIELD = "slot_field"
 ATTR_USERCODE = "usercode"
 ATTR_FROM = "from"
 ATTR_TO = "to"

--- a/custom_components/lock_code_manager/entity.py
+++ b/custom_components/lock_code_manager/entity.py
@@ -22,6 +22,7 @@ from homeassistant.helpers.event import TrackStates, async_track_state_change_fi
 
 from .const import (
     ATTR_CODE_SLOT,
+    ATTR_SLOT_FIELD,
     ATTR_TO,
     DOMAIN,
 )
@@ -88,8 +89,9 @@ class BaseLockCodeManagerEntity(Entity):
         self._attr_device_info = build_slot_device_info(config_entry, slot_num)
 
         self._attr_unique_id = build_slot_unique_id(self.base_unique_id, slot_num, key)
-        self._attr_extra_state_attributes: dict[str, int | list[str]] = {
-            ATTR_CODE_SLOT: int(slot_num)
+        self._attr_extra_state_attributes: dict[str, int | str | list[str]] = {
+            ATTR_CODE_SLOT: int(slot_num),
+            ATTR_SLOT_FIELD: key,
         }
 
         # Resolved in ``async_added_to_hass``; the coordinator instance is

--- a/custom_components/lock_code_manager/entity.py
+++ b/custom_components/lock_code_manager/entity.py
@@ -27,6 +27,7 @@ from .const import (
 )
 from .domain.config import build_slot_device_identifier, build_slot_unique_id
 from .domain.models import LockCodeManagerConfigEntry
+from .domain.names import fallback_name
 from .domain.queries import get_entry_config
 from .domain.slot_coordinator import SlotEntityCoordinator
 from .providers import BaseLock
@@ -38,14 +39,22 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def build_slot_device_info(config_entry: ConfigEntry, slot_num: int) -> DeviceInfo:
-    """Describe the device that carries every entity for one code slot."""
+    """
+    Describe the device that carries every entity for one user.
+
+    The name is looked up here rather than passed in, so no caller can name a
+    device something the configuration disagrees with. A slot with no user is
+    named as the migration would name it: this is reachable while entities are
+    being moved off a foreign device before their slot is swept away.
+    """
     return DeviceInfo(
         identifiers={
             (DOMAIN, build_slot_device_identifier(config_entry.entry_id, slot_num))
         },
-        name=f"{config_entry.title} Code slot {slot_num}",
+        name=get_entry_config(config_entry).name_for(slot_num)
+        or fallback_name(slot_num),
         manufacturer="Lock Code Manager",
-        model="Code Slot",
+        model="User",
         via_device=(DOMAIN, config_entry.entry_id),
     )
 

--- a/custom_components/lock_code_manager/event.py
+++ b/custom_components/lock_code_manager/event.py
@@ -101,8 +101,13 @@ class LockCodeManagerCodeSlotEventEntity(BaseLockCodeManagerEntity, EventEntity)
 
         Includes unsupported_locks list for locks that can't fire code slot events.
         Computed dynamically to reflect any changes in lock capabilities.
+
+        Starts from what the base class publishes: a property shadows
+        ``_attr_extra_state_attributes`` outright, so building a fresh dict
+        here dropped this entity's slot identity and left it the one entity a
+        template could not find by slot.
         """
-        attrs: dict[str, Any] = {}
+        attrs: dict[str, Any] = dict(self._attr_extra_state_attributes)
         unsupported = [
             lock.lock.entity_id
             for lock in self.locks

--- a/custom_components/lock_code_manager/repairs.py
+++ b/custom_components/lock_code_manager/repairs.py
@@ -24,7 +24,13 @@ async def async_create_fix_flow(
 ) -> RepairsFlow:
     """Create a fix flow for a repair issue."""
     if issue_id.startswith(
-        ("number_of_uses_removed", "slot_disabled_", "pin_required_", "slot_suspended_")
+        (
+            "number_of_uses_removed",
+            "slot_disabled_",
+            "pin_required_",
+            "slot_suspended_",
+            "entity_ids_renamed_",
+        )
     ):
         return AcknowledgeRepairFlow()
     raise ValueError(f"Unknown issue: {issue_id}")

--- a/custom_components/lock_code_manager/strings.json
+++ b/custom_components/lock_code_manager/strings.json
@@ -238,6 +238,17 @@
     "lock_setup_failed": {
       "title": "Lock setup failed: {lock_entity_id}",
       "description": "Lock Code Manager could not set up `{lock_entity_id}`: {error}\n\nIts entities are created but unavailable, and code synchronization is paused for this lock. After addressing the cause, reload the lock's integration (or Lock Code Manager) to retry. This issue will be automatically dismissed when setup succeeds."
+    },
+    "entity_ids_renamed": {
+      "title": "Entity IDs now follow your users' names",
+      "fix_flow": {
+        "step": {
+          "init": {
+            "title": "Entity IDs now follow your users' names",
+            "description": "Lock Code Manager identifies each user by name rather than by slot number, so the entity IDs in **{entry_title}** were renamed to match:\n\n{renames}\n\nHistory and statistics moved with them, and dashboards built by Lock Code Manager keep working. Anything that refers to the old IDs by name needs updating: your own automations, scripts and template sensors, and automations created from the Slot Usage Limiter or Slot Usage Notifier blueprints, which store an entity ID when you set them up."
+          }
+        }
+      }
     }
   },
   "exceptions": {

--- a/custom_components/lock_code_manager/translations/en.json
+++ b/custom_components/lock_code_manager/translations/en.json
@@ -238,6 +238,17 @@
     "lock_setup_failed": {
       "title": "Lock setup failed: {lock_entity_id}",
       "description": "Lock Code Manager could not set up `{lock_entity_id}`: {error}\n\nIts entities are created but unavailable, and code synchronization is paused for this lock. After addressing the cause, reload the lock's integration (or Lock Code Manager) to retry. This issue will be automatically dismissed when setup succeeds."
+    },
+    "entity_ids_renamed": {
+      "title": "Entity IDs now follow your users' names",
+      "fix_flow": {
+        "step": {
+          "init": {
+            "title": "Entity IDs now follow your users' names",
+            "description": "Lock Code Manager identifies each user by name rather than by slot number, so the entity IDs in **{entry_title}** were renamed to match:\n\n{renames}\n\nHistory and statistics moved with them, and dashboards built by Lock Code Manager keep working. Anything that refers to the old IDs by name needs updating: your own automations, scripts and template sensors, and automations created from the Slot Usage Limiter or Slot Usage Notifier blueprints, which store an entity ID when you set them up."
+          }
+        }
+      }
     }
   },
   "exceptions": {

--- a/tests/common.py
+++ b/tests/common.py
@@ -99,22 +99,42 @@ def _per_lock_entity_id(
     return entity_id
 
 
+def slot_entity_id(
+    hass: HomeAssistant,
+    platform: str,
+    config_entry: ConfigEntry,
+    slot_num: int,
+    key: str,
+) -> str:
+    """
+    Resolve a slot's entity by unique ID.
+
+    Spelling the entity ID out ties the test to the name of whoever holds the
+    slot, since that is what the device -- and so the slug -- is named after.
+    """
+    entity_id = er.async_get(hass).async_get_entity_id(
+        platform, DOMAIN, build_slot_unique_id(config_entry.entry_id, slot_num, key)
+    )
+    assert entity_id, f"No {key} entity for slot {slot_num}"
+    return entity_id
+
+
 # The integration the mock lock entities belong to.
 LOCK_DEVICE_DOMAIN = "test"
 
-SLOT_1_ACTIVE_ENTITY = "binary_sensor.mock_title_code_slot_1_active"
-SLOT_1_ENABLED_ENTITY = "switch.mock_title_code_slot_1_enabled"
-SLOT_1_EVENT_ENTITY = "event.mock_title_code_slot_1"
-SLOT_1_NAME_ENTITY = "text.mock_title_code_slot_1_name"
-SLOT_1_PIN_ENTITY = "text.mock_title_code_slot_1_pin"
-SLOT_1_IN_SYNC_ENTITY = "binary_sensor.mock_title_code_slot_1_test_1_in_sync"
+SLOT_1_ACTIVE_ENTITY = "binary_sensor.test1_active"
+SLOT_1_ENABLED_ENTITY = "switch.test1_enabled"
+SLOT_1_EVENT_ENTITY = "event.test1"
+SLOT_1_NAME_ENTITY = "text.test1_name"
+SLOT_1_PIN_ENTITY = "text.test1_pin"
+SLOT_1_IN_SYNC_ENTITY = "binary_sensor.test1_test_1_in_sync"
 
-SLOT_2_ENABLED_ENTITY = "switch.mock_title_code_slot_2_enabled"
-SLOT_2_ACTIVE_ENTITY = "binary_sensor.mock_title_code_slot_2_active"
-SLOT_2_EVENT_ENTITY = "event.mock_title_code_slot_2"
-SLOT_2_PIN_ENTITY = "text.mock_title_code_slot_2_pin"
-SLOT_2_NAME_ENTITY = "text.mock_title_code_slot_2_name"
-SLOT_2_IN_SYNC_ENTITY = "binary_sensor.mock_title_code_slot_2_test_1_in_sync"
+SLOT_2_ENABLED_ENTITY = "switch.test2_enabled"
+SLOT_2_ACTIVE_ENTITY = "binary_sensor.test2_active"
+SLOT_2_EVENT_ENTITY = "event.test2"
+SLOT_2_PIN_ENTITY = "text.test2_pin"
+SLOT_2_NAME_ENTITY = "text.test2_name"
+SLOT_2_IN_SYNC_ENTITY = "binary_sensor.test2_test_1_in_sync"
 
 
 @dataclass(repr=False, eq=False)

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.components.text import (
     ATTR_VALUE,
@@ -33,6 +34,7 @@ from homeassistant.helpers.update_coordinator import UpdateFailed
 from homeassistant.util import dt as dt_util
 
 from custom_components.lock_code_manager.const import (
+    ATTR_ACTIVE,
     ATTR_CODE_SLOT,
     ATTR_LOCK_ENTITY_ID,
     ATTR_USERCODE,
@@ -70,6 +72,7 @@ from .common import (
     SLOT_2_PIN_ENTITY,
     MockLCMLock,
     in_sync_entity_id,
+    slot_entity_id,
 )
 from .conftest import (
     async_advance_time,
@@ -392,7 +395,9 @@ async def test_startup_waits_for_valid_active_state(
     await hass.async_block_till_done()
 
     # Get the entity IDs
-    active_entity_id = "binary_sensor.test_lcm_code_slot_1_active"
+    active_entity_id = slot_entity_id(
+        hass, BINARY_SENSOR_DOMAIN, config_entry, 1, ATTR_ACTIVE
+    )
     in_sync_entity = in_sync_entity_id(hass, config_entry, 1)
 
     # Verify entities exist
@@ -769,7 +774,9 @@ async def test_condition_entity_subscription_updates_on_config_change(
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    active_entity = "binary_sensor.test_lcm_code_slot_1_active"
+    active_entity = slot_entity_id(
+        hass, BINARY_SENSOR_DOMAIN, config_entry, 1, ATTR_ACTIVE
+    )
 
     # Initial state: access_1 is ON, so slot should be active
     state = hass.states.get(active_entity)

--- a/tests/test_blueprint_behavior.py
+++ b/tests/test_blueprint_behavior.py
@@ -12,6 +12,7 @@ import contextlib
 import pathlib
 from unittest.mock import patch
 
+import pytest
 from pytest_homeassistant_custom_component.common import (
     MockConfigEntry,
     async_mock_service,
@@ -22,10 +23,15 @@ from homeassistant.components import automation
 from homeassistant.components.blueprint import models
 from homeassistant.const import ATTR_FRIENDLY_NAME
 from homeassistant.core import Event, HomeAssistant, ServiceCall, State, callback
+from homeassistant.helpers import entity_registry as er, template
 from homeassistant.setup import async_setup_component
 from homeassistant.util import yaml as yaml_util
 
-from custom_components.lock_code_manager.const import DOMAIN
+from custom_components.lock_code_manager.const import (
+    ATTR_CODE_SLOT,
+    ATTR_SLOT_FIELD,
+    DOMAIN,
+)
 from custom_components.lock_code_manager.providers import BaseLock
 
 from .common import (
@@ -37,12 +43,8 @@ from .common import (
     SLOT_2_EVENT_ENTITY,
 )
 
-BLUEPRINT_FOLDER = (
-    pathlib.Path(__file__).resolve().parent.parent
-    / "blueprints"
-    / "automation"
-    / "lock_code_manager"
-)
+BLUEPRINTS_ROOT = pathlib.Path(__file__).resolve().parent.parent / "blueprints"
+BLUEPRINT_FOLDER = BLUEPRINTS_ROOT / "automation" / "lock_code_manager"
 
 NOTIFIER_PATH = "slot_usage_notifier.yaml"
 LIMITER_PATH = "slot_usage_limiter.yaml"
@@ -711,3 +713,77 @@ async def test_limiter_derives_slot_and_config_entry(
     # `_slot_number` ← state_attr(event_entity, 'code_slot') = 1
     assert "Mock Title" in title
     assert "Slot 1" in title
+
+
+@pytest.mark.parametrize(
+    ("blueprint", "variable", "slot_field"),
+    [
+        ("template/lock_code_manager/calendar_condition.yaml", "_name_entity", "name"),
+        (
+            "template/lock_code_manager/calendar_condition.yaml",
+            "_event_entity",
+            "pin_used",
+        ),
+        (
+            "automation/lock_code_manager/calendar_pin_setter.yaml",
+            "pin_entity",
+            "pin",
+        ),
+    ],
+)
+async def test_blueprints_find_the_entity_they_are_looking_for(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+    blueprint: str,
+    variable: str,
+    slot_field: str,
+) -> None:
+    """
+    Render the lookups out of the shipped YAML against a real setup.
+
+    These templates resolve Lock Code Manager's own entities, and nothing else
+    renders them -- which is how one of them shipped matching an entity ID
+    suffix no entity has ever had. Reading the expression out of the file
+    rather than restating it here means the test cannot drift from what
+    users actually run.
+    """
+    source = yaml_util.parse_yaml(
+        (BLUEPRINTS_ROOT / blueprint).read_text(encoding="utf-8")
+    )
+    expression = _find_variable(source, variable)
+    assert expression, f"{blueprint} no longer defines {variable}"
+
+    entry_id = lock_code_manager_config_entry.entry_id
+    rendered = template.Template(expression, hass).async_render(
+        variables={
+            "_all_entities": template.Template(
+                "{{ integration_entities(title) }}", hass
+            ).async_render(variables={"title": lock_code_manager_config_entry.title}),
+            "slot_number": 1,
+        },
+        parse_result=False,
+    )
+
+    assert rendered, f"{blueprint}:{variable} matched nothing"
+    state = hass.states.get(rendered)
+    assert state is not None
+    assert state.attributes[ATTR_CODE_SLOT] == 1
+    assert state.attributes[ATTR_SLOT_FIELD] == slot_field
+    # Belongs to this entry, not merely to something named alike.
+    assert er.async_get(hass).async_get(rendered).config_entry_id == entry_id
+
+
+def _find_variable(source: dict, name: str) -> str | None:
+    """Return the template a blueprint assigns to ``name``, wherever it sits."""
+    if isinstance(source, dict):
+        for key, value in source.items():
+            if key == name and isinstance(value, str):
+                return value
+            if (found := _find_variable(value, name)) is not None:
+                return found
+    elif isinstance(source, list):
+        for item in source:
+            if (found := _find_variable(item, name)) is not None:
+                return found
+    return None

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2495,6 +2495,15 @@ async def test_migration_reslugs_entity_ids_onto_the_user_name(
     assert ent_reg.async_get(after).id == before.id
     assert ent_reg.async_get(after).area_id == "kitchen"
 
+    # Nothing rewrites an entity id stored inside an automation, so the user
+    # is handed the mapping rather than left to discover it.
+    issue = ir.async_get(hass).async_get_issue(
+        DOMAIN, f"entity_ids_renamed_{entry.entry_id}"
+    )
+    assert issue is not None
+    assert before.entity_id in issue.translation_placeholders["renames"]
+    assert after in issue.translation_placeholders["renames"]
+
     await hass.config_entries.async_unload(entry.entry_id)
 
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -10,6 +10,11 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from homeassistant.components.lovelace import DOMAIN as LL_DOMAIN
 from homeassistant.components.lovelace.const import CONF_RESOURCE_TYPE_WS
+from homeassistant.components.text import (
+    ATTR_VALUE,
+    DOMAIN as TEXT_DOMAIN,
+    SERVICE_SET_VALUE,
+)
 from homeassistant.config_entries import SOURCE_REAUTH
 from homeassistant.const import (
     ATTR_CODE,
@@ -73,6 +78,7 @@ from .common import (
     LOCK_2_ENTITY_ID,
     LOCK_DEVICE_DOMAIN,
     SLOT_1_IN_SYNC_ENTITY,
+    SLOT_1_NAME_ENTITY,
     MockLCMLock,
     in_sync_entity_id,
 )
@@ -2392,3 +2398,50 @@ async def test_migration_of_a_real_world_entry_shape(
         )
 
     await hass.config_entries.async_unload(entry.entry_id)
+
+
+async def test_a_slot_device_is_named_for_the_user_who_holds_it(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+) -> None:
+    """The slot number is bookkeeping, so it must not be what the user reads."""
+    entry_id = lock_code_manager_config_entry.entry_id
+    dev_reg = dr.async_get(hass)
+    config = get_entry_config(lock_code_manager_config_entry)
+
+    for slot_num in config.slot_numbers:
+        device = dev_reg.async_get_device({(DOMAIN, f"{entry_id}|{slot_num}")})
+        assert device is not None
+        assert device.name == config.name_for(slot_num)
+
+
+async def test_renaming_a_user_renames_their_device(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+) -> None:
+    """
+    Driven through the name entity, which is how a user actually renames.
+
+    That path writes to data with empty options, so it returns before the
+    update listener does any entity work -- the device would keep the old
+    name if the rename were handled alongside entity creation.
+    """
+    entry_id = lock_code_manager_config_entry.entry_id
+    dev_reg = dr.async_get(hass)
+    identifiers = {(DOMAIN, f"{entry_id}|1")}
+    before = get_entry_config(lock_code_manager_config_entry).name_for(1)
+    assert dev_reg.async_get_device(identifiers).name == before
+
+    await hass.services.async_call(
+        TEXT_DOMAIN,
+        SERVICE_SET_VALUE,
+        service_data={ATTR_VALUE: "Sherene"},
+        target={ATTR_ENTITY_ID: SLOT_1_NAME_ENTITY},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert get_entry_config(lock_code_manager_config_entry).name_for(1) == "Sherene"
+    assert dev_reg.async_get_device(identifiers).name == "Sherene"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -34,6 +34,7 @@ from homeassistant.helpers import (
     entity_registry as er,
     issue_registry as ir,
 )
+from homeassistant.util import slugify
 
 from custom_components.lock_code_manager import (
     _setup_entry_after_start,
@@ -2360,15 +2361,16 @@ async def test_migration_of_a_real_world_entry_shape(
     entry.add_to_hass(hass)
     ent_reg = er.async_get(hass)
 
-    # The registry as a released version leaves it, keyed on the slot number.
+    # The registry as a released version leaves it: entity IDs slugged from
+    # the entry title and the slot number, keyed on the slot number.
     seeded = {
         slot: ent_reg.async_get_or_create(
             "text",
             DOMAIN,
             f"{entry.entry_id}|{slot}|{CONF_PIN}",
             config_entry=entry,
-            suggested_object_id=f"chosen_by_the_user_{slot}",
-        ).entity_id
+            suggested_object_id=f"all_locks_code_slot_{slot}_pin",
+        )
         for slot in range(1, 7)
     }
 
@@ -2388,14 +2390,15 @@ async def test_migration_of_a_real_world_entry_shape(
     assert config.slot(3)[CONF_PIN] == "3333"
     assert config.slot(6)[CONF_PIN] == "6666"
 
-    # And every entity the user already had is the same entity.
-    for slot, entity_id in seeded.items():
-        assert (
-            ent_reg.async_get_entity_id(
-                "text", DOMAIN, f"{entry.entry_id}|{slot}|{CONF_PIN}"
-            )
-            == entity_id
+    # The entity IDs move onto the users, but the registry ENTRIES are the
+    # same rows: everything hanging off them -- settings, area, and the
+    # recorder history the registry repoints -- follows the entity.
+    for slot, entry_before in seeded.items():
+        moved = ent_reg.async_get_entity_id(
+            "text", DOMAIN, f"{entry.entry_id}|{slot}|{CONF_PIN}"
         )
+        assert moved == f"text.{slugify(config.name_for(slot))}_pin"
+        assert ent_reg.async_get(moved).id == entry_before.id
 
     await hass.config_entries.async_unload(entry.entry_id)
 
@@ -2445,3 +2448,92 @@ async def test_renaming_a_user_renames_their_device(
 
     assert get_entry_config(lock_code_manager_config_entry).name_for(1) == "Sherene"
     assert dev_reg.async_get_device(identifiers).name == "Sherene"
+
+
+async def test_migration_reslugs_entity_ids_onto_the_user_name(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """
+    An upgraded install must end up shaped like a fresh one.
+
+    The registry entry itself is kept, not rebuilt: the unique ID still
+    carries the slot number, so settings, area and recorder history follow
+    the entity rather than being stranded under the old ID.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="All Locks",
+        data={
+            "locks": [LOCK_1_ENTITY_ID],
+            "slots": {1: {"enabled": True, "name": "Raman", "pin": "1111"}},
+        },
+        version=3,
+        minor_version=1,
+    )
+    entry.add_to_hass(hass)
+    ent_reg = er.async_get(hass)
+
+    # The registry as the released version leaves it.
+    before = ent_reg.async_get_or_create(
+        "text",
+        DOMAIN,
+        f"{entry.entry_id}|1|{CONF_PIN}",
+        config_entry=entry,
+        suggested_object_id="all_locks_code_slot_1_pin",
+    )
+    ent_reg.async_update_entity(before.entity_id, area_id="kitchen")
+    assert before.entity_id == "text.all_locks_code_slot_1_pin"
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    after = ent_reg.async_get_entity_id(
+        "text", DOMAIN, f"{entry.entry_id}|1|{CONF_PIN}"
+    )
+    assert after == "text.raman_pin"
+    # Same registry entry, so everything hanging off it came along.
+    assert ent_reg.async_get(after).id == before.id
+    assert ent_reg.async_get(after).area_id == "kitchen"
+
+    await hass.config_entries.async_unload(entry.entry_id)
+
+
+async def test_migration_leaves_an_unrecognized_entity_id_alone(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """
+    Only the prefix this integration generated can be swapped.
+
+    The rest of an entity ID comes from the entity's own translated name, so
+    an ID that does not start with the expected prefix cannot be taken apart
+    into a prefix and a suffix, and is left as it is.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="All Locks",
+        data={
+            "locks": [LOCK_1_ENTITY_ID],
+            "slots": {1: {"enabled": True, "name": "Raman", "pin": "1111"}},
+        },
+        version=3,
+        minor_version=1,
+    )
+    entry.add_to_hass(hass)
+    ent_reg = er.async_get(hass)
+    before = ent_reg.async_get_or_create(
+        "text",
+        DOMAIN,
+        f"{entry.entry_id}|1|{CONF_PIN}",
+        config_entry=entry,
+        suggested_object_id="something_else_entirely",
+    )
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert (
+        ent_reg.async_get_entity_id("text", DOMAIN, f"{entry.entry_id}|1|{CONF_PIN}")
+        == before.entity_id
+    )
+
+    await hass.config_entries.async_unload(entry.entry_id)

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -91,6 +91,7 @@ from .common import (
     SLOT_1_ENABLED_ENTITY,
     SLOT_1_IN_SYNC_ENTITY,
     SLOT_1_PIN_ENTITY,
+    SLOT_2_EVENT_ENTITY,
 )
 from .conftest import async_initial_tick, async_trigger_sync_tick
 
@@ -366,7 +367,7 @@ async def test_subscribe_lock_codes_entity_state_change(
     assert event["type"] == "event"
 
     # Change an LCM entity state (enabled switch for slot 1)
-    enabled_entity_id = "switch.mock_title_code_slot_1_enabled"
+    enabled_entity_id = SLOT_1_ENABLED_ENTITY
     hass.states.async_set(enabled_entity_id, STATE_OFF)
     await hass.async_block_till_done()
 
@@ -402,7 +403,7 @@ async def test_subscribe_lock_codes_ignores_metadata_changes(
     assert event["type"] == "event"
 
     # Change only metadata (same state value, different attributes)
-    enabled_entity_id = "switch.mock_title_code_slot_1_enabled"
+    enabled_entity_id = SLOT_1_ENABLED_ENTITY
     current_state = hass.states.get(enabled_entity_id)
     hass.states.async_set(
         enabled_entity_id,
@@ -681,7 +682,7 @@ async def test_subscribe_code_slot_state_change(
     assert event["type"] == "event"
 
     # Change an entity state (enabled switch for slot 1)
-    enabled_entity_id = "switch.mock_title_code_slot_1_enabled"
+    enabled_entity_id = SLOT_1_ENABLED_ENTITY
     hass.states.async_set(enabled_entity_id, STATE_OFF)
     await hass.async_block_till_done()
 
@@ -768,7 +769,7 @@ async def test_subscribe_code_slot_ignores_metadata_changes(
     assert event["type"] == "event"
 
     # Change only metadata (same state value, different attributes)
-    enabled_entity_id = "switch.mock_title_code_slot_1_enabled"
+    enabled_entity_id = SLOT_1_ENABLED_ENTITY
     current_state = hass.states.get(enabled_entity_id)
     hass.states.async_set(
         enabled_entity_id,
@@ -958,7 +959,7 @@ async def test_subscribe_code_slot_with_event_type(
 
     # Check event entity state to verify event_type is set (this is what
     # websocket code reads to determine last_used_lock_name)
-    event_state = hass.states.get("event.mock_title_code_slot_2")
+    event_state = hass.states.get(SLOT_2_EVENT_ENTITY)
     assert event_state is not None
     assert event_state.state not in ("unknown", "unavailable")
     assert event_state.attributes.get("event_type") == LOCK_1_ENTITY_ID
@@ -2642,7 +2643,7 @@ async def test_subscribe_lock_codes_entity_tracking_refreshes_on_update(
     real_ids = _get_slot_state_entity_ids(hass, LOCK_1_ENTITY_ID)
 
     # Create a synthetic new entity that will appear on the second call
-    new_entity_id = "switch.mock_title_code_slot_99_enabled"
+    new_entity_id = "switch.test99_enabled"
     hass.states.async_set(new_entity_id, STATE_ON)
     await hass.async_block_till_done()
 
@@ -2729,7 +2730,7 @@ async def test_subscribe_lock_codes_tracking_refresh_noop_when_unchanged(
     assert updated["type"] == "event"
 
     # Verify state tracking still works (entity state change produces update)
-    enabled_entity_id = "switch.mock_title_code_slot_1_enabled"
+    enabled_entity_id = SLOT_1_ENABLED_ENTITY
     hass.states.async_set(enabled_entity_id, STATE_OFF)
     await hass.async_block_till_done()
 
@@ -2757,7 +2758,7 @@ async def test_subscribe_code_slot_entity_tracking_refreshes_on_update(
     )
 
     # Create a synthetic new entity that will appear on subsequent calls
-    new_entity_id = "text.mock_title_code_slot_1_extra"
+    new_entity_id = "text.test1_extra"
     hass.states.async_set(new_entity_id, "test_value")
     await hass.async_block_till_done()
 


### PR DESCRIPTION
## Summary

First slice of B3. The slot number is internal bookkeeping, so it should not be what a user reads on their dashboard. The per-slot device becomes **"Raman"** instead of **"All Locks Code slot 3"**, and its model becomes `User`.

Two design points worth calling out:

**The name is looked up inside `build_slot_device_info` rather than passed in**, so no caller can name a device something the configuration disagrees with. A slot with no user falls back to the name the migration would give it, which is reachable while entities are being moved off a foreign device before their slot is swept away.

**Renames need explicit handling.** `DeviceInfo` only names a device as it is created, so a rename would otherwise leave the old name standing until the entity was rebuilt. The rename that matters most — the name text entity — writes to `data` with empty options, which means `async_update_listener` returns at its early exit before doing any entity work. `_async_rename_slot_devices` therefore runs *above* that return. `name_by_user` is untouched, so a device the user renamed themselves keeps their name.

## Consequence to be aware of

Entity IDs follow the device name for **newly created** entities: `text.raman_pin` rather than `text.mock_title_code_slot_1_pin`.

**Existing installs are unaffected.** The registry keys on unique ID, which still carries the slot number, so entity IDs and their history survive — this is the same mechanism the production-shape migration test in `test_init.py` pins, and it passes here.

A user who renames themselves later keeps their original slug, which is standard Home Assistant behavior for entity IDs.

## Testing

Two new tests: one asserting each slot device is named for its holder, one driving a rename through the name text entity — deliberately through that entity, because it is the path that returns early and would have been missed by handling renames alongside entity creation.

Tests that spelled an entity ID out inline now resolve it by unique ID via a new `slot_entity_id` helper, since the slug now depends on whoever holds the slot.

`pytest tests/` — 1690 passed, 3 skipped. `prek` clean.