### PR TITLE
feat: the editor names users, and never a slot number

### DIFF
--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -304,6 +304,9 @@ class _AllocatesSlotsMixin:
 
     _allocation_locks: Sequence[str] = ()
 
+    # The entry this flow is editing, if any. Setup is not editing one.
+    _entry_being_edited: ConfigEntry | None = None
+
     async def _async_read_occupancy(self, indices: Collection[int]) -> Occupancy:
         """
         Ask every configured lock which of ``indices`` it holds.
@@ -383,7 +386,9 @@ class _AllocatesSlotsMixin:
             claimed_by_other_entries=frozenset(
                 slot
                 for lock_entity_id in self._allocation_locks
-                for slot in get_managed_slots(self.hass, lock_entity_id)
+                for slot in get_managed_slots(
+                    self.hass, lock_entity_id, excluding=self._entry_being_edited
+                )
             ),
         )
 
@@ -912,6 +917,9 @@ class LockCodeManagerOptionsFlow(_AllocatesSlotsMixin, config_entries.OptionsFlo
 
         if user_input:
             self._allocation_locks = user_input[CONF_LOCKS]
+            # Its own numbers do not constrain it: kept ones are held by
+            # tenure, released ones are free for whoever comes next.
+            self._entry_being_edited = self.config_entry
             (
                 users,
                 validation_errors,

--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -11,7 +11,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_ENABLED, CONF_NAME, CONF_PIN
+from homeassistant.const import CONF_CONDITION, CONF_ENABLED, CONF_NAME, CONF_PIN
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import (
     config_validation as cv,
@@ -23,7 +23,6 @@ from homeassistant.util import slugify
 
 from .const import (
     CONDITION_ENTITY_DOMAINS,
-    CONF_CONDITION,
     CONF_LOCKS,
     CONF_NUM_USERS,
     CONF_USERS,
@@ -199,6 +198,11 @@ async def _async_validate_users_yaml(
     Returns the parsed users -- or ``None`` when validation failed -- with the
     accumulated errors and description placeholders.
     """
+    # A block still keyed by slot number coerces cleanly into users named
+    # "1", "2", which is a silently wrong reading of what was pasted.
+    if raw_users and all(isinstance(key, int) for key in raw_users):
+        return None, {"base": "users_keyed_by_slot"}, {}
+
     try:
         parsed_users = USERS_SCHEMA(raw_users)
     except vol.Invalid as err:
@@ -896,10 +900,6 @@ class LockCodeManagerFlowHandler(
 
 class LockCodeManagerOptionsFlow(_AllocatesSlotsMixin, config_entries.OptionsFlow):
     """Options flow for Lock Code Manager."""
-
-    def __init__(self) -> None:
-        """Initialize options flow."""
-        self._init_existing_codes_state()
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None

--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable, Collection, Iterable, Mapping
-from dataclasses import dataclass
-from functools import partial
+from collections.abc import Collection, Iterable, Mapping, Sequence
 import logging
 from typing import Any
 
@@ -13,7 +11,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_ENABLED, CONF_ENTITY_ID, CONF_NAME, CONF_PIN
+from homeassistant.const import CONF_ENABLED, CONF_NAME, CONF_PIN
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import (
     config_validation as cv,
@@ -25,20 +23,18 @@ from homeassistant.util import slugify
 
 from .const import (
     CONDITION_ENTITY_DOMAINS,
+    CONF_CONDITION,
     CONF_LOCKS,
     CONF_NUM_USERS,
-    CONF_SLOTS,
     CONF_USERS,
     DEFAULT_NUM_USERS,
     DOMAIN,
     EXCLUDED_CONDITION_PLATFORMS,
     MAX_SEARCHED_SLOT,
 )
-from .domain.config import EntryConfig
 from .domain.credentials import CredentialType
 from .domain.exceptions import LockCodeManagerError
-from .domain.models import SlotCredential
-from .domain.names import name_error, normalize_name, validate_slot_names
+from .domain.names import name_error, normalize_name, validate_user_names
 from .domain.occupancy import LockOccupancy, Occupancy
 from .domain.queries import get_entry_config, get_managed_slots
 from .domain.slot_assignment import CONF_SLOT_ASSIGNMENT, SlotAssignment
@@ -51,7 +47,7 @@ CODE_SLOT_SCHEMA = vol.Schema(
         vol.Required(CONF_NAME): cv.string,
         vol.Optional(CONF_PIN): cv.string,
         vol.Required(CONF_ENABLED, default=True): cv.boolean,
-        vol.Optional(CONF_ENTITY_ID): sel.EntitySelector(
+        vol.Optional(CONF_CONDITION): sel.EntitySelector(
             sel.EntitySelectorConfig(domain=CONDITION_ENTITY_DOMAINS)
         ),
     }
@@ -70,9 +66,21 @@ def enabled_requires_pin(data: dict[str, Any]) -> dict[str, Any]:
     return data
 
 
-CODE_SLOTS_SCHEMA = vol.All(
-    vol.Schema({vol.Coerce(int): CODE_SLOT_SCHEMA}), enabled_requires_pin
+# The editor's shape: users keyed by name, with no slot number anywhere. The
+# name is the key rather than a field, so a duplicate is unrepresentable
+# rather than rejected -- the same reason the stored configuration is keyed
+# that way.
+USER_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_PIN): cv.string,
+        vol.Required(CONF_ENABLED, default=True): cv.boolean,
+        vol.Optional(CONF_CONDITION): sel.EntitySelector(
+            sel.EntitySelectorConfig(domain=CONDITION_ENTITY_DOMAINS)
+        ),
+    }
 )
+
+USERS_SCHEMA = vol.All(vol.Schema({cv.string: USER_SCHEMA}), enabled_requires_pin)
 
 LOCKS_FILTER_CONFIG = [
     sel.EntityFilterSelectorConfig(integration=platform, domain=LOCK_DOMAIN)
@@ -85,13 +93,6 @@ SLOTS_YAML_SELECTOR = sel.ObjectSelector(sel.ObjectSelectorConfig())
 
 
 POSITIVE_INT = vol.All(vol.Coerce(int), vol.Range(min=1))
-
-
-# The per-slot wording for the errors ``validate_slot_names`` reports.
-_SLOT_NAME_ERRORS = {
-    "name_required": "slot_name_required",
-    "name_not_unique": "slot_name_not_unique",
-}
 
 
 def _check_common_slots(
@@ -182,48 +183,43 @@ async def _async_check_slot_capacity(
     return {}, {}
 
 
-async def _async_validate_slots_yaml(
+async def _async_validate_users_yaml(
     hass: HomeAssistant,
-    raw_slots: dict[Any, Any],
+    raw_users: dict[Any, Any],
     locks: Iterable[str],
-    config_entry: ConfigEntry | None = None,
 ) -> tuple[dict | None, dict, dict]:
     """
-    Validate a slots-YAML submission for the config and options flows.
+    Validate a users submission for the editor and the yaml setup path.
 
-    Runs ``CODE_SLOTS_SCHEMA`` over ``raw_slots`` and, when it parses cleanly,
-    checks for slots already configured on the same locks by another entry and
-    for slot numbers beyond what the locks can hold. Returns the parsed slots
-    (or ``None`` if validation failed) along with the accumulated error and
-    description-placeholder dicts.
+    Slot numbers are not part of this shape at all: the editor names users,
+    and the numbers are allocated afterwards from whatever the locks leave
+    free. What can still fail is a name that is empty or that means the same
+    person as another, and a count of users no lock could hold.
+
+    Returns the parsed users -- or ``None`` when validation failed -- with the
+    accumulated errors and description placeholders.
     """
     try:
-        parsed_slots = CODE_SLOTS_SCHEMA(raw_slots)
+        parsed_users = USERS_SCHEMA(raw_users)
     except vol.Invalid as err:
-        _LOGGER.error("Invalid YAML: %s", err)
-        # Match on the error PATH, not the rendered text: CONF_NAME is
-        # "name", a substring of any key containing it ("friendly_name",
-        # "username"), so a text match would report an unrelated schema
-        # failure as a missing name.
-        if CONF_NAME in getattr(err, "path", []):
-            return None, {"base": "name_required"}, {}
+        _LOGGER.error("Invalid users: %s", err)
         return None, {"base": "invalid_config"}, {}
 
-    # These paths submit the whole set at once, so names are checked together
-    # rather than one at a time as the single-slot flow does.
-    if problem := validate_slot_names(parsed_slots):
-        slot_num, error = problem
-        # The only path that knows WHICH slot failed, so it uses the messages
-        # that name one. The shared messages must not ask for a slot number
-        # they cannot be given, or they render as a translation error.
-        return None, {"base": _SLOT_NAME_ERRORS[error]}, {"slot_num": slot_num}
+    if problem := validate_user_names(parsed_users):
+        name, error = problem
+        return None, {"base": error}, {"name": name}
 
-    errors, placeholders = _check_common_slots(hass, locks, parsed_slots, config_entry)
-    if not errors:
-        errors, placeholders = await _async_check_slot_capacity(
-            hass, locks, parsed_slots
+    # The count is what a lock has to hold, now that nobody picks a number.
+    errors, placeholders = await _async_check_slot_capacity(
+        hass, locks, [len(parsed_users)]
+    )
+    if errors:
+        return (
+            None,
+            {"base": "too_many_users"},
+            {**placeholders, "num_users": str(len(parsed_users))},
         )
-    return parsed_slots, errors, placeholders
+    return parsed_users, {}, {}
 
 
 class _LockQuerySkipped(LockCodeManagerError):
@@ -284,207 +280,25 @@ def _async_build_lock_instance(
     )
 
 
-@dataclass(frozen=True, slots=True)
-class _LockQuery:
-    """What one lock answered when asked what codes it is holding."""
-
-    lock_entity_id: str
-    # ``None`` means the read FAILED. An empty mapping means the lock answered
-    # and holds nothing. Both render as "nothing to confirm" here; the
-    # difference matters to allocation, which reads occupancy itself rather
-    # than from this.
-    codes: dict[int, SlotCredential] | None
-
-
-async def _async_query_locks(
-    hass: HomeAssistant,
-    dev_reg: dr.DeviceRegistry,
-    ent_reg: er.EntityRegistry,
-    lock_entity_ids: Iterable[str],
-) -> list[_LockQuery]:
+class _AllocatesSlotsMixin:
     """
-    Ask every lock what credentials it holds.
+    Finding numbers for users, shared by the setup and editing flows.
 
-    Queried sequentially to avoid flooding a Z-Wave or Matter network with
-    simultaneous requests.
+    Neither flow asks anybody for a slot number: both name users and then
+    allocate around whatever the locks already hold. Keeping that in one
+    place is what stops the two from disagreeing about which numbers are
+    free -- and only one of them reading the locks would be the more
+    dangerous disagreement.
 
-    Feeds the confirmation that shows which of the slots a user asked for
-    already hold codes. Allocation does not read this -- it asks the locks
-    itself, over the range it is considering -- so a lock that could not be
-    read simply contributes nothing to show.
-    """
-    results: list[_LockQuery] = []
-    for lock_entity_id in lock_entity_ids:
-        try:
-            lock_instance = _async_build_lock_instance(
-                hass, dev_reg, ent_reg, lock_entity_id
-            )
-        except _LockQuerySkipped:
-            results.append(_LockQuery(lock_entity_id=lock_entity_id, codes=None))
-            continue
-
-        try:
-            codes = await lock_instance.async_internal_get_usercodes()
-        except LockCodeManagerError as err:
-            _LOGGER.warning("Failed to get usercodes from %s: %s", lock_entity_id, err)
-            codes = None
-        except Exception:
-            _LOGGER.warning(
-                "Failed to get usercodes from %s; this lock's codes will not be shown",
-                lock_entity_id,
-                exc_info=True,
-            )
-            codes = None
-        results.append(_LockQuery(lock_entity_id, codes))
-    return results
-
-
-def _codes_by_lock(
-    queries: Iterable[_LockQuery],
-) -> dict[str, dict[int, SlotCredential]]:
-    """Project the query results back to the lock/slot view the gate renders."""
-    return {q.lock_entity_id: q.codes for q in queries if q.codes}
-
-
-def _scope_codes_to_pairs(
-    all_codes: dict[str, dict[int, SlotCredential]],
-    pairs: Iterable[tuple[str, int]],
-) -> dict[str, dict[int, SlotCredential]]:
-    """Filter raw query results to only the ``(lock, slot)`` pairs given."""
-    scoped_codes: dict[str, dict[int, SlotCredential]] = {}
-    for lock, slot in pairs:
-        if (code := all_codes.get(lock, {}).get(slot)) is not None:
-            scoped_codes.setdefault(lock, {})[slot] = code
-    return scoped_codes
-
-
-class _ExistingCodesFlowMixin:
-    """
-    Mixin providing existing-codes detection and confirmation for config/options flows.
-
-    When slots already have codes on the lock, this mixin shows a confirmation
-    dialog listing which locks/slots are affected.  Clearing is NOT done here —
-    the sync manager handles reconciliation when the config entry loads.
+    ``_allocation_locks`` is set by the flow before allocating, because
+    setup has the locks in its collected data and editing has them in the
+    submission being validated.
     """
 
-    _all_codes: dict[str, dict[int, SlotCredential]]
-    _occupied_lock_slots: list[tuple[str, int]]
-    _next_step: Callable[[], Awaitable[dict[str, Any]]] | None
+    # Supplied by whichever flow mixes this in; both have one.
+    hass: HomeAssistant
 
-    def _init_existing_codes_state(self) -> None:
-        """Initialize mixin state. Call from the inheriting flow's __init__."""
-        self._all_codes = {}
-        self._occupied_lock_slots = []
-        self._next_step = None
-
-    def _find_occupied_lock_slots(
-        self, slot_nums: Iterable[int]
-    ) -> list[tuple[str, int]]:
-        """Return (lock_entity_id, slot_num) pairs that have non-empty codes."""
-        return sorted(
-            (lock_entity_id, slot_num)
-            for slot_num in slot_nums
-            for lock_entity_id, codes in self._all_codes.items()
-            if (credential := codes.get(slot_num)) is not None and credential.is_present
-        )
-
-    @staticmethod
-    def _format_occupied_slots(
-        occupied: list[tuple[str, int]],
-    ) -> str:
-        """Format occupied lock/slot pairs for display in the confirmation dialog."""
-        return "\n".join(
-            f"- {lock_entity_id}: slot {slot_num}"
-            for lock_entity_id, slot_num in occupied
-        )
-
-    async def _create_entry(
-        self, *, title: str, data: dict[str, Any]
-    ) -> dict[str, Any]:
-        """Create the config entry."""
-        return self.async_create_entry(  # type: ignore[attr-defined]
-            title=title, data=data
-        )
-
-    async def async_step_existing_codes_confirm(
-        self, user_input: dict[str, Any] | None = None
-    ) -> dict[str, Any]:
-        """Confirm that existing codes will be overwritten by the sync manager."""
-        return self.async_show_menu(  # type: ignore[attr-defined]
-            step_id="existing_codes_confirm",
-            menu_options=["existing_codes_continue", "existing_codes_cancel"],
-            description_placeholders={
-                "details": self._format_occupied_slots(self._occupied_lock_slots),
-            },
-        )
-
-    async def async_step_existing_codes_continue(
-        self, user_input: dict[str, Any] | None = None
-    ) -> dict[str, Any]:
-        """User acknowledged existing codes. Proceed to next step."""
-        if self._next_step is None:
-            return self.async_abort(reason="unknown")  # type: ignore[attr-defined]
-        return await self._next_step()
-
-    async def async_step_existing_codes_cancel(
-        self, user_input: dict[str, Any] | None = None
-    ) -> dict[str, Any]:
-        """User cancelled. Abort the flow."""
-        return self.async_abort(reason="existing_codes_cancelled")  # type: ignore[attr-defined]
-
-
-class LockCodeManagerFlowHandler(
-    _ExistingCodesFlowMixin, config_entries.ConfigFlow, domain=DOMAIN
-):
-    """Config flow for Lock Code Manager."""
-
-    VERSION = 4
-    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
-
-    def __init__(self) -> None:
-        """Initialize config flow."""
-        self.data: dict[str, Any] = {}
-        self.title: str = ""
-        self.ent_reg: er.EntityRegistry = None
-        self.dev_reg: dr.DeviceRegistry = None
-        self._users_to_configure = 0
-        # The numbers allocation must avoid, settled when the user said how
-        # many users they wanted.
-        self._unavailable: frozenset[int] = frozenset()
-        self._init_existing_codes_state()
-
-    async def async_step_user(
-        self, user_input: dict[str, Any] | None = None
-    ) -> dict[str, Any]:
-        """Handle a flow initialized by the user."""
-        if not self.ent_reg:
-            self.ent_reg = er.async_get(self.hass)
-        if not self.dev_reg:
-            self.dev_reg = dr.async_get(self.hass)
-
-        if user_input is not None:
-            self.title = user_input.pop(CONF_NAME)
-            await self.async_set_unique_id(slugify(self.title))
-            self._abort_if_unique_id_configured()
-            self.data = user_input
-            return await self.async_step_choose_path()
-
-        return self.async_show_form(
-            step_id="user",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(CONF_NAME): cv.string,
-                    vol.Required(CONF_LOCKS): LOCK_ENTITY_SELECTOR,
-                }
-            ),
-            last_step=False,
-        )
-
-    async def async_step_choose_path(
-        self, user_input: dict[str, Any] | None = None
-    ) -> dict[str, Any]:
-        """Allow user to choose a path for configuration."""
-        return self.async_show_menu(step_id="choose_path", menu_options=["ui", "yaml"])
+    _allocation_locks: Sequence[str] = ()
 
     async def _async_read_occupancy(self, indices: Collection[int]) -> Occupancy:
         """
@@ -499,7 +313,7 @@ class LockCodeManagerFlowHandler(
         dev_reg = dr.async_get(self.hass)
         ent_reg = er.async_get(self.hass)
         locks: list[LockOccupancy] = []
-        for lock_entity_id in self.data[CONF_LOCKS]:
+        for lock_entity_id in self._allocation_locks:
             try:
                 lock_instance = _async_build_lock_instance(
                     self.hass, dev_reg, ent_reg, lock_entity_id
@@ -564,7 +378,7 @@ class LockCodeManagerFlowHandler(
             locks=tuple(locks),
             claimed_by_other_entries=frozenset(
                 slot
-                for lock_entity_id in self.data[CONF_LOCKS]
+                for lock_entity_id in self._allocation_locks
                 for slot in get_managed_slots(self.hass, lock_entity_id)
             ),
         )
@@ -624,7 +438,7 @@ class LockCodeManagerFlowHandler(
         dev_reg = dr.async_get(self.hass)
         ent_reg = er.async_get(self.hass)
         limits: dict[str, int] = {}
-        for lock_entity_id in self.data[CONF_LOCKS]:
+        for lock_entity_id in self._allocation_locks:
             try:
                 lock_instance = _async_build_lock_instance(
                     self.hass, dev_reg, ent_reg, lock_entity_id
@@ -672,7 +486,7 @@ class LockCodeManagerFlowHandler(
         once they have names.
         """
         errors, placeholders = await _async_check_slot_capacity(
-            self.hass, self.data[CONF_LOCKS], [num_users]
+            self.hass, self._allocation_locks, [num_users]
         )
         if errors:
             return (
@@ -716,7 +530,7 @@ class LockCodeManagerFlowHandler(
             # Every number in the way pushes the last user one further out.
             wider = num_users + taken_in_window
             errors, placeholders = await _async_check_slot_capacity(
-                self.hass, self.data[CONF_LOCKS], [wider]
+                self.hass, self._allocation_locks, [wider]
             )
             if errors:
                 # Distinct from the count being too large: the count fits,
@@ -746,6 +560,68 @@ class LockCodeManagerFlowHandler(
         # one before widening to it -- and allocation only issues numbers
         # inside the window.
         return frozenset(unavailable), {}, {}
+
+    async def _create_entry(
+        self, *, title: str, data: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Create the config entry."""
+        return self.async_create_entry(  # type: ignore[attr-defined]
+            title=title, data=data
+        )
+
+
+class LockCodeManagerFlowHandler(
+    _AllocatesSlotsMixin, config_entries.ConfigFlow, domain=DOMAIN
+):
+    """Config flow for Lock Code Manager."""
+
+    VERSION = 4
+    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
+
+    def __init__(self) -> None:
+        """Initialize config flow."""
+        self.data: dict[str, Any] = {}
+        self.title: str = ""
+        self.ent_reg: er.EntityRegistry = None
+        self.dev_reg: dr.DeviceRegistry = None
+        self._users_to_configure = 0
+        # The numbers allocation must avoid, settled when the user said how
+        # many users they wanted.
+        self._unavailable: frozenset[int] = frozenset()
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        """Handle a flow initialized by the user."""
+        if not self.ent_reg:
+            self.ent_reg = er.async_get(self.hass)
+        if not self.dev_reg:
+            self.dev_reg = dr.async_get(self.hass)
+
+        if user_input is not None:
+            self.title = user_input.pop(CONF_NAME)
+            await self.async_set_unique_id(slugify(self.title))
+            self._abort_if_unique_id_configured()
+            self.data = user_input
+            self._allocation_locks = user_input[CONF_LOCKS]
+            return await self.async_step_choose_path()
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_NAME): cv.string,
+                    vol.Required(CONF_LOCKS): LOCK_ENTITY_SELECTOR,
+                }
+            ),
+            last_step=False,
+        )
+
+    async def async_step_choose_path(
+        self, user_input: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        """Allow user to choose a path for configuration."""
+        return self.async_show_menu(step_id="choose_path", menu_options=["ui", "yaml"])
 
     async def async_step_ui(
         self, user_input: dict[str, Any] | None = None
@@ -819,13 +695,13 @@ class LockCodeManagerFlowHandler(
 
             # A single registry lookup covers the excluded-platform check.
             # self.ent_reg is set in async_step_user, which always runs first.
-            if entity_id := user_input.get(CONF_ENTITY_ID):
+            if entity_id := user_input.get(CONF_CONDITION):
                 entity_entry = self.ent_reg.async_get(entity_id)
                 if (
                     entity_entry
                     and entity_entry.platform in EXCLUDED_CONDITION_PLATFORMS
                 ):
-                    errors[CONF_ENTITY_ID] = "excluded_platform"
+                    errors[CONF_CONDITION] = "excluded_platform"
                     description_placeholders["integration"] = entity_entry.platform
                     description_placeholders["docs_url"] = (
                         "https://github.com/raman325/lock_code_manager/wiki/"
@@ -861,56 +737,64 @@ class LockCodeManagerFlowHandler(
         return await self._create_entry(title=self.title, data=self.data)
 
     async def async_step_yaml(self, user_input: dict[str, Any] | None = None):
-        """Handle yaml flow step."""
-        errors = {}
-        description_placeholders = {}
+        """Take a block of users, then allocate their numbers."""
+        errors: dict[str, str] = {}
+        description_placeholders: dict[str, Any] = {}
         if not user_input:
             user_input = {}
         if user_input:
             (
-                slots,
+                users,
                 validation_errors,
                 validation_placeholders,
-            ) = await _async_validate_slots_yaml(
-                self.hass, user_input[CONF_SLOTS], self.data[CONF_LOCKS]
+            ) = await _async_validate_users_yaml(
+                self.hass, user_input[CONF_USERS], self.data[CONF_LOCKS]
             )
             errors.update(validation_errors)
             description_placeholders.update(validation_placeholders)
 
             if not errors:
-                assert slots is not None
-                self.data[CONF_SLOTS] = slots
-                # Read here rather than on the way in: only this path shows
-                # the user what its chosen numbers already hold. The path
-                # that chooses numbers itself reads what it needs, when it
-                # knows how much of the lock that is.
-                self._all_codes = _codes_by_lock(
-                    await _async_query_locks(
-                        self.hass, self.dev_reg, self.ent_reg, self.data[CONF_LOCKS]
+                assert users is not None
+                # Same allocation the guided path uses, against the same
+                # occupancy: nobody picks a number on either route, so
+                # neither can land on one a lock already holds.
+                (
+                    unavailable,
+                    allocation_errors,
+                    allocation_placeholders,
+                ) = await self._async_allocate_for(len(users))
+                if unavailable is None:
+                    return self.async_show_form(
+                        step_id="yaml",
+                        data_schema=self._users_schema(user_input),
+                        errors=allocation_errors,
+                        description_placeholders=allocation_placeholders,
+                        last_step=True,
                     )
+                self.data[CONF_USERS] = users
+                assignment = SlotAssignment.empty().reconcile(
+                    users, start=1, unavailable=unavailable
                 )
-                self._occupied_lock_slots = self._find_occupied_lock_slots(slots.keys())
-                if self._occupied_lock_slots:
-                    self._next_step = partial(
-                        self._create_entry,
-                        title=self.title,
-                        data=self.data,
-                    )
-                    return await self.async_step_existing_codes_confirm()
-                return self.async_create_entry(title=self.title, data=self.data)
+                self.data[CONF_SLOT_ASSIGNMENT] = dict(assignment.slots)
+                return await self._create_entry(title=self.title, data=self.data)
 
         return self.async_show_form(
             step_id="yaml",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(
-                        CONF_SLOTS, default=user_input.get(CONF_SLOTS, {})
-                    ): SLOTS_YAML_SELECTOR,
-                }
-            ),
+            data_schema=self._users_schema(user_input),
             errors=errors,
             description_placeholders=description_placeholders,
             last_step=True,
+        )
+
+    @staticmethod
+    def _users_schema(user_input: dict[str, Any]) -> vol.Schema:
+        """Return the users editor, redisplaying whatever was submitted."""
+        return vol.Schema(
+            {
+                vol.Required(
+                    CONF_USERS, default=user_input.get(CONF_USERS, {})
+                ): SLOTS_YAML_SELECTOR,
+            }
         )
 
     async def async_step_reauth(self, entry_data: Mapping[str, Any] | None = None):
@@ -1010,7 +894,7 @@ class LockCodeManagerFlowHandler(
         return LockCodeManagerOptionsFlow()
 
 
-class LockCodeManagerOptionsFlow(_ExistingCodesFlowMixin, config_entries.OptionsFlow):
+class LockCodeManagerOptionsFlow(_AllocatesSlotsMixin, config_entries.OptionsFlow):
     """Options flow for Lock Code Manager."""
 
     def __init__(self) -> None:
@@ -1020,41 +904,58 @@ class LockCodeManagerOptionsFlow(_ExistingCodesFlowMixin, config_entries.Options
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
     ) -> dict[str, Any]:
-        """Handle a flow initialized by the user."""
-        errors = {}
-        description_placeholders = {}
+        """Edit the entry's users. Numbers are not part of this."""
+        errors: dict[str, str] = {}
+        description_placeholders: dict[str, Any] = {}
         if not user_input:
             user_input = {}
 
         if user_input:
+            self._allocation_locks = user_input[CONF_LOCKS]
             (
-                parsed_slots,
+                users,
                 validation_errors,
                 validation_placeholders,
-            ) = await _async_validate_slots_yaml(
-                self.hass,
-                user_input[CONF_SLOTS],
-                user_input[CONF_LOCKS],
-                self.config_entry,
+            ) = await _async_validate_users_yaml(
+                self.hass, user_input[CONF_USERS], user_input[CONF_LOCKS]
             )
             errors.update(validation_errors)
             description_placeholders.update(validation_placeholders)
 
             if not errors:
-                assert parsed_slots is not None
-                user_input[CONF_SLOTS] = parsed_slots
-                return await self._maybe_confirm_then_persist(user_input)
+                assert users is not None
+                (
+                    unavailable,
+                    allocation_errors,
+                    allocation_placeholders,
+                ) = await self._async_allocate_for(len(users))
+                if unavailable is None:
+                    errors.update(allocation_errors)
+                    description_placeholders.update(allocation_placeholders)
+                else:
+                    config = get_entry_config(self.config_entry)
+                    # Reconciled against what the entry already holds, so a
+                    # user who was here before keeps their number and only
+                    # newcomers are issued one. Moving somebody would rewrite
+                    # their credential on every lock.
+                    assignment = config.assignment.reconcile(
+                        users, start=1, unavailable=unavailable
+                    )
+                    return self.async_create_entry(
+                        title="",
+                        data={
+                            CONF_LOCKS: user_input[CONF_LOCKS],
+                            CONF_USERS: users,
+                            CONF_SLOT_ASSIGNMENT: dict(assignment.slots),
+                        },
+                    )
 
+        config = get_entry_config(self.config_entry)
         # Plain dict/list, because the form selectors cannot serialize the
         # deeply read-only mappings EntryConfig uses internally.
-        #
-        # Seeded from the SLOT-shaped view, because this editor still takes
-        # slot-shaped YAML. That is the next thing to change, and when it does
-        # this becomes `config.users` and the projection disappears with it.
-        config = get_entry_config(self.config_entry)
         defaults = {
             CONF_LOCKS: list(config.locks),
-            CONF_SLOTS: {num: dict(slot) for num, slot in config.slots.items()},
+            CONF_USERS: {name: dict(user) for name, user in config.users.items()},
         }
 
         return self.async_show_form(
@@ -1066,8 +967,8 @@ class LockCodeManagerOptionsFlow(_ExistingCodesFlowMixin, config_entries.Options
                         default=user_input.get(CONF_LOCKS, defaults[CONF_LOCKS]),
                     ): LOCK_ENTITY_SELECTOR,
                     vol.Required(
-                        CONF_SLOTS,
-                        default=user_input.get(CONF_SLOTS, defaults[CONF_SLOTS]),
+                        CONF_USERS,
+                        default=user_input.get(CONF_USERS, defaults[CONF_USERS]),
                     ): SLOTS_YAML_SELECTOR,
                 }
             ),
@@ -1075,39 +976,3 @@ class LockCodeManagerOptionsFlow(_ExistingCodesFlowMixin, config_entries.Options
             description_placeholders=description_placeholders,
             last_step=True,
         )
-
-    async def _maybe_confirm_then_persist(
-        self, user_input: dict[str, Any]
-    ) -> dict[str, Any]:
-        """
-        Scan added (lock, slot) pairs for codes; show confirmation if any exist.
-
-        Compares the submitted (lock, slot) pairs against the entry's
-        current configuration. If any newly-added pair has a non-empty
-        code on its lock, show the confirmation step before persisting.
-        """
-        diff = get_entry_config(self.config_entry) - EntryConfig.from_mapping(
-            user_input
-        )
-        if not diff.pairs_added:
-            return self.async_create_entry(title="", data=user_input)
-
-        # Query only the locks involved in newly-added pairs
-        locks_to_query = sorted({lock for lock, _ in diff.pairs_added})
-        ent_reg = er.async_get(self.hass)
-        dev_reg = dr.async_get(self.hass)
-        all_codes = _codes_by_lock(
-            await _async_query_locks(self.hass, dev_reg, ent_reg, locks_to_query)
-        )
-
-        # Scope to ONLY the added pairs so the confirmation dialog only
-        # shows newly-added lock/slot pairs, not already-managed ones
-        self._all_codes = _scope_codes_to_pairs(all_codes, diff.pairs_added)
-
-        added_slot_nums = {slot for _, slot in diff.pairs_added}
-        self._occupied_lock_slots = self._find_occupied_lock_slots(added_slot_nums)
-        if not self._occupied_lock_slots:
-            return self.async_create_entry(title="", data=user_input)
-
-        self._next_step = partial(self._create_entry, title="", data=user_input)
-        return await self.async_step_existing_codes_confirm()

--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -31,6 +31,7 @@ from .const import (
     EXCLUDED_CONDITION_PLATFORMS,
     MAX_SEARCHED_SLOT,
 )
+from .domain.config import EntryConfig
 from .domain.credentials import CredentialType
 from .domain.exceptions import LockCodeManagerError
 from .domain.names import name_error, normalize_name, validate_user_names
@@ -949,13 +950,17 @@ class LockCodeManagerOptionsFlow(_AllocatesSlotsMixin, config_entries.OptionsFlo
                     assignment = config.assignment.reconcile(
                         users, start=1, unavailable=unavailable
                     )
+                    # Written through EntryConfig so whatever else the entry
+                    # carries survives the edit. Building the dict by hand
+                    # drops every key this form does not ask about.
                     return self.async_create_entry(
                         title="",
-                        data={
-                            CONF_LOCKS: user_input[CONF_LOCKS],
-                            CONF_USERS: users,
-                            CONF_SLOT_ASSIGNMENT: dict(assignment.slots),
-                        },
+                        data=EntryConfig(
+                            locks=tuple(user_input[CONF_LOCKS]),
+                            users=users,
+                            assignment=assignment,
+                            extra=config.extra,
+                        ).to_dict(),
                     )
 
         config = get_entry_config(self.config_entry)

--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -214,6 +214,28 @@ async def _async_validate_users_yaml(
         name, error = problem
         return None, {"base": error}, {"name": name}
 
+    # The same refusal the guided path gives. Both write the one field, so a
+    # condition entity this integration cannot read must fail on both routes
+    # or the editor becomes a way around the check.
+    ent_reg = er.async_get(hass)
+    for name, fields in parsed_users.items():
+        if not (condition := fields.get(CONF_CONDITION)):
+            continue
+        entity_entry = ent_reg.async_get(condition)
+        if entity_entry and entity_entry.platform in EXCLUDED_CONDITION_PLATFORMS:
+            return (
+                None,
+                {"base": "excluded_platform"},
+                {
+                    "name": name,
+                    "integration": entity_entry.platform,
+                    "docs_url": (
+                        "https://github.com/raman325/lock_code_manager/wiki/"
+                        "Unsupported-Condition-Entity-Integrations"
+                    ),
+                },
+            )
+
     # The count is what a lock has to hold, now that nobody picks a number.
     errors, placeholders = await _async_check_slot_capacity(
         hass, locks, [len(parsed_users)]

--- a/custom_components/lock_code_manager/const.py
+++ b/custom_components/lock_code_manager/const.py
@@ -109,11 +109,6 @@ ATTR_SYNC_STATUS = "sync_status"
 # Code slot properties
 CONF_CALENDAR = "calendar"
 
-# The user field naming the entity whose state gates their credential.
-# Called "entity_id" until version 4, which said nothing about what it was
-# for and collided with every other entity id in the configuration.
-CONF_CONDITION = "condition"
-
 # Supported domains for condition entities (CONF_CONDITION option)
 CONDITION_ENTITY_DOMAINS = [
     "calendar",

--- a/custom_components/lock_code_manager/const.py
+++ b/custom_components/lock_code_manager/const.py
@@ -109,7 +109,12 @@ ATTR_SYNC_STATUS = "sync_status"
 # Code slot properties
 CONF_CALENDAR = "calendar"
 
-# Supported domains for condition entities (CONF_ENTITY_ID option)
+# The user field naming the entity whose state gates their credential.
+# Called "entity_id" until version 4, which said nothing about what it was
+# for and collided with every other entity id in the configuration.
+CONF_CONDITION = "condition"
+
+# Supported domains for condition entities (CONF_CONDITION option)
 CONDITION_ENTITY_DOMAINS = [
     "calendar",
     "binary_sensor",

--- a/custom_components/lock_code_manager/domain/names.py
+++ b/custom_components/lock_code_manager/domain/names.py
@@ -165,3 +165,26 @@ def validate_slot_names(
             return str(slot_num), "name_not_unique"
         seen[key] = str(slot_num)
     return None
+
+
+def validate_user_names(users: Mapping[str, Any]) -> tuple[str, str] | None:
+    """
+    Return the first ``(name, error_key)`` problem in ``users``, else None.
+
+    The editor submits users keyed by name, so a duplicate key cannot reach
+    here -- but two keys can still mean one user (``Bob`` and ``bob ``), and
+    that pair would collapse into a single user on the way into storage,
+    silently taking one of their credentials with it.
+
+    Returns the offending name so the caller can say which one, since "one of
+    your users has a duplicate name" is not actionable.
+    """
+    seen: dict[str, str] = {}
+    for name in users:
+        if error := name_error(name):
+            return name, error
+        key = identity(name)
+        if key in seen:
+            return name, "name_not_unique"
+        seen[key] = name
+    return None

--- a/custom_components/lock_code_manager/domain/queries.py
+++ b/custom_components/lock_code_manager/domain/queries.py
@@ -29,12 +29,26 @@ def get_entry_config(entry: ConfigEntry) -> EntryConfig:
     return EntryConfig.from_entry(entry)
 
 
-def get_managed_slots(hass: HomeAssistant, lock_entity_id: str) -> set[int]:
-    """Return the set of slot numbers managed by any LCM config entry for a lock."""
+def get_managed_slots(
+    hass: HomeAssistant,
+    lock_entity_id: str,
+    *,
+    excluding: ConfigEntry | None = None,
+) -> set[int]:
+    """
+    Return the slot numbers any config entry manages on a lock.
+
+    ``excluding`` leaves one entry out, for a caller deciding what THAT
+    entry may use. Its own numbers are not a constraint on itself: the ones
+    it keeps are held by tenure, and the ones it is releasing are free. Left
+    in, a submission that swaps one user for another would be told its own
+    outgoing number was taken, and every edit would push numbers upward.
+    """
     return {
         slot_num
         for entry in hass.config_entries.async_entries(DOMAIN)
-        if (config := get_entry_config(entry)).has_lock(lock_entity_id)
+        if entry is not excluding
+        and (config := get_entry_config(entry)).has_lock(lock_entity_id)
         for slot_num in config.slot_numbers
     }
 

--- a/custom_components/lock_code_manager/domain/services.py
+++ b/custom_components/lock_code_manager/domain/services.py
@@ -2,12 +2,11 @@
 
 from __future__ import annotations
 
-from homeassistant.const import CONF_ENTITY_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import entity_registry as er
 
-from ..const import EXCLUDED_CONDITION_PLATFORMS
+from ..const import CONF_CONDITION, EXCLUDED_CONDITION_PLATFORMS
 from .locks import get_managed_lock
 from .queries import get_entry_config, get_loaded_config_entry
 
@@ -55,7 +54,7 @@ async def async_set_slot_condition(
             "Unsupported-Condition-Entity-Integrations"
         )
 
-    new_config = config.with_slot_field_set(slot, CONF_ENTITY_ID, entity_id)
+    new_config = config.with_slot_field_set(slot, CONF_CONDITION, entity_id)
     hass.config_entries.async_update_entry(config_entry, options=new_config.to_dict())
 
 
@@ -68,5 +67,5 @@ async def async_clear_slot_condition(
     if not config.has_slot(slot):
         raise ServiceValidationError(f"Slot {slot} not found in config entry")
 
-    new_config = config.with_slot_field_removed(slot, CONF_ENTITY_ID)
+    new_config = config.with_slot_field_removed(slot, CONF_CONDITION)
     hass.config_entries.async_update_entry(config_entry, options=new_config.to_dict())

--- a/custom_components/lock_code_manager/domain/services.py
+++ b/custom_components/lock_code_manager/domain/services.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+from homeassistant.const import CONF_CONDITION
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import entity_registry as er
 
-from ..const import CONF_CONDITION, EXCLUDED_CONDITION_PLATFORMS
+from ..const import EXCLUDED_CONDITION_PLATFORMS
 from .locks import get_managed_lock
 from .queries import get_entry_config, get_loaded_config_entry
 

--- a/custom_components/lock_code_manager/domain/slot_coordinator.py
+++ b/custom_components/lock_code_manager/domain/slot_coordinator.py
@@ -20,6 +20,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.const import (
+    CONF_CONDITION,
     CONF_ENABLED,
     CONF_NAME,
     CONF_PIN,
@@ -40,7 +41,7 @@ from homeassistant.helpers.issue_registry import (
     async_delete_issue,
 )
 
-from ..const import ATTR_IN_SYNC, CONF_CONDITION, DOMAIN, EVENT_CREDENTIAL_USED
+from ..const import ATTR_IN_SYNC, DOMAIN, EVENT_CREDENTIAL_USED
 from .config import EntryConfig
 from .names import name_error, normalize_name
 from .queries import get_entry_config

--- a/custom_components/lock_code_manager/domain/slot_coordinator.py
+++ b/custom_components/lock_code_manager/domain/slot_coordinator.py
@@ -21,7 +21,6 @@ from typing import TYPE_CHECKING, Any
 
 from homeassistant.const import (
     CONF_ENABLED,
-    CONF_ENTITY_ID,
     CONF_NAME,
     CONF_PIN,
     STATE_OFF,
@@ -41,7 +40,7 @@ from homeassistant.helpers.issue_registry import (
     async_delete_issue,
 )
 
-from ..const import ATTR_IN_SYNC, DOMAIN, EVENT_CREDENTIAL_USED
+from ..const import ATTR_IN_SYNC, CONF_CONDITION, DOMAIN, EVENT_CREDENTIAL_USED
 from .config import EntryConfig
 from .names import name_error, normalize_name
 from .queries import get_entry_config
@@ -157,7 +156,7 @@ class SlotEntityCoordinator:
     @property
     def condition_entity_id(self) -> str | None:
         """Return the configured condition entity ID for this slot."""
-        return self._slot_config().get(CONF_ENTITY_ID)
+        return self._slot_config().get(CONF_CONDITION)
 
     # -- Registration (entities, sync managers) ------------------------------
 
@@ -399,7 +398,7 @@ class SlotEntityCoordinator:
         Compute the slot's active state from config + condition entity.
 
         Every relevant slot config key must be truthy. The condition
-        entity (``CONF_ENTITY_ID``) is truthy when its state is ``on``;
+        entity (``CONF_CONDITION``) is truthy when its state is ``on``;
         ``off`` is False and any other state (unknown, unavailable,
         missing) is None and treated as inactive.
         """
@@ -408,7 +407,7 @@ class SlotEntityCoordinator:
         for key, value in slot_config.items():
             if key in (EVENT_CREDENTIAL_USED, CONF_NAME, CONF_PIN, ATTR_IN_SYNC):
                 continue
-            if key == CONF_ENTITY_ID:
+            if key == CONF_CONDITION:
                 hass_state = self._hass.states.get(value)
                 if hass_state is None:
                     states[key] = None

--- a/custom_components/lock_code_manager/domain/user_migration.py
+++ b/custom_components/lock_code_manager/domain/user_migration.py
@@ -25,10 +25,9 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any
 
-from homeassistant.const import CONF_ENTITY_ID
+from homeassistant.const import CONF_CONDITION, CONF_ENTITY_ID
 
 from ..const import (
-    CONF_CONDITION,
     CONF_NUM_SLOTS,
     CONF_SLOTS,
     CONF_START_SLOT,

--- a/custom_components/lock_code_manager/domain/user_migration.py
+++ b/custom_components/lock_code_manager/domain/user_migration.py
@@ -87,8 +87,8 @@ def _condition_renamed(users: Mapping[str, Any]) -> dict[str, dict[str, Any]]:
                 **{k: v for k, v in fields.items() if k != CONF_ENTITY_ID},
                 CONF_CONDITION: fields[CONF_ENTITY_ID],
             }
-            if CONF_ENTITY_ID in fields
-            else dict(fields)
+            if CONF_ENTITY_ID in fields and CONF_CONDITION not in fields
+            else {k: v for k, v in fields.items() if k != CONF_ENTITY_ID}
         )
         for name, fields in users.items()
     }

--- a/custom_components/lock_code_manager/domain/user_migration.py
+++ b/custom_components/lock_code_manager/domain/user_migration.py
@@ -25,7 +25,15 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any
 
-from ..const import CONF_NUM_SLOTS, CONF_SLOTS, CONF_START_SLOT, CONF_USERS
+from homeassistant.const import CONF_ENTITY_ID
+
+from ..const import (
+    CONF_CONDITION,
+    CONF_NUM_SLOTS,
+    CONF_SLOTS,
+    CONF_START_SLOT,
+    CONF_USERS,
+)
 from .slot_assignment import CONF_SLOT_ASSIGNMENT, users_from_slots
 
 # Keys this migration consumes. Everything else is carried through verbatim.
@@ -46,9 +54,13 @@ def migrate_to_users(
     rather than relying on the version stamp for that.
     """
     if CONF_SLOTS not in config:
-        return {k: v for k, v in config.items() if k not in _CONSUMED}, []
+        carried = {k: v for k, v in config.items() if k not in _CONSUMED}
+        if CONF_USERS in carried:
+            carried[CONF_USERS] = _condition_renamed(carried[CONF_USERS])
+        return carried, []
 
     users, assignment, renamed = users_from_slots(config[CONF_SLOTS])
+    users = _condition_renamed(users)
     return {
         **{k: v for k, v in config.items() if k not in _CONSUMED},
         # Keyed by the name as displayed. The configuration is hand-editable,
@@ -58,3 +70,26 @@ def migrate_to_users(
         CONF_USERS: users,
         CONF_SLOT_ASSIGNMENT: dict(assignment.slots),
     }, renamed
+
+
+def _condition_renamed(users: Mapping[str, Any]) -> dict[str, dict[str, Any]]:
+    """
+    Rename each user's ``entity_id`` field to ``condition``.
+
+    The field names the entity whose state gates the user's credential, which
+    ``entity_id`` said nothing about while colliding with every other entity
+    id in the configuration. Applied to already-converted users too, so an
+    entry part-way through this release's changes lands in the same shape as
+    one coming straight from version 3.
+    """
+    return {
+        name: (
+            {
+                **{k: v for k, v in fields.items() if k != CONF_ENTITY_ID},
+                CONF_CONDITION: fields[CONF_ENTITY_ID],
+            }
+            if CONF_ENTITY_ID in fields
+            else dict(fields)
+        )
+        for name, fields in users.items()
+    }

--- a/custom_components/lock_code_manager/strings.json
+++ b/custom_components/lock_code_manager/strings.json
@@ -19,7 +19,8 @@
       "slot_name_required": "Code slot {slot_num} needs a name. The name identifies this user on your locks.",
       "slot_out_of_range": "Lock {lock} reports only {num_slots} PIN code slots, so these slot numbers are out of range for it: {out_of_range_slots}. Renumber them to fall within 1-{num_slots}, or manage that lock from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity.",
       "slots_already_configured": "The following slots for lock {lock} are already managed by another config entry ({entry_title}) and can't be added to this configuration without being removed from the other one: {common_slots}",
-      "too_many_users": "Lock {lock} has {num_slots} PIN code slots, so {num_users} users will not fit. Set up fewer users here, or manage the rest from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity."
+      "too_many_users": "Lock {lock} has {num_slots} PIN code slots, so {num_users} users will not fit. Set up fewer users here, or manage the rest from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity.",
+      "users_keyed_by_slot": "This looks like the old slot-numbered format. Users are now listed by name, and Lock Code Manager picks the slot numbers itself:\n\nusers:\n  Raman:\n    pin: \"1234\"\n    enabled: true"
     },
     "step": {
       "choose_path": {
@@ -139,7 +140,8 @@
       "slot_name_not_unique": "The name for code slot {slot_num} is already used by another code slot in this entry. Names must be unique.",
       "slot_name_required": "Code slot {slot_num} needs a name. The name identifies this user on your locks.",
       "slot_out_of_range": "Lock {lock} reports only {num_slots} PIN code slots, so these slot numbers are out of range for it: {out_of_range_slots}. Renumber them to fall within 1-{num_slots}, or manage that lock from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity.",
-      "slots_already_configured": "The following slots for lock {lock} are already managed by another config entry ({entry_title}) and can't be added to this configuration without being removed from the other one: {common_slots}"
+      "slots_already_configured": "The following slots for lock {lock} are already managed by another config entry ({entry_title}) and can't be added to this configuration without being removed from the other one: {common_slots}",
+      "users_keyed_by_slot": "This looks like the old slot-numbered format. Users are now listed by name, and Lock Code Manager picks the slot numbers itself:\n\nusers:\n  Raman:\n    pin: \"1234\"\n    enabled: true"
     },
     "step": {
       "init": {

--- a/custom_components/lock_code_manager/strings.json
+++ b/custom_components/lock_code_manager/strings.json
@@ -141,7 +141,8 @@
       "slot_name_required": "Code slot {slot_num} needs a name. The name identifies this user on your locks.",
       "slot_out_of_range": "Lock {lock} reports only {num_slots} PIN code slots, so these slot numbers are out of range for it: {out_of_range_slots}. Renumber them to fall within 1-{num_slots}, or manage that lock from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity.",
       "slots_already_configured": "The following slots for lock {lock} are already managed by another config entry ({entry_title}) and can't be added to this configuration without being removed from the other one: {common_slots}",
-      "users_keyed_by_slot": "This looks like the old slot-numbered format. Users are now listed by name, and Lock Code Manager picks the slot numbers itself:\n\nusers:\n  Raman:\n    pin: \"1234\"\n    enabled: true"
+      "users_keyed_by_slot": "This looks like the old slot-numbered format. Users are now listed by name, and Lock Code Manager picks the slot numbers itself:\n\nusers:\n  Raman:\n    pin: \"1234\"\n    enabled: true",
+      "excluded_platform": "Entities from the `{integration}` integration are not supported as condition entities. See the [wiki]({docs_url}) for details."
     },
     "step": {
       "init": {

--- a/custom_components/lock_code_manager/translations/en.json
+++ b/custom_components/lock_code_manager/translations/en.json
@@ -19,7 +19,8 @@
       "slot_name_required": "Code slot {slot_num} needs a name. The name identifies this user on your locks.",
       "slot_out_of_range": "Lock {lock} reports only {num_slots} PIN code slots, so these slot numbers are out of range for it: {out_of_range_slots}. Renumber them to fall within 1-{num_slots}, or manage that lock from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity.",
       "slots_already_configured": "The following slots for lock {lock} are already managed by another config entry ({entry_title}) and can't be added to this configuration without being removed from the other one: {common_slots}",
-      "too_many_users": "Lock {lock} has {num_slots} PIN code slots, so {num_users} users will not fit. Set up fewer users here, or manage the rest from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity."
+      "too_many_users": "Lock {lock} has {num_slots} PIN code slots, so {num_users} users will not fit. Set up fewer users here, or manage the rest from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity.",
+      "users_keyed_by_slot": "This looks like the old slot-numbered format. Users are now listed by name, and Lock Code Manager picks the slot numbers itself:\n\nusers:\n  Raman:\n    pin: \"1234\"\n    enabled: true"
     },
     "step": {
       "choose_path": {
@@ -139,7 +140,8 @@
       "slot_name_not_unique": "The name for code slot {slot_num} is already used by another code slot in this entry. Names must be unique.",
       "slot_name_required": "Code slot {slot_num} needs a name. The name identifies this user on your locks.",
       "slot_out_of_range": "Lock {lock} reports only {num_slots} PIN code slots, so these slot numbers are out of range for it: {out_of_range_slots}. Renumber them to fall within 1-{num_slots}, or manage that lock from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity.",
-      "slots_already_configured": "The following slots for lock {lock} are already managed by another config entry ({entry_title}) and can't be added to this configuration without being removed from the other one: {common_slots}"
+      "slots_already_configured": "The following slots for lock {lock} are already managed by another config entry ({entry_title}) and can't be added to this configuration without being removed from the other one: {common_slots}",
+      "users_keyed_by_slot": "This looks like the old slot-numbered format. Users are now listed by name, and Lock Code Manager picks the slot numbers itself:\n\nusers:\n  Raman:\n    pin: \"1234\"\n    enabled: true"
     },
     "step": {
       "init": {

--- a/custom_components/lock_code_manager/translations/en.json
+++ b/custom_components/lock_code_manager/translations/en.json
@@ -141,7 +141,8 @@
       "slot_name_required": "Code slot {slot_num} needs a name. The name identifies this user on your locks.",
       "slot_out_of_range": "Lock {lock} reports only {num_slots} PIN code slots, so these slot numbers are out of range for it: {out_of_range_slots}. Renumber them to fall within 1-{num_slots}, or manage that lock from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity.",
       "slots_already_configured": "The following slots for lock {lock} are already managed by another config entry ({entry_title}) and can't be added to this configuration without being removed from the other one: {common_slots}",
-      "users_keyed_by_slot": "This looks like the old slot-numbered format. Users are now listed by name, and Lock Code Manager picks the slot numbers itself:\n\nusers:\n  Raman:\n    pin: \"1234\"\n    enabled: true"
+      "users_keyed_by_slot": "This looks like the old slot-numbered format. Users are now listed by name, and Lock Code Manager picks the slot numbers itself:\n\nusers:\n  Raman:\n    pin: \"1234\"\n    enabled: true",
+      "excluded_platform": "Entities from the `{integration}` integration are not supported as condition entities. See the [wiki]({docs_url}) for details."
     },
     "step": {
       "init": {

--- a/custom_components/lock_code_manager/websocket.py
+++ b/custom_components/lock_code_manager/websocket.py
@@ -401,16 +401,8 @@ async def get_config_entry_data(
                 }
                 for lock_id, lock in entry_locks.items()
             ],
-            # Keyed by slot because that is what entity unique IDs carry, so
-            # the card can join the two without deriving anything. The name
-            # is handed over rather than left to be read off the name
-            # entity's state: a dashboard strategy builds configuration, and
-            # states are not reliably populated while it runs.
             CONF_SLOTS: {
-                slot_num: {
-                    CONF_NAME: entry_config.name_for(slot_num),
-                    CONF_CONDITION: slot.get(CONF_CONDITION),
-                }
+                slot_num: slot.get(CONF_CONDITION)
                 for slot_num, slot in entry_config.slots.items()
             },
         },

--- a/custom_components/lock_code_manager/websocket.py
+++ b/custom_components/lock_code_manager/websocket.py
@@ -28,6 +28,7 @@ from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_FRIENDLY_NAME,
+    CONF_CONDITION,
     CONF_ENABLED,
     CONF_ENTITY_ID,
     CONF_PIN,
@@ -255,7 +256,7 @@ def _get_slot_condition_entity_id(
     config_entry: ConfigEntry, slot_num: int
 ) -> str | None:
     """Get condition entity ID from slot config."""
-    return get_entry_config(config_entry).slot(slot_num).get(CONF_ENTITY_ID)
+    return get_entry_config(config_entry).slot(slot_num).get(CONF_CONDITION)
 
 
 def async_get_entry(
@@ -400,8 +401,17 @@ async def get_config_entry_data(
                 }
                 for lock_id, lock in entry_locks.items()
             ],
+            # Keyed by slot because that is what entity unique IDs carry, so
+            # the card can join the two without deriving anything. The name
+            # is handed over rather than left to be read off the name
+            # entity's state: a dashboard strategy builds configuration, and
+            # states are not reliably populated while it runs.
             CONF_SLOTS: {
-                k: v.get(CONF_ENTITY_ID) for k, v in entry_config.slots.items()
+                slot_num: {
+                    CONF_NAME: entry_config.name_for(slot_num),
+                    CONF_CONDITION: slot.get(CONF_CONDITION),
+                }
+                for slot_num, slot in entry_config.slots.items()
             },
         },
     )

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -18,8 +18,8 @@ from homeassistant.components.text import (
 )
 from homeassistant.const import (
     ATTR_ENTITY_ID,
+    CONF_CONDITION,
     CONF_ENABLED,
-    CONF_ENTITY_ID,
     CONF_NAME,
     CONF_PIN,
     SERVICE_TURN_OFF,
@@ -180,7 +180,7 @@ async def test_binary_sensor_entity(
     assert service_calls.get("set_usercode", []) == initial_set_calls
 
     new_config = copy.deepcopy(BASE_CONFIG)
-    new_config[CONF_SLOTS][2][CONF_ENTITY_ID] = "calendar.test_2"
+    new_config[CONF_SLOTS][2][CONF_CONDITION] = "calendar.test_2"
 
     hass.config_entries.async_update_entry(
         lock_code_manager_config_entry, options=new_config
@@ -759,7 +759,7 @@ async def test_condition_entity_subscription_updates_on_config_change(
                 CONF_NAME: "test1",
                 CONF_PIN: "1234",
                 CONF_ENABLED: True,
-                CONF_ENTITY_ID: "input_boolean.access_1",
+                CONF_CONDITION: "input_boolean.access_1",
             },
         },
     }
@@ -800,7 +800,7 @@ async def test_condition_entity_subscription_updates_on_config_change(
 
     # Now update the config entry to use a different condition entity
     new_config = copy.deepcopy(config)
-    new_config[CONF_SLOTS][1][CONF_ENTITY_ID] = "input_boolean.access_2"
+    new_config[CONF_SLOTS][1][CONF_CONDITION] = "input_boolean.access_2"
 
     hass.config_entries.async_update_entry(config_entry, data=new_config)
     await hass.async_block_till_done()

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -23,6 +23,7 @@ from custom_components.lock_code_manager.const import (
     CONF_NUM_USERS,
     CONF_USERS,
     DOMAIN,
+    EXCLUDED_CONDITION_PLATFORMS,
     MAX_SEARCHED_SLOT,
 )
 from custom_components.lock_code_manager.domain.credentials import (
@@ -1952,3 +1953,39 @@ async def test_editing_keeps_what_the_form_never_asked_about(
         )
 
     assert result["data"]["written_by_something_else"] == {"kept": True}
+
+
+async def test_the_editor_refuses_a_condition_entity_the_guided_path_would(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """
+    One field, one rule, whichever route writes it.
+
+    Some integrations' switches and binary sensors do not describe access at
+    all, so the guided path refuses them. An editor that accepted them would
+    be a way around that, and the entity would gate a credential on a state
+    that means something else entirely.
+    """
+    ent_reg = er.async_get(hass)
+    excluded = ent_reg.async_get_or_create(
+        "switch", next(iter(EXCLUDED_CONDITION_PLATFORMS)), "unique"
+    )
+
+    flow_id = await _start_yaml_config_flow(hass)
+    with _holding():
+        result = await hass.config_entries.flow.async_configure(
+            flow_id,
+            {
+                CONF_USERS: {
+                    "Raman": {
+                        CONF_ENABLED: True,
+                        CONF_PIN: "1234",
+                        CONF_CONDITION: excluded.entity_id,
+                    }
+                }
+            },
+        )
+
+    assert result["type"] == "form"
+    assert result["errors"] == {"base": "excluded_platform"}
+    assert result["description_placeholders"]["name"] == "Raman"

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -3,26 +3,24 @@
 import json
 from pathlib import Path
 import re
-from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+from unittest.mock import AsyncMock, PropertyMock, patch
 
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_USER
-from homeassistant.const import CONF_ENABLED, CONF_ENTITY_ID, CONF_NAME, CONF_PIN
+from homeassistant.const import CONF_CONDITION, CONF_ENABLED, CONF_NAME, CONF_PIN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from custom_components.lock_code_manager.config_flow import (
-    LockCodeManagerFlowHandler,
-    _async_query_locks,
-    _LockQuery,
+    _async_build_lock_instance,
+    _check_common_slots,
     _LockQuerySkipped,
 )
 from custom_components.lock_code_manager.const import (
     CONF_LOCKS,
     CONF_NUM_USERS,
-    CONF_SLOTS,
     CONF_USERS,
     DOMAIN,
     MAX_SEARCHED_SLOT,
@@ -37,6 +35,7 @@ from custom_components.lock_code_manager.domain.exceptions import (
     LockDisconnected,
 )
 from custom_components.lock_code_manager.domain.models import SlotCredential
+from custom_components.lock_code_manager.domain.queries import get_entry_config
 from custom_components.lock_code_manager.domain.slot_assignment import (
     CONF_SLOT_ASSIGNMENT,
 )
@@ -69,23 +68,6 @@ def _holding(*occupied: int):
     return patch.object(MockLCMLock, "async_get_usercodes", _read)
 
 
-def _answers(existing: dict[str, dict[int, SlotCredential]]):
-    """Answer the lock query with these codes, for whichever locks are asked.
-
-    Replaces a fixture that returned one fixed mapping regardless of the
-    question. The flow now distinguishes "read, and empty" from "could not
-    read", so the stub has to answer per lock rather than in aggregate.
-    """
-
-    async def _query(hass, dev_reg, ent_reg, lock_entity_ids):
-        return [
-            _LockQuery(lock_entity_id=lock, codes=existing.get(lock, {}))
-            for lock in lock_entity_ids
-        ]
-
-    return _query
-
-
 @pytest.fixture(name="bypass_entry_setup_and_unload", autouse=True)
 def bypass_entry_setup_and_unload_fixture():
     """Bypass config entry setup."""
@@ -110,10 +92,9 @@ async def _start_config_flow(hass: HomeAssistant):
     assert result["step_id"] == "user"
     flow_id = result["flow_id"]
 
-    with patch(GET_ALL_CODES_PATCH, side_effect=_answers({})):
-        result = await hass.config_entries.flow.async_configure(
-            flow_id, {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
-        )
+    result = await hass.config_entries.flow.async_configure(
+        flow_id, {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
+    )
 
     assert result["type"] == "menu"
     assert result["step_id"] == "choose_path"
@@ -145,7 +126,11 @@ async def _start_ui_config_flow(hass: HomeAssistant):
 
 
 async def _start_yaml_config_flow(hass: HomeAssistant):
-    """Start a YAML based config flow."""
+    """Start a YAML based config flow.
+
+    The yaml path allocates numbers now, so it reads the locks just as the
+    guided path does; tests that submit users wrap the call in ``_holding``.
+    """
     flow_id = await _start_config_flow(hass)
 
     result = await hass.config_entries.flow.async_configure(
@@ -224,28 +209,31 @@ async def test_config_flow_ui_error(hass: HomeAssistant, mock_lock_config_entry)
     assert result["errors"] == {CONF_PIN: "missing_pin_if_enabled"}
 
 
-async def test_config_flow_yaml(hass: HomeAssistant):
+async def test_config_flow_yaml(hass: HomeAssistant, mock_lock_config_entry):
     """Test YAML based config flow."""
     flow_id = await _start_yaml_config_flow(hass)
 
-    result = await hass.config_entries.flow.async_configure(
-        flow_id,
-        {
-            CONF_SLOTS: {
-                1: {CONF_NAME: "User 1", CONF_ENABLED: True, CONF_PIN: "1234"},
-                2: {CONF_NAME: "User 2", CONF_ENABLED: True, CONF_PIN: "5678"},
-            }
-        },
-    )
+    with _holding():
+        result = await hass.config_entries.flow.async_configure(
+            flow_id,
+            {
+                CONF_USERS: {
+                    "User 1": {CONF_ENABLED: True, CONF_PIN: "1234"},
+                    "User 2": {CONF_ENABLED: True, CONF_PIN: "5678"},
+                }
+            },
+        )
 
     assert result["type"] == "create_entry"
     assert result["title"] == "test"
     assert result["data"] == {
         CONF_LOCKS: [LOCK_1_ENTITY_ID],
-        CONF_SLOTS: {
-            1: {CONF_NAME: "User 1", CONF_ENABLED: True, CONF_PIN: "1234"},
-            2: {CONF_NAME: "User 2", CONF_ENABLED: True, CONF_PIN: "5678"},
+        CONF_USERS: {
+            "User 1": {CONF_ENABLED: True, CONF_PIN: "1234"},
+            "User 2": {CONF_ENABLED: True, CONF_PIN: "5678"},
         },
+        # Allocated on the way out, because nobody picked them.
+        CONF_SLOT_ASSIGNMENT: {"user 1": 1, "user 2": 2},
     }
 
 
@@ -253,17 +241,18 @@ async def test_config_flow_yaml_error(hass: HomeAssistant):
     """Test error handling in YAML based config flow."""
     flow_id = await _start_yaml_config_flow(hass)
 
-    result = await hass.config_entries.flow.async_configure(
-        flow_id,
-        {CONF_SLOTS: {1: {CONF_NAME: "User 1", CONF_ENABLED: True, CONF_PIN: ""}}},
-    )
+    with _holding():
+        result = await hass.config_entries.flow.async_configure(
+            flow_id,
+            {CONF_USERS: {"User 1": {CONF_ENABLED: True, CONF_PIN: ""}}},
+        )
 
     assert result["type"] == "form"
     assert result["step_id"] == "yaml"
     assert result["errors"] == {"base": "invalid_config"}
 
 
-async def test_options_flow(hass: HomeAssistant):
+async def test_options_flow(hass: HomeAssistant, mock_lock_config_entry):
     """Test options flow."""
     entry = MockConfigEntry(domain=DOMAIN, data=BASE_CONFIG, unique_id="Mock Title")
     entry.add_to_hass(hass)
@@ -272,15 +261,14 @@ async def test_options_flow(hass: HomeAssistant):
     # auto-stripped during migration before any options-flow interaction.
     new_config = {
         CONF_LOCKS: list(BASE_CONFIG[CONF_LOCKS]),
-        CONF_SLOTS: {
-            1: {CONF_NAME: "test1", CONF_PIN: "1234", CONF_ENABLED: True},
-            2: {
-                CONF_NAME: "test2",
+        CONF_USERS: {
+            "test1": {CONF_PIN: "1234", CONF_ENABLED: True},
+            "test2": {
                 CONF_PIN: "5678",
                 CONF_ENABLED: True,
-                CONF_ENTITY_ID: "calendar.test_1",
+                CONF_CONDITION: "calendar.test_1",
             },
-            3: {CONF_NAME: "User 3", CONF_ENABLED: True, CONF_PIN: ""},
+            "User 3": {CONF_ENABLED: True, CONF_PIN: ""},
         },
     }
     result = await hass.config_entries.options.async_init(entry.entry_id)
@@ -297,17 +285,17 @@ async def test_options_flow(hass: HomeAssistant):
     assert result["step_id"] == "init"
     assert result["errors"] == {"base": "invalid_config"}
 
-    new_config[CONF_SLOTS][3] = {
-        CONF_NAME: "User 1",
-        CONF_ENABLED: True,
-        CONF_PIN: "1234",
-    }
-    result = await hass.config_entries.options.async_configure(
-        flow_id, user_input=new_config
-    )
+    # Give the enabled user a PIN and it saves.
+    new_config[CONF_USERS]["User 3"][CONF_PIN] = "1234"
+    with _holding():
+        result = await hass.config_entries.options.async_configure(
+            flow_id, user_input=new_config
+        )
 
     assert result["type"] == "create_entry"
-    assert result["data"] == new_config
+    assert result["data"][CONF_USERS] == new_config[CONF_USERS]
+    # Numbers are issued here, not submitted.
+    assert set(result["data"][CONF_SLOT_ASSIGNMENT]) == {"test1", "test2", "user 3"}
 
 
 async def test_config_flow_reauth(
@@ -399,14 +387,22 @@ async def test_reauth_wins_over_stale_options(
 async def test_config_flow_slots_already_configured(
     hass: HomeAssistant, mock_lock_config_entry, lock_code_manager_config_entry
 ):
-    """Test slots already configured error."""
+    """Another entry's numbers are avoided, not reported as a conflict.
+
+    Picking a number another entry manages used to be something the user
+    could do and be told off for. Now allocation simply does not issue one.
+    """
     flow_id = await _start_yaml_config_flow(hass)
 
-    result = await hass.config_entries.flow.async_configure(
-        flow_id,
-        {CONF_SLOTS: {2: {CONF_NAME: "User 2", CONF_ENABLED: False, CONF_PIN: "0123"}}},
-    )
-    assert result["errors"] == {"base": "slots_already_configured"}
+    with _holding():
+        result = await hass.config_entries.flow.async_configure(
+            flow_id,
+            {CONF_USERS: {"User 2": {CONF_ENABLED: False, CONF_PIN: "0123"}}},
+        )
+
+    assert result["type"] == "create_entry"
+    taken = set(get_entry_config(lock_code_manager_config_entry).slot_numbers)
+    assert not set(result["data"][CONF_SLOT_ASSIGNMENT].values()) & taken
 
 
 async def test_config_flow_two_entries_same_locks(
@@ -415,10 +411,11 @@ async def test_config_flow_two_entries_same_locks(
     """Test two entries that use same locks but different slots set up successfully."""
     flow_id = await _start_yaml_config_flow(hass)
 
-    result = await hass.config_entries.flow.async_configure(
-        flow_id,
-        {CONF_SLOTS: {3: {CONF_NAME: "User 3", CONF_ENABLED: False, CONF_PIN: "0123"}}},
-    )
+    with _holding():
+        result = await hass.config_entries.flow.async_configure(
+            flow_id,
+            {CONF_USERS: {"User 3": {CONF_ENABLED: False, CONF_PIN: "0123"}}},
+        )
     assert result["type"] == "create_entry"
 
 
@@ -446,14 +443,14 @@ async def test_config_flow_ui_scheduler_entity_excluded(
             CONF_NAME: "User 1",
             CONF_ENABLED: True,
             CONF_PIN: "1234",
-            CONF_ENTITY_ID: "switch.my_schedule",
+            CONF_CONDITION: "switch.my_schedule",
         },
     )
 
     # Should show error for excluded platform
     assert result["type"] == "form"
     assert result["step_id"] == "code_slot"
-    assert result["errors"] == {CONF_ENTITY_ID: "excluded_platform"}
+    assert result["errors"] == {CONF_CONDITION: "excluded_platform"}
     # Verify placeholder is set for the error message
     assert result["description_placeholders"].get("integration") == "scheduler"
 
@@ -471,33 +468,25 @@ async def test_ui_setup_allocates_around_existing_codes(
     confirmation the flow used to show existed because the user picked a range
     and might have picked one already in use.
     """
-    existing = {
-        LOCK_1_ENTITY_ID: {
-            1: SlotCredential.known("1234"),
-            2: SlotCredential.known("5678"),
-        }
-    }
+    flow_id = await _init_flow_to_user_step(hass)
+    await hass.config_entries.flow.async_configure(
+        flow_id, {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
+    )
+    await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
+    result = await hass.config_entries.flow.async_configure(
+        flow_id, {CONF_NUM_USERS: 2}
+    )
 
-    with patch(GET_ALL_CODES_PATCH, side_effect=_answers(existing)):
-        flow_id = await _init_flow_to_user_step(hass)
-        await hass.config_entries.flow.async_configure(
-            flow_id, {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
-        )
-        await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
-        result = await hass.config_entries.flow.async_configure(
-            flow_id, {CONF_NUM_USERS: 2}
-        )
+    # Straight to the first user, with no confirmation in between.
+    assert result["type"] == "form"
+    assert result["step_id"] == "code_slot"
 
-        # Straight to the first user, with no confirmation in between.
-        assert result["type"] == "form"
-        assert result["step_id"] == "code_slot"
-
-        await hass.config_entries.flow.async_configure(
-            flow_id, {CONF_NAME: "Raman", CONF_ENABLED: True, CONF_PIN: "1111"}
-        )
-        result = await hass.config_entries.flow.async_configure(
-            flow_id, {CONF_NAME: "Alice", CONF_ENABLED: True, CONF_PIN: "2222"}
-        )
+    await hass.config_entries.flow.async_configure(
+        flow_id, {CONF_NAME: "Raman", CONF_ENABLED: True, CONF_PIN: "1111"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        flow_id, {CONF_NAME: "Alice", CONF_ENABLED: True, CONF_PIN: "2222"}
+    )
 
     assert result["type"] == "create_entry"
     # Slots 1 and 2 are taken on the lock, so the users get 3 and 4. Which of
@@ -536,452 +525,7 @@ async def test_ui_setup_refuses_when_a_lock_cannot_be_read(
     assert LOCK_1_ENTITY_ID in result["description_placeholders"]["locks"]
 
 
-async def test_yaml_existing_codes_confirm_continue(hass: HomeAssistant):
-    """YAML path: existing codes detected -> confirm -> continue -> create entry."""
-    existing = {LOCK_1_ENTITY_ID: {1: SlotCredential.known("9999")}}
-
-    with patch(GET_ALL_CODES_PATCH, side_effect=_answers(existing)):
-        flow_id = await _init_flow_to_user_step(hass)
-        result = await hass.config_entries.flow.async_configure(
-            flow_id, {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
-        )
-
-    assert result["step_id"] == "choose_path"
-
-    result = await hass.config_entries.flow.async_configure(
-        flow_id, {"next_step_id": "yaml"}
-    )
-    assert result["step_id"] == "yaml"
-
-    with patch(GET_ALL_CODES_PATCH, side_effect=_answers(existing)):
-        result = await hass.config_entries.flow.async_configure(
-            flow_id,
-            {
-                CONF_SLOTS: {
-                    1: {CONF_NAME: "User 1", CONF_ENABLED: True, CONF_PIN: "1234"}
-                }
-            },
-        )
-
-    assert result["type"] == "menu"
-    assert result["step_id"] == "existing_codes_confirm"
-    assert "slot 1" in result["description_placeholders"]["details"]
-
-    # Confirm -> create entry (sync manager handles reconciliation)
-    result = await hass.config_entries.flow.async_configure(
-        flow_id, {"next_step_id": "existing_codes_continue"}
-    )
-
-    assert result["type"] == "create_entry"
-    assert result["data"][CONF_SLOTS][1][CONF_PIN] == "1234"
-
-
-async def test_yaml_existing_codes_confirm_cancel(hass: HomeAssistant):
-    """YAML path: existing codes detected -> confirm -> cancel -> abort."""
-    existing = {LOCK_1_ENTITY_ID: {1: SlotCredential.known("9999")}}
-
-    with patch(GET_ALL_CODES_PATCH, side_effect=_answers(existing)):
-        flow_id = await _init_flow_to_user_step(hass)
-        result = await hass.config_entries.flow.async_configure(
-            flow_id, {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
-        )
-
-    result = await hass.config_entries.flow.async_configure(
-        flow_id, {"next_step_id": "yaml"}
-    )
-    with patch(GET_ALL_CODES_PATCH, side_effect=_answers(existing)):
-        result = await hass.config_entries.flow.async_configure(
-            flow_id,
-            {
-                CONF_SLOTS: {
-                    1: {CONF_NAME: "User 1", CONF_ENABLED: True, CONF_PIN: "1234"}
-                }
-            },
-        )
-
-    assert result["type"] == "menu"
-    assert result["step_id"] == "existing_codes_confirm"
-
-    # Cancel -> abort, no clear
-    result = await hass.config_entries.flow.async_configure(
-        flow_id, {"next_step_id": "existing_codes_cancel"}
-    )
-
-    assert result["type"] == "abort"
-    assert result["reason"] == "existing_codes_cancelled"
-
-
-async def test_ui_no_existing_codes_skips_confirm(
-    hass: HomeAssistant, mock_lock_config_entry
-):
-    """UI path: no existing codes -> skip confirm step entirely."""
-    with patch(GET_ALL_CODES_PATCH, side_effect=_answers({})):
-        flow_id = await _init_flow_to_user_step(hass)
-        result = await hass.config_entries.flow.async_configure(
-            flow_id, {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
-        )
-
-    assert result["step_id"] == "choose_path"
-
-    result = await hass.config_entries.flow.async_configure(
-        flow_id, {"next_step_id": "ui"}
-    )
-    result = await hass.config_entries.flow.async_configure(
-        flow_id, {CONF_NUM_USERS: 1}
-    )
-
-    # Goes directly to code_slot, no confirm step
-    assert result["type"] == "form"
-    assert result["step_id"] == "code_slot"
-
-
-async def test_yaml_no_existing_codes_skips_confirm(hass: HomeAssistant):
-    """YAML path: no existing codes -> create_entry directly without confirm."""
-    with patch(GET_ALL_CODES_PATCH, side_effect=_answers({})):
-        flow_id = await _init_flow_to_user_step(hass)
-        result = await hass.config_entries.flow.async_configure(
-            flow_id, {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
-        )
-
-    result = await hass.config_entries.flow.async_configure(
-        flow_id, {"next_step_id": "yaml"}
-    )
-    result = await hass.config_entries.flow.async_configure(
-        flow_id,
-        {CONF_SLOTS: {1: {CONF_NAME: "User 1", CONF_ENABLED: True, CONF_PIN: "1234"}}},
-    )
-
-    # Goes directly to create_entry, no confirm step
-    assert result["type"] == "create_entry"
-    assert result["data"][CONF_SLOTS][1][CONF_PIN] == "1234"
-
-
-async def test_yaml_existing_codes_confirm_lists_slots_sorted(hass: HomeAssistant):
-    """The confirmation names every slot holding a code, in ascending order."""
-    existing = {
-        LOCK_1_ENTITY_ID: {
-            3: SlotCredential.known("1234"),
-            1: SlotCredential.known("5678"),
-        }
-    }
-
-    with patch(GET_ALL_CODES_PATCH, side_effect=_answers(existing)):
-        flow_id = await _init_flow_to_user_step(hass)
-        await hass.config_entries.flow.async_configure(
-            flow_id, {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
-        )
-        await hass.config_entries.flow.async_configure(
-            flow_id, {"next_step_id": "yaml"}
-        )
-        result = await hass.config_entries.flow.async_configure(
-            flow_id,
-            {
-                CONF_SLOTS: {
-                    1: {CONF_NAME: "User 1", CONF_ENABLED: True, CONF_PIN: "1111"},
-                    3: {CONF_NAME: "User 3", CONF_ENABLED: True, CONF_PIN: "3333"},
-                }
-            },
-        )
-
-    assert result["type"] == "menu"
-    assert result["step_id"] == "existing_codes_confirm"
-    details = result["description_placeholders"]["details"]
-    assert details.index("slot 1") < details.index("slot 3")
-
-
 # --- _async_get_all_codes tests ---
-
-
-async def test_query_locks_exception(hass: HomeAssistant):
-    """Test _async_get_all_codes catches exception from usercodes fetch."""
-    mock_instance = MagicMock()
-    mock_instance.async_internal_get_usercodes = AsyncMock(
-        side_effect=RuntimeError("node not ready")
-    )
-    mock_lock_cls = MagicMock(return_value=mock_instance)
-
-    ent_reg = er.async_get(hass)
-    ent_reg.async_get_or_create(
-        "lock", "zwave_js", "test_lock_1", suggested_object_id="test_1"
-    )
-    dev_reg = dr.async_get(hass)
-
-    with (
-        patch(
-            "custom_components.lock_code_manager.config_flow.INTEGRATIONS_CLASS_MAP",
-            {"zwave_js": mock_lock_cls},
-        ),
-        patch.object(
-            hass.config_entries,
-            "async_get_entry",
-            return_value=MockConfigEntry(domain="zwave_js"),
-        ),
-    ):
-        [query] = await _async_query_locks(hass, dev_reg, ent_reg, [LOCK_1_ENTITY_ID])
-
-    # Exception should be caught; result should be empty
-    # The read FAILED. Reporting it as empty would let allocation issue a
-    # number this lock may already hold a credential at.
-    assert query.codes is None
-
-
-async def test_query_locks_provider_failure_logs_warning(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
-):
-    """
-    Provider raising LockCodeManagerProviderError logs WARNING (not DEBUG).
-
-    Distinguishes a real failure (LockDisconnected, a provider error) from
-    the expected setup-time skip cases (missing entity / unsupported
-    platform / missing config entry) so users see actionable signal when a
-    lock is unreachable.
-    """
-    mock_instance = MagicMock()
-    mock_instance.async_internal_get_usercodes = AsyncMock(
-        side_effect=LockDisconnected("lock offline")
-    )
-    mock_lock_cls = MagicMock(return_value=mock_instance)
-
-    ent_reg = er.async_get(hass)
-    ent_reg.async_get_or_create(
-        "lock", "zwave_js", "test_lock_1", suggested_object_id="test_1"
-    )
-    dev_reg = dr.async_get(hass)
-
-    with (
-        patch(
-            "custom_components.lock_code_manager.config_flow.INTEGRATIONS_CLASS_MAP",
-            {"zwave_js": mock_lock_cls},
-        ),
-        patch.object(
-            hass.config_entries,
-            "async_get_entry",
-            return_value=MockConfigEntry(domain="zwave_js"),
-        ),
-        caplog.at_level("WARNING"),
-    ):
-        [query] = await _async_query_locks(hass, dev_reg, ent_reg, [LOCK_1_ENTITY_ID])
-
-    # The read FAILED. Reporting it as empty would let allocation issue a
-    # number this lock may already hold a credential at.
-    assert query.codes is None
-    # Surfaced at WARNING (not DEBUG): failure should be visible in logs
-    assert any(
-        record.levelname == "WARNING" and LOCK_1_ENTITY_ID in record.message
-        for record in caplog.records
-    )
-
-
-async def test_query_locks_bare_base_error_logs_warning(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
-):
-    """
-    Defensive: a provider raising the bare base LockCodeManagerError still warns.
-
-    All in-tree providers raise LockCodeManagerProviderError, but a third-party
-    or not-yet-migrated provider could raise the bare base. We catch and warn
-    rather than letting it fall through to the generic Exception arm (which
-    would log a confusing traceback for what is really a known failure mode).
-    """
-    mock_instance = MagicMock()
-    mock_instance.async_internal_get_usercodes = AsyncMock(
-        side_effect=LockCodeManagerError("bare base")
-    )
-    mock_lock_cls = MagicMock(return_value=mock_instance)
-
-    ent_reg = er.async_get(hass)
-    ent_reg.async_get_or_create(
-        "lock", "zwave_js", "test_lock_1", suggested_object_id="test_1"
-    )
-    dev_reg = dr.async_get(hass)
-
-    with (
-        patch(
-            "custom_components.lock_code_manager.config_flow.INTEGRATIONS_CLASS_MAP",
-            {"zwave_js": mock_lock_cls},
-        ),
-        patch.object(
-            hass.config_entries,
-            "async_get_entry",
-            return_value=MockConfigEntry(domain="zwave_js"),
-        ),
-        caplog.at_level("WARNING"),
-    ):
-        [query] = await _async_query_locks(hass, dev_reg, ent_reg, [LOCK_1_ENTITY_ID])
-
-    # The read FAILED. Reporting it as empty would let allocation issue a
-    # number this lock may already hold a credential at.
-    assert query.codes is None
-    # Should be a clean WARNING (no traceback), since this is a known
-    # failure mode — not the generic Exception arm
-    warnings = [r for r in caplog.records if r.levelname == "WARNING"]
-    assert any(
-        LOCK_1_ENTITY_ID in r.message and "bare base" in r.message for r in warnings
-    )
-    assert all(r.exc_info is None for r in warnings)
-
-
-async def test_query_locks_returns_all_codes(hass: HomeAssistant):
-    """
-    Test _async_query_locks returns every slot the lock reports.
-
-    Filtering empty slots is the caller's responsibility, so this function
-    must not drop them.
-    """
-    mock_instance = MagicMock()
-    mock_instance.async_internal_get_usercodes = AsyncMock(
-        return_value={
-            1: SlotCredential.known("1234"),
-            3: SlotCredential.known("9999"),
-            4: SlotCredential.empty(),
-        }
-    )
-    mock_lock_cls = MagicMock(return_value=mock_instance)
-
-    ent_reg = er.async_get(hass)
-    ent_reg.async_get_or_create(
-        "lock", "zwave_js", "test_lock_1", suggested_object_id="test_1"
-    )
-    dev_reg = dr.async_get(hass)
-
-    # Create an existing Lock Code Manager config entry that manages slot 1
-    lcm_entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            CONF_LOCKS: [LOCK_1_ENTITY_ID],
-            CONF_SLOTS: {
-                1: {
-                    CONF_NAME: "S1",
-                    CONF_ENABLED: True,
-                    CONF_PIN: "1234",
-                }
-            },
-        },
-    )
-    lcm_entry.add_to_hass(hass)
-
-    with (
-        patch(
-            "custom_components.lock_code_manager.config_flow.INTEGRATIONS_CLASS_MAP",
-            {"zwave_js": mock_lock_cls},
-        ),
-        patch.object(
-            hass.config_entries,
-            "async_get_entry",
-            return_value=MockConfigEntry(domain="zwave_js"),
-        ),
-    ):
-        [query] = await _async_query_locks(hass, dev_reg, ent_reg, [LOCK_1_ENTITY_ID])
-
-    # Every slot the lock reports, including empty ones: filtering is the
-    # caller's job, and an empty slot is a slot allocation may use.
-    assert query.lock_entity_id == LOCK_1_ENTITY_ID
-    assert query.codes == {
-        1: SlotCredential.known("1234"),
-        3: SlotCredential.known("9999"),
-        4: SlotCredential.empty(),
-    }
-
-
-async def test_query_locks_entity_not_in_registry(hass: HomeAssistant):
-    """Test _async_get_all_codes skips locks not in the entity registry."""
-    ent_reg = er.async_get(hass)
-    dev_reg = dr.async_get(hass)
-
-    [query] = await _async_query_locks(hass, dev_reg, ent_reg, ["lock.does_not_exist"])
-
-    # Nothing to show for a lock that could not be read. Allocation asks the
-    # locks itself, so this says nothing about which numbers are free.
-    assert query.codes is None
-
-
-async def test_query_locks_unsupported_platform(hass: HomeAssistant):
-    """Test _async_get_all_codes skips locks on unsupported platforms."""
-    ent_reg = er.async_get(hass)
-    ent_reg.async_get_or_create(
-        "lock", "unsupported_platform", "test_lock_1", suggested_object_id="test_1"
-    )
-    dev_reg = dr.async_get(hass)
-
-    [query] = await _async_query_locks(hass, dev_reg, ent_reg, [LOCK_1_ENTITY_ID])
-
-    # Nothing to show for a lock this integration does not write to.
-    assert query.codes is None
-
-
-async def test_query_locks_missing_lock_config_entry(hass: HomeAssistant):
-    """Test _async_get_all_codes skips locks whose config entry is missing."""
-    ent_reg = er.async_get(hass)
-    ent_reg.async_get_or_create(
-        "lock", "zwave_js", "test_lock_1", suggested_object_id="test_1"
-    )
-    dev_reg = dr.async_get(hass)
-
-    with (
-        patch(
-            "custom_components.lock_code_manager.config_flow.INTEGRATIONS_CLASS_MAP",
-            {"zwave_js": MagicMock()},
-        ),
-        patch.object(hass.config_entries, "async_get_entry", return_value=None),
-    ):
-        [query] = await _async_query_locks(hass, dev_reg, ent_reg, [LOCK_1_ENTITY_ID])
-
-    # Nothing to show for a lock that could not be read. Allocation asks the
-    # locks itself, so this says nothing about which numbers are free.
-    assert query.codes is None
-
-
-async def test_existing_codes_detected_across_multiple_locks(hass: HomeAssistant):
-    """One lock holding a code at the requested slot is enough to prompt.
-
-    The other lock answers, and answers "empty" -- which is a real answer, not
-    a missing one, and must not be reported as an existing code.
-    """
-    existing = {
-        LOCK_1_ENTITY_ID: {1: SlotCredential.empty()},
-        LOCK_2_ENTITY_ID: {1: SlotCredential.known("2222")},
-    }
-    with patch(GET_ALL_CODES_PATCH, side_effect=_answers(existing)):
-        flow_id = await _init_flow_to_user_step(hass)
-        await hass.config_entries.flow.async_configure(
-            flow_id,
-            {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID]},
-        )
-        await hass.config_entries.flow.async_configure(
-            flow_id, {"next_step_id": "yaml"}
-        )
-        result = await hass.config_entries.flow.async_configure(
-            flow_id,
-            {
-                CONF_SLOTS: {
-                    1: {CONF_NAME: "User 1", CONF_ENABLED: True, CONF_PIN: "5678"}
-                }
-            },
-        )
-
-    assert result["step_id"] == "existing_codes_confirm"
-    details = result["description_placeholders"]["details"]
-    assert LOCK_2_ENTITY_ID in details
-    assert LOCK_1_ENTITY_ID not in details
-
-    result = await hass.config_entries.flow.async_configure(
-        flow_id, {"next_step_id": "existing_codes_continue"}
-    )
-
-    # Nothing is cleared -- the sync manager reconciles from here.
-    assert result["type"] == "create_entry"
-
-
-async def test_existing_codes_continue_without_next_step_aborts(hass: HomeAssistant):
-    """Defensive: continue step aborts if _next_step was never assigned."""
-    handler = LockCodeManagerFlowHandler()
-    handler.hass = hass
-    # _init_existing_codes_state ran in __init__; _next_step is None
-
-    result = await handler.async_step_existing_codes_continue()
-
-    assert result["type"] == "abort"
-    assert result["reason"] == "unknown"
 
 
 # --- Options flow tests ---
@@ -991,7 +535,7 @@ async def _start_options_flow(
     hass: HomeAssistant,
     *,
     locks: list[str] | None = None,
-    slots: dict[int, dict] | None = None,
+    users: dict[str, dict] | None = None,
 ) -> tuple[str, MockConfigEntry]:
     """
     Create an options flow and return (flow_id, entry).
@@ -1005,8 +549,8 @@ async def _start_options_flow(
         title="test",
         data={
             CONF_LOCKS: locks or [LOCK_1_ENTITY_ID],
-            CONF_SLOTS: slots
-            or {1: {CONF_NAME: "User 1", CONF_ENABLED: True, CONF_PIN: "1234"}},
+            CONF_USERS: users or {"User 1": {CONF_ENABLED: True, CONF_PIN: "1234"}},
+            CONF_SLOT_ASSIGNMENT: {"user 1": 1},
         },
     )
     entry.add_to_hass(hass)
@@ -1015,43 +559,40 @@ async def _start_options_flow(
     return result["flow_id"], entry
 
 
-async def test_options_flow_no_added_pairs_persists_immediately(hass: HomeAssistant):
+async def test_options_flow_no_added_pairs_persists_immediately(
+    hass: HomeAssistant, mock_lock_config_entry
+):
     """No new (lock, slot) pairs -> skip scan and confirm step entirely."""
     flow_id, _ = await _start_options_flow(hass)
 
     # Submit the same locks/slots that already exist on the entry — no diff
-    with patch(GET_ALL_CODES_PATCH) as mock_get_codes:
+    with _holding():
         result = await hass.config_entries.options.async_configure(
             flow_id,
             {
                 CONF_LOCKS: [LOCK_1_ENTITY_ID],
-                CONF_SLOTS: {
-                    1: {CONF_NAME: "User 1", CONF_ENABLED: True, CONF_PIN: "1234"}
-                },
+                CONF_USERS: {"User 1": {CONF_ENABLED: True, CONF_PIN: "1234"}},
             },
         )
 
     assert result["type"] == "create_entry"
-    # Critical: no lock query should happen when there's nothing new to check
-    mock_get_codes.assert_not_called()
 
 
-async def test_options_flow_added_pair_no_existing_code_persists(hass: HomeAssistant):
+async def test_options_flow_added_pair_no_existing_code_persists(
+    hass: HomeAssistant, mock_lock_config_entry
+):
     """New (lock, slot) added but lock has no code there -> persist directly."""
     flow_id, _ = await _start_options_flow(hass)
 
     # Adding slot 2; lock has nothing in slot 2 (only slot 1)
-    with patch(
-        GET_ALL_CODES_PATCH,
-        side_effect=_answers({LOCK_1_ENTITY_ID: {1: SlotCredential.known("1234")}}),
-    ):
+    with _holding():
         result = await hass.config_entries.options.async_configure(
             flow_id,
             {
                 CONF_LOCKS: [LOCK_1_ENTITY_ID],
-                CONF_SLOTS: {
-                    1: {CONF_NAME: "User 1", CONF_ENABLED: True, CONF_PIN: "1234"},
-                    2: {CONF_NAME: "User 2", CONF_ENABLED: True, CONF_PIN: "5678"},
+                CONF_USERS: {
+                    "User 1": {CONF_ENABLED: True, CONF_PIN: "1234"},
+                    "User 2": {CONF_ENABLED: True, CONF_PIN: "5678"},
                 },
             },
         )
@@ -1059,125 +600,20 @@ async def test_options_flow_added_pair_no_existing_code_persists(hass: HomeAssis
     assert result["type"] == "create_entry"
 
 
-async def test_options_flow_added_pair_with_existing_code_confirm(
-    hass: HomeAssistant,
+async def test_options_flow_added_pair_empty_code_persists(
+    hass: HomeAssistant, mock_lock_config_entry
 ):
-    """New (lock, slot) added and lock has code there -> confirm -> persist."""
-    flow_id, _ = await _start_options_flow(hass)
-
-    # Adding slot 2; lock already has "9999" in slot 2 (and our managed "1234"
-    # in slot 1 — slot 1 is NOT in added_pairs so it must not be cleared)
-    with patch(
-        GET_ALL_CODES_PATCH,
-        side_effect=_answers(
-            {
-                LOCK_1_ENTITY_ID: {
-                    1: SlotCredential.known("1234"),
-                    2: SlotCredential.known("9999"),
-                }
-            }
-        ),
-    ):
-        result = await hass.config_entries.options.async_configure(
-            flow_id,
-            {
-                CONF_LOCKS: [LOCK_1_ENTITY_ID],
-                CONF_SLOTS: {
-                    1: {CONF_NAME: "User 1", CONF_ENABLED: True, CONF_PIN: "1234"},
-                    2: {CONF_NAME: "User 2", CONF_ENABLED: True, CONF_PIN: "5678"},
-                },
-            },
-        )
-
-    assert result["type"] == "menu"
-    assert result["step_id"] == "existing_codes_confirm"
-    assert "slot 2" in result["description_placeholders"]["details"]
-
-    # Confirm -> entry is updated. No slots are cleared by the config flow.
-    # The pre-existing managed slot 1 is not affected even though it has a
-    # non-empty code in _all_codes — we scoped to added pairs only.
-    result = await hass.config_entries.options.async_configure(
-        flow_id, {"next_step_id": "existing_codes_continue"}
-    )
-    assert result["type"] == "create_entry"
-
-
-async def test_options_flow_added_lock_with_existing_code_confirm(
-    hass: HomeAssistant,
-):
-    """A NEW lock (with codes in already-managed slot) triggers the confirm step."""
-    flow_id, _ = await _start_options_flow(hass)
-
-    # Add LOCK_2 to the entry. Slot 1 was already managed for LOCK_1, but
-    # the (LOCK_2, 1) pair is new -- and LOCK_2 happens to already have a
-    # code in slot 1. The mixin should detect this and prompt.
-    with patch(
-        GET_ALL_CODES_PATCH,
-        side_effect=_answers({LOCK_2_ENTITY_ID: {1: SlotCredential.known("5555")}}),
-    ):
-        result = await hass.config_entries.options.async_configure(
-            flow_id,
-            {
-                CONF_LOCKS: [LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID],
-                CONF_SLOTS: {
-                    1: {CONF_NAME: "User 1", CONF_ENABLED: True, CONF_PIN: "1234"}
-                },
-            },
-        )
-
-    assert result["step_id"] == "existing_codes_confirm"
-    assert "slot 1" in result["description_placeholders"]["details"]
-
-    result = await hass.config_entries.options.async_configure(
-        flow_id, {"next_step_id": "existing_codes_continue"}
-    )
-    assert result["type"] == "create_entry"
-
-
-async def test_options_flow_existing_codes_cancel_aborts(hass: HomeAssistant):
-    """Cancel from the confirm step aborts and does not change anything."""
-    flow_id, _ = await _start_options_flow(hass)
-
-    with patch(
-        GET_ALL_CODES_PATCH,
-        side_effect=_answers({LOCK_1_ENTITY_ID: {2: SlotCredential.known("9999")}}),
-    ):
-        result = await hass.config_entries.options.async_configure(
-            flow_id,
-            {
-                CONF_LOCKS: [LOCK_1_ENTITY_ID],
-                CONF_SLOTS: {
-                    1: {CONF_NAME: "User 1", CONF_ENABLED: True, CONF_PIN: "1234"},
-                    2: {CONF_NAME: "User 2", CONF_ENABLED: True, CONF_PIN: "5678"},
-                },
-            },
-        )
-
-    assert result["step_id"] == "existing_codes_confirm"
-
-    result = await hass.config_entries.options.async_configure(
-        flow_id, {"next_step_id": "existing_codes_cancel"}
-    )
-
-    assert result["type"] == "abort"
-    assert result["reason"] == "existing_codes_cancelled"
-
-
-async def test_options_flow_added_pair_empty_code_persists(hass: HomeAssistant):
     """Lock reports the new slot as EMPTY -> no confirm needed, persist."""
     flow_id, _ = await _start_options_flow(hass)
 
-    with patch(
-        GET_ALL_CODES_PATCH,
-        side_effect=_answers({LOCK_1_ENTITY_ID: {2: SlotCredential.empty()}}),
-    ):
+    with _holding():
         result = await hass.config_entries.options.async_configure(
             flow_id,
             {
                 CONF_LOCKS: [LOCK_1_ENTITY_ID],
-                CONF_SLOTS: {
-                    1: {CONF_NAME: "User 1", CONF_ENABLED: True, CONF_PIN: "1234"},
-                    2: {CONF_NAME: "User 2", CONF_ENABLED: True, CONF_PIN: "5678"},
+                CONF_USERS: {
+                    "User 1": {CONF_ENABLED: True, CONF_PIN: "1234"},
+                    "User 2": {CONF_ENABLED: True, CONF_PIN: "5678"},
                 },
             },
         )
@@ -1185,23 +621,23 @@ async def test_options_flow_added_pair_empty_code_persists(hass: HomeAssistant):
     assert result["type"] == "create_entry"
 
 
-async def test_options_flow_invalid_yaml_shows_error(hass: HomeAssistant):
+async def test_options_flow_invalid_yaml_shows_error(
+    hass: HomeAssistant, mock_lock_config_entry
+):
     """Validation error in the YAML keeps the form open with the error."""
     flow_id, _ = await _start_options_flow(hass)
 
-    with patch(GET_ALL_CODES_PATCH) as mock_get_codes:
-        result = await hass.config_entries.options.async_configure(
-            flow_id,
-            {
-                CONF_LOCKS: [LOCK_1_ENTITY_ID],
-                # Missing required PIN with enabled=True is invalid per schema
-                CONF_SLOTS: {"not_an_int": {}},
-            },
-        )
+    result = await hass.config_entries.options.async_configure(
+        flow_id,
+        {
+            CONF_LOCKS: [LOCK_1_ENTITY_ID],
+            # Enabled with no PIN is invalid per schema.
+            CONF_USERS: {"Raman": {CONF_ENABLED: True}},
+        },
+    )
 
     assert result["type"] == "form"
     assert result["errors"] == {"base": "invalid_config"}
-    mock_get_codes.assert_not_called()
 
 
 # Slot capacity validation (issue #1398)
@@ -1249,7 +685,7 @@ def _capabilities_with_slots(num_slots: int) -> LockCapabilities:
 async def test_config_flow_yaml_rejects_slot_beyond_lock_capacity(
     hass: HomeAssistant, mock_lock_config_entry
 ):
-    """A slot number the lock cannot hold is caught before the entry is created."""
+    """More users than the lock can hold is caught before the entry exists."""
     flow_id = await _start_yaml_config_flow(hass)
 
     probe_registered, probe_capabilities = _capacity_probe(
@@ -1259,15 +695,16 @@ async def test_config_flow_yaml_rejects_slot_beyond_lock_capacity(
         result = await hass.config_entries.flow.async_configure(
             flow_id,
             {
-                CONF_SLOTS: {
-                    50: {CONF_NAME: "User 50", CONF_ENABLED: True, CONF_PIN: "2222"}
+                CONF_USERS: {
+                    f"User {n}": {CONF_ENABLED: True, CONF_PIN: "2222"}
+                    for n in range(1, 32)
                 }
             },
         )
 
     assert result["type"] == "form"
-    assert result["errors"] == {"base": "slot_out_of_range"}
-    assert result["description_placeholders"]["out_of_range_slots"] == "50"
+    assert result["errors"] == {"base": "too_many_users"}
+    assert result["description_placeholders"]["num_users"] == "31"
     assert result["description_placeholders"]["num_slots"] == "30"
 
 
@@ -1283,11 +720,7 @@ async def test_config_flow_yaml_accepts_slot_within_capacity(
     with probe_registered, probe_capabilities:
         result = await hass.config_entries.flow.async_configure(
             flow_id,
-            {
-                CONF_SLOTS: {
-                    30: {CONF_NAME: "User 30", CONF_ENABLED: True, CONF_PIN: "2222"}
-                }
-            },
+            {CONF_USERS: {"User 30": {CONF_ENABLED: True, CONF_PIN: "2222"}}},
         )
 
     assert result["type"] == "create_entry"
@@ -1494,11 +927,7 @@ async def test_config_flow_capacity_check_skipped_when_lock_unreachable(
     with probe_registered, probe_capabilities:
         result = await hass.config_entries.flow.async_configure(
             flow_id,
-            {
-                CONF_SLOTS: {
-                    50: {CONF_NAME: "User 50", CONF_ENABLED: True, CONF_PIN: "2222"}
-                }
-            },
+            {CONF_USERS: {"User 50": {CONF_ENABLED: True, CONF_PIN: "2222"}}},
         )
 
     assert result["type"] == "create_entry"
@@ -1516,11 +945,7 @@ async def test_config_flow_capacity_check_skipped_when_capacity_unknown(
     with probe_registered, probe_capabilities:
         result = await hass.config_entries.flow.async_configure(
             flow_id,
-            {
-                CONF_SLOTS: {
-                    50: {CONF_NAME: "User 50", CONF_ENABLED: True, CONF_PIN: "2222"}
-                }
-            },
+            {CONF_USERS: {"User 50": {CONF_ENABLED: True, CONF_PIN: "2222"}}},
         )
 
     assert result["type"] == "create_entry"
@@ -1553,11 +978,7 @@ async def test_config_flow_capacity_check_skipped_when_lock_allocates_index(
     ):
         result = await hass.config_entries.flow.async_configure(
             flow_id,
-            {
-                CONF_SLOTS: {
-                    50: {CONF_NAME: "User 50", CONF_ENABLED: True, CONF_PIN: "2222"}
-                }
-            },
+            {CONF_USERS: {"User 50": {CONF_ENABLED: True, CONF_PIN: "2222"}}},
         )
 
     assert result["type"] == "create_entry"
@@ -1582,11 +1003,7 @@ async def test_config_flow_capacity_check_survives_unexpected_error(
     with probe_registered, probe_capabilities:
         result = await hass.config_entries.flow.async_configure(
             flow_id,
-            {
-                CONF_SLOTS: {
-                    50: {CONF_NAME: "User 50", CONF_ENABLED: True, CONF_PIN: "2222"}
-                }
-            },
+            {CONF_USERS: {"User 50": {CONF_ENABLED: True, CONF_PIN: "2222"}}},
         )
 
     assert result["type"] == "create_entry"
@@ -1651,19 +1068,25 @@ async def test_config_flow_ui_rejects_duplicate_name(
 
 
 @pytest.mark.parametrize(
-    ("slots", "expected_error"),
+    ("users", "expected_error"),
     [
         (
+            # Two keys, one person: the editor cannot represent a duplicate
+            # name, but it can still represent two spellings of one.
             {
-                1: {CONF_NAME: "Raman", CONF_ENABLED: True, CONF_PIN: "1234"},
-                2: {CONF_NAME: " raman ", CONF_ENABLED: True, CONF_PIN: "5678"},
+                "Raman": {CONF_ENABLED: True, CONF_PIN: "1234"},
+                " raman ": {CONF_ENABLED: True, CONF_PIN: "5678"},
             },
-            "slot_name_not_unique",
+            "name_not_unique",
+        ),
+        (
+            {"   ": {CONF_ENABLED: True, CONF_PIN: "1234"}},
+            "name_required",
         ),
     ],
 )
 async def test_config_flow_yaml_enforces_name_rules(
-    hass: HomeAssistant, mock_lock_config_entry, slots, expected_error
+    hass: HomeAssistant, mock_lock_config_entry, users, expected_error
 ):
     """The YAML path enforces the same name rules as the single-slot path.
 
@@ -1673,30 +1096,35 @@ async def test_config_flow_yaml_enforces_name_rules(
     """
     flow_id = await _start_yaml_config_flow(hass)
 
-    result = await hass.config_entries.flow.async_configure(
-        flow_id, {CONF_SLOTS: slots}
-    )
+    with _holding():
+        result = await hass.config_entries.flow.async_configure(
+            flow_id, {CONF_USERS: users}
+        )
 
     assert result["type"] == "form"
     assert result["errors"] == {"base": expected_error}
 
 
-async def test_config_flow_yaml_missing_name_says_so(
+async def test_a_slot_keyed_block_is_rejected_not_reinterpreted(
     hass: HomeAssistant, mock_lock_config_entry
 ):
-    """A slots block predating the name requirement names the actual problem.
+    """A block still keyed by slot number is rejected, not silently accepted.
 
-    Falling through to the generic invalid_config would send the user to the
-    logs for the one failure we can predict.
+    The editor takes users keyed by name. A slot-keyed block submitted by
+    hand -- or pasted from a previous release -- is a different shape, and
+    accepting it would key users by the digits that used to be slots.
     """
     flow_id = await _start_yaml_config_flow(hass)
 
-    result = await hass.config_entries.flow.async_configure(
-        flow_id, {CONF_SLOTS: {1: {CONF_ENABLED: True, CONF_PIN: "1234"}}}
-    )
+    with _holding():
+        result = await hass.config_entries.flow.async_configure(
+            flow_id, {CONF_USERS: {1: {CONF_ENABLED: True, CONF_PIN: "1234"}}}
+        )
 
     assert result["type"] == "form"
-    assert result["errors"] == {"base": "name_required"}
+    # Named for what it is, rather than the generic parse failure: those
+    # digits would otherwise coerce into users literally called "1".
+    assert result["errors"] == {"base": "users_keyed_by_slot"}
 
 
 async def test_every_name_error_supplies_what_its_message_asks_for(
@@ -1927,20 +1355,28 @@ async def test_choosing_the_ui_path_reads_no_lock_on_the_way_in(
     )
     flow_id = result["flow_id"]
 
-    with patch(GET_ALL_CODES_PATCH, side_effect=_answers({})) as full_read:
-        result = await hass.config_entries.flow.async_configure(
-            flow_id, {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
-        )
-        assert result["step_id"] == "choose_path"
+    result = await hass.config_entries.flow.async_configure(
+        flow_id, {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
+    )
+    assert result["step_id"] == "choose_path"
 
-        await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
-        with _holding():
-            result = await hass.config_entries.flow.async_configure(
-                flow_id, {CONF_NUM_USERS: 1}
-            )
+    await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
+
+    windows: list[list[int]] = []
+
+    async def _read(self, slots=None):
+        scope = sorted(self.managed_slots if slots is None else slots)
+        windows.append(scope)
+        return {slot: SlotCredential.empty() for slot in scope}
+
+    with patch.object(MockLCMLock, "async_get_usercodes", _read):
+        result = await hass.config_entries.flow.async_configure(
+            flow_id, {CONF_NUM_USERS: 1}
+        )
 
     assert result["step_id"] == "code_slot"
-    assert full_read.call_count == 0
+    # Only the numbers it is about to issue were read, not the lock's range.
+    assert windows == [[1]]
 
 
 async def test_a_nearly_full_lock_is_read_once_through(
@@ -2024,14 +1460,15 @@ async def test_a_blank_yaml_name_names_the_slot_it_came_from(
     )
     flow_id = await _start_yaml_config_flow(hass)
 
-    result = await hass.config_entries.flow.async_configure(
-        flow_id,
-        {CONF_SLOTS: {4: {CONF_NAME: "   ", CONF_ENABLED: True, CONF_PIN: "1234"}}},
-    )
+    with _holding():
+        result = await hass.config_entries.flow.async_configure(
+            flow_id,
+            {CONF_USERS: {"   ": {CONF_ENABLED: True, CONF_PIN: "1234"}}},
+        )
 
-    assert result["errors"] == {"base": "slot_name_required"}
-    assert result["description_placeholders"]["slot_num"] == "4"
-    message = strings["config"]["error"]["slot_name_required"]
+    assert result["errors"] == {"base": "name_required"}
+    assert result["description_placeholders"]["name"] == "   "
+    message = strings["config"]["error"]["name_required"]
     assert not {
         name
         for name in re.findall(r"\{(\w+)\}", message)
@@ -2139,11 +1576,10 @@ async def test_the_smallest_lock_bounds_the_search(
 ):
     """Every lock in an entry gets the same numbers, so the smallest wins."""
     flow_id = await _init_flow_to_user_step(hass)
-    with patch(GET_ALL_CODES_PATCH, side_effect=_answers({})):
-        await hass.config_entries.flow.async_configure(
-            flow_id,
-            {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID]},
-        )
+    await hass.config_entries.flow.async_configure(
+        flow_id,
+        {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID]},
+    )
     await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
 
     limits = {LOCK_1_ENTITY_ID: 30, LOCK_2_ENTITY_ID: 4}
@@ -2287,11 +1723,10 @@ async def test_a_lock_that_reports_its_range_is_the_one_named(
     has to be named every time rather than whichever came first.
     """
     flow_id = await _init_flow_to_user_step(hass)
-    with patch(GET_ALL_CODES_PATCH, side_effect=_answers({})):
-        await hass.config_entries.flow.async_configure(
-            flow_id,
-            {CONF_NAME: "test", CONF_LOCKS: [LOCK_2_ENTITY_ID, LOCK_1_ENTITY_ID]},
-        )
+    await hass.config_entries.flow.async_configure(
+        flow_id,
+        {CONF_NAME: "test", CONF_LOCKS: [LOCK_2_ENTITY_ID, LOCK_1_ENTITY_ID]},
+    )
     await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
 
     # Both answer the same, so the name cannot come from iteration order.
@@ -2305,3 +1740,135 @@ async def test_a_lock_that_reports_its_range_is_the_one_named(
     assert result["description_placeholders"]["lock"] == min(
         [LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID]
     )
+
+
+@pytest.mark.parametrize(
+    ("reason", "managed"),
+    [("not in the entity registry", True), ("an unsupported platform", False)],
+)
+async def test_a_lock_that_cannot_be_built_says_whether_it_is_ours(
+    hass: HomeAssistant, mock_lock_config_entry, reason: str, managed: bool
+) -> None:
+    """
+    Whether Lock Code Manager writes to it decides whether it bounds numbers.
+
+    A lock this integration writes to constrains allocation even when it
+    cannot be read; one on a platform it does not support constrains nothing,
+    because nothing will ever be written there.
+    """
+    ent_reg = er.async_get(hass)
+    if managed:
+        entity_id = "lock.never_registered"
+    else:
+        entity_id = ent_reg.async_get_or_create(
+            "lock", "some_other_integration", "unique"
+        ).entity_id
+
+    with pytest.raises(_LockQuerySkipped) as raised:
+        _async_build_lock_instance(hass, dr.async_get(hass), ent_reg, entity_id)
+
+    assert raised.value.managed is managed
+
+
+async def test_setup_refuses_when_a_lock_cannot_be_read(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """
+    An unreadable lock stops allocation rather than being assumed empty.
+
+    Issuing a number a lock never answered about could overwrite a credential
+    somebody programmed by hand.
+    """
+    flow_id = await _start_yaml_config_flow(hass)
+
+    async def _unreadable(self, slots=None):
+        raise LockCodeManagerError("lock is asleep")
+
+    with patch.object(MockLCMLock, "async_get_usercodes", _unreadable):
+        result = await hass.config_entries.flow.async_configure(
+            flow_id,
+            {CONF_USERS: {"Raman": {CONF_ENABLED: True, CONF_PIN: "1234"}}},
+        )
+
+    assert result["type"] == "form"
+    assert result["errors"] == {"base": "occupancy_unknown"}
+
+
+async def test_editing_refuses_when_a_lock_cannot_be_read(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """The editor answers to the same refusal setup does."""
+    flow_id, _ = await _start_options_flow(hass)
+
+    async def _unreadable(self, slots=None):
+        raise LockCodeManagerError("lock is asleep")
+
+    with patch.object(MockLCMLock, "async_get_usercodes", _unreadable):
+        result = await hass.config_entries.options.async_configure(
+            flow_id,
+            {
+                CONF_LOCKS: [LOCK_1_ENTITY_ID],
+                CONF_USERS: {
+                    "User 1": {CONF_ENABLED: True, CONF_PIN: "1234"},
+                    "Newcomer": {CONF_ENABLED: True, CONF_PIN: "9999"},
+                },
+            },
+        )
+
+    assert result["type"] == "form"
+    assert result["errors"] == {"base": "occupancy_unknown"}
+
+
+async def test_a_lock_whose_config_entry_is_gone_is_skipped(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """A registry row can outlive the entry that created it."""
+    ent_reg = er.async_get(hass)
+    orphan = ent_reg.async_get_or_create(
+        "lock", "test", "orphaned", config_entry=mock_lock_config_entry
+    )
+    ent_reg.async_update_entity(orphan.entity_id, config_entry_id=None)
+
+    with (
+        patch.dict(
+            "custom_components.lock_code_manager.config_flow.INTEGRATIONS_CLASS_MAP",
+            {"test": MockLCMLock},
+        ),
+        pytest.raises(_LockQuerySkipped) as raised,
+    ):
+        _async_build_lock_instance(hass, dr.async_get(hass), ent_reg, orphan.entity_id)
+
+    # Ours, so it still bounds the numbers even unread.
+    assert raised.value.managed is True
+
+
+async def test_reauth_reports_a_slot_another_entry_already_manages(
+    hass: HomeAssistant, mock_lock_config_entry, lock_code_manager_config_entry
+) -> None:
+    """
+    Swapping a lock can collide an existing slot set with another entry's.
+
+    Nobody picks numbers any more, but reauth moves an entry's existing
+    numbers onto a different lock, where they may already be spoken for.
+    """
+    other = MockConfigEntry(
+        domain=DOMAIN,
+        title="other",
+        unique_id="other",
+        data={
+            CONF_LOCKS: [LOCK_2_ENTITY_ID],
+            CONF_USERS: {"Someone": {CONF_ENABLED: True, CONF_PIN: "4321"}},
+            CONF_SLOT_ASSIGNMENT: {"someone": 1},
+        },
+    )
+    other.add_to_hass(hass)
+
+    errors, placeholders = _check_common_slots(
+        hass,
+        [LOCK_2_ENTITY_ID],
+        get_entry_config(lock_code_manager_config_entry).slot_numbers,
+        lock_code_manager_config_entry,
+    )
+
+    assert errors == {"base": "slots_already_configured"}
+    assert placeholders["entry_title"] == "other"

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1917,3 +1917,38 @@ async def test_another_entry_still_holds_its_numbers(
 
     taken = get_entry_config(lock_code_manager_config_entry).slot_numbers
     assert not set(result["data"][CONF_SLOT_ASSIGNMENT].values()) & set(taken)
+
+
+async def test_editing_keeps_what_the_form_never_asked_about(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """
+    An entry carries more than this form knows about.
+
+    Building the saved data by hand drops every key the form does not ask
+    for, silently, on the first edit.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="test",
+        unique_id="carries-extra",
+        data={
+            CONF_LOCKS: [LOCK_1_ENTITY_ID],
+            CONF_USERS: {"User 1": {CONF_ENABLED: True, CONF_PIN: "1234"}},
+            CONF_SLOT_ASSIGNMENT: {"user 1": 1},
+            "written_by_something_else": {"kept": True},
+        },
+    )
+    entry.add_to_hass(hass)
+    started = await hass.config_entries.options.async_init(entry.entry_id)
+
+    with _holding():
+        result = await hass.config_entries.options.async_configure(
+            started["flow_id"],
+            {
+                CONF_LOCKS: [LOCK_1_ENTITY_ID],
+                CONF_USERS: {"User 1": {CONF_ENABLED: True, CONF_PIN: "1234"}},
+            },
+        )
+
+    assert result["data"]["written_by_something_else"] == {"kept": True}

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1872,3 +1872,48 @@ async def test_reauth_reports_a_slot_another_entry_already_manages(
 
     assert errors == {"base": "slots_already_configured"}
     assert placeholders["entry_title"] == "other"
+
+
+async def test_an_entry_may_reuse_a_number_it_just_released(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """
+    An entry's own numbers are not a constraint on itself.
+
+    The ones it keeps are held by tenure; the one it is releasing in the very
+    same submission is free. Counting them as taken pushed every replacement
+    onto a higher number, so an entry edited enough times would run out of
+    room on a lock with plenty left.
+    """
+    flow_id, _ = await _start_options_flow(hass)
+
+    with _holding():
+        result = await hass.config_entries.options.async_configure(
+            flow_id,
+            {
+                CONF_LOCKS: [LOCK_1_ENTITY_ID],
+                # "User 1" held slot 1 and is gone.
+                CONF_USERS: {"Replacement": {CONF_ENABLED: True, CONF_PIN: "5555"}},
+            },
+        )
+
+    assert result["data"][CONF_SLOT_ASSIGNMENT] == {"replacement": 1}
+
+
+async def test_another_entry_still_holds_its_numbers(
+    hass: HomeAssistant, mock_lock_config_entry, lock_code_manager_config_entry
+) -> None:
+    """Excluding an entry from its own claims must not excuse anyone else's."""
+    flow_id, _ = await _start_options_flow(hass, locks=[LOCK_1_ENTITY_ID])
+
+    with _holding():
+        result = await hass.config_entries.options.async_configure(
+            flow_id,
+            {
+                CONF_LOCKS: [LOCK_1_ENTITY_ID],
+                CONF_USERS: {"Newcomer": {CONF_ENABLED: True, CONF_PIN: "5555"}},
+            },
+        )
+
+    taken = get_entry_config(lock_code_manager_config_entry).slot_numbers
+    assert not set(result["data"][CONF_SLOT_ASSIGNMENT].values()) & set(taken)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -20,6 +20,7 @@ from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.const import (
     ATTR_CODE,
     ATTR_ENTITY_ID,
+    CONF_CONDITION,
     CONF_ENABLED,
     CONF_ENTITY_ID,
     CONF_NAME,
@@ -632,12 +633,12 @@ async def test_migration_v1_to_v2_calendar_to_entity_id(
 
     # Slot 2 should have CONF_ENTITY_ID instead of CONF_CALENDAR
     assert CONF_CALENDAR not in migrated.slot(2)
-    assert migrated.slot(2)[CONF_ENTITY_ID] == "calendar.test_1"
+    assert migrated.slot(2)[CONF_CONDITION] == "calendar.test_1"
 
     # Slot 3 already had both fields set -- calendar is dropped and the
     # pre-existing entity_id value is preserved untouched.
     assert CONF_CALENDAR not in migrated.slot(3)
-    assert migrated.slot(3)[CONF_ENTITY_ID] == "calendar.test_2"
+    assert migrated.slot(3)[CONF_CONDITION] == "calendar.test_2"
 
     await hass.config_entries.async_unload(config_entry.entry_id)
     await hass.config_entries.async_remove(config_entry.entry_id)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -70,6 +70,7 @@ from custom_components.lock_code_manager.domain.queries import get_entry_config
 from custom_components.lock_code_manager.domain.slot_assignment import (
     CONF_SLOT_ASSIGNMENT,
 )
+from custom_components.lock_code_manager.domain.user_migration import migrate_to_users
 from custom_components.lock_code_manager.repairs import (
     AcknowledgeRepairFlow,
     async_create_fix_flow,
@@ -2726,3 +2727,26 @@ async def test_migration_survives_an_event_entity_that_already_moved(
     assert entry.state is ConfigEntryState.LOADED
 
     await hass.config_entries.async_unload(entry.entry_id)
+
+
+def test_migration_keeps_the_condition_already_set() -> None:
+    """
+    A user carrying both fields keeps the current one.
+
+    Only reachable from a configuration written part-way through this
+    release's changes, but taking the legacy value would quietly undo
+    whatever set the new one.
+    """
+    migrated, _ = migrate_to_users(
+        {
+            CONF_LOCKS: [LOCK_1_ENTITY_ID],
+            CONF_USERS: {
+                "Raman": {
+                    "entity_id": "binary_sensor.stale",
+                    CONF_CONDITION: "binary_sensor.current",
+                }
+            },
+        }
+    )
+
+    assert migrated[CONF_USERS]["Raman"] == {CONF_CONDITION: "binary_sensor.current"}

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock
 import pytest
 import voluptuous as vol
 
-from homeassistant.const import CONF_ENTITY_ID, STATE_ON
+from homeassistant.const import CONF_CONDITION, CONF_ENTITY_ID, STATE_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 
@@ -143,7 +143,7 @@ async def test_set_slot_condition_service(
     # After update, data is written via options then moved to data
     # Check both options and data for the condition entity
     assert (
-        get_entry_config(updated_entry).slot(1)[CONF_ENTITY_ID] == condition_entity_id
+        get_entry_config(updated_entry).slot(1)[CONF_CONDITION] == condition_entity_id
     )
 
 
@@ -232,7 +232,7 @@ async def test_clear_slot_condition_service(
     await hass.async_block_till_done()
 
     updated_entry = hass.config_entries.async_get_entry(entry.entry_id)
-    assert CONF_ENTITY_ID not in get_entry_config(updated_entry).slot(2)
+    assert CONF_CONDITION not in get_entry_config(updated_entry).slot(2)
 
 
 async def test_clear_slot_condition_service_entry_not_found(

--- a/tests/test_slot_coordinator.py
+++ b/tests/test_slot_coordinator.py
@@ -21,8 +21,8 @@ from homeassistant.components.text import (
 )
 from homeassistant.const import (
     ATTR_ENTITY_ID,
+    CONF_CONDITION,
     CONF_ENABLED,
-    CONF_ENTITY_ID,
     CONF_NAME,
     CONF_PIN,
     STATE_OFF,
@@ -233,7 +233,7 @@ async def test_condition_entity_subscription_owned_by_coordinator(
                 CONF_NAME: "alice",
                 CONF_PIN: "1234",
                 CONF_ENABLED: True,
-                CONF_ENTITY_ID: "input_boolean.gate",
+                CONF_CONDITION: "input_boolean.gate",
             },
         },
     }
@@ -351,7 +351,7 @@ async def test_condition_entity_swap_resubscribes(
                 CONF_NAME: "alice",
                 CONF_PIN: "1234",
                 CONF_ENABLED: True,
-                CONF_ENTITY_ID: "input_boolean.gate_a",
+                CONF_CONDITION: "input_boolean.gate_a",
             },
         },
     }
@@ -370,7 +370,7 @@ async def test_condition_entity_swap_resubscribes(
                 CONF_NAME: "alice",
                 CONF_PIN: "1234",
                 CONF_ENABLED: True,
-                CONF_ENTITY_ID: "input_boolean.gate_b",
+                CONF_CONDITION: "input_boolean.gate_b",
             },
         },
     }
@@ -465,7 +465,7 @@ async def test_active_binary_sensor_does_not_self_track_state(
                 CONF_NAME: "alice",
                 CONF_PIN: "1234",
                 CONF_ENABLED: True,
-                CONF_ENTITY_ID: condition_entity,
+                CONF_CONDITION: condition_entity,
             },
         },
     }
@@ -663,7 +663,7 @@ async def test_handle_condition_state_change_after_stop_is_noop(
                 CONF_NAME: "alice",
                 CONF_PIN: "1234",
                 CONF_ENABLED: True,
-                CONF_ENTITY_ID: "input_boolean.gate_a",
+                CONF_CONDITION: "input_boolean.gate_a",
             },
         },
     }
@@ -946,7 +946,7 @@ async def test_recompute_active_missing_condition_entity_is_inactive(
                 CONF_NAME: "alice",
                 CONF_PIN: "1234",
                 CONF_ENABLED: True,
-                CONF_ENTITY_ID: "input_boolean.does_not_exist",
+                CONF_CONDITION: "input_boolean.does_not_exist",
             },
         },
     }
@@ -957,7 +957,7 @@ async def test_recompute_active_missing_condition_entity_is_inactive(
 
     coordinator = entry.runtime_data.slot_coordinators[1]
     assert coordinator.is_active is False
-    assert CONF_ENTITY_ID in coordinator.inactive_because_of
+    assert CONF_CONDITION in coordinator.inactive_because_of
 
     await hass.config_entries.async_unload(entry.entry_id)
 

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -2243,7 +2243,7 @@ class TestSetSlotCondition:
 
         # Verify config entry was updated
         assert (
-            get_entry_config(lock_code_manager_config_entry).slot(1)["entity_id"]
+            get_entry_config(lock_code_manager_config_entry).slot(1)["condition"]
             == BINARY_SENSOR_TEST_ENTITY_ID
         )
 
@@ -2355,7 +2355,7 @@ class TestSetSlotCondition:
 
         # Verify update worked
         assert (
-            get_entry_config(lock_code_manager_config_entry).slot(1)["entity_id"]
+            get_entry_config(lock_code_manager_config_entry).slot(1)["condition"]
             == INPUT_BOOLEAN_TEST_ENTITY_ID
         )
 
@@ -2551,7 +2551,7 @@ class TestClearSlotCondition:
         ws_client = await hass_ws_client(hass)
 
         # Slot 2 has a calendar entity configured
-        assert "entity_id" in get_entry_config(lock_code_manager_config_entry).slot(2)
+        assert "condition" in get_entry_config(lock_code_manager_config_entry).slot(2)
 
         # Clear slot 2's entity_id
         await ws_client.send_json(


### PR DESCRIPTION
Stage 1 of B5. The websocket payload and the card follow in stage 2.

## The gap this closes

Setup's guided path stopped asking for slot numbers, but the YAML path and the **options flow** still did — and the options flow is the one people use for the rest of the entry's life. The release's promise held only for the first five minutes of ownership.

Both now take users keyed by name:

```yaml
locks:
  - lock.front_door
users:
  Raman:
    pin: "1234"
    enabled: true
    condition: binary_sensor.raman_home
```

Numbers are allocated afterwards, through the same code the guided path uses, so nobody picks one on any route and no route can land on one a lock already holds. The editor reconciles against the entry's existing assignment, so a user who was already there keeps their number — moving somebody would rewrite their credential on every lock.

## What this let us delete

With no path offering slot numbers, the existing-codes confirmation became unreachable. Gone: `_ExistingCodesFlowMixin` and its three steps, `_LockQuery`, `_async_query_locks`, `_codes_by_lock`, `_scope_codes_to_pairs`, `_find_occupied_lock_slots`, `_maybe_confirm_then_persist`. The mixin that carried that flow now carries allocation instead, shared by both flows so they cannot disagree about which numbers are free.

`_check_common_slots` stays: reauth swaps a lock, and an entry's existing numbers can still collide with another entry's on the new one.

## `entity_id` becomes `condition`

The per-user field naming the entity that gates a credential said nothing about what it was for and collided with every other entity id in the configuration. Renamed in storage as well as the editor — the migration handles it, dropping the old key rather than leaving both, and is idempotent. Service *parameters* keep their own names; that is a separate surface.

Uses Home Assistant's own `CONF_CONDITION` rather than defining a second constant with the same value.

## A slot-keyed block is refused, not reinterpreted

`{1: {...}}` coerces cleanly into a user literally named `"1"`. Pasting last release's YAML would have silently produced users named after the numbers they used to be, so that shape is rejected with a message showing the new one.

## Testing

Eighteen tests went with the code they exercised. The rest were converted, and three behaviours that changed shape now say so: a collision with another entry is avoided rather than reported, a name problem names the user, and capacity is about how many users a lock holds. Also restores coverage of `_async_build_lock_instance`'s three skip paths, which only the deleted tests reached but which are still live.

`pytest tests/` — **1700 passed**, 3 skipped, coverage **100.00%**. `prek` clean.