### PR TITLE
chore: remove what v3 deleted but left behind, and dissolve a spent mixin

### DIFF
--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -191,55 +191,29 @@ async def _async_validate_users_yaml(
     return parsed_users, {}, {}
 
 
-class _AllocatesSlotsMixin:
+async def _allocate_for(
+    hass: HomeAssistant,
+    locks: Sequence[str],
+    num_users: int,
+    *,
+    excluding: ConfigEntry | None = None,
+) -> tuple[frozenset[int] | None, dict[str, str], dict[str, Any]]:
     """
-    Finding numbers for users, shared by the setup and editing flows.
+    Find numbers for ``num_users``, or say why it could not.
 
-    Neither flow asks anybody for a slot number: both name users and then
-    allocate around whatever the locks already hold. The allocation itself
-    lives in ``domain.allocation``, which the services call too; this turns
-    its refusals into the form errors a flow renders.
-
-    ``_allocation_locks`` is set by the flow before allocating, because
-    setup has the locks in its collected data and editing has them in the
-    submission being validated.
+    Allocation itself lives in ``domain.allocation``, which the services call
+    too; this only turns its refusals into the form errors a flow renders.
     """
-
-    # Supplied by whichever flow mixes this in; both have one.
-    hass: HomeAssistant
-
-    _allocation_locks: Sequence[str] = ()
-
-    # The entry this flow is editing, if any. Setup is not editing one.
-    _entry_being_edited: ConfigEntry | None = None
-
-    async def _async_allocate_for(
-        self, num_users: int
-    ) -> tuple[frozenset[int] | None, dict[str, str], dict[str, Any]]:
-        """Find numbers for ``num_users``, or say why it could not."""
-        try:
-            unavailable = await async_allocate_for(
-                self.hass,
-                self._allocation_locks,
-                num_users,
-                excluding=self._entry_being_edited,
-            )
-        except SlotAllocationError as err:
-            return None, {"base": err.translation_key}, err.placeholders
-        return unavailable, {}, {}
-
-    async def _create_entry(
-        self, *, title: str, data: dict[str, Any]
-    ) -> dict[str, Any]:
-        """Create the config entry."""
-        return self.async_create_entry(  # type: ignore[attr-defined]
-            title=title, data=data
+    try:
+        unavailable = await async_allocate_for(
+            hass, locks, num_users, excluding=excluding
         )
+    except SlotAllocationError as err:
+        return None, {"base": err.translation_key}, err.placeholders
+    return unavailable, {}, {}
 
 
-class LockCodeManagerFlowHandler(
-    _AllocatesSlotsMixin, config_entries.ConfigFlow, domain=DOMAIN
-):
+class LockCodeManagerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Config flow for Lock Code Manager."""
 
     VERSION = 4
@@ -270,7 +244,6 @@ class LockCodeManagerFlowHandler(
             await self.async_set_unique_id(slugify(self.title))
             self._abort_if_unique_id_configured()
             self.data = user_input
-            self._allocation_locks = user_input[CONF_LOCKS]
             return await self.async_step_choose_path()
 
         return self.async_show_form(
@@ -306,7 +279,7 @@ class LockCodeManagerFlowHandler(
                 unavailable,
                 errors,
                 description_placeholders,
-            ) = await self._async_allocate_for(num_users)
+            ) = await _allocate_for(self.hass, self.data[CONF_LOCKS], num_users)
             if unavailable is not None:
                 self._users_to_configure = num_users
                 self._unavailable = unavailable
@@ -401,7 +374,7 @@ class LockCodeManagerFlowHandler(
             self.data[CONF_USERS], start=1, unavailable=self._unavailable
         )
         self.data[CONF_SLOT_ASSIGNMENT] = dict(assignment.slots)
-        return await self._create_entry(title=self.title, data=self.data)
+        return self.async_create_entry(title=self.title, data=self.data)
 
     async def async_step_yaml(self, user_input: dict[str, Any] | None = None):
         """Take a block of users, then allocate their numbers."""
@@ -429,7 +402,7 @@ class LockCodeManagerFlowHandler(
                     unavailable,
                     allocation_errors,
                     allocation_placeholders,
-                ) = await self._async_allocate_for(len(users))
+                ) = await _allocate_for(self.hass, self.data[CONF_LOCKS], len(users))
                 if unavailable is None:
                     return self.async_show_form(
                         step_id="yaml",
@@ -443,7 +416,7 @@ class LockCodeManagerFlowHandler(
                     users, start=1, unavailable=unavailable
                 )
                 self.data[CONF_SLOT_ASSIGNMENT] = dict(assignment.slots)
-                return await self._create_entry(title=self.title, data=self.data)
+                return self.async_create_entry(title=self.title, data=self.data)
 
         return self.async_show_form(
             step_id="yaml",
@@ -562,7 +535,7 @@ class LockCodeManagerFlowHandler(
         return LockCodeManagerOptionsFlow()
 
 
-class LockCodeManagerOptionsFlow(_AllocatesSlotsMixin, config_entries.OptionsFlow):
+class LockCodeManagerOptionsFlow(config_entries.OptionsFlow):
     """Options flow for Lock Code Manager."""
 
     async def async_step_init(
@@ -575,10 +548,6 @@ class LockCodeManagerOptionsFlow(_AllocatesSlotsMixin, config_entries.OptionsFlo
             user_input = {}
 
         if user_input:
-            self._allocation_locks = user_input[CONF_LOCKS]
-            # Its own numbers do not constrain it: kept ones are held by
-            # tenure, released ones are free for whoever comes next.
-            self._entry_being_edited = self.config_entry
             (
                 users,
                 validation_errors,
@@ -595,7 +564,14 @@ class LockCodeManagerOptionsFlow(_AllocatesSlotsMixin, config_entries.OptionsFlo
                     unavailable,
                     allocation_errors,
                     allocation_placeholders,
-                ) = await self._async_allocate_for(len(users))
+                ) = await _allocate_for(
+                    self.hass,
+                    user_input[CONF_LOCKS],
+                    len(users),
+                    # Its own numbers do not constrain it: kept ones are held
+                    # by tenure, released ones are free for whoever comes next.
+                    excluding=self.config_entry,
+                )
                 if unavailable is None:
                     errors.update(allocation_errors)
                     description_placeholders.update(allocation_placeholders)

--- a/custom_components/lock_code_manager/domain/config.py
+++ b/custom_components/lock_code_manager/domain/config.py
@@ -356,10 +356,10 @@ class EntryConfigDiff:
     - **By axis** (slot dict + lock list): used by the update listener,
       which adds/removes slot entities and lock providers along independent
       axes.
-    - **By cartesian pair**: ``pairs_added`` / ``pairs_removed`` give
-      ``(lock, slot)`` tuples that are new or gone, which the options flow
-      uses to detect existing-codes hazards on newly-added pairs (catches
-      both "new slot on existing lock" and "new lock with existing slot").
+    - **By cartesian pair**: ``pairs_removed`` gives the ``(lock, slot)``
+      tuples that are gone, which the update listener uses to release the
+      lock-side state a slot owned (catches both "slot dropped from an
+      existing lock" and "lock dropped while its slots remain").
 
     All slot keys are ``int``, inherited from :class:`EntryConfig`.
     """
@@ -372,7 +372,6 @@ class EntryConfigDiff:
     slots_removed: Mapping[int, Mapping[str, Any]] = field(init=False)
     locks_added: tuple[str, ...] = field(init=False)
     locks_removed: tuple[str, ...] = field(init=False)
-    pairs_added: frozenset[tuple[str, int]] = field(init=False)
     pairs_removed: frozenset[tuple[str, int]] = field(init=False)
 
     def __post_init__(self) -> None:
@@ -425,7 +424,6 @@ class EntryConfigDiff:
             "locks_removed",
             tuple(lock for lock in self.old.locks if lock not in new_lock_set),
         )
-        set_field(self, "pairs_added", frozenset(new_pairs - old_pairs))
         set_field(self, "pairs_removed", frozenset(old_pairs - new_pairs))
 
     @property

--- a/custom_components/lock_code_manager/domain/names.py
+++ b/custom_components/lock_code_manager/domain/names.py
@@ -139,34 +139,6 @@ def normalize_slot_names(
     return repaired, changed
 
 
-def validate_slot_names(
-    slots: Mapping[Any, Mapping[str, Any]],
-) -> tuple[str, str] | None:
-    """
-    Return the first ``(slot_num, error_key)`` problem in ``slots``, else None.
-
-    The single-slot config flow validates one name at a time against the
-    slots already accepted, but the YAML and options flows submit every slot
-    at once and need the whole set checked together. Returning the offending
-    slot number lets the caller name it in the error, since "one of your
-    slots has a duplicate name" is not actionable.
-
-    Uniqueness is compared on the normalized, case-folded name, matching how
-    the migration deduplicates -- otherwise a pair the migration would repair
-    could be re-entered by hand.
-    """
-    seen: dict[str, str] = {}
-    for slot_num in sorted(slots, key=int):
-        name = slots[slot_num].get(CONF_NAME)
-        if error := name_error(name):
-            return str(slot_num), error
-        key = identity(name)
-        if key in seen:
-            return str(slot_num), "name_not_unique"
-        seen[key] = str(slot_num)
-    return None
-
-
 def validate_user_names(users: Mapping[str, Any]) -> tuple[str, str] | None:
     """
     Return the first ``(name, error_key)`` problem in ``users``, else None.

--- a/custom_components/lock_code_manager/strings.json
+++ b/custom_components/lock_code_manager/strings.json
@@ -2,7 +2,6 @@
   "config": {
     "abort": {
       "already_configured": "Lock Code Manager config entry with same slugified name already exists.",
-      "existing_codes_cancelled": "Setup cancelled. Existing codes were not modified.",
       "locks_updated": "The locks for your config entry have been updated.",
       "unknown": "An unexpected error occurred during setup."
     },
@@ -38,14 +37,6 @@
         },
         "description": "A user is active when their condition entity (if configured) is 'on'. For calendars, 'on' means an event is in progress. Supported entity types: calendar, binary_sensor, switch, schedule, input_boolean.",
         "title": "User {user_num} of {num_users}"
-      },
-      "existing_codes_confirm": {
-        "title": "Existing Codes Detected",
-        "description": "Existing codes were found on the following lock slots:\n\n{details}\n\nThese codes will be overwritten when the sync manager reconciles the configured state. Continue to proceed or cancel to back out.",
-        "menu_options": {
-          "existing_codes_continue": "Continue",
-          "existing_codes_cancel": "Cancel"
-        }
       },
       "ui": {
         "data": {
@@ -129,7 +120,6 @@
   },
   "options": {
     "abort": {
-      "existing_codes_cancelled": "Update cancelled. Existing codes were not modified.",
       "unknown": "An unexpected error occurred while updating options."
     },
     "error": {
@@ -154,14 +144,6 @@
         },
         "description": "Update the locks that are associated with this config entry and/or the slot configurations.",
         "title": "Lock Code Manager"
-      },
-      "existing_codes_confirm": {
-        "title": "Existing Codes Detected",
-        "description": "Existing codes were found on newly-added lock slots:\n\n{details}\n\nThese codes will be overwritten when the sync manager reconciles the configured state. Continue to proceed or cancel to back out without saving.",
-        "menu_options": {
-          "existing_codes_continue": "Continue",
-          "existing_codes_cancel": "Cancel"
-        }
       }
     }
   },

--- a/custom_components/lock_code_manager/translations/en.json
+++ b/custom_components/lock_code_manager/translations/en.json
@@ -2,7 +2,6 @@
   "config": {
     "abort": {
       "already_configured": "Lock Code Manager config entry with same slugified name already exists.",
-      "existing_codes_cancelled": "Setup cancelled. Existing codes were not modified.",
       "locks_updated": "The locks for your config entry have been updated.",
       "unknown": "An unexpected error occurred during setup."
     },
@@ -38,14 +37,6 @@
         },
         "description": "A user is active when their condition entity (if configured) is 'on'. For calendars, 'on' means an event is in progress. Supported entity types: calendar, binary_sensor, switch, schedule, input_boolean.",
         "title": "User {user_num} of {num_users}"
-      },
-      "existing_codes_confirm": {
-        "title": "Existing Codes Detected",
-        "description": "Existing codes were found on the following lock slots:\n\n{details}\n\nThese codes will be overwritten when the sync manager reconciles the configured state. Continue to proceed or cancel to back out.",
-        "menu_options": {
-          "existing_codes_continue": "Continue",
-          "existing_codes_cancel": "Cancel"
-        }
       },
       "ui": {
         "data": {
@@ -129,7 +120,6 @@
   },
   "options": {
     "abort": {
-      "existing_codes_cancelled": "Update cancelled. Existing codes were not modified.",
       "unknown": "An unexpected error occurred while updating options."
     },
     "error": {
@@ -154,14 +144,6 @@
         },
         "description": "Update the locks that are associated with this config entry and/or the slot configurations.",
         "title": "Lock Code Manager"
-      },
-      "existing_codes_confirm": {
-        "title": "Existing Codes Detected",
-        "description": "Existing codes were found on newly-added lock slots:\n\n{details}\n\nThese codes will be overwritten when the sync manager reconciles the configured state. Continue to proceed or cancel to back out without saving.",
-        "menu_options": {
-          "existing_codes_continue": "Continue",
-          "existing_codes_cancel": "Cancel"
-        }
       }
     }
   },

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -56,7 +56,6 @@ def test_diff_empty_inputs() -> None:
     assert dict(diff.slots_removed) == {}
     assert diff.locks_added == ()
     assert diff.locks_removed == ()
-    assert diff.pairs_added == frozenset()
     assert diff.pairs_removed == frozenset()
     assert not diff.has_changes
     # Source configs are accessible after construction (default to empty)
@@ -72,7 +71,6 @@ def test_diff_added_slots_and_locks() -> None:
 
     assert dict(diff.slots_added) == {1: _named(1), 2: _named(2)}
     assert diff.locks_added == ("lock.a",)
-    assert diff.pairs_added == frozenset({("lock.a", 1), ("lock.a", 2)})
     assert diff.has_changes
 
 
@@ -95,7 +93,6 @@ def test_diff_no_changes() -> None:
     diff = EntryConfigDiff(old=config, new=config)
 
     assert not diff.has_changes
-    assert diff.pairs_added == frozenset()
     assert diff.pairs_removed == frozenset()
 
 
@@ -116,7 +113,6 @@ def test_diff_str_keys_match_int_keys() -> None:
 
     assert dict(diff.slots_added) == {}
     assert dict(diff.slots_removed) == {}
-    assert diff.pairs_added == frozenset()
     assert diff.pairs_removed == frozenset()
     assert not diff.has_changes
 
@@ -150,7 +146,6 @@ def test_diff_pair_added_for_new_lock_with_existing_slot() -> None:
     assert diff.locks_added == ("lock.b",)
     assert dict(diff.slots_added) == {}
     # (lock.b, 1) is new even though slot 1 isn't
-    assert diff.pairs_added == frozenset({("lock.b", 1)})
 
 
 def test_diff_pair_added_for_new_slot_on_existing_lock() -> None:
@@ -161,7 +156,6 @@ def test_diff_pair_added_for_new_slot_on_existing_lock() -> None:
     diff = EntryConfigDiff(old=old, new=new)
 
     assert dict(diff.slots_added) == {2: _named(2)}
-    assert diff.pairs_added == frozenset({("lock.a", 2), ("lock.b", 2)})
 
 
 def test_subtraction_operator_is_diff_sugar() -> None:
@@ -175,7 +169,6 @@ def test_subtraction_operator_is_diff_sugar() -> None:
     # Same diff content (the dataclasses are equal field-for-field;
     # the source configs are also equal so __eq__ matches)
     assert dict(via_operator.slots_added) == dict(via_constructor.slots_added)
-    assert via_operator.pairs_added == via_constructor.pairs_added
     assert via_operator.has_changes is via_constructor.has_changes
 
 
@@ -234,7 +227,6 @@ def test_diff_is_deeply_immutable() -> None:
         diff.slots_removed[1]["pin"] = "9999"  # type: ignore[index]
 
     # Contained sets cannot grow
-    assert not hasattr(diff.pairs_added, "add")
 
     # Contained lists are tuples (no mutation methods)
     assert not hasattr(diff.locks_added, "append")

--- a/tests/test_names.py
+++ b/tests/test_names.py
@@ -9,7 +9,6 @@ from custom_components.lock_code_manager.domain.names import (
     fallback_name,
     name_error,
     normalize_slot_names,
-    validate_slot_names,
 )
 
 
@@ -147,27 +146,6 @@ def test_normalize_accepts_string_slot_keys() -> None:
 
     assert repaired["1"][CONF_NAME] == "User 1"
     assert changed == ["1"]
-
-
-@pytest.mark.parametrize(
-    ("slots", "expected"),
-    [
-        ({1: {CONF_NAME: "Raman"}, 2: {CONF_NAME: "Alice"}}, None),
-        ({1: {CONF_ENABLED: True}}, ("1", "name_required")),
-        ({1: {CONF_NAME: "  "}}, ("1", "name_required")),
-        ({1: {CONF_NAME: "Raman"}, 2: {CONF_NAME: "raman"}}, ("2", "name_not_unique")),
-        # Whitespace-padded duplicates must be caught in BOTH orders. Comparing
-        # a stripped candidate against unstripped stored names caught only one.
-        ({1: {CONF_NAME: "Raman "}, 2: {CONF_NAME: "Raman"}}, ("2", "name_not_unique")),
-        (
-            {1: {CONF_NAME: "Raman"}, 2: {CONF_NAME: " Raman "}},
-            ("2", "name_not_unique"),
-        ),
-    ],
-)
-def test_validate_slot_names(slots, expected) -> None:
-    """Whole-set validation reports the offending slot and why."""
-    assert validate_slot_names(slots) == expected
 
 
 def test_normalize_does_not_steal_a_later_slots_valid_name() -> None:


### PR DESCRIPTION
## Proposed change

Findings from an audit over `main...v3`: an AST pass counting production vs test references for every symbol the branch introduced, and a second pass matching every translation key against anything in the code that could produce it.

**Dead code** — all of it debris from the existing-codes confirmation flow that #1447 removed when allocation started routing around occupied slots instead of asking permission to clear them:

- its ten strings, four key groups across both string files
- `EntryConfigDiff.pairs_added` — computed on every diff, consumed by nothing. Its only consumer was that flow's hazard check. `pairs_removed` stays; the update listener releases slots with it.
- the docstring naming the consumer that no longer exists
- `domain.names.validate_slot_names`, superseded by `validate_user_names`

That last one is worth a note. It is **part of the repository's 100% coverage** — its own test executes every line, so a dead function with a live test is indistinguishable from a healthy one. Coverage measures whether code runs, not whether anything needs it. Reference counting is what finds these.

(`config.abort.already_configured` looks equally orphaned and was **kept** — Home Assistant raises it from `_abort_if_unique_id_configured`.)

**`_AllocatesSlotsMixin` no longer earns being a mixin.** Once allocation moved to `domain/allocation.py`, what remained was two attributes whose only purpose was passing two arguments implicitly (a "set this first" protocol with nothing enforcing it), a twelve-line try/except, and `_create_entry` — which only the config flow called; the options flow used `async_create_entry` directly. It is now a module-level function taking its arguments explicitly. Both flows create their entry the same way, and the config flow's copy of the lock list turned out to be redundant with `self.data[CONF_LOCKS]`.

**One audit finding withdrawn.** I had flagged a runtime import cycle between `domain` and `providers`. Checked properly with Tarjan over the runtime import graph, **there is no cycle** — `domain` is two tiers (a leaf tier providers depend on, and a factory tier that depends on providers), and they never meet. Nothing to fix; no change here.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

Net −118 lines. 1776 passed, 3 skipped, 100% coverage.

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XDxiHpQJkRKWctS9BfQmbY