### PR TITLE
fix: name and describe the four services that had neither

### DIFF
--- a/custom_components/lock_code_manager/strings.json
+++ b/custom_components/lock_code_manager/strings.json
@@ -151,9 +151,43 @@
     }
   },
   "services": {
-    "hard_refresh_usercodes": {
-      "description": "If Lock Code Manager supports the lock's integration, and the lock's integration supports it, this will query the lock for all usercodes. This is potentially useful for integrations that cache data from the lock and a usercode(s) is configured outside of Home Assistant.",
-      "name": "Hard refresh usercodes"
+    "clear_slot_condition": {
+      "name": "Clear slot condition",
+      "description": "Remove a code slot's condition entity, leaving its PIN active whenever the slot is enabled.",
+      "fields": {
+        "config_entry_id": {
+          "name": "Config entry",
+          "description": "The Lock Code Manager entry that manages the slot."
+        },
+        "slot": {
+          "name": "Code slot",
+          "description": "The code slot within that entry."
+        }
+      }
+    },
+    "clear_usercode": {
+      "name": "Clear usercode",
+      "description": "Clear a slot on a lock directly, bypassing Lock Code Manager's own configuration. The next sync will rewrite it if the slot is one Lock Code Manager manages.",
+      "fields": {
+        "lock_entity_id": {
+          "name": "Lock",
+          "description": "The lock to act on."
+        },
+        "code_slot": {
+          "name": "Code slot",
+          "description": "The code slot on the lock, addressed by its number."
+        }
+      }
+    },
+    "deobfuscate_log": {
+      "name": "Deobfuscate log",
+      "description": "Replace mask_pin tokens (pin#xxxxxxxx) in pasted log text with the plaintext PINs configured in any loaded Lock Code Manager entry. WARNING: the response contains plaintext PINs — do not paste it into public issues, forums, or any shared channel.",
+      "fields": {
+        "text": {
+          "name": "Text",
+          "description": "The log text to deobfuscate. Paste raw log lines or a full log file."
+        }
+      }
     },
     "generate_pin": {
       "description": "Generate a random PIN that avoids known unsafe patterns (all-same digits, sequential digits, repeating sub-sequences, and common weak PINs). Returns the PIN via response_variable.",
@@ -165,13 +199,43 @@
         }
       }
     },
-    "deobfuscate_log": {
-      "name": "Deobfuscate log",
-      "description": "Replace mask_pin tokens (pin#xxxxxxxx) in pasted log text with the plaintext PINs configured in any loaded Lock Code Manager entry. WARNING: the response contains plaintext PINs — do not paste it into public issues, forums, or any shared channel.",
+    "hard_refresh_usercodes": {
+      "description": "If Lock Code Manager supports the lock's integration, and the lock's integration supports it, this will query the lock for all usercodes. This is potentially useful for integrations that cache data from the lock and a usercode(s) is configured outside of Home Assistant.",
+      "name": "Hard refresh usercodes"
+    },
+    "set_slot_condition": {
+      "name": "Set slot condition",
+      "description": "Attach a condition entity to a code slot. The slot's PIN is active only while that entity says so.",
       "fields": {
-        "text": {
-          "name": "Text",
-          "description": "The log text to deobfuscate. Paste raw log lines or a full log file."
+        "config_entry_id": {
+          "name": "Config entry",
+          "description": "The Lock Code Manager entry that manages the slot."
+        },
+        "slot": {
+          "name": "Code slot",
+          "description": "The code slot within that entry."
+        },
+        "entity_id": {
+          "name": "Condition entity",
+          "description": "The entity whose state decides when the slot's PIN is active."
+        }
+      }
+    },
+    "set_usercode": {
+      "name": "Set usercode",
+      "description": "Write a PIN directly to a slot on a lock, bypassing Lock Code Manager's own configuration. The next sync will overwrite it if the slot is one Lock Code Manager manages.",
+      "fields": {
+        "lock_entity_id": {
+          "name": "Lock",
+          "description": "The lock to act on."
+        },
+        "code_slot": {
+          "name": "Code slot",
+          "description": "The code slot on the lock, addressed by its number."
+        },
+        "usercode": {
+          "name": "Usercode",
+          "description": "The PIN to write."
         }
       }
     }

--- a/custom_components/lock_code_manager/translations/en.json
+++ b/custom_components/lock_code_manager/translations/en.json
@@ -151,9 +151,43 @@
     }
   },
   "services": {
-    "hard_refresh_usercodes": {
-      "description": "If Lock Code Manager supports the lock's integration, and the lock's integration supports it, this will query the lock for all usercodes. This is potentially useful for integrations that cache data from the lock and a usercode(s) is configured outside of Home Assistant.",
-      "name": "Hard refresh usercodes"
+    "clear_slot_condition": {
+      "name": "Clear slot condition",
+      "description": "Remove a code slot's condition entity, leaving its PIN active whenever the slot is enabled.",
+      "fields": {
+        "config_entry_id": {
+          "name": "Config entry",
+          "description": "The Lock Code Manager entry that manages the slot."
+        },
+        "slot": {
+          "name": "Code slot",
+          "description": "The code slot within that entry."
+        }
+      }
+    },
+    "clear_usercode": {
+      "name": "Clear usercode",
+      "description": "Clear a slot on a lock directly, bypassing Lock Code Manager's own configuration. The next sync will rewrite it if the slot is one Lock Code Manager manages.",
+      "fields": {
+        "lock_entity_id": {
+          "name": "Lock",
+          "description": "The lock to act on."
+        },
+        "code_slot": {
+          "name": "Code slot",
+          "description": "The code slot on the lock, addressed by its number."
+        }
+      }
+    },
+    "deobfuscate_log": {
+      "name": "Deobfuscate log",
+      "description": "Replace mask_pin tokens (pin#xxxxxxxx) in pasted log text with the plaintext PINs configured in any loaded Lock Code Manager entry. WARNING: the response contains plaintext PINs — do not paste it into public issues, forums, or any shared channel.",
+      "fields": {
+        "text": {
+          "name": "Text",
+          "description": "The log text to deobfuscate. Paste raw log lines or a full log file."
+        }
+      }
     },
     "generate_pin": {
       "description": "Generate a random PIN that avoids known unsafe patterns (all-same digits, sequential digits, repeating sub-sequences, and common weak PINs). Returns the PIN via response_variable.",
@@ -165,13 +199,43 @@
         }
       }
     },
-    "deobfuscate_log": {
-      "name": "Deobfuscate log",
-      "description": "Replace mask_pin tokens (pin#xxxxxxxx) in pasted log text with the plaintext PINs configured in any loaded Lock Code Manager entry. WARNING: the response contains plaintext PINs — do not paste it into public issues, forums, or any shared channel.",
+    "hard_refresh_usercodes": {
+      "description": "If Lock Code Manager supports the lock's integration, and the lock's integration supports it, this will query the lock for all usercodes. This is potentially useful for integrations that cache data from the lock and a usercode(s) is configured outside of Home Assistant.",
+      "name": "Hard refresh usercodes"
+    },
+    "set_slot_condition": {
+      "name": "Set slot condition",
+      "description": "Attach a condition entity to a code slot. The slot's PIN is active only while that entity says so.",
       "fields": {
-        "text": {
-          "name": "Text",
-          "description": "The log text to deobfuscate. Paste raw log lines or a full log file."
+        "config_entry_id": {
+          "name": "Config entry",
+          "description": "The Lock Code Manager entry that manages the slot."
+        },
+        "slot": {
+          "name": "Code slot",
+          "description": "The code slot within that entry."
+        },
+        "entity_id": {
+          "name": "Condition entity",
+          "description": "The entity whose state decides when the slot's PIN is active."
+        }
+      }
+    },
+    "set_usercode": {
+      "name": "Set usercode",
+      "description": "Write a PIN directly to a slot on a lock, bypassing Lock Code Manager's own configuration. The next sync will overwrite it if the slot is one Lock Code Manager manages.",
+      "fields": {
+        "lock_entity_id": {
+          "name": "Lock",
+          "description": "The lock to act on."
+        },
+        "code_slot": {
+          "name": "Code slot",
+          "description": "The code slot on the lock, addressed by its number."
+        },
+        "usercode": {
+          "name": "Usercode",
+          "description": "The PIN to write."
         }
       }
     }

--- a/tests/test_service_catalog.py
+++ b/tests/test_service_catalog.py
@@ -1,0 +1,67 @@
+"""Every registered service is described everywhere a service is described.
+
+A service missing from ``strings.json`` still works, and still appears in the
+action picker -- under its raw key, with no description and unlabelled fields.
+Nothing fails, so nothing catches it: four services shipped that way.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import re
+
+import pytest
+import yaml
+
+_COMPONENT = (
+    pathlib.Path(__file__).resolve().parent.parent
+    / "custom_components"
+    / "lock_code_manager"
+)
+
+_REGISTERED = sorted(
+    set(
+        re.findall(
+            r'^SERVICE_\w+ = "(\w+)"', (_COMPONENT / "const.py").read_text(), re.M
+        )
+    )
+)
+
+_SERVICES_YAML = yaml.safe_load((_COMPONENT / "services.yaml").read_text())
+_ICONS = json.loads((_COMPONENT / "icons.json").read_text())["services"]
+_TRANSLATIONS = {
+    name: json.loads((_COMPONENT / name).read_text())
+    for name in ("strings.json", "translations/en.json")
+}
+
+
+def test_every_service_constant_is_registered() -> None:
+    """The catalog below covers every service the integration defines."""
+    assert _REGISTERED
+    assert set(_SERVICES_YAML) == set(_REGISTERED)
+
+
+@pytest.mark.parametrize("service", _REGISTERED)
+@pytest.mark.parametrize("source", sorted(_TRANSLATIONS))
+def test_service_is_translated(service: str, source: str) -> None:
+    """A service carries a name and a description on both string files."""
+    described = _TRANSLATIONS[source]["services"]
+    assert service in described, f"{service} is missing from {source}"
+    assert described[service].get("name")
+    assert described[service].get("description")
+
+
+@pytest.mark.parametrize("service", _REGISTERED)
+@pytest.mark.parametrize("source", sorted(_TRANSLATIONS))
+def test_service_fields_are_translated(service: str, source: str) -> None:
+    """Every field the schema accepts is labelled, and no label is stale."""
+    declared = set(_SERVICES_YAML[service].get("fields", {}))
+    described = set(_TRANSLATIONS[source]["services"][service].get("fields", {}))
+    assert described == declared, f"{service} in {source}"
+
+
+@pytest.mark.parametrize("service", _REGISTERED)
+def test_service_has_an_icon(service: str) -> None:
+    """A service with no icon falls back to a generic one in the picker."""
+    assert service in _ICONS


### PR DESCRIPTION
## Proposed change

`set_usercode`, `clear_usercode`, `set_slot_condition` and `clear_slot_condition` are registered and fully specified in `services.yaml`, but have no entry in `strings.json` or `translations/en.json`. Home Assistant falls back to the raw key, so they appear in the action picker as **set_usercode** with no description and unlabelled fields, while the other three services render properly.

Nothing failed, which is why it lasted — a missing translation is not an error anywhere, at any layer.

`tests/test_service_catalog.py` now asserts, for every `SERVICE_*` constant:

- it appears in `services.yaml`
- it has a `name` and `description` in both string files
- the fields described match the fields the schema actually accepts (catches stale labels too, not just missing ones)
- it has an icon in `icons.json`

The test fails on `main` before this change with exactly the four services above.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

Found while adding two new services on the v3 branch — the audit that turned this up was worth running on `main` on its own.

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XDxiHpQJkRKWctS9BfQmbY