### PR TITLE
test: hold the read scope every provider promises to honour

### DIFF
--- a/tests/providers/zha/test_provider.py
+++ b/tests/providers/zha/test_provider.py
@@ -1152,3 +1152,34 @@ async def test_max_slot_survives_a_reply_it_cannot_unpack(
     cluster.read_attributes = AsyncMock(return_value=None)
 
     assert await zha_lock.async_get_max_slot() is None
+
+
+async def test_a_scoped_read_touches_only_the_slots_asked_for(
+    hass: HomeAssistant,
+    zha_lock: ZHALock,
+    simple_lcm_config_entry: MockConfigEntry,
+) -> None:
+    """
+    The scope is the whole reason allocation is affordable.
+
+    This cluster answers one index per round trip, so reading past the scope
+    is not wrong, only slow -- which is exactly why nothing would catch it.
+    Allocation widens its search a few numbers at a time precisely so a lock
+    is asked about a handful of indices rather than its whole range.
+    """
+    cluster = zha_lock._get_door_lock_cluster()
+    assert cluster is not None
+
+    async def mock_get_pin_code(slot_num):
+        return type(
+            "Response",
+            (),
+            {"user_status": DoorLock.UserStatus.Available, "code": ""},
+        )()
+
+    cluster.get_pin_code = AsyncMock(side_effect=mock_get_pin_code)
+
+    await zha_lock.async_get_users(slots={2})
+
+    asked = {call.args[0] for call in cluster.get_pin_code.call_args_list}
+    assert asked == {2}

--- a/tests/providers/zigbee2mqtt/test_provider.py
+++ b/tests/providers/zigbee2mqtt/test_provider.py
@@ -319,6 +319,43 @@ class TestAsyncGetUsers:
         by_slot = {u.user_id: u for u in users}
         assert by_slot[11].pin_credentials[0].state is SlotCredential.unreadable()
 
+    async def test_a_scoped_read_asks_about_only_the_slots_asked_for(
+        self,
+        hass: HomeAssistant,
+        zigbee2mqtt_lock_connected: Zigbee2MQTTLock,
+    ) -> None:
+        """
+        One request per index, so the scope is what makes allocation cheap.
+
+        Reading past the scope is not wrong, only slow, which is exactly why
+        nothing else would catch it. Allocation widens a few numbers at a
+        time so a lock is asked about a handful of indices, not its range.
+        """
+        lock = zigbee2mqtt_lock_connected
+
+        with (
+            patch(
+                "custom_components.lock_code_manager.providers._base.get_managed_slots",
+                return_value={1, 2, 3, 11},
+            ),
+            patch(
+                "custom_components.lock_code_manager.providers.zigbee2mqtt.async_publish",
+                new_callable=AsyncMock,
+            ) as publish,
+            patch(
+                "custom_components.lock_code_manager.providers.zigbee2mqtt.asyncio.wait_for",
+                new_callable=AsyncMock,
+                side_effect=TimeoutError,
+            ),
+        ):
+            await lock.async_get_users(slots={3})
+
+        asked = "".join(str(call) for call in publish.call_args_list)
+        assert '"user": 3' in asked or "'user': 3" in asked
+        for absent in (1, 2, 11):
+            assert f'"user": {absent}' not in asked
+            assert f"'user': {absent}" not in asked
+
     async def test_publish_failure_maps_slot_to_unreadable(
         self,
         hass: HomeAssistant,


### PR DESCRIPTION
Second audit pass over `v3`, targeting what #1445 did not reach: `config_flow.py`'s validation functions and the provider read-scoping seam.

## Finding — a contract honoured in eight places, checked in none

Eight providers implement `async_get_users(slots=...)`, and each must bound its work to the slots it was handed. **No test asserted that any of them did.**

Breaking it is silent. The data still comes back correct, just read from far more of the lock. On a cluster that answers one index per round trip, the difference measured earlier on this branch was **31 reads against 271**. Allocation widens its search a few numbers at a time precisely so a lock is asked about a handful of indices rather than its whole range — a provider quietly reading everything gives that up without failing anything.

Pinned on the two providers that read per index, where the cost is real. Both currently honour it; each test fails if its provider stops. Verified by mutation on both.

## Checked and clean

- **`config_flow.py`'s four slot-validation functions** answer genuinely different questions — another entry owns this slot, the lock cannot hold this number, how far to search, and how to word the refusal. No shared logic.
- **The 0-means-unknown convention** lives once, in `LockCapabilities.bounded_slot_count`, and says so in its docstring. All three call sites go through it, including `async_get_max_slot`.

## Method

Same heuristic as #1445: look for one fact, or one contract, that several places must independently respect. That is where every serious finding on this branch has come from — the Python/TypeScript key mismatch, the unique-ID shape, and now the read scope.

## Testing

`pytest tests/` — 1712 passed, 3 skipped, coverage **100.00%**. `prek` clean.