### PR TITLE
docs: describe users where the docs still described slots

### DIFF
--- a/BLUEPRINTS.md
+++ b/BLUEPRINTS.md
@@ -28,29 +28,31 @@ for additional setup guides and examples.
 
 ### Slot Usage Limiter
 
-Decrements an `input_number` helper each time a code slot PIN is
-used. When the counter reaches 0, the slot is automatically disabled.
-Optionally resets the counter when the slot is re-enabled.
+Decrements an `input_number` helper each time a user's credential is
+used. When the counter reaches 0, that user is automatically disabled.
+Optionally resets the counter when the user is re-enabled.
 
 - Set counter to **-1** for unlimited uses
 - Set counter to **0** to disable on next use
-- Requires a lock that supports code slot events
+- Requires a lock that reports credential use
 
 [![Import Blueprint](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Framan325%2Flock_code_manager%2Fblob%2Fmain%2Fblueprints%2Fautomation%2Flock_code_manager%2Fslot_usage_limiter.yaml)
 
 | Input | Description | Default |
 | ----- | ----------- | ------- |
-| Config entry | LCM config entry that manages your locks | Required |
-| Slot number | Code slot to monitor | Required |
-| Uses counter | `input_number` helper for tracking remaining uses | Required |
-| Initial uses | Number of uses to reset to when slot is re-enabled (0 = no reset) | 0 |
+| Credential used event entity | The user's event entity, which fires when their credential is used | Required |
+| Locks (optional) | Only count uses on these locks | All locks |
+| Slot enabled switch | The user's Enabled switch, turned off when the counter runs out | Required |
+| Uses counter | `input_number` helper tracking remaining uses | Required |
+| Initial uses on re-enable | Number of uses to reset to when the user is re-enabled (0 = no reset) | 0 |
+| Notification service (optional) | Service called when the user is disabled | None |
 
 ### Calendar Condition
 
 Creates a template binary sensor that turns ON when a calendar
 event is active and an optional condition template evaluates to
-true. Assign the sensor as a condition entity on a code slot to
-control when the PIN is active.
+true. Assign the sensor as a user's condition entity to control when
+their PIN is active.
 
 - Filter by event title, description, or location using Jinja2 templates
 - Supports any HA calendar integration (local, Google, CalDAV, etc.)
@@ -59,7 +61,8 @@ control when the PIN is active.
 
 | Input | Description | Default |
 | ----- | ----------- | ------- |
-| Config entry | LCM config entry | Required |
+| Lock Code Manager config entry | Config entry holding the user | Required |
+| Slot number | The user's slot number (see [Finding a slot number](#finding-a-slot-number)) | Required |
 | Calendar entity | Calendar to monitor | Required |
 | Condition template | Jinja2 template to filter events | `{{ true }}` |
 
@@ -83,23 +86,23 @@ access windows with specific check-in/check-out times.
 ### Calendar PIN Setter
 
 Extracts a PIN from calendar event attributes using a Jinja2
-template and sets it on a code slot. Optionally clears the PIN
-when the event ends. Useful for automated guest access via shared
+template and sets it as a user's PIN. Optionally clears the PIN when
+the event ends. Useful for automated guest access via shared
 calendars.
 
 - Extract PINs from event title, description, or location
-- Optionally set the slot number dynamically from the event
 - Supports optional notifications when PINs are set/cleared
 
 [![Import Blueprint](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Framan325%2Flock_code_manager%2Fblob%2Fmain%2Fblueprints%2Fautomation%2Flock_code_manager%2Fcalendar_pin_setter.yaml)
 
 | Input | Description | Default |
 | ----- | ----------- | ------- |
-| Config entry | LCM config entry | Required |
+| Lock Code Manager config entry | Config entry holding the user | Required |
+| Slot number | The user whose PIN to set (see [Finding a slot number](#finding-a-slot-number)) | Required |
 | Calendar entity | Calendar to monitor for events | Required |
-| PIN template | Jinja2 template to extract PIN from event | Required |
-| Slot number | Code slot to set the PIN on | Required |
-| Clear on event end | Clear the PIN when the calendar event ends | `true` |
+| PIN template | Jinja2 template to extract the PIN from the event | Required |
+| Clear PIN when event ends | Clear the PIN when the calendar event ends | `true` |
+| Notification service (optional) | Service called when the PIN is set or cleared | None |
 
 ---
 
@@ -120,8 +123,8 @@ based on the sun entity's state (sunrise/sunset).
 | Input | Description | Default |
 | ----- | ----------- | ------- |
 | Lock | Lock entity to auto-relock | Required |
-| Day delay | Minutes to wait before re-locking during the day | 5 |
-| Night delay | Minutes to wait at night (0 = use day delay) | 0 |
+| Day delay (minutes) | Minutes to wait before re-locking during the day | 5 |
+| Night delay (minutes) | Minutes to wait at night (0 = use day delay) | 0 |
 
 ### Lock on Door Close
 
@@ -138,7 +141,7 @@ has closed while the lock is unlocked.
 | ----- | ----------- | ------- |
 | Lock | Lock entity to control | Required |
 | Door sensor | Binary sensor (door class) for open/closed state | Required |
-| Lock delay | Seconds to wait after door closes before locking | 5 |
+| Lock delay (seconds) | Seconds to wait after door closes before locking | 5 |
 
 ---
 
@@ -146,10 +149,10 @@ has closed while the lock is unlocked.
 
 ### Slot Usage Notifier
 
-Runs actions when a code slot PIN is used on a lock. Use it to
+Runs actions when a user's credential is used on a lock. Use it to
 send notifications, trigger scripts, or run any HA action.
 
-- Requires a lock that supports code slot events
+- Requires a lock that reports credential use
 - Template variables: `slot_name`, `slot_num`, `lock_name`, `timestamp`
 - Uses `mode: queued` to handle rapid successive uses
 
@@ -157,7 +160,8 @@ send notifications, trigger scripts, or run any HA action.
 
 | Input | Description | Default |
 | ----- | ----------- | ------- |
-| Event entity | Code slot event entity (fires on PIN use) | Required |
+| Credential used event entities | One or more users' event entities | Required |
+| Locks (optional) | Only run for uses on these locks | All locks |
 | Actions | HA actions to run (notifications, scripts, etc.) | Required |
 
 ---
@@ -166,10 +170,9 @@ send notifications, trigger scripts, or run any HA action.
 
 ### Condition Linker
 
-A one-shot automation that assigns a condition entity to a code
-slot via the `lock_code_manager.set_slot_condition` service. Run
-it once from the Automations page, then delete or keep for
-reference.
+A one-shot automation that assigns a condition entity to a user via
+the `lock_code_manager.set_slot_condition` service. Run it once from
+the Automations page, then delete or keep for reference.
 
 - Uses a synthetic event trigger that never fires automatically
 - Manually run from the Automations page (three-dot menu > Run)
@@ -178,6 +181,22 @@ reference.
 
 | Input | Description | Default |
 | ----- | ----------- | ------- |
-| Config entry | LCM config entry | Required |
-| Slot number | Code slot to assign the condition to (1-9999) | Required |
+| Lock Code Manager config entry | Config entry holding the user | Required |
+| Slot number | The user to assign the condition to (see [Finding a slot number](#finding-a-slot-number)) | Required |
 | Condition entity | Entity to use as the condition | Required |
+
+---
+
+## Finding a slot number
+
+Lock Code Manager assigns each user a slot number and manages it for
+you, so the configuration editor and the dashboard cards never show
+it. Blueprints and services still take one, because a lock addresses
+its credentials by position.
+
+To find the number for a user, open any of that user's entities and
+look at its `code_slot` attribute. In a template:
+
+```jinja
+{{ state_attr('text.raman_pin', 'code_slot') }}
+```

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ PINs across an Airbnb fleet on a nightly schedule, LCM has you covered.
 
 Features:
 
+- Give each person a name and a PIN; Lock Code Manager works out which slot
+  on which lock they land in
 - Synchronize PIN codes across multiple locks and providers
 - Automatic sync — codes are set and cleared as needed, with retry and
   drift detection
@@ -105,17 +107,17 @@ input tables, and import buttons.
 
 ### Template blueprints
 
-- **Calendar Condition** — Binary sensor for calendar-based slot access
+- **Calendar Condition** — Binary sensor for calendar-based access
 - **Date Range Condition** — Binary sensor for start/end date access
 
 ### Automation blueprints
 
-- **Slot Usage Limiter** — Disable a slot after a set number of uses
+- **Slot Usage Limiter** — Disable a user after a set number of uses
 - **Calendar PIN Setter** — Extract and set PINs from calendar events
 - **Auto Re-lock** — Re-lock after a delay with day/night support
 - **Lock on Door Close** — Lock when a door sensor detects closure
-- **Slot Usage Notifier** — Notify when a code slot PIN is used
-- **Condition Linker** — Assign a condition entity to a slot via UI
+- **Slot Usage Notifier** — Notify when someone's credential is used
+- **Condition Linker** — Assign a condition entity to a user via UI
 
 ## Learn More
 

--- a/custom_components/lock_code_manager/strings.json
+++ b/custom_components/lock_code_manager/strings.json
@@ -8,16 +8,14 @@
     },
     "error": {
       "excluded_platform": "Entities from the `{integration}` integration are not supported as condition entities. See the [wiki]({docs_url}) for details.",
-      "invalid_config": "Slots configuration is invalid. For more information, check the logs and the docs.",
-      "missing_pin_if_enabled": "PIN must be set if slot is enabled.",
+      "invalid_config": "The users configuration is invalid. For more information, check the logs and the docs.",
+      "missing_pin_if_enabled": "A PIN must be set for any user who is enabled.",
       "name_not_unique": "That name is already used by another user in this configuration. Names must be unique.",
       "name_required": "Every user needs a name. The name identifies them on your locks.",
       "numbers_needed_exceed_capacity": "Placing {num_users} users would need slot numbers up to {needed}, and lock {lock} has {num_slots} PIN code slots -- some of them already holding codes. Set up fewer users here, or manage the rest from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity.",
       "occupancy_unknown": "Could not read the existing codes on {locks}. Lock Code Manager will not choose slot numbers it could not check, because one of them may already hold a code. Wake the lock or check it is reachable, then try again.",
       "search_limit_reached": "Placing {num_users} users would need slot numbers past {max_slot}, which is as far as Lock Code Manager looks. No lock here reported how many PIN code slots it has, so this limit is Lock Code Manager's own rather than the lock's. Set up fewer users, or re-interview the lock so it reports its capacity.",
-      "slot_name_not_unique": "The name for code slot {slot_num} is already used by another code slot in this entry. Names must be unique.",
-      "slot_name_required": "Code slot {slot_num} needs a name. The name identifies this user on your locks.",
-      "slot_out_of_range": "Lock {lock} reports only {num_slots} PIN code slots, so these slot numbers are out of range for it: {out_of_range_slots}. Renumber them to fall within 1-{num_slots}, or manage that lock from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity.",
+      "slot_out_of_range": "Lock {lock} reports only {num_slots} PIN code slots, and this configuration already uses numbers beyond that: {out_of_range_slots}. Lock Code Manager assigns those numbers itself, so the way to free them is to remove some users, or to manage the rest from a separate configuration.",
       "slots_already_configured": "The following slots for lock {lock} are already managed by another config entry ({entry_title}) and can't be added to this configuration without being removed from the other one: {common_slots}",
       "too_many_users": "Lock {lock} has {num_slots} PIN code slots, so {num_users} users will not fit. Set up fewer users here, or manage the rest from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity.",
       "users_keyed_by_slot": "This looks like the old slot-numbered format. Users are now listed by name, and Lock Code Manager picks the slot numbers itself:\n\nusers:\n  Raman:\n    pin: \"1234\"\n    enabled: true"
@@ -135,11 +133,9 @@
       "unknown": "An unexpected error occurred while updating options."
     },
     "error": {
-      "invalid_config": "Slots configuration is invalid. For more information, check the logs and the docs.",
+      "invalid_config": "The users configuration is invalid. For more information, check the logs and the docs.",
       "name_required": "Every user needs a name. The name identifies them on your locks.",
-      "slot_name_not_unique": "The name for code slot {slot_num} is already used by another code slot in this entry. Names must be unique.",
-      "slot_name_required": "Code slot {slot_num} needs a name. The name identifies this user on your locks.",
-      "slot_out_of_range": "Lock {lock} reports only {num_slots} PIN code slots, so these slot numbers are out of range for it: {out_of_range_slots}. Renumber them to fall within 1-{num_slots}, or manage that lock from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity.",
+      "slot_out_of_range": "Lock {lock} reports only {num_slots} PIN code slots, and this configuration already uses numbers beyond that: {out_of_range_slots}. Lock Code Manager assigns those numbers itself, so the way to free them is to remove some users, or to manage the rest from a separate configuration.",
       "slots_already_configured": "The following slots for lock {lock} are already managed by another config entry ({entry_title}) and can't be added to this configuration without being removed from the other one: {common_slots}",
       "users_keyed_by_slot": "This looks like the old slot-numbered format. Users are now listed by name, and Lock Code Manager picks the slot numbers itself:\n\nusers:\n  Raman:\n    pin: \"1234\"\n    enabled: true",
       "excluded_platform": "Entities from the `{integration}` integration are not supported as condition entities. See the [wiki]({docs_url}) for details."

--- a/custom_components/lock_code_manager/translations/en.json
+++ b/custom_components/lock_code_manager/translations/en.json
@@ -8,16 +8,14 @@
     },
     "error": {
       "excluded_platform": "Entities from the `{integration}` integration are not supported as condition entities. See the [wiki]({docs_url}) for details.",
-      "invalid_config": "Slots configuration is invalid. For more information, check the logs and the docs.",
-      "missing_pin_if_enabled": "PIN must be set if slot is enabled.",
+      "invalid_config": "The users configuration is invalid. For more information, check the logs and the docs.",
+      "missing_pin_if_enabled": "A PIN must be set for any user who is enabled.",
       "name_not_unique": "That name is already used by another user in this configuration. Names must be unique.",
       "name_required": "Every user needs a name. The name identifies them on your locks.",
       "numbers_needed_exceed_capacity": "Placing {num_users} users would need slot numbers up to {needed}, and lock {lock} has {num_slots} PIN code slots -- some of them already holding codes. Set up fewer users here, or manage the rest from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity.",
       "occupancy_unknown": "Could not read the existing codes on {locks}. Lock Code Manager will not choose slot numbers it could not check, because one of them may already hold a code. Wake the lock or check it is reachable, then try again.",
       "search_limit_reached": "Placing {num_users} users would need slot numbers past {max_slot}, which is as far as Lock Code Manager looks. No lock here reported how many PIN code slots it has, so this limit is Lock Code Manager's own rather than the lock's. Set up fewer users, or re-interview the lock so it reports its capacity.",
-      "slot_name_not_unique": "The name for code slot {slot_num} is already used by another code slot in this entry. Names must be unique.",
-      "slot_name_required": "Code slot {slot_num} needs a name. The name identifies this user on your locks.",
-      "slot_out_of_range": "Lock {lock} reports only {num_slots} PIN code slots, so these slot numbers are out of range for it: {out_of_range_slots}. Renumber them to fall within 1-{num_slots}, or manage that lock from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity.",
+      "slot_out_of_range": "Lock {lock} reports only {num_slots} PIN code slots, and this configuration already uses numbers beyond that: {out_of_range_slots}. Lock Code Manager assigns those numbers itself, so the way to free them is to remove some users, or to manage the rest from a separate configuration.",
       "slots_already_configured": "The following slots for lock {lock} are already managed by another config entry ({entry_title}) and can't be added to this configuration without being removed from the other one: {common_slots}",
       "too_many_users": "Lock {lock} has {num_slots} PIN code slots, so {num_users} users will not fit. Set up fewer users here, or manage the rest from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity.",
       "users_keyed_by_slot": "This looks like the old slot-numbered format. Users are now listed by name, and Lock Code Manager picks the slot numbers itself:\n\nusers:\n  Raman:\n    pin: \"1234\"\n    enabled: true"
@@ -135,11 +133,9 @@
       "unknown": "An unexpected error occurred while updating options."
     },
     "error": {
-      "invalid_config": "Slots configuration is invalid. For more information, check the logs and the docs.",
+      "invalid_config": "The users configuration is invalid. For more information, check the logs and the docs.",
       "name_required": "Every user needs a name. The name identifies them on your locks.",
-      "slot_name_not_unique": "The name for code slot {slot_num} is already used by another code slot in this entry. Names must be unique.",
-      "slot_name_required": "Code slot {slot_num} needs a name. The name identifies this user on your locks.",
-      "slot_out_of_range": "Lock {lock} reports only {num_slots} PIN code slots, so these slot numbers are out of range for it: {out_of_range_slots}. Renumber them to fall within 1-{num_slots}, or manage that lock from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity.",
+      "slot_out_of_range": "Lock {lock} reports only {num_slots} PIN code slots, and this configuration already uses numbers beyond that: {out_of_range_slots}. Lock Code Manager assigns those numbers itself, so the way to free them is to remove some users, or to manage the rest from a separate configuration.",
       "slots_already_configured": "The following slots for lock {lock} are already managed by another config entry ({entry_title}) and can't be added to this configuration without being removed from the other one: {common_slots}",
       "users_keyed_by_slot": "This looks like the old slot-numbered format. Users are now listed by name, and Lock Code Manager picks the slot numbers itself:\n\nusers:\n  Raman:\n    pin: \"1234\"\n    enabled: true",
       "excluded_platform": "Entities from the `{integration}` integration are not supported as condition entities. See the [wiki]({docs_url}) for details."

--- a/tests/test_blueprint_docs.py
+++ b/tests/test_blueprint_docs.py
@@ -1,0 +1,63 @@
+"""The inputs BLUEPRINTS.md documents are the ones the blueprints declare."""
+
+from __future__ import annotations
+
+import pathlib
+import re
+from typing import Any
+
+import pytest
+import yaml
+
+_REPO = pathlib.Path(__file__).resolve().parent.parent
+_DOC = _REPO / "BLUEPRINTS.md"
+_BLUEPRINTS = sorted(
+    (_REPO / "blueprints").glob("*/lock_code_manager/*.yaml"),
+    key=lambda path: path.stem,
+)
+
+# The doc's headings are prose, so the file name cannot be derived from them.
+# The import badge in each section links back to the blueprint it documents,
+# which is what ties a table to its source.
+_IMPORT_LINK = re.compile(r"blueprints%2F\w+%2Flock_code_manager%2F(\w+)\.yaml")
+
+
+class _BlueprintLoader(yaml.SafeLoader):
+    """Reads a blueprint without resolving the ``!input`` references in it.
+
+    Subclasses ``SafeLoader``, so the added tag is the only one beyond the
+    plain-data set and no Python object can be constructed from a blueprint.
+    """
+
+
+def _keep_input_tag(loader: _BlueprintLoader, node: yaml.Node) -> dict[str, Any]:
+    assert isinstance(node, yaml.ScalarNode)
+    return {"!input": loader.construct_scalar(node)}
+
+
+_BlueprintLoader.add_constructor("!input", _keep_input_tag)
+
+
+def _documented_inputs() -> dict[str, list[str]]:
+    """Map each blueprint's file name to the input names its table lists."""
+    sections: dict[str, list[str]] = {}
+    current: list[str] | None = None
+    for line in _DOC.read_text().splitlines():
+        if match := _IMPORT_LINK.search(line):
+            current = sections.setdefault(match[1], [])
+        elif current is not None and line.startswith("|"):
+            name = line.split("|")[1].strip()
+            if name != "Input" and not name.startswith("--"):
+                current.append(name)
+    return sections
+
+
+_DOCUMENTED = _documented_inputs()
+
+
+@pytest.mark.parametrize("path", _BLUEPRINTS, ids=lambda path: path.stem)
+def test_documented_inputs_match_the_blueprint(path: pathlib.Path) -> None:
+    """Every input is documented, under the name the blueprint gives it."""
+    blueprint = yaml.load(path.read_text(), _BlueprintLoader)["blueprint"]
+    declared = [config.get("name", key) for key, config in blueprint["input"].items()]
+    assert _DOCUMENTED[path.stem] == declared


### PR DESCRIPTION
## Proposed change

The README, `BLUEPRINTS.md` and the config-flow strings still described the product where you pick a slot number for each PIN. You now name people, so these read as instructions for something that no longer exists — one error string told you to renumber slots you can no longer number.

While checking the blueprint tables against the blueprints, they turned out to have already drifted, silently, before this branch: the Slot Usage Limiter table listed a "Config entry" and a "Slot number" input that blueprint has never had, and omitted four inputs it does have. Nothing tied the two together, so nothing caught it. `tests/test_blueprint_docs.py` now reads the inputs out of every blueprint and asserts the doc lists exactly those, under the names the blueprint gives them.

Also adds a "Finding a slot number" section. Four blueprints and both condition services still take a slot number, and no screen shows one any more, so the doc says where to find it (the `code_slot` attribute on any of the user's entities).

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

Part of the v3 release prep. Hand-written 5.0.0 release notes are drafted locally (not committed — no precedent for a release-notes file in the repo; the text goes in the GitHub release body).

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XDxiHpQJkRKWctS9BfQmbY