### PR TITLE
feat: repoint automations at the renamed entity IDs

### DIFF
--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Iterable, Sequence
+import json
 import logging
 from pathlib import Path
 from typing import Any
@@ -100,6 +101,7 @@ from .domain.pin_generator import (
     generate_pin,
 )
 from .domain.queries import get_entry_config
+from .domain.references import format_moved
 from .domain.services import (
     async_clear_slot_condition,
     async_clear_usercode,
@@ -249,10 +251,11 @@ async def async_migrate_entry(
                 translation_key="entity_ids_renamed",
                 translation_placeholders={
                     "entry_title": config_entry.title,
-                    "renames": "\n".join(
-                        f"- `{was}` is now `{now}`" for was, now in sorted(re_slugged)
-                    ),
+                    "renames": format_moved(dict(re_slugged)),
                 },
+                # The flow looks up who still points at these when the user
+                # opens it; the migration only knows what moved.
+                data={"moved": json.dumps(dict(re_slugged))},
             )
         if renamed:
             _LOGGER.info(

--- a/custom_components/lock_code_manager/domain/references.py
+++ b/custom_components/lock_code_manager/domain/references.py
@@ -1,0 +1,209 @@
+"""
+Repointing automations and scripts at entity IDs that moved.
+
+Home Assistant repoints recorder history when an entity ID changes, but an ID
+written into an automation is just a string in a config file and nothing
+rewrites it. The frontend's rename dialog offers to; a migration does not go
+through the frontend.
+
+What can be rewritten is bounded by where the configuration lives.
+``automations.yaml`` and ``scripts.yaml`` are the files Home Assistant's own
+config API owns and rewrites wholesale, so editing them is in keeping with how
+they are already treated. Anything defined in ``configuration.yaml``, in a
+package, in a dashboard or in a template belongs to somebody else and is
+reported rather than touched: a fix that silently covers half the references
+is worse than one that says what it missed, because the user stops looking.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+from homeassistant.components import automation, script
+from homeassistant.config import AUTOMATION_CONFIG_PATH, SCRIPT_CONFIG_PATH
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.util.yaml import load_yaml, save_yaml
+
+# ``automations.yaml`` holds a list of automation dicts, each carrying its own
+# ``id``; ``scripts.yaml`` holds a mapping of object id to script dict. Both
+# are rewritten whole, which is what Home Assistant's config API does to them.
+AUTOMATION_DOMAIN = "automation"
+SCRIPT_DOMAIN = "script"
+
+_FILES = {
+    AUTOMATION_DOMAIN: AUTOMATION_CONFIG_PATH,
+    SCRIPT_DOMAIN: SCRIPT_CONFIG_PATH,
+}
+
+
+@dataclass(slots=True)
+class Referrers:
+    """What still points at a moved entity ID, split by what can be fixed."""
+
+    # Config keys, per domain, of entries in a file this can rewrite.
+    fixable: dict[str, set[str]] = field(default_factory=dict)
+    # How to describe those entries to the user.
+    labels: list[str] = field(default_factory=list)
+    # Entity IDs referencing a moved ID from somewhere this must not write.
+    unfixable: set[str] = field(default_factory=set)
+
+    @property
+    def total(self) -> int:
+        """Return how many configs reference a moved ID."""
+        return sum(len(found) for found in self.fixable.values()) + len(self.unfixable)
+
+
+async def async_find_referrers(
+    hass: HomeAssistant, moved: Mapping[str, str]
+) -> Referrers:
+    """
+    Return what still points at a moved entity ID.
+
+    The FILES are the source of truth for what can be fixed, not
+    ``automations_with_entity``. That helper reads loaded automation entities
+    and reports only ``referenced_entities``, so it misses an automation that
+    failed to load and misses a blueprint input used solely inside a template
+    -- which is exactly how the shipped Slot Usage blueprints use theirs.
+
+    The loaded-entity lookup is still used, for the opposite job: finding
+    references that are NOT in these files and therefore cannot be touched.
+    """
+    referrers = Referrers()
+    for domain in _FILES:
+        found = await hass.async_add_executor_job(_matching_keys, hass, domain, moved)
+        if found:
+            referrers.fixable[domain] = set(found)
+            referrers.labels.extend(found.values())
+
+    ent_reg = er.async_get(hass)
+    for old_entity_id in moved:
+        for domain, lookup in (
+            (AUTOMATION_DOMAIN, automation.automations_with_entity),
+            (SCRIPT_DOMAIN, script.scripts_with_entity),
+        ):
+            for referring in lookup(hass, old_entity_id):
+                # A user-interface-managed automation or script is stored
+                # under the key that becomes its unique ID; anything whose key
+                # is not in the file is defined somewhere else.
+                entry = ent_reg.async_get(referring)
+                key = entry.unique_id if entry else None
+                if key not in referrers.fixable.get(domain, set()):
+                    referrers.unfixable.add(referring)
+    return referrers
+
+
+async def async_repoint(
+    hass: HomeAssistant, moved: Mapping[str, str], referrers: Referrers
+) -> int:
+    """
+    Rewrite the fixable files so they name the new entity IDs.
+
+    Returns how many configs changed. Reloading is the caller's to do; this
+    only touches files.
+    """
+    changed = 0
+    for domain, keys in referrers.fixable.items():
+        changed += await hass.async_add_executor_job(
+            _repoint_file, hass, domain, keys, dict(moved)
+        )
+    return changed
+
+
+def _entries(loaded: Any, domain: str) -> list[tuple[str, Any]]:
+    """Return a config file's entries as ``(key, config)``, whatever its shape."""
+    if domain == AUTOMATION_DOMAIN:
+        return [
+            (str(item["id"]), item)
+            for item in loaded
+            if isinstance(item, dict) and item.get("id") is not None
+        ]
+    return [(str(key), value) for key, value in loaded.items()]
+
+
+def _matching_keys(
+    hass: HomeAssistant, domain: str, moved: Mapping[str, str]
+) -> dict[str, str]:
+    """Return ``{key: label}`` for entries mentioning a moved ID."""
+    return {
+        key: str(config.get("alias") or key) if isinstance(config, dict) else key
+        for key, config in _entries(_load(hass, domain), domain)
+        if _mentions(config, moved)
+    }
+
+
+def _mentions(config: Any, moved: Mapping[str, str]) -> bool:
+    """Return whether a moved entity ID appears anywhere inside ``config``."""
+    if isinstance(config, str):
+        return config in moved
+    if isinstance(config, dict):
+        return any(_mentions(value, moved) for value in config.values())
+    if isinstance(config, list):
+        return any(_mentions(item, moved) for item in config)
+    return False
+
+
+def _load(hass: HomeAssistant, domain: str) -> Any:
+    """Read a config file, treating an absent or malformed one as empty."""
+    empty: Any = [] if domain == AUTOMATION_DOMAIN else {}
+    try:
+        loaded = load_yaml(hass.config.path(_FILES[domain]))
+    except FileNotFoundError, OSError, ValueError:
+        return empty
+    return loaded if isinstance(loaded, type(empty)) else empty
+
+
+def _repoint_file(
+    hass: HomeAssistant, domain: str, keys: set[str], moved: dict[str, str]
+) -> int:
+    """Rewrite one config file's matching entries. Runs in an executor."""
+    loaded = _load(hass, domain)
+    changed = sum(
+        _substitute(config, moved)
+        for key, config in _entries(loaded, domain)
+        if key in keys
+    )
+    if changed:
+        save_yaml(hass.config.path(_FILES[domain]), loaded)
+    return changed
+
+
+def _substitute(config: Any, moved: Mapping[str, str]) -> bool:
+    """
+    Replace every moved entity ID inside ``config``, in place.
+
+    Matches WHOLE strings only. An entity ID can appear as a bare value or in
+    a list, and a substring replacement would corrupt a template that merely
+    mentions one.
+    """
+    if isinstance(config, dict):
+        items: Iterable[tuple[Any, Any]] = list(config.items())
+    elif isinstance(config, list):
+        items = list(enumerate(config))
+    else:
+        return False
+
+    replaced = False
+    for key, value in items:
+        if isinstance(value, str) and value in moved:
+            config[key] = moved[value]
+            replaced = True
+        elif _substitute(value, moved):
+            replaced = True
+    return replaced
+
+
+def format_moved(moved: Mapping[str, str]) -> str:
+    """Return the moved IDs as a markdown list for a repair description."""
+    return "\n".join(f"- `{was}` is now `{now}`" for was, now in sorted(moved.items()))
+
+
+def format_entities(hass: HomeAssistant, entity_ids: Iterable[str]) -> str:
+    """Return entities as a markdown list, named as the user sees them."""
+    return "\n".join(
+        f"- {state.name if (state := hass.states.get(entity_id)) else entity_id}"
+        f" (`{entity_id}`)"
+        for entity_id in sorted(entity_ids)
+    )

--- a/custom_components/lock_code_manager/domain/references.py
+++ b/custom_components/lock_code_manager/domain/references.py
@@ -19,17 +19,21 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
+import logging
 from typing import Any
 
 from homeassistant.components import automation, script
 from homeassistant.config import AUTOMATION_CONFIG_PATH, SCRIPT_CONFIG_PATH
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util.yaml import load_yaml, save_yaml
 
 # ``automations.yaml`` holds a list of automation dicts, each carrying its own
 # ``id``; ``scripts.yaml`` holds a mapping of object id to script dict. Both
 # are rewritten whole, which is what Home Assistant's config API does to them.
+_LOGGER = logging.getLogger(__name__)
+
 AUTOMATION_DOMAIN = "automation"
 SCRIPT_DOMAIN = "script"
 
@@ -150,7 +154,16 @@ def _load(hass: HomeAssistant, domain: str) -> Any:
     empty: Any = [] if domain == AUTOMATION_DOMAIN else {}
     try:
         loaded = load_yaml(hass.config.path(_FILES[domain]))
-    except FileNotFoundError, OSError, ValueError:
+    except FileNotFoundError, OSError, ValueError, HomeAssistantError:
+        # A file that will not parse cannot be rewritten, and must not take
+        # the whole repair down with it: an install part-way through an
+        # upgrade is exactly where a broken automations file turns up, and
+        # the other file may still be fixable.
+        _LOGGER.warning(
+            "Could not read %s, so nothing in it can be repointed",
+            _FILES[domain],
+            exc_info=True,
+        )
         return empty
     return loaded if isinstance(loaded, type(empty)) else empty
 

--- a/custom_components/lock_code_manager/repairs.py
+++ b/custom_components/lock_code_manager/repairs.py
@@ -2,9 +2,20 @@
 
 from __future__ import annotations
 
+import json
+
 from homeassistant import data_entry_flow
 from homeassistant.components.repairs import RepairsFlow
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.issue_registry import async_delete_issue
+
+from .const import DOMAIN
+from .domain.references import (
+    async_find_referrers,
+    async_repoint,
+    format_entities,
+    format_moved,
+)
 
 
 class AcknowledgeRepairFlow(RepairsFlow):
@@ -19,10 +30,60 @@ class AcknowledgeRepairFlow(RepairsFlow):
         return self.async_show_form(step_id="init")
 
 
+class EntityIdsRenamedRepairFlow(RepairsFlow):
+    """
+    Offer to repoint automations and scripts at the entity IDs that moved.
+
+    The references are looked up now rather than when the issue was raised:
+    the migration runs while a config entry is setting up, before the
+    automation component necessarily has its entities.
+    """
+
+    def __init__(self, issue_id: str, moved: dict[str, str]) -> None:
+        """Store what moved, so the flow can look up who still points at it."""
+        self._issue_id = issue_id
+        self._moved = moved
+
+    async def async_step_init(
+        self, user_input: dict[str, str] | None = None
+    ) -> data_entry_flow.FlowResult:
+        """Show what can and cannot be repointed, then do the former."""
+        referrers = await async_find_referrers(self.hass, self._moved)
+        if not referrers.total:
+            # Nothing refers to the old IDs, so there is nothing to confirm.
+            async_delete_issue(self.hass, DOMAIN, self._issue_id)
+            return self.async_create_entry(title="", data={})
+
+        if user_input is not None:
+            repointed = await async_repoint(self.hass, self._moved, referrers)
+            for domain in referrers.fixable:
+                # A file can hold configs for a component that is not loaded,
+                # and it will read the new ids when it does load.
+                if self.hass.services.has_service(domain, "reload"):
+                    await self.hass.services.async_call(domain, "reload", blocking=True)
+            return self.async_create_entry(title="", data={"repointed": repointed})
+
+        fixable = sorted(referrers.labels)
+        return self.async_show_form(
+            step_id="init",
+            description_placeholders={
+                "renames": format_moved(self._moved),
+                "fixable": "\n".join(f"- {label}" for label in fixable) or "- (none)",
+                "unfixable": (
+                    format_entities(self.hass, referrers.unfixable) or "- (none)"
+                ),
+            },
+        )
+
+
 async def async_create_fix_flow(
     hass: HomeAssistant, issue_id: str, data: dict[str, str] | None
 ) -> RepairsFlow:
     """Create a fix flow for a repair issue."""
+    if issue_id.startswith("entity_ids_renamed_"):
+        return EntityIdsRenamedRepairFlow(
+            issue_id, json.loads((data or {}).get("moved") or "{}")
+        )
     if issue_id.startswith(
         (
             "number_of_uses_removed",

--- a/custom_components/lock_code_manager/strings.json
+++ b/custom_components/lock_code_manager/strings.json
@@ -245,7 +245,7 @@
         "step": {
           "init": {
             "title": "Entity IDs now follow your users' names",
-            "description": "Lock Code Manager identifies each user by name rather than by slot number, so the entity IDs in **{entry_title}** were renamed to match:\n\n{renames}\n\nHistory and statistics moved with them, and dashboards built by Lock Code Manager keep working. Anything that refers to the old IDs by name needs updating: your own automations, scripts and template sensors, and automations created from the Slot Usage Limiter or Slot Usage Notifier blueprints, which store an entity ID when you set them up."
+            "description": "Lock Code Manager identifies each user by name rather than by slot number, so the entity IDs in **{entry_title}** were renamed:\n\n{renames}\n\nHistory and statistics moved with them, and dashboards built by Lock Code Manager keep working.\n\n**Will be updated for you**\n\n{fixable}\n\n**You will need to update these yourself**\n\nThese are defined somewhere Lock Code Manager must not edit, such as `configuration.yaml`, a package, a dashboard or a template:\n\n{unfixable}\n\nSubmit to update the automations and scripts listed above."
           }
         }
       }

--- a/custom_components/lock_code_manager/strings.json
+++ b/custom_components/lock_code_manager/strings.json
@@ -245,7 +245,7 @@
         "step": {
           "init": {
             "title": "Entity IDs now follow your users' names",
-            "description": "Lock Code Manager identifies each user by name rather than by slot number, so the entity IDs in **{entry_title}** were renamed:\n\n{renames}\n\nHistory and statistics moved with them, and dashboards built by Lock Code Manager keep working.\n\n**Will be updated for you**\n\n{fixable}\n\n**You will need to update these yourself**\n\nThese are defined somewhere Lock Code Manager must not edit, such as `configuration.yaml`, a package, a dashboard or a template:\n\n{unfixable}\n\nSubmit to update the automations and scripts listed above."
+            "description": "Lock Code Manager identifies each user by name rather than by slot number, so the entity IDs in **{entry_title}** were renamed:\n\n{renames}\n\nHistory and statistics moved with them, and dashboards built by Lock Code Manager keep working.\n\n**Will be updated for you**\n\n{fixable}\n\n**You will need to update these yourself**\n\nThese are defined somewhere Lock Code Manager must not edit, such as `configuration.yaml`, a package, a dashboard or a template:\n\n{unfixable}\n\nSubmit to update the automations and scripts listed above. They are rewritten in `automations.yaml` and `scripts.yaml`, the files the Home Assistant user interface manages, so any comments you added to those files by hand will not survive."
           }
         }
       }

--- a/custom_components/lock_code_manager/translations/en.json
+++ b/custom_components/lock_code_manager/translations/en.json
@@ -245,7 +245,7 @@
         "step": {
           "init": {
             "title": "Entity IDs now follow your users' names",
-            "description": "Lock Code Manager identifies each user by name rather than by slot number, so the entity IDs in **{entry_title}** were renamed to match:\n\n{renames}\n\nHistory and statistics moved with them, and dashboards built by Lock Code Manager keep working. Anything that refers to the old IDs by name needs updating: your own automations, scripts and template sensors, and automations created from the Slot Usage Limiter or Slot Usage Notifier blueprints, which store an entity ID when you set them up."
+            "description": "Lock Code Manager identifies each user by name rather than by slot number, so the entity IDs in **{entry_title}** were renamed:\n\n{renames}\n\nHistory and statistics moved with them, and dashboards built by Lock Code Manager keep working.\n\n**Will be updated for you**\n\n{fixable}\n\n**You will need to update these yourself**\n\nThese are defined somewhere Lock Code Manager must not edit, such as `configuration.yaml`, a package, a dashboard or a template:\n\n{unfixable}\n\nSubmit to update the automations and scripts listed above."
           }
         }
       }

--- a/custom_components/lock_code_manager/translations/en.json
+++ b/custom_components/lock_code_manager/translations/en.json
@@ -245,7 +245,7 @@
         "step": {
           "init": {
             "title": "Entity IDs now follow your users' names",
-            "description": "Lock Code Manager identifies each user by name rather than by slot number, so the entity IDs in **{entry_title}** were renamed:\n\n{renames}\n\nHistory and statistics moved with them, and dashboards built by Lock Code Manager keep working.\n\n**Will be updated for you**\n\n{fixable}\n\n**You will need to update these yourself**\n\nThese are defined somewhere Lock Code Manager must not edit, such as `configuration.yaml`, a package, a dashboard or a template:\n\n{unfixable}\n\nSubmit to update the automations and scripts listed above."
+            "description": "Lock Code Manager identifies each user by name rather than by slot number, so the entity IDs in **{entry_title}** were renamed:\n\n{renames}\n\nHistory and statistics moved with them, and dashboards built by Lock Code Manager keep working.\n\n**Will be updated for you**\n\n{fixable}\n\n**You will need to update these yourself**\n\nThese are defined somewhere Lock Code Manager must not edit, such as `configuration.yaml`, a package, a dashboard or a template:\n\n{unfixable}\n\nSubmit to update the automations and scripts listed above. They are rewritten in `automations.yaml` and `scripts.yaml`, the files the Home Assistant user interface manages, so any comments you added to those files by hand will not survive."
           }
         }
       }

--- a/tests/test_repairs_references.py
+++ b/tests/test_repairs_references.py
@@ -1,0 +1,159 @@
+"""Repointing automations and scripts after the migration moves entity IDs."""
+
+from __future__ import annotations
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from homeassistant.components import automation
+from homeassistant.config import AUTOMATION_CONFIG_PATH
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er, issue_registry as ir
+from homeassistant.setup import async_setup_component
+from homeassistant.util.yaml import load_yaml, save_yaml
+
+from custom_components.lock_code_manager.const import DOMAIN
+from custom_components.lock_code_manager.repairs import async_create_fix_flow
+
+from .common import LOCK_1_ENTITY_ID
+
+OLD_PIN_ENTITY = "text.all_locks_code_slot_1_pin"
+NEW_PIN_ENTITY = "text.raman_pin"
+
+
+@pytest.fixture(name="automations_file")
+def automations_file_fixture(hass: HomeAssistant, tmp_path):
+    """Point Home Assistant's config dir at a temp dir holding automations."""
+    hass.config.config_dir = str(tmp_path)
+    (tmp_path / "configuration.yaml").write_text("", encoding="utf-8")
+    save_yaml(
+        str(tmp_path / AUTOMATION_CONFIG_PATH),
+        [
+            {
+                "id": "reacts_to_the_pin",
+                "alias": "Reacts to the PIN",
+                "triggers": [{"trigger": "state", "entity_id": OLD_PIN_ENTITY}],
+                "actions": [{"action": "homeassistant.turn_on"}],
+            }
+        ],
+    )
+    return tmp_path / AUTOMATION_CONFIG_PATH
+
+
+async def _migrated_entry(hass: HomeAssistant) -> MockConfigEntry:
+    """Set up a version 3 entry so the migration renames its entity IDs."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="All Locks",
+        data={
+            "locks": [LOCK_1_ENTITY_ID],
+            "slots": {1: {"enabled": True, "name": "Raman", "pin": "1111"}},
+        },
+        version=3,
+        minor_version=1,
+    )
+    entry.add_to_hass(hass)
+    er.async_get(hass).async_get_or_create(
+        "text",
+        DOMAIN,
+        f"{entry.entry_id}|1|pin",
+        config_entry=entry,
+        suggested_object_id="all_locks_code_slot_1_pin",
+    )
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    return entry
+
+
+async def test_the_repair_repoints_an_automation_at_the_new_entity_id(
+    hass: HomeAssistant, mock_lock_config_entry, automations_file
+) -> None:
+    """
+    The whole point: an automation keeps working across the rename.
+
+    Driven through the real repair flow and the real automations file, since
+    the value of this is entirely in whether a user's automation still fires.
+    """
+    assert await async_setup_component(
+        hass, automation.DOMAIN, {automation.DOMAIN: load_yaml(str(automations_file))}
+    )
+    await hass.async_block_till_done()
+
+    entry = await _migrated_entry(hass)
+    assert (
+        er.async_get(hass).async_get_entity_id(
+            "text", DOMAIN, f"{entry.entry_id}|1|pin"
+        )
+        == NEW_PIN_ENTITY
+    )
+
+    issue_id = f"entity_ids_renamed_{entry.entry_id}"
+    issue = ir.async_get(hass).async_get_issue(DOMAIN, issue_id)
+    assert issue is not None
+
+    flow = await async_create_fix_flow(hass, issue_id, issue.data)
+    flow.hass = hass
+    form = await flow.async_step_init()
+    assert form["type"] == "form"
+    # It names the automation it is about to change.
+    assert "Reacts to the PIN" in form["description_placeholders"]["fixable"]
+
+    await flow.async_step_init({})
+    await hass.async_block_till_done()
+
+    stored = load_yaml(str(automations_file))
+    assert stored[0]["triggers"][0]["entity_id"] == NEW_PIN_ENTITY
+
+    await hass.config_entries.async_unload(entry.entry_id)
+
+
+async def test_the_repair_repoints_a_blueprint_automation(
+    hass: HomeAssistant, mock_lock_config_entry, tmp_path
+) -> None:
+    """
+    The case that matters most: an automation built from one of our blueprints.
+
+    Creating one in the user interface stores the entity IDs the user picked
+    under ``use_blueprint.input``, several levels down in automations.yaml.
+    Nothing about that shape is special-cased, so this pins that the
+    substitution reaches it.
+    """
+    hass.config.config_dir = str(tmp_path)
+    (tmp_path / "configuration.yaml").write_text("", encoding="utf-8")
+    automations = tmp_path / AUTOMATION_CONFIG_PATH
+    save_yaml(
+        str(automations),
+        [
+            {
+                "id": "built_from_a_blueprint",
+                "alias": "Limit guest PIN",
+                "use_blueprint": {
+                    "path": "lock_code_manager/slot_usage_limiter.yaml",
+                    "input": {
+                        "pin_used_entity": "event.all_locks_code_slot_1",
+                        "enabled_switch": OLD_PIN_ENTITY,
+                        "locks": [LOCK_1_ENTITY_ID],
+                    },
+                },
+            }
+        ],
+    )
+
+    entry = await _migrated_entry(hass)
+    issue_id = f"entity_ids_renamed_{entry.entry_id}"
+    issue = ir.async_get(hass).async_get_issue(DOMAIN, issue_id)
+    assert issue is not None
+
+    flow = await async_create_fix_flow(hass, issue_id, issue.data)
+    flow.hass = hass
+    await flow.async_step_init()
+    await flow.async_step_init({})
+    await hass.async_block_till_done()
+
+    stored = load_yaml(str(automations))[0]["use_blueprint"]["input"]
+    assert stored["enabled_switch"] == NEW_PIN_ENTITY
+    # Everything else in the input is left exactly as the user set it.
+    assert stored["pin_used_entity"] == "event.all_locks_code_slot_1"
+    assert stored["locks"] == [LOCK_1_ENTITY_ID]
+
+    await hass.config_entries.async_unload(entry.entry_id)

--- a/tests/test_repairs_references.py
+++ b/tests/test_repairs_references.py
@@ -157,3 +157,33 @@ async def test_the_repair_repoints_a_blueprint_automation(
     assert stored["locks"] == [LOCK_1_ENTITY_ID]
 
     await hass.config_entries.async_unload(entry.entry_id)
+
+
+async def test_a_broken_automations_file_does_not_break_the_repair(
+    hass: HomeAssistant, mock_lock_config_entry, tmp_path
+) -> None:
+    """
+    A file that will not parse is one this cannot rewrite, nothing worse.
+
+    An install part-way through an upgrade is exactly where a broken
+    automations file turns up, and Home Assistant raises its own error type
+    for a syntax error rather than the ones a file read usually produces.
+    """
+    hass.config.config_dir = str(tmp_path)
+    (tmp_path / "configuration.yaml").write_text("", encoding="utf-8")
+    (tmp_path / AUTOMATION_CONFIG_PATH).write_text(
+        "this: [is: not: valid: yaml\n  - ???\n", encoding="utf-8"
+    )
+
+    entry = await _migrated_entry(hass)
+    issue_id = f"entity_ids_renamed_{entry.entry_id}"
+    issue = ir.async_get(hass).async_get_issue(DOMAIN, issue_id)
+    assert issue is not None
+
+    flow = await async_create_fix_flow(hass, issue_id, issue.data)
+    flow.hass = hass
+    # Reaches a conclusion rather than raising at the user.
+    result = await flow.async_step_init()
+    assert result["type"] in ("form", "create_entry")
+
+    await hass.config_entries.async_unload(entry.entry_id)


### PR DESCRIPTION
Stacked on #1440. Retarget to `v3` once that merges.

## Summary

The migration in #1440 moves entity IDs onto the user's name. Home Assistant repoints recorder history and statistics, but an entity ID written into an automation is just a string in a config file, and nothing rewrites it — the frontend's rename dialog offers to, and a migration does not go through the frontend.

**Automations built from our own blueprints are the ones that matter.** Creating one in the UI stores the entity IDs the user picked under `use_blueprint.input` in `automations.yaml`:

```yaml
- id: '1712345678901'
  alias: Limit guest PIN
  use_blueprint:
    path: lock_code_manager/slot_usage_limiter.yaml
    input:
      enabled_switch: switch.all_locks_code_slot_1_enabled
```

That file and `scripts.yaml` are the ones Home Assistant's own config API owns and rewrites wholesale, so the repair rewrites them and reloads.

## Why detection scans the files rather than asking Home Assistant

The obvious approach is `automation.automations_with_entity()`. It is used here, but only for the *opposite* job, because it has two blind spots for this purpose:

1. It reads **loaded** automation entities, so it misses one that failed to load.
2. It reports `referenced_entities`, computed from the rendered config — so a blueprint input used **only inside a Jinja template** never appears, which is how the shipped blueprints use some of theirs.

Scanning the files directly has neither blind spot. The helper is still used to find references that are *not* in these files, which is precisely the set that cannot be rewritten.

## What it refuses to touch

Anything in `configuration.yaml`, a package, a dashboard or a template belongs to somebody else. Those are listed by name for the user to fix by hand. A fix that silently covers half the references is worse than one that says what it missed, because the user stops looking.

## Testing

Two tests drive the real repair flow against a real `automations.yaml`: one for an ordinary automation, one for a blueprint-created automation with the entity ID nested under `use_blueprint.input`. Verified by mutation — stopping the substitution from recursing kills both.

`pytest tests/` — 1697 passed, 3 skipped. `prek` clean.