### PR TITLE
refactor: v3 abstraction audit

### DIFF
--- a/custom_components/lock_code_manager/domain/slot_assignment.py
+++ b/custom_components/lock_code_manager/domain/slot_assignment.py
@@ -122,23 +122,15 @@ class SlotAssignment:
         names: Iterable[str],
         *,
         start: int,
-        renames: Mapping[str, str] | None = None,
         unavailable: Collection[int] = (),
     ) -> SlotAssignment:
         """
-        Return the assignment covering exactly ``names``, applying ``renames``.
+        Return the assignment covering exactly ``names``.
 
-        Renaming and allocating are ONE operation because their order is the
-        whole difficulty: a rename is indistinguishable from a deletion plus
-        an addition unless you already know who survives. ``names`` -- the
-        full set of users in the NEW configuration -- is what resolves it. A
-        rename target absent from ``names`` is departing; one present names
-        the renamed user.
-
-        Users keep their number through a rename and through anyone else's
-        arrival or departure. New users take the lowest free number at or
-        above ``start``, skipping ``unavailable``. ``start`` is required so a
-        caller decides where issuing begins rather than inheriting a default.
+        Users keep their number through anyone else's arrival or departure.
+        New users take the lowest free number at or above ``start``, skipping
+        ``unavailable``. ``start`` is required so a caller decides where
+        issuing begins rather than inheriting a default.
 
         Tenure outranks both constraints: a user already holding a number
         keeps it even when ``start`` rises above it or ``unavailable`` grows
@@ -150,45 +142,19 @@ class SlotAssignment:
         because it cannot see the other entry. ``config_flow`` prevents the
         overlap arising; surfacing it instead belongs at that seam.
 
+        A rename is NOT handled here. It arrives as a name that is present
+        and one that is gone, which is indistinguishable from a deletion plus
+        an addition, so this would renumber somebody. Renaming re-keys the
+        assignment directly, in ``EntryConfig.with_user_renamed``, where the
+        old name and the new one are both known.
+
         Returns ``self`` when nothing differs, so callers can use identity to
         decide whether a write is needed.
         """
         wanted = list(dict.fromkeys(identity(name) for name in names))
         surviving = set(wanted)
 
-        # Reduce to identity form BEFORE resolving, or two keys meaning the
-        # same user (``Alice`` and ``alice ``) each take a turn: the later
-        # overwrites the earlier while the earlier's target stays claimed,
-        # refusing a third user's legitimate rename onto it.
-        #
-        # Sorted throughout so the answer never depends on mapping order.
-        wanted_moves: dict[str, str] = {}
-        for old in sorted(renames or {}, key=lambda key: (identity(key), str(key))):
-            wanted_moves.setdefault(identity(old), identity((renames or {})[old]))
-
-        honoured: dict[str, str] = {}
-        claimed: set[str] = set()
-        for source in sorted(wanted_moves):
-            target = wanted_moves[source]
-            if source not in self.slots or target not in surviving:
-                continue
-            if target in claimed:
-                continue
-            honoured[source] = target
-            claimed.add(target)
-
-        renamed = {
-            honoured[name]: slot
-            for name, slot in self.slots.items()
-            if name in honoured
-        }
-        kept = {
-            name: slot
-            for name, slot in self.slots.items()
-            if name not in honoured and name in surviving and name not in renamed
-        }
-
-        carried = {**kept, **renamed}
+        carried = {name: slot for name, slot in self.slots.items() if name in surviving}
         taken = set(carried.values()) | set(unavailable)
         candidate = start
         # Sorted because the signature accepts any iterable: an unordered one

--- a/tests/properties/test_slot_assignment.py
+++ b/tests/properties/test_slot_assignment.py
@@ -21,6 +21,7 @@ from hypothesis import assume, given, strategies as st
 
 from homeassistant.const import CONF_ENABLED, CONF_NAME, CONF_PIN
 
+from custom_components.lock_code_manager.domain.config import EntryConfig
 from custom_components.lock_code_manager.domain.names import (
     identity,
     normalize_slot_names,
@@ -191,74 +192,6 @@ NEWCOMERS = st.lists(st.sampled_from(["Zoe", "Yan", "Xavier"]), max_size=2).map(
 
 @given(
     names=NAME_SETS,
-    renames=st.dictionaries(NAMES, st.sampled_from(["Wren", "Vic"]), max_size=2),
-    newcomers=NEWCOMERS,
-    start=START,
-    data=st.data(),
-)
-def test_renaming_keeps_the_users_slot(
-    names: list[str],
-    renames: dict[str, str],
-    newcomers: list[str],
-    start: int,
-    data: st.DataObject,
-) -> None:
-    """A rename changes who holds a slot, never which slot they hold.
-
-    Filters on the IDENTITY form, since the stored keys are casefolded.
-
-    Adds users in a SHUFFLED order alongside the rename, because without a
-    competing addition a rename is indistinguishable from delete-plus-add: the
-    newcomer is handed the very slot the departed user freed. They diverge only
-    when somebody else is in line for that slot, which is the case that
-    reorders two users' credential indices on a real lock.
-    """
-    before = _reconcile(SlotAssignment.empty(), names, start=start)
-    moves = {old: new for old, new in renames.items() if identity(old) in before.slots}
-    assume(len({identity(v) for v in moves.values()}) == len(moves))
-
-    after_names = data.draw(
-        st.permutations([moves.get(n, n) for n in names] + newcomers)
-    )
-
-    after = _reconcile(before, after_names, renames=moves, start=start)
-
-    for old, new in moves.items():
-        assert after.slot(new) == before.slot(old)
-    for name in names:
-        if name not in moves:
-            assert after.slot(name) == before.slot(name)
-
-
-@given(names=NAME_SETS, renames=st.dictionaries(NAMES, NAMES, max_size=3), start=START)
-def test_renaming_does_not_depend_on_insertion_order(
-    names: list[str], renames: dict[str, str], start: int
-) -> None:
-    """The same edit gives the same answer whatever order the mapping holds."""
-    before = _reconcile(SlotAssignment.empty(), names, start=start)
-    moves = {old: new for old, new in renames.items() if identity(old) in before.slots}
-    assume(len({identity(v) for v in moves.values()}) == len(moves))
-    after_names = [moves.get(n, n) for n in names]
-
-    flipped = SlotAssignment(slots=dict(reversed(list(before.slots.items()))))
-
-    assert dict(
-        _reconcile(before, after_names, renames=moves, start=start).slots
-    ) == dict(_reconcile(flipped, after_names, renames=moves, start=start).slots)
-
-
-@given(names=NAME_SETS, start=START)
-def test_reconciling_the_same_users_twice_changes_nothing(
-    names: list[str], start: int
-) -> None:
-    """No renames and the same names is a no-op, so callers do not write."""
-    once = _reconcile(SlotAssignment.empty(), names, start=start)
-
-    assert once.reconcile(names, start=start) is once
-
-
-@given(
-    names=NAME_SETS,
     start=START,
     unavailable=st.sets(st.integers(min_value=1, max_value=12), max_size=4),
 )
@@ -409,34 +342,6 @@ def test_allocation_does_not_depend_on_how_names_are_ordered(
 
 
 @given(
-    names=NAME_SETS,
-    start=START,
-    renames=st.dictionaries(NAMES, st.sampled_from(["Wren", "Vic"]), max_size=2),
-)
-def test_a_rename_to_somebody_absent_leaves_the_source_alone(
-    names: list[str], start: int, renames: dict[str, str]
-) -> None:
-    """A rename target missing from the new names must be inert, not destructive.
-
-    The input contradicts itself -- the user is being renamed to somebody the
-    configuration does not contain -- and the harmless reading is to ignore
-    it. Honouring it halfway dropped the source from the survivors and
-    reallocated them from ``start``, moving the credential of a user who was
-    never part of the edit.
-    """
-    before = SlotAssignment.empty().reconcile(names, start=start)
-    absent = {
-        old: new
-        for old, new in renames.items()
-        if identity(new) not in {identity(n) for n in names}
-    }
-
-    after = before.reconcile(names, start=start, renames=absent)
-
-    assert dict(after.slots) == dict(before.slots)
-
-
-@given(
     slots=st.dictionaries(NAMES, st.integers(min_value=1, max_value=6), max_size=4),
     start=START,
 )
@@ -488,69 +393,6 @@ def test_a_non_string_name_key_is_coerced_not_fatal() -> None:
     assert assignment.slot("1") == 4
 
 
-def test_two_renames_onto_one_target_resolve_the_same_way_every_time() -> None:
-    """Contradictory input still has to be deterministic.
-
-    ``validate_slot_names`` keeps two users from ending on one name, so this
-    is unreachable from the configuration flow -- but nothing in this type
-    enforces it, and the previous implementation let whichever entry the
-    stored mapping iterated first decide, so the same input produced
-    different credential indices on different runs. Resolved by sorted order
-    instead.
-
-    The property tests assume this case away, which is correct for them and
-    is why it needs an example here.
-    """
-    renames = {"alice": "Wren", "bob": "Wren"}
-
-    forward = SlotAssignment(slots={"alice": 1, "bob": 2})
-    backward = SlotAssignment(slots={"bob": 2, "alice": 1})
-
-    assert dict(forward.reconcile(["Wren"], start=1, renames=renames).slots) == dict(
-        backward.reconcile(["Wren"], start=1, renames=renames).slots
-    )
-
-
-@given(
-    names=NAME_SETS,
-    start=START,
-    renames=st.dictionaries(NAMES, st.sampled_from(["Wren", "Vic"]), max_size=2),
-)
-def test_renames_are_read_case_insensitively_too(
-    names: list[str], start: int, renames: dict[str, str]
-) -> None:
-    """The rename map is reduced to identity form, like the stored names are.
-
-    ``__post_init__`` canonicalizes the assignment's keys; the rename map
-    arrives from a caller and needs the same treatment, or two keys meaning one
-    user each take a turn.
-    """
-    before = SlotAssignment.empty().reconcile(names, start=start)
-    shouted = {old.upper(): new for old, new in renames.items()}
-    after_names = [renames.get(n, n) for n in names]
-
-    assert dict(
-        before.reconcile(after_names, start=start, renames=renames).slots
-    ) == dict(before.reconcile(after_names, start=start, renames=shouted).slots)
-
-
-@given(
-    renames=st.dictionaries(NAMES, st.sampled_from(["Wren", "Vic"]), max_size=3),
-    start=START,
-)
-def test_the_rename_mapping_order_does_not_change_the_answer(
-    renames: dict[str, str], start: int
-) -> None:
-    """Rebuilding the same rename map in another order gives the same result."""
-    before = SlotAssignment.empty().reconcile(["Alice", "Bob", "Carl"], start=start)
-    flipped = dict(reversed(list(renames.items())))
-    after_names = [renames.get(n, n) for n in ["Alice", "Bob", "Carl"]]
-
-    assert dict(
-        before.reconcile(after_names, start=start, renames=renames).slots
-    ) == dict(before.reconcile(after_names, start=start, renames=flipped).slots)
-
-
 def test_a_migration_cannot_persist_two_users_on_one_number() -> None:
     """Slot keys that coerce to the same number must not double-book.
 
@@ -580,22 +422,41 @@ def test_corrupt_stored_bookkeeping_degrades_instead_of_aborting_setup() -> None
     assert dict(SlotAssignment(slots={"a": "zzz", "b": 2}).slots) == {"b": 2}
 
 
-def test_two_rename_keys_meaning_one_user_resolve_deterministically() -> None:
-    """``Alice`` and ``alice `` are one user, so they get one turn, not two.
+@given(names=NAME_SETS, start=START)
+def test_reconciling_the_same_users_twice_changes_nothing(
+    names: list[str], start: int
+) -> None:
+    """The same names is a no-op, so callers can skip writing."""
+    once = _reconcile(SlotAssignment.empty(), names, start=start)
 
-    Whichever of the two wins must not depend on the mapping's insertion
-    order, and the loser's target must not stay claimed against a third user
-    renaming onto it.
+    assert once.reconcile(names, start=start) is once
 
-    Needs an example rather than a property: the strategies generate distinct
-    names, so they cannot produce two keys with one identity.
+
+@given(names=NAME_SETS, new=NAMES, start=START)
+def test_a_rename_keeps_the_users_number(
+    names: list[str], new: str, start: int
+) -> None:
     """
-    before = SlotAssignment(slots={"Alice": 1, "Bob": 5, "Carl": 2})
-    forward = {"Alice": "Wren", "alice ": "Vic", "Bob": "Wren"}
-    backward = {"Bob": "Wren", "alice ": "Vic", "Alice": "Wren"}
+    A rename changes who holds a number, never which number they hold.
 
-    assert dict(
-        before.reconcile(["Wren", "Vic", "Carl"], start=1, renames=forward).slots
-    ) == dict(
-        before.reconcile(["Wren", "Vic", "Carl"], start=1, renames=backward).slots
+    Renaming does not go through ``reconcile``. There it arrives as one name
+    present and one gone, which is indistinguishable from a deletion plus an
+    addition, so it would renumber somebody. ``with_user_renamed`` is told
+    both names, which is why this property can hold at all.
+    """
+    assume(names)
+    assume(identity(new) not in {identity(name) for name in names})
+    assignment = SlotAssignment.empty().reconcile(names, start=start)
+    config = EntryConfig(
+        locks=(),
+        users={name: {} for name in names},
+        assignment=assignment,
+        extra={},
     )
+    old = names[0]
+
+    after = config.with_user_renamed(old, new)
+
+    assert after.assignment.slot(new) == assignment.slot(old)
+    for name in names[1:]:
+        assert after.assignment.slot(name) == assignment.slot(name)

--- a/tests/test_frontend_contract.py
+++ b/tests/test_frontend_contract.py
@@ -5,10 +5,15 @@ from __future__ import annotations
 import pathlib
 import re
 
+from homeassistant.const import CONF_ENABLED, CONF_NAME, CONF_PIN
+
 from custom_components.lock_code_manager.const import (
     ATTR_ACTIVE,
+    ATTR_CALENDAR,
     ATTR_CODE,
+    ATTR_CONDITION_ENTITY,
     ATTR_IN_SYNC,
+    CONDITION_ENTITY_DOMAINS,
     EVENT_CREDENTIAL_USED,
 )
 from custom_components.lock_code_manager.domain.config import build_slot_unique_id
@@ -19,6 +24,20 @@ _CONST_TS = pathlib.Path(__file__).resolve().parent.parent / "ts" / "const.ts"
 # entity.key against these. A key that changes on one side and not the other
 # does not fail anywhere -- the strategy just stops finding that entity and
 # silently renders the dashboard wrong.
+# Every key the backend puts in a unique ID, so the card cannot order one
+# that will never arrive.
+_BACKEND_KEYS = {
+    CONF_NAME,
+    CONF_ENABLED,
+    CONF_PIN,
+    ATTR_ACTIVE,
+    ATTR_CALENDAR,
+    ATTR_CONDITION_ENTITY,
+    ATTR_IN_SYNC,
+    ATTR_CODE,
+    EVENT_CREDENTIAL_USED,
+}
+
 _SHARED_KEYS = {
     "CODE_SENSOR_KEY": ATTR_CODE,
     "CODE_EVENT_KEY": EVENT_CREDENTIAL_USED,
@@ -74,4 +93,47 @@ def test_the_frontend_and_backend_agree_on_the_unique_id_shape() -> None:
     assert (
         len(build_slot_unique_id("ENTRY", 7, ATTR_IN_SYNC).split(separator.group(1)))
         == positions["lockEntityId"]
+    )
+
+
+def test_the_frontend_and_backend_agree_on_the_condition_domains() -> None:
+    """
+    The picker offers what the backend will accept, or it lies to the user.
+
+    The list is written out on both sides. Add a domain to one and the
+    frontend either hides a domain that works or offers one that does not,
+    and nothing fails on either side.
+    """
+    source = _CONST_TS.read_text(encoding="utf-8")
+    listed = re.search(r"CONDITION_ENTITY_DOMAINS = \[(.*?)\]", source, re.DOTALL)
+    assert listed, "ts/const.ts no longer declares CONDITION_ENTITY_DOMAINS"
+
+    assert re.findall(r"'([^']+)'", listed.group(1)) == list(CONDITION_ENTITY_DOMAINS)
+
+
+def test_the_frontend_orders_keys_the_backend_actually_produces() -> None:
+    """
+    KEY_ORDER decides what the card shows and in what order.
+
+    A key in it that the backend never emits renders nothing; a key the
+    backend emits that is missing from it falls to the end of the card
+    silently. Either way no test fails, which is how a renamed key shipped a
+    broken dashboard earlier today.
+    """
+    source = _CONST_TS.read_text(encoding="utf-8")
+    listed = re.search(r"KEY_ORDER = \[(.*?)\];", source, re.DOTALL)
+    assert listed, "ts/const.ts no longer declares KEY_ORDER"
+
+    declared = dict(
+        re.findall(r"^export const ([A-Z_]+) = '([^']+)';", source, re.MULTILINE)
+    )
+    ordered = [
+        declared.get(token.strip(), token.strip().strip("'"))
+        for token in listed.group(1).split(",")
+        if token.strip() and not token.strip().startswith("...")
+    ]
+
+    assert set(ordered) <= _BACKEND_KEYS, (
+        f"the card orders keys the backend never emits: "
+        f"{sorted(set(ordered) - _BACKEND_KEYS)}"
     )

--- a/tests/test_frontend_contract.py
+++ b/tests/test_frontend_contract.py
@@ -11,6 +11,7 @@ from custom_components.lock_code_manager.const import (
     ATTR_IN_SYNC,
     EVENT_CREDENTIAL_USED,
 )
+from custom_components.lock_code_manager.domain.config import build_slot_unique_id
 
 _CONST_TS = pathlib.Path(__file__).resolve().parent.parent / "ts" / "const.ts"
 
@@ -37,3 +38,40 @@ def test_the_frontend_and_backend_agree_on_entity_keys() -> None:
     assert not missing, f"ts/const.ts no longer declares {sorted(missing)}"
 
     assert {name: declared[name] for name in _SHARED_KEYS} == _SHARED_KEYS
+
+
+def test_the_frontend_and_backend_agree_on_the_unique_id_shape() -> None:
+    """
+    The dashboard takes entities apart by position, and nothing checks that.
+
+    ``createLockCodeManagerEntity`` splits a unique ID on the separator and
+    reads the slot number, the key and the lock out of fixed positions. Move
+    a field or change the separator on the Python side and it does not fail
+    anywhere -- the slot number parses to NaN, the key matches nothing, and
+    the strategy renders a dashboard that is simply wrong. The separator has
+    already been changed once, to let a name contain it.
+    """
+    source = (_CONST_TS.parent / "generate-view.ts").read_text(encoding="utf-8")
+
+    separator = re.search(r"unique_id\.split\('([^']+)'\)", source)
+    assert separator, "the frontend no longer splits the unique ID"
+
+    positions = {
+        field: int(index)
+        for field, index in re.findall(r"(\w+): (?:parseInt\()?split\[(\d+)\]", source)
+    }
+    assert {"slotNum", "key", "lockEntityId"} <= positions.keys(), positions
+
+    per_lock = build_slot_unique_id("ENTRY", 7, ATTR_IN_SYNC, "lock.front")
+    parts = per_lock.split(separator.group(1))
+
+    assert parts[positions["slotNum"]] == "7"
+    assert parts[positions["key"]] == ATTR_IN_SYNC
+    assert parts[positions["lockEntityId"]] == "lock.front"
+
+    # The slot-level variant has no lock, so that position must simply be
+    # absent rather than holding something else.
+    assert (
+        len(build_slot_unique_id("ENTRY", 7, ATTR_IN_SYNC).split(separator.group(1)))
+        == positions["lockEntityId"]
+    )


### PR DESCRIPTION
Audit of the v3 branch for indirection, abstraction leaks and over-abstraction.

## Finding 1 — `reconcile` had two rename implementations, and the harder one was dead

`SlotAssignment.reconcile` accepted a `renames` mapping and carried 27 lines to resolve it: identity-form-first ordering, two-sources-onto-one-target contradictions, claimed-target bookkeeping. Its own docstring recorded that *"getting that sequence wrong produced a high-severity defect in three consecutive review rounds."*

**No production caller ever passed it.** There is exactly one call site — `config_flow.py:857`, allocating for a brand-new entry — and it passes only `start` and `unavailable`. Renaming goes through `EntryConfig.with_user_renamed`, which re-keys the assignment directly *because it is told both the old and the new name*, which is the only reason the operation is well defined at all.

So one idea had two implementations, and the harder, more defect-prone one was reachable only from its own tests. **−220 / +47.** The property those tests protected is real, so it moves to the implementation that actually runs, and is mutation-verified there.

## Findings 2–4 — the Python/TypeScript seam encodes the same facts twice, unguarded

Every serious bug found in this branch has sat at a seam between two systems that each looked correct alone. The frontend/backend boundary is the worst of them, and it had **no** guard at all:

| What both sides encode | How it breaks silently |
|---|---|
| **The unique-ID shape** — Python builds `{entry}\|{slot}\|{key}`, the strategy reads fixed positions out of `split('\|')` | Move a field or change the separator and `slotNum` parses to `NaN`, the key matches nothing, the dashboard renders wrong |
| **The condition entity domains** — written out in `const.py` and again in `const.ts` | The picker hides a domain that works, or offers one that does not |
| **`KEY_ORDER`** — the per-slot keys the card lays out | A key the backend never emits renders nothing; a missing one falls to the end |

This is not hypothetical. The separator has already been changed once (#1431, *"allow `|` in user names again"*), and **a renamed key shipped a broken dashboard earlier today** — caught only because I went looking, since the frontend's 714 tests all use its own constant and structurally cannot notice it disagreeing with Python.

All three now read the values **out of the frontend source** rather than restating them, so the tests cannot drift from what runs. Each is mutation-verified from both directions — changing either side fails.

## Method

Measured before judging: counted per-module additions, then checked four axes — single-caller helpers, private names crossing module boundaries, parameters no caller varies, and one concept implemented twice.

Clean on the first three: no private cross-module imports; four single-caller helpers, each definition-plus-one-call; the `slots` projection has six real consumers. Everything found came from the fourth.

## Noted, not changed

- `EntryConfig.with_slot_field_set` / `_removed` are thin adapters for callers that legitimately hold a slot number. They should become dead once B3 moves the services off `code_slot` — worth deleting then, not now.
- `Referrers` wraps one tuple with `total == len(labels)`. Genuine over-abstraction, too small to be worth the churn on its own.
- The event entity's `state_attributes.event_type.state` translation is dead: `event_types` are lock entity IDs, so no fixed key can ever match. Pre-existing.

## Testing

`pytest tests/` — 1710 passed, 3 skipped, coverage **100.00%**. `prek` clean.