### PR TITLE
fix: clear a slot's code off the lock when the slot is removed

### DIFF
--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -1671,15 +1671,18 @@ class BaseLock:
         survives PIN clear/rewrite cycles, so it can only be torn down
         when the slot itself is removed from LCM management).
 
-        Default is a no-op: slot-only providers have no user record to
-        tear down, and native-user providers that have not yet migrated
-        to the tag scheme don't carry a recoverable slot binding either.
-        Providers that DO carry the binding (Matter, eventually Z-Wave
-        User Credential CC) override this to find the user tagged for
-        ``slot`` and delete it -- the cascade defined by the lock's
-        protocol then removes the user's credentials.
+        Clears the credential. A slot-only provider has no user record,
+        but the credential IS lock-side state this integration owns, and
+        leaving it programmed means a deleted user's PIN still opens the
+        door -- and that the slot number can never be reissued, because
+        allocation refuses to write over a code it can still read.
+
+        Providers that anchor a slot to a lock-side user (Matter,
+        eventually Z-Wave User Credential CC) override this to delete
+        that user instead; the cascade defined by the lock's protocol
+        removes its credentials, so they must not also clear here.
         """
-        return
+        await self.async_internal_clear_usercode(slot)
 
     async def async_set_user(self, user: User) -> SetUserResult:
         """

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -57,6 +57,7 @@ from custom_components.lock_code_manager.domain.exceptions import (
     LockDisconnected,
 )
 from custom_components.lock_code_manager.domain.models import SlotCredential, SyncState
+from custom_components.lock_code_manager.domain.queries import get_entry_config
 from custom_components.lock_code_manager.repairs import (
     AcknowledgeRepairFlow,
     async_create_fix_flow,
@@ -2223,3 +2224,39 @@ async def test_reclaim_moves_an_entity_off_the_lock_integrations_device(
     assert dev_reg.async_get(lock_device.id) is not None
 
     await hass.config_entries.async_unload(entry_id)
+
+
+async def test_removing_a_slot_clears_its_code_off_the_lock(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+) -> None:
+    """
+    A slot leaving the configuration takes its credential with it.
+
+    Two things go wrong when it does not. The obvious one: a PIN nobody
+    manages any more still opens the door. The quieter one: allocation
+    refuses to issue a number it can still read a code at, so the slot is
+    burned -- every add-then-remove cycle costs a slot the lock never gets
+    back.
+    """
+    entry = lock_code_manager_config_entry
+    locks = list(entry.runtime_data.locks.values())
+    for lock in locks:
+        assert (await lock.async_get_usercodes())[2].pin
+
+    config = dict(entry.data)
+    remaining = {k: v for k, v in config[CONF_SLOTS].items() if int(k) != 2}
+    hass.config_entries.async_update_entry(
+        entry, options={**config, CONF_SLOTS: remaining}
+    )
+    await hass.async_block_till_done()
+
+    assert not get_entry_config(entry).has_slot(2)
+    # Every lock in the entry, not just the first: the slot was written to
+    # all of them.
+    for lock in locks:
+        # A cleared slot may drop out of the lock's view entirely or come
+        # back empty; both mean nothing is programmed there.
+        credential = (await lock.async_get_usercodes()).get(2)
+        assert not (credential and credential.pin)


### PR DESCRIPTION
## Proposed change

Removing a slot from a config entry left its PIN programmed on the lock. **The code keeps opening the door**, and nothing ever comes back for it — the only automatic clear lives in the sync loop, and a removed slot's sync manager is torn down before it could run.

Reproduced against this branch's parent:

```
BEFORE: slot 2 = SlotCredential(present=True, pin='5678')
slot 2 still in config? False
AFTER : slot 2 = SlotCredential(present=True, pin='5678')
```

The teardown path does call `async_release_managed_slot`, but the base implementation was a no-op, reasoning that slot-only providers have no user record to tear down. That is true and beside the point — they own the credential itself. It now clears the credential. Matter overrides this to delete the lock-side user, whose `ClearUser` cascade removes its credentials, so it must not also clear; that override is untouched.

### The second symptom

Allocation refuses to issue a slot number it can still read a code at — correctly, since it cannot tell an orphan from a code someone set by hand. So **every add-then-remove cycle burned a slot the lock never got back.** Rare when removal meant editing YAML; about to become routine.

### How it surfaced

I was testing whether a recycled slot number lets a new user inherit the previous holder's entity IDs. It does not — removal purges the registry rows. But the slot was never recycled in the first place, which is what led here.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

Present since #1239. Targeting `main` rather than `v3` so it reaches released users; v3 will pick it up.

`test_removing_a_slot_clears_its_code_off_the_lock` fails on the parent commit with `assert not '5678'` and passes here. 1571 passed, 3 skipped, 100% coverage.

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XDxiHpQJkRKWctS9BfQmbY