### PR TITLE
fix: rebuild renamed entity IDs from the registry, not the entry title

### DIFF
--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -987,12 +987,11 @@ def _async_rename_slot_entity_ids(
     long-term statistics follow the rename: the registry emits
     ``old_entity_id`` and ``recorder.entity_registry`` repoints them.
 
-    The device-slug PREFIX is swapped rather than the whole ID rebuilt,
-    because the rest of the ID comes from the entity's own name, which is
-    translated -- an install created in another language does not spell its
-    suffixes the way this code would. An entity whose ID does not start with
-    the prefix this integration would have generated is left alone, since
-    there is no way to tell which part of it was the prefix.
+    The target is rebuilt from what the REGISTRY holds rather than derived
+    from the current ID. Deriving it meant reconstructing the old device slug
+    from the entry's title, and the title in force now is not necessarily the
+    one the entity was created under -- renaming the entry at any point left
+    every ID unmatched, so nothing was renamed at all.
     """
     ent_reg = er.async_get(hass)
     entry_id = config_entry.entry_id
@@ -1002,13 +1001,25 @@ def _async_rename_slot_entity_ids(
         slot_num = parse_slot_unique_id(entry_id, entity.unique_id)
         if slot_num is None or not (name := config.name_for(slot_num)):
             continue
-        old_prefix = slugify(f"{config_entry.title} Code slot {slot_num}")
         domain, object_id = entity.entity_id.split(".", 1)
-        if object_id != old_prefix and not object_id.startswith(f"{old_prefix}_"):
-            continue
-        suffix = object_id.removeprefix(old_prefix)
+        if entity.original_name:
+            # What Home Assistant would generate today: the device's name
+            # followed by the entity's own. ``original_name`` is that name as
+            # translated for THIS installation, so a system set up in another
+            # language re-slugs into its own words -- and none of it depends
+            # on the entry's title, which may have changed since.
+            suggested = f"{name} {entity.original_name}"
+        else:
+            # The event entity has no name of its own, and a registry written
+            # by an older Home Assistant may not have kept one. Swap the
+            # device slug instead, which needs the ID to still look like one
+            # this integration generated.
+            old_prefix = slugify(f"{config_entry.title} Code slot {slot_num}")
+            if object_id != old_prefix and not object_id.startswith(f"{old_prefix}_"):
+                continue
+            suggested = f"{slugify(name)}{object_id.removeprefix(old_prefix)}"
         new_entity_id = ent_reg.async_generate_entity_id(
-            domain, f"{slugify(name)}{suffix}", current_entity_id=entity.entity_id
+            domain, suggested, current_entity_id=entity.entity_id
         )
         if new_entity_id == entity.entity_id:
             continue

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2546,3 +2546,47 @@ async def test_migration_leaves_an_unrecognized_entity_id_alone(
     )
 
     await hass.config_entries.async_unload(entry.entry_id)
+
+
+async def test_migration_renames_even_after_the_entry_was_retitled(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """
+    The entry's title is not a way back to an existing entity ID.
+
+    An entity is slugged from the title in force when it was created, so
+    rebuilding the old ID from today's title matches nothing once the entry
+    has been renamed -- and silently renamed nothing at all. The registry's
+    own ``original_name`` is what a released version left behind, and it does
+    not depend on the title.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Renamed Since",
+        data={
+            "locks": [LOCK_1_ENTITY_ID],
+            "slots": {1: {"enabled": True, "name": "Raman", "pin": "1111"}},
+        },
+        version=3,
+        minor_version=1,
+    )
+    entry.add_to_hass(hass)
+    ent_reg = er.async_get(hass)
+    ent_reg.async_get_or_create(
+        "text",
+        DOMAIN,
+        f"{entry.entry_id}|1|{CONF_PIN}",
+        config_entry=entry,
+        original_name="PIN",
+        suggested_object_id="the_original_title_code_slot_1_pin",
+    )
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert (
+        ent_reg.async_get_entity_id("text", DOMAIN, f"{entry.entry_id}|1|{CONF_PIN}")
+        == "text.raman_pin"
+    )
+
+    await hass.config_entries.async_unload(entry.entry_id)


### PR DESCRIPTION
Found by post-hoc review of #1440.

## The bug

`_async_rename_slot_entity_ids` reconstructed each entity's *old* ID as `slugify(f"{config_entry.title} Code slot {slot_num}")` so it could swap the prefix. But an entity is slugged from the title **in force when it was created**, and a config entry can be renamed at any point.

Rename the entry once — at any time, for any reason — and no entity ID matches. Nothing is renamed, and because `re_slugged` comes back empty, the repair that reports what moved is never raised either. The user is left on old-shaped IDs with no signal that the migration's headline change did nothing.

Reproduced: an entry now titled "Renamed Since" holding `text.the_original_title_code_slot_1_pin` came out unchanged.

## The fix

The registry already holds what's needed. `original_name` is the entity's own name as translated **for this installation** (`'PIN'`, `'Enabled'`, `'test 1 in sync'`) — the second half of what Home Assistant slugs an entity ID from. The first half is the device's name, which is now the user's. Rebuilding from those two owes nothing to the title, and stays correct for an install first set up in another language.

The title-derived swap stays as the fallback for entities the registry has no name for: the event entity has none by design, and a registry written by an older Home Assistant may not have kept one. Keeping it also means an entity that no longer looks like one we generated is still left alone rather than losing its distinguishing suffix.

## Testing

New regression test seeding a retitled entry, with `original_name` set the way a real registry holds it. Verified by mutation — forcing the old title-derived path fails it.

`pytest tests/` — 1696 passed, 3 skipped. `prek` clean.