### PR TITLE
fix: what a live migration showed that the tests could not

### DIFF
--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Iterable, Sequence
+from collections.abc import Collection, Iterable, Sequence
 import json
 import logging
 from pathlib import Path
@@ -75,10 +75,12 @@ from .const import (
     CONF_CALENDAR,
     CONF_SLOTS,
     DOMAIN,
+    ENTITY_IDS_RENAMED_ISSUE,
     EVENT_CREDENTIAL_USED,
     LEGACY_EVENT_PIN_USED,
     PLATFORM_MAP,
     PLATFORMS,
+    RENAMES_KEY,
     SERVICE_ADD_USER,
     SERVICE_CLEAR_SLOT_CONDITION,
     SERVICE_CLEAR_USERCODE,
@@ -254,9 +256,12 @@ async def async_migrate_entry(
         # IDENTIFIERS do not move -- unique IDs keep the slot number, so no
         # entity loses its registry entry, its settings or its history. Only
         # the entity IDs are re-slugged, below, once the names are known.
-        new_data, renamed_in_data = migrate_to_users(config_entry.data)
-        new_options, renamed_in_options = migrate_to_users(config_entry.options)
+        new_data, renamed_in_data, dropped_in_data = migrate_to_users(config_entry.data)
+        new_options, renamed_in_options, dropped_in_options = migrate_to_users(
+            config_entry.options
+        )
         renamed = set(renamed_in_data) | set(renamed_in_options)
+        dropped = set(dropped_in_data) | set(dropped_in_options)
         hass.config_entries.async_update_entry(
             config_entry, data=new_data, options=new_options, version=4
         )
@@ -275,21 +280,34 @@ async def async_migrate_entry(
             # not go through it. Automations built from the Slot Usage Limiter
             # and Slot Usage Notifier blueprints hold these ids directly, so
             # the user is given the mapping rather than left to find it.
+            # Accumulated across entries so a system with several of them
+            # gets ONE repair. Every entry migrates in the same restart, and
+            # each re-raises the issue with the union, so whichever goes last
+            # leaves it complete.
+            moved = hass.data.setdefault(DOMAIN, {}).setdefault(RENAMES_KEY, {})
+            moved.update(dict(re_slugged))
             async_create_issue(
                 hass,
                 DOMAIN,
-                f"entity_ids_renamed_{config_entry.entry_id}",
+                ENTITY_IDS_RENAMED_ISSUE,
                 is_fixable=True,
                 is_persistent=True,
                 severity=IssueSeverity.WARNING,
                 translation_key="entity_ids_renamed",
-                translation_placeholders={
-                    "entry_title": config_entry.title,
-                    "renames": format_moved(dict(re_slugged)),
-                },
+                translation_placeholders={"renames": format_moved(moved)},
                 # The flow looks up who still points at these when the user
                 # opens it; the migration only knows what moved.
-                data={"moved": json.dumps(dict(re_slugged))},
+                data={"moved": json.dumps(moved)},
+            )
+        if dropped:
+            _async_purge_dropped_slots(hass, config_entry, dropped)
+            _LOGGER.info(
+                "%s (%s): dropped %d empty slot(s) with neither a name nor a "
+                "PIN: %s. They held no credential and named nobody",
+                config_entry.entry_id,
+                config_entry.title,
+                len(dropped),
+                ", ".join(sorted(dropped, key=int)),
             )
         if renamed:
             _LOGGER.info(
@@ -1103,6 +1121,35 @@ def _async_rename_event_unique_ids(
 
 
 @callback
+def _async_purge_dropped_slots(
+    hass: HomeAssistant,
+    config_entry: LockCodeManagerConfigEntry,
+    dropped: Collection[str],
+) -> None:
+    """
+    Remove the registry rows of slots the migration did not carry across.
+
+    The update listener tears down a slot's entities when it leaves the
+    configuration, but it works from the difference between data and options
+    and the migration writes the new shape to both -- so from its point of
+    view these slots were never there. Left alone they would linger as
+    entities named for a user who does not exist, and a device to match.
+    """
+    slots = {int(slot_num) for slot_num in dropped}
+    ent_reg = er.async_get(hass)
+    for entity in er.async_entries_for_config_entry(ent_reg, config_entry.entry_id):
+        if parse_slot_unique_id(config_entry.entry_id, entity.unique_id) in slots:
+            ent_reg.async_remove(entity.entity_id)
+    dev_reg = dr.async_get(hass)
+    for slot_num in slots:
+        identifiers = {
+            (DOMAIN, build_slot_device_identifier(config_entry.entry_id, slot_num))
+        }
+        if device := dev_reg.async_get_device(identifiers):
+            dev_reg.async_remove_device(device.id)
+
+
+@callback
 def _async_rename_slot_entity_ids(
     hass: HomeAssistant, config_entry: LockCodeManagerConfigEntry
 ) -> list[tuple[str, str]]:
@@ -1146,7 +1193,7 @@ def _async_rename_slot_entity_ids(
             if object_id != old_prefix and not object_id.startswith(f"{old_prefix}_"):
                 continue
             suggested = f"{slugify(name)}{object_id.removeprefix(old_prefix)}"
-        new_entity_id = ent_reg.async_generate_entity_id(
+        new_entity_id = ent_reg.async_get_available_entity_id(
             domain, suggested, current_entity_id=entity.entity_id
         )
         if new_entity_id == entity.entity_id:

--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -1202,7 +1202,8 @@ def _async_rename_slot_entity_ids(
             # read back: ``original_name`` is the text stored when the entity
             # was created, which on an upgraded install predates this shape.
             suggested = (
-                f"{name} {_lock_display_name(ent_reg, lock_entity_id)} "
+                f"{config_entry.title} {name} "
+                f"{_lock_display_name(ent_reg, lock_entity_id)} "
                 f"{PER_LOCK_ENTITY_SUFFIX[entity.unique_id.split('|')[2]]}"
             )
         elif entity.original_name:
@@ -1211,7 +1212,7 @@ def _async_rename_slot_entity_ids(
             # translated for THIS installation, so a system set up in another
             # language re-slugs into its own words -- and none of it depends
             # on the entry's title, which may have changed since.
-            suggested = f"{name} {entity.original_name}"
+            suggested = f"{config_entry.title} {name} {entity.original_name}"
         else:
             # The event entity has no name of its own, and a registry written
             # by an older Home Assistant may not have kept one. Swap the
@@ -1220,7 +1221,10 @@ def _async_rename_slot_entity_ids(
             old_prefix = slugify(f"{config_entry.title} Code slot {slot_num}")
             if object_id != old_prefix and not object_id.startswith(f"{old_prefix}_"):
                 continue
-            suggested = f"{slugify(name)}{object_id.removeprefix(old_prefix)}"
+            suggested = (
+                f"{slugify(f'{config_entry.title} {name}')}"
+                f"{object_id.removeprefix(old_prefix)}"
+            )
         new_entity_id = ent_reg.async_get_available_entity_id(
             domain, suggested, current_entity_id=entity.entity_id
         )
@@ -1253,8 +1257,12 @@ def _async_rename_slot_devices(
     for slot_num, name in ((num, config.name_for(num)) for num in config.slot_numbers):
         identifier = build_slot_device_identifier(entry_id, slot_num)
         device = dev_reg.async_get_device(identifiers={(DOMAIN, identifier)})
-        if device is not None and name and device.name != name:
-            dev_reg.async_update_device(device.id, name=name)
+        # Same shape build_slot_device_info uses, entry title included: a
+        # rename that dropped the prefix would leave the device disagreeing
+        # with the entity IDs derived from it.
+        titled = f"{config_entry.title} {name}" if name else None
+        if device is not None and titled and device.name != titled:
+            dev_reg.async_update_device(device.id, name=titled)
 
 
 @callback

--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -78,6 +78,7 @@ from .const import (
     ENTITY_IDS_RENAMED_ISSUE,
     EVENT_CREDENTIAL_USED,
     LEGACY_EVENT_PIN_USED,
+    PER_LOCK_ENTITY_SUFFIX,
     PLATFORM_MAP,
     PLATFORMS,
     RENAMES_KEY,
@@ -1120,6 +1121,22 @@ def _async_rename_event_unique_ids(
         ent_reg.async_update_entity(entity_id, new_unique_id=wanted)
 
 
+def _lock_of(entry_id: str, unique_id: str) -> str | None:
+    """Return the lock a per-lock entity belongs to, or None if it has none."""
+    parts = unique_id.split("|")
+    return parts[3] if unique_id.startswith(f"{entry_id}|") and len(parts) > 3 else None
+
+
+def _lock_display_name(ent_reg: er.EntityRegistry, lock_entity_id: str) -> str:
+    """Name a lock the way its own integration does."""
+    entity = ent_reg.async_get(lock_entity_id)
+    if entity and (display := entity.name or entity.original_name):
+        return display
+    # No registry row to ask, so fall back to the object id, which is what
+    # the lock's own entity id was slugged from in the first place.
+    return lock_entity_id.split(".", 1)[-1].replace("_", " ")
+
+
 @callback
 def _async_purge_dropped_slots(
     hass: HomeAssistant,
@@ -1177,7 +1194,18 @@ def _async_rename_slot_entity_ids(
         if slot_num is None or not (name := config.name_for(slot_num)):
             continue
         domain, object_id = entity.entity_id.split(".", 1)
-        if entity.original_name:
+        if lock_entity_id := _lock_of(config_entry.entry_id, entity.unique_id):
+            # Per-lock entities are one per lock on the SAME slot device, so
+            # the user's name alone names them all identically and Home
+            # Assistant separates them with a meaningless _2, _3. Their own
+            # name carries the lock, and it has to be rebuilt rather than
+            # read back: ``original_name`` is the text stored when the entity
+            # was created, which on an upgraded install predates this shape.
+            suggested = (
+                f"{name} {_lock_display_name(ent_reg, lock_entity_id)} "
+                f"{PER_LOCK_ENTITY_SUFFIX[entity.unique_id.split('|')[2]]}"
+            )
+        elif entity.original_name:
             # What Home Assistant would generate today: the device's name
             # followed by the entity's own. ``original_name`` is that name as
             # translated for THIS installation, so a system set up in another

--- a/custom_components/lock_code_manager/const.py
+++ b/custom_components/lock_code_manager/const.py
@@ -41,6 +41,12 @@ ATTR_LOCK_CONFIG_ENTRY_ID = "lock_config_entry_id"
 ATTR_EXTRA_DATA = "extra_data"
 ATTR_MANAGED = "managed"
 # One repair for the whole entity-ID rename, however many entries moved.
+# What a per-lock entity is called after the lock's name. Mirrors the
+# ``entity`` names in strings.json, which the migration cannot read: it has to
+# build the id the running integration would generate. test_frontend_contract
+# holds the two together.
+PER_LOCK_ENTITY_SUFFIX = {"code": "PIN", "in_sync": "in sync"}
+
 ENTITY_IDS_RENAMED_ISSUE = "entity_ids_renamed"
 # Where the migration accumulates those renames while entries migrate.
 RENAMES_KEY = "migration_renames"

--- a/custom_components/lock_code_manager/const.py
+++ b/custom_components/lock_code_manager/const.py
@@ -40,6 +40,11 @@ ATTR_LCM_CONFIG_ENTRY_ID = "lock_code_manager_config_entry_id"
 ATTR_LOCK_CONFIG_ENTRY_ID = "lock_config_entry_id"
 ATTR_EXTRA_DATA = "extra_data"
 ATTR_MANAGED = "managed"
+# One repair for the whole entity-ID rename, however many entries moved.
+ENTITY_IDS_RENAMED_ISSUE = "entity_ids_renamed"
+# Where the migration accumulates those renames while entries migrate.
+RENAMES_KEY = "migration_renames"
+
 ATTR_CLEAR_CREDENTIALS = "clear_credentials"
 ATTR_SLOT = "slot"
 ATTR_SLOT_NUM = "slot_num"

--- a/custom_components/lock_code_manager/domain/config.py
+++ b/custom_components/lock_code_manager/domain/config.py
@@ -128,7 +128,9 @@ class EntryConfig:
         if raw_users is None:
             # Converted by the migration's own function so the two cannot
             # disagree about what a slot-keyed entry means.
-            converted, assignment, _ = users_from_slots(mapping.get(CONF_SLOTS) or {})
+            converted, assignment, _, _ = users_from_slots(
+                mapping.get(CONF_SLOTS) or {}
+            )
             users = dict(converted)
         else:
             # Two keys reducing to one identity keep the FIRST. Both

--- a/custom_components/lock_code_manager/domain/slot_assignment.py
+++ b/custom_components/lock_code_manager/domain/slot_assignment.py
@@ -26,9 +26,9 @@ from dataclasses import dataclass
 from types import MappingProxyType
 from typing import Any
 
-from homeassistant.const import CONF_NAME
+from homeassistant.const import CONF_NAME, CONF_PIN
 
-from .names import identity, normalize_slot_names
+from .names import identity, normalize_name, normalize_slot_names
 
 CONF_SLOT_ASSIGNMENT = "slot_assignment"
 
@@ -173,14 +173,14 @@ class SlotAssignment:
 
 def users_from_slots(
     slots: Mapping[Any, Mapping[str, Any]],
-) -> tuple[dict[str, dict[str, Any]], SlotAssignment, list[str]]:
+) -> tuple[dict[str, dict[str, Any]], SlotAssignment, list[str], list[str]]:
     """
     Convert slot-keyed configuration into name-keyed users plus an assignment.
 
-    Pure, so the properties that matter -- nothing lost, nobody renumbered --
-    can be stated over it directly rather than through a config entry. Also
-    returns the slots whose name the repair changed, for the migration to
-    report.
+    Pure, so the properties that matter -- nothing lost that was ever a
+    user, nobody renumbered -- can be stated over it directly rather than
+    through a config entry. Also returns the slots whose name the repair
+    changed, and the empty ones dropped, for the migration to report.
 
     Repairs names itself rather than requiring callers to. The name becomes
     the mapping key here, so a duplicate would collapse two slots into one
@@ -192,11 +192,26 @@ def users_from_slots(
     and a string surviving into the assignment misses ``candidate in taken``
     and issues an already-occupied number.
     """
-    repaired, renamed = normalize_slot_names(slots)
+    # A slot with neither a name nor a PIN is not a person: it is an empty
+    # position left over from choosing how many slots to set up. Naming it
+    # would invent a user who never existed and hold a slot number against
+    # them, so it is dropped instead. Anything with a PIN survives, named
+    # after its number if it has to be -- there is a credential on the lock
+    # and somebody must own it.
+    populated = {
+        slot_num: slot
+        for slot_num, slot in slots.items()
+        if (slot or {}).get(CONF_PIN) or normalize_name((slot or {}).get(CONF_NAME))
+    }
+    dropped = [
+        str(slot_num) for slot_num in sorted(set(slots) - set(populated), key=int)
+    ]
+
+    repaired, renamed = normalize_slot_names(populated)
     users: dict[str, dict[str, Any]] = {}
     assignment: dict[str, int] = {}
     for raw_slot_num, slot in sorted(repaired.items(), key=lambda kv: int(kv[0])):
         name = slot[CONF_NAME]
         users[name] = {k: v for k, v in slot.items() if k != CONF_NAME}
         assignment[name] = int(raw_slot_num)
-    return users, SlotAssignment(slots=assignment), renamed
+    return users, SlotAssignment(slots=assignment), renamed, dropped

--- a/custom_components/lock_code_manager/domain/user_migration.py
+++ b/custom_components/lock_code_manager/domain/user_migration.py
@@ -41,9 +41,13 @@ _CONSUMED = frozenset({CONF_SLOTS, CONF_START_SLOT, CONF_NUM_SLOTS})
 
 def migrate_to_users(
     config: Mapping[str, Any],
-) -> tuple[dict[str, Any], list[str]]:
+) -> tuple[dict[str, Any], list[str], list[str]]:
     """
-    Return the user-keyed form of ``config``, and the slots whose name changed.
+    Return the user-keyed form of ``config``, and what it had to touch.
+
+    Reports the slots whose name changed, and the empty ones dropped: a slot
+    with neither a name nor a PIN was never a user, and carrying it across
+    would invent one.
 
     ``start_slot`` and ``num_slots`` are dropped rather than translated:
     allocation takes the lowest unoccupied slot, and the number of users is
@@ -56,19 +60,23 @@ def migrate_to_users(
         carried = {k: v for k, v in config.items() if k not in _CONSUMED}
         if CONF_USERS in carried:
             carried[CONF_USERS] = _condition_renamed(carried[CONF_USERS])
-        return carried, []
+        return carried, [], []
 
-    users, assignment, renamed = users_from_slots(config[CONF_SLOTS])
+    users, assignment, renamed, dropped = users_from_slots(config[CONF_SLOTS])
     users = _condition_renamed(users)
-    return {
-        **{k: v for k, v in config.items() if k not in _CONSUMED},
-        # Keyed by the name as displayed. The configuration is hand-editable,
-        # and this key is the only place a user's capitalization survives now
-        # that the name is not a field. Uniqueness stays case-insensitive:
-        # storage keeps the display form, comparison folds the case.
-        CONF_USERS: users,
-        CONF_SLOT_ASSIGNMENT: dict(assignment.slots),
-    }, renamed
+    return (
+        {
+            **{k: v for k, v in config.items() if k not in _CONSUMED},
+            # Keyed by the name as displayed. The configuration is hand-editable,
+            # and this key is the only place a user's capitalization survives now
+            # that the name is not a field. Uniqueness stays case-insensitive:
+            # storage keeps the display form, comparison folds the case.
+            CONF_USERS: users,
+            CONF_SLOT_ASSIGNMENT: dict(assignment.slots),
+        },
+        renamed,
+        dropped,
+    )
 
 
 def _condition_renamed(users: Mapping[str, Any]) -> dict[str, dict[str, Any]]:

--- a/custom_components/lock_code_manager/entity.py
+++ b/custom_components/lock_code_manager/entity.py
@@ -47,13 +47,18 @@ def build_slot_device_info(config_entry: ConfigEntry, slot_num: int) -> DeviceIn
     device something the configuration disagrees with. A slot with no user is
     named as the migration would name it: this is reachable while entities are
     being moved off a foreign device before their slot is swept away.
+
+    Prefixed with the entry's title, because the entity IDs Home Assistant
+    derives from this name have to be unique across the whole installation
+    and a name is only unique within its entry. Two entries each holding a
+    "Raman" would otherwise collide into an arbitrary "_2".
     """
+    name = get_entry_config(config_entry).name_for(slot_num) or fallback_name(slot_num)
     return DeviceInfo(
         identifiers={
             (DOMAIN, build_slot_device_identifier(config_entry.entry_id, slot_num))
         },
-        name=get_entry_config(config_entry).name_for(slot_num)
-        or fallback_name(slot_num),
+        name=f"{config_entry.title} {name}",
         manufacturer="Lock Code Manager",
         model="User",
         via_device=(DOMAIN, config_entry.entry_id),

--- a/custom_components/lock_code_manager/repairs.py
+++ b/custom_components/lock_code_manager/repairs.py
@@ -12,7 +12,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.issue_registry import async_delete_issue
 
-from .const import DOMAIN
+from .const import DOMAIN, ENTITY_IDS_RENAMED_ISSUE
 from .domain.exceptions import LockCodeManagerError
 from .domain.locks import get_managed_lock
 from .domain.references import (
@@ -149,7 +149,7 @@ async def async_create_fix_flow(
     if issue_id.startswith(UNMANAGED_ISSUE_KEY):
         assert data is not None
         return UnmanagedCodeRepairFlow(data)
-    if issue_id.startswith("entity_ids_renamed_"):
+    if issue_id == ENTITY_IDS_RENAMED_ISSUE:
         return EntityIdsRenamedRepairFlow(
             issue_id, json.loads((data or {}).get("moved") or "{}")
         )

--- a/custom_components/lock_code_manager/strings.json
+++ b/custom_components/lock_code_manager/strings.json
@@ -356,7 +356,7 @@
         "step": {
           "init": {
             "title": "Entity IDs now follow your users' names",
-            "description": "Lock Code Manager identifies each user by name rather than by slot number, so the entity IDs in **{entry_title}** were renamed:\n\n{renames}\n\nHistory and statistics moved with them, and dashboards built by Lock Code Manager keep working.\n\n**These still refer to the old IDs and need updating**\n\n{referrers}\n\nFor an automation built from a Lock Code Manager blueprint, the quickest fix is to open it and pick the entity again, or recreate it. Lock Code Manager does not edit your automations for you.\n\nSubmit to dismiss this message."
+            "description": "Lock Code Manager identifies each user by name rather than by slot number, so the entity IDs in **Lock Code Manager** were renamed:\n\n{renames}\n\nHistory and statistics moved with them, and dashboards built by Lock Code Manager keep working.\n\n**These still refer to the old IDs and need updating**\n\n{referrers}\n\nFor an automation built from a Lock Code Manager blueprint, the quickest fix is to open it and pick the entity again, or recreate it. Lock Code Manager does not edit your automations for you.\n\nSubmit to dismiss this message."
           }
         }
       }

--- a/custom_components/lock_code_manager/strings.json
+++ b/custom_components/lock_code_manager/strings.json
@@ -101,7 +101,7 @@
     },
     "sensor": {
       "code": {
-        "name": "{lock_name} code"
+        "name": "{lock_name} PIN"
       }
     },
     "switch": {

--- a/custom_components/lock_code_manager/translations/en.json
+++ b/custom_components/lock_code_manager/translations/en.json
@@ -356,7 +356,7 @@
         "step": {
           "init": {
             "title": "Entity IDs now follow your users' names",
-            "description": "Lock Code Manager identifies each user by name rather than by slot number, so the entity IDs in **{entry_title}** were renamed:\n\n{renames}\n\nHistory and statistics moved with them, and dashboards built by Lock Code Manager keep working.\n\n**These still refer to the old IDs and need updating**\n\n{referrers}\n\nFor an automation built from a Lock Code Manager blueprint, the quickest fix is to open it and pick the entity again, or recreate it. Lock Code Manager does not edit your automations for you.\n\nSubmit to dismiss this message."
+            "description": "Lock Code Manager identifies each user by name rather than by slot number, so the entity IDs in **Lock Code Manager** were renamed:\n\n{renames}\n\nHistory and statistics moved with them, and dashboards built by Lock Code Manager keep working.\n\n**These still refer to the old IDs and need updating**\n\n{referrers}\n\nFor an automation built from a Lock Code Manager blueprint, the quickest fix is to open it and pick the entity again, or recreate it. Lock Code Manager does not edit your automations for you.\n\nSubmit to dismiss this message."
           }
         }
       }

--- a/custom_components/lock_code_manager/translations/en.json
+++ b/custom_components/lock_code_manager/translations/en.json
@@ -101,7 +101,7 @@
     },
     "sensor": {
       "code": {
-        "name": "{lock_name} code"
+        "name": "{lock_name} PIN"
       }
     },
     "switch": {

--- a/tests/common.py
+++ b/tests/common.py
@@ -122,19 +122,19 @@ def slot_entity_id(
 # The integration the mock lock entities belong to.
 LOCK_DEVICE_DOMAIN = "test"
 
-SLOT_1_ACTIVE_ENTITY = "binary_sensor.test1_active"
-SLOT_1_ENABLED_ENTITY = "switch.test1_enabled"
-SLOT_1_EVENT_ENTITY = "event.test1"
-SLOT_1_NAME_ENTITY = "text.test1_name"
-SLOT_1_PIN_ENTITY = "text.test1_pin"
-SLOT_1_IN_SYNC_ENTITY = "binary_sensor.test1_test_1_in_sync"
+SLOT_1_ACTIVE_ENTITY = "binary_sensor.mock_title_test1_active"
+SLOT_1_ENABLED_ENTITY = "switch.mock_title_test1_enabled"
+SLOT_1_EVENT_ENTITY = "event.mock_title_test1"
+SLOT_1_NAME_ENTITY = "text.mock_title_test1_name"
+SLOT_1_PIN_ENTITY = "text.mock_title_test1_pin"
+SLOT_1_IN_SYNC_ENTITY = "binary_sensor.mock_title_test1_test_1_in_sync"
 
-SLOT_2_ENABLED_ENTITY = "switch.test2_enabled"
-SLOT_2_ACTIVE_ENTITY = "binary_sensor.test2_active"
-SLOT_2_EVENT_ENTITY = "event.test2"
-SLOT_2_PIN_ENTITY = "text.test2_pin"
-SLOT_2_NAME_ENTITY = "text.test2_name"
-SLOT_2_IN_SYNC_ENTITY = "binary_sensor.test2_test_1_in_sync"
+SLOT_2_ENABLED_ENTITY = "switch.mock_title_test2_enabled"
+SLOT_2_ACTIVE_ENTITY = "binary_sensor.mock_title_test2_active"
+SLOT_2_EVENT_ENTITY = "event.mock_title_test2"
+SLOT_2_PIN_ENTITY = "text.mock_title_test2_pin"
+SLOT_2_NAME_ENTITY = "text.mock_title_test2_name"
+SLOT_2_IN_SYNC_ENTITY = "binary_sensor.mock_title_test2_test_1_in_sync"
 
 
 @dataclass(repr=False, eq=False)

--- a/tests/properties/test_slot_assignment.py
+++ b/tests/properties/test_slot_assignment.py
@@ -82,7 +82,7 @@ def stored_slot_mappings(draw: st.DrawFn) -> dict:
 @given(slots=slot_mappings())
 def test_conversion_loses_no_user(slots: dict[int, dict]) -> None:
     """Every configured slot becomes exactly one user."""
-    users, assignment, _ = users_from_slots(slots)
+    users, assignment, _, _dropped = users_from_slots(slots)
 
     assert len(users) == len(slots)
     assert set(users) == {slot[CONF_NAME] for slot in slots.values()}
@@ -101,7 +101,7 @@ def test_conversion_loses_no_field(slots: dict[int, dict]) -> None:
     going missing is silent data loss -- the result still validates, the user
     just quietly has no code.
     """
-    users, _, _ = users_from_slots(slots)
+    users, _, _, _dropped = users_from_slots(slots)
 
     for slot in slots.values():
         user = users[slot[CONF_NAME]]
@@ -117,7 +117,7 @@ def test_conversion_renumbers_nobody(slots: dict[int, dict]) -> None:
     changed would have their entities orphaned AND their code written to a
     different index.
     """
-    _, assignment, _ = users_from_slots(slots)
+    _, assignment, _, _dropped = users_from_slots(slots)
 
     for slot_num, slot in slots.items():
         assert assignment.slot(slot[CONF_NAME]) == slot_num
@@ -131,7 +131,7 @@ def test_conversion_round_trips(slots: dict[int, dict]) -> None:
     reshaping that happens to preserve counts and fields separately while
     still pairing them up wrongly.
     """
-    users, assignment, _ = users_from_slots(slots)
+    users, assignment, _, _dropped = users_from_slots(slots)
 
     rebuilt = {
         assignment.slot(name): {CONF_NAME: name, **user} for name, user in users.items()
@@ -250,7 +250,7 @@ def test_editing_after_a_migration_never_double_books_a_slot(
     storage, never from ``empty()``. That gap hid a string-key collision that
     issued one credential index to two users.
     """
-    _, assignment, _ = users_from_slots(stored)
+    _, assignment, _, _dropped = users_from_slots(stored)
     after = _reconcile(assignment, [*assignment.slots, *later], start=start)
 
     numbers = list(after.slots.values())
@@ -261,7 +261,7 @@ def test_editing_after_a_migration_never_double_books_a_slot(
 @given(stored=stored_slot_mappings())
 def test_migration_always_produces_one_user_per_slot(stored: dict) -> None:
     """No slot is lost to a missing or duplicated name."""
-    users, assignment, _ = users_from_slots(stored)
+    users, assignment, _, _dropped = users_from_slots(stored)
 
     assert len(users) == len(stored)
     assert len(assignment.slots) == len(stored)
@@ -271,7 +271,7 @@ def test_migration_always_produces_one_user_per_slot(stored: dict) -> None:
 @given(stored=stored_slot_mappings())
 def test_repair_pairs_each_user_with_their_own_fields_and_slot(stored: dict) -> None:
     """Repaired names stay attached to the right fields and the right slot."""
-    users, assignment, _ = users_from_slots(stored)
+    users, assignment, _, _dropped = users_from_slots(stored)
     repaired, _ = normalize_slot_names(stored)
 
     for raw_key, slot in repaired.items():
@@ -401,7 +401,7 @@ def test_a_migration_cannot_persist_two_users_on_one_number() -> None:
     persisted straight out of a migration that has no rollback, and both users
     would overwrite each other on the lock every sync.
     """
-    _, assignment, _ = users_from_slots(
+    _, assignment, _, _dropped = users_from_slots(
         {"01": {CONF_NAME: "A", CONF_PIN: "1"}, "1": {CONF_NAME: "B", CONF_PIN: "2"}}
     )
 

--- a/tests/properties/test_user_migration.py
+++ b/tests/properties/test_user_migration.py
@@ -79,7 +79,7 @@ def v2_entries(draw: st.DrawFn) -> dict:
 @given(entry=v2_entries())
 def test_every_slot_becomes_exactly_one_user(entry: dict) -> None:
     """Nobody is lost, however badly the names were configured."""
-    migrated, _ = migrate_to_users(entry)
+    migrated, _, _dropped = migrate_to_users(entry)
 
     assert len(migrated[CONF_USERS]) == len(entry[CONF_SLOTS])
 
@@ -92,7 +92,7 @@ def test_nobody_is_renumbered(entry: dict) -> None:
     the lock, so a changed number orphans that user's entities and writes
     their code to a different index.
     """
-    migrated, _ = migrate_to_users(entry)
+    migrated, _, _dropped = migrate_to_users(entry)
     assignment = SlotAssignment(slots=migrated[CONF_SLOT_ASSIGNMENT])
 
     assert sorted(assignment.slots.values()) == sorted(
@@ -109,7 +109,7 @@ def test_no_field_is_lost_except_the_name(entry: dict) -> None:
     Anything else going missing is silent: the result still validates, the
     user simply has no code any more.
     """
-    migrated, _ = migrate_to_users(entry)
+    migrated, _, _dropped = migrate_to_users(entry)
     assignment = SlotAssignment(slots=migrated[CONF_SLOT_ASSIGNMENT])
     by_slot = {
         assignment.slot(name): user for name, user in migrated[CONF_USERS].items()
@@ -127,7 +127,7 @@ def test_the_retired_keys_are_gone(entry: dict) -> None:
     Allocation takes the lowest unoccupied slot, so a start slot configures
     nothing; a stale key would eventually be read by something.
     """
-    migrated, _ = migrate_to_users(entry)
+    migrated, _, _dropped = migrate_to_users(entry)
 
     assert CONF_SLOTS not in migrated
     assert CONF_START_SLOT not in migrated
@@ -137,7 +137,7 @@ def test_the_retired_keys_are_gone(entry: dict) -> None:
 @given(entry=v2_entries())
 def test_everything_else_is_carried_through(entry: dict) -> None:
     """Locks and any key this migration does not know about survive verbatim."""
-    migrated, _ = migrate_to_users(entry)
+    migrated, _, _dropped = migrate_to_users(entry)
 
     assert migrated[CONF_LOCKS] == entry[CONF_LOCKS]
     if "some_future_key" in entry:
@@ -155,7 +155,7 @@ def test_user_keys_keep_the_name_as_displayed(entry: dict) -> None:
     Uniqueness stays case-insensitive: storage keeps the display form,
     comparison folds the case.
     """
-    migrated, _ = migrate_to_users(entry)
+    migrated, _, _dropped = migrate_to_users(entry)
 
     for name in migrated[CONF_USERS]:
         assert name == name.strip()
@@ -170,8 +170,8 @@ def test_migrating_twice_changes_nothing(entry: dict) -> None:
     The version stamp should prevent a second run, but a migration with no
     rollback should not depend on that.
     """
-    once, _ = migrate_to_users(entry)
-    twice, renamed = migrate_to_users(once)
+    once, _, _dropped = migrate_to_users(entry)
+    twice, renamed, _dropped = migrate_to_users(once)
 
     assert twice == once
     assert renamed == []

--- a/tests/providers/zwave_js/test_provider.py
+++ b/tests/providers/zwave_js/test_provider.py
@@ -19,6 +19,7 @@ from zwave_js_server.model.node import Node
 from homeassistant.components.zwave_js import lock_helpers
 from homeassistant.components.zwave_js.const import DOMAIN as ZWAVE_JS_DOMAIN
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 
@@ -341,7 +342,7 @@ async def test_hard_refresh_codes_calls_access_control(
         domain=DOMAIN,
         data={
             CONF_LOCKS: [zwave_js_lock.lock.entity_id],
-            CONF_SLOTS: {"1": {}, "2": {}},
+            CONF_SLOTS: {"1": {CONF_NAME: "User 1"}, "2": {CONF_NAME: "User 2"}},
         },
     )
     lcm_entry.add_to_hass(hass)
@@ -409,7 +410,7 @@ async def test_async_get_usercodes_returns_projection_with_managed_slots(
         domain=DOMAIN,
         data={
             CONF_LOCKS: [zwave_js_lock.lock.entity_id],
-            CONF_SLOTS: {"3": {}, "4": {}},
+            CONF_SLOTS: {"3": {CONF_NAME: "User 3"}, "4": {CONF_NAME: "User 4"}},
         },
     )
     lcm_entry.add_to_hass(hass)
@@ -443,7 +444,7 @@ async def test_async_get_usercodes_overlays_pin_credentials(
         domain=DOMAIN,
         data={
             CONF_LOCKS: [zwave_js_lock.lock.entity_id],
-            CONF_SLOTS: {"1": {}, "3": {}},
+            CONF_SLOTS: {"1": {CONF_NAME: "User 1"}, "3": {CONF_NAME: "User 3"}},
         },
     )
     lcm_entry.add_to_hass(hass)
@@ -496,7 +497,7 @@ async def test_async_get_usercodes_reports_occupied_uc_slot_as_unreadable(
         domain=DOMAIN,
         data={
             CONF_LOCKS: [zwave_js_lock.lock.entity_id],
-            CONF_SLOTS: {"2": {}, "3": {}},
+            CONF_SLOTS: {"2": {CONF_NAME: "User 2"}, "3": {CONF_NAME: "User 3"}},
         },
     )
     lcm_entry.add_to_hass(hass)
@@ -536,7 +537,7 @@ async def test_async_get_usercodes_reports_occupied_slot_with_no_user_as_unreada
         domain=DOMAIN,
         data={
             CONF_LOCKS: [zwave_js_lock.lock.entity_id],
-            CONF_SLOTS: {"1": {}, "3": {}},
+            CONF_SLOTS: {"1": {CONF_NAME: "User 1"}, "3": {CONF_NAME: "User 3"}},
         },
     )
     lcm_entry.add_to_hass(hass)
@@ -568,7 +569,7 @@ async def test_async_get_usercodes_readable_credential_outranks_uc_occupancy(
         domain=DOMAIN,
         data={
             CONF_LOCKS: [zwave_js_lock.lock.entity_id],
-            CONF_SLOTS: {"1": {}, "2": {}},
+            CONF_SLOTS: {"1": {CONF_NAME: "User 1"}, "2": {CONF_NAME: "User 2"}},
         },
     )
     lcm_entry.add_to_hass(hass)
@@ -626,7 +627,7 @@ async def test_async_get_usercodes_skips_uc_occupancy_without_user_code_cc(
         domain=DOMAIN,
         data={
             CONF_LOCKS: [zwave_js_lock.lock.entity_id],
-            CONF_SLOTS: {"1": {}, "2": {}},
+            CONF_SLOTS: {"1": {CONF_NAME: "User 1"}, "2": {CONF_NAME: "User 2"}},
         },
     )
     lcm_entry.add_to_hass(hass)
@@ -658,7 +659,7 @@ async def test_async_internal_set_usercode_calls_primitives(
         domain=DOMAIN,
         data={
             CONF_LOCKS: [zwave_js_lock.lock.entity_id],
-            CONF_SLOTS: {"1": {}},
+            CONF_SLOTS: {"1": {CONF_NAME: "User 1"}},
         },
     )
     lcm_entry.add_to_hass(hass)
@@ -701,7 +702,7 @@ async def test_async_internal_clear_usercode_calls_delete_primitives(
         domain=DOMAIN,
         data={
             CONF_LOCKS: [zwave_js_lock.lock.entity_id],
-            CONF_SLOTS: {"1": {}},
+            CONF_SLOTS: {"1": {CONF_NAME: "User 1"}},
         },
     )
     lcm_entry.add_to_hass(hass)
@@ -1696,7 +1697,7 @@ async def test_set_usercode_user_code_cc_skips_set_user_and_writes_credential_on
         domain=DOMAIN,
         data={
             CONF_LOCKS: [zwave_js_lock.lock.entity_id],
-            CONF_SLOTS: {"5": {}},
+            CONF_SLOTS: {"5": {CONF_NAME: "User 5"}},
         },
     )
     lcm_entry.add_to_hass(hass)
@@ -1772,7 +1773,7 @@ async def test_async_set_usercode_builds_tagged_name_within_lock_limit(
         domain=DOMAIN,
         data={
             CONF_LOCKS: [zwave_js_lock.lock.entity_id],
-            CONF_SLOTS: {"1": {}},
+            CONF_SLOTS: {"1": {CONF_NAME: "User 1"}},
         },
     )
     lcm_entry.add_to_hass(hass)

--- a/tests/test_frontend_contract.py
+++ b/tests/test_frontend_contract.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import pathlib
 import re
 
@@ -15,6 +16,7 @@ from custom_components.lock_code_manager.const import (
     ATTR_IN_SYNC,
     CONDITION_ENTITY_DOMAINS,
     EVENT_CREDENTIAL_USED,
+    PER_LOCK_ENTITY_SUFFIX,
 )
 from custom_components.lock_code_manager.domain.config import build_slot_unique_id
 
@@ -155,3 +157,32 @@ def test_the_frontend_and_backend_agree_on_the_slot_payload() -> None:
         CONF_NAME,
         CONF_CONDITION,
     }
+
+
+def test_per_lock_suffixes_match_the_entity_names() -> None:
+    """
+    The migration's per-lock suffixes are the ones the entities really use.
+
+    The migration has to build the entity ID the running integration would
+    generate, but it runs before any entity exists, so it cannot read the
+    name off one. It carries its own copy of the suffix instead -- and a copy
+    that drifts renames every per-lock entity onto an ID nothing else agrees
+    with.
+    """
+    names = json.loads(
+        (
+            pathlib.Path(__file__).resolve().parent.parent
+            / "custom_components"
+            / "lock_code_manager"
+            / "strings.json"
+        ).read_text()
+    )["entity"]
+
+    for key, suffix in PER_LOCK_ENTITY_SUFFIX.items():
+        declared = next(
+            entity["name"]
+            for domain in names.values()
+            for entity_key, entity in domain.items()
+            if entity_key == key
+        )
+        assert declared == f"{{lock_name}} {suffix}"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2064,7 +2064,8 @@ async def test_setup_reclaims_entities_left_on_a_split_device(
         {(DOMAIN, build_slot_device_identifier(entry_id, 1))}
     )
     assert slot_device
-    assert ent_reg.async_get(stranded.entity_id).device_id == slot_device.id
+    reclaimed = ent_reg.async_get_entity_id(stranded.domain, DOMAIN, stranded.unique_id)
+    assert ent_reg.async_get(reclaimed).device_id == slot_device.id
     assert dev_reg.async_get(split.id) is None
 
     await hass.config_entries.async_unload(entry_id)
@@ -2156,7 +2157,12 @@ async def test_reclaim_skips_entities_it_has_no_slot_device_for(
 
     assert ent_reg.async_get(no_device.entity_id).device_id is None
     # Already on one of our devices, so the sweep has nothing to do for it.
-    assert ent_reg.async_get(settled.entity_id).device_id == ours.id
+    assert (
+        ent_reg.async_get(
+            ent_reg.async_get_entity_id(settled.domain, DOMAIN, settled.unique_id)
+        ).device_id
+        == ours.id
+    )
     # Still on the foreign device, which therefore survives the removal pass.
     assert ent_reg.async_get(unparseable.entity_id).device_id == foreign.id
     assert dev_reg.async_get(foreign.id) is not None
@@ -2233,7 +2239,9 @@ async def test_reclaim_moves_a_disabled_entity_rather_than_deleting_it(
     await hass.config_entries.async_setup(entry_id)
     await hass.async_block_till_done()
 
-    survivor = ent_reg.async_get(disabled.entity_id)
+    survivor = ent_reg.async_get(
+        ent_reg.async_get_entity_id(disabled.domain, DOMAIN, disabled.unique_id)
+    )
     assert survivor is not None
     assert survivor.disabled_by is er.RegistryEntryDisabler.USER
     slot_device = dev_reg.async_get_device(
@@ -2328,7 +2336,8 @@ async def test_reclaim_moves_an_entity_off_the_lock_integrations_device(
         {(DOMAIN, build_slot_device_identifier(entry_id, 1))}
     )
     assert slot_device
-    assert ent_reg.async_get(stranded.entity_id).device_id == slot_device.id
+    reclaimed = ent_reg.async_get_entity_id(stranded.domain, DOMAIN, stranded.unique_id)
+    assert ent_reg.async_get(reclaimed).device_id == slot_device.id
     # The lock's own device is another integration's and must survive.
     assert dev_reg.async_get(lock_device.id) is not None
 
@@ -2819,3 +2828,103 @@ async def test_removing_a_slot_clears_its_code_off_the_lock(
         # back empty; both mean nothing is programmed there.
         credential = (await lock.async_get_usercodes()).get(2)
         assert not (credential and credential.pin)
+
+
+async def test_a_per_lock_entity_id_names_the_lock_it_belongs_to(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """
+    One user, several locks: each per-lock entity has to say which lock.
+
+    They all sit on the same slot device, so naming them after the user alone
+    makes identical slugs and Home Assistant separates them with _2 and _3 --
+    suffixes assigned in whatever order the rename happened to run, which
+    identify nothing and are worse than the lock-shaped IDs they replaced.
+    Rebuilding the name from the lock is what keeps them tellable apart.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="All Locks",
+        data={
+            CONF_LOCKS: [LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID],
+            CONF_SLOTS: {1: {"enabled": True, "name": "Raman", "pin": "1111"}},
+        },
+        version=3,
+        minor_version=1,
+    )
+    entry.add_to_hass(hass)
+    ent_reg = er.async_get(hass)
+    for lock_entity_id in (LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID):
+        ent_reg.async_get_or_create(
+            "sensor",
+            DOMAIN,
+            f"{entry.entry_id}|1|{ATTR_CODE}|{lock_entity_id}",
+            config_entry=entry,
+            suggested_object_id=f"{lock_entity_id.split('.')[1]}_code_slot_1",
+            # As a released version stored it: no lock in the entity's own
+            # name, which is why it cannot be read back and reused.
+            original_name="Code slot 1",
+        )
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    moved = [
+        ent_reg.async_get_entity_id(
+            "sensor", DOMAIN, f"{entry.entry_id}|1|{ATTR_CODE}|{lock_entity_id}"
+        )
+        for lock_entity_id in (LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID)
+    ]
+    # The user, then the lock, then the credential type -- no slot number and
+    # no collision suffix.
+    assert moved == ["sensor.raman_test_1_pin", "sensor.raman_test_2_pin"]
+
+    await hass.config_entries.async_unload(entry.entry_id)
+
+
+async def test_a_per_lock_entity_survives_its_lock_leaving_the_registry(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """
+    A lock with no registry row still has to name its entities.
+
+    The lock's entity can be gone by the time this runs -- excluded from
+    Z-Wave, integration removed -- while Lock Code Manager's own entities for
+    it remain. Skipping them would leave slot-shaped IDs behind forever, so
+    the name falls back to the lock's object id, which is what its entity id
+    was slugged from to begin with.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="All Locks",
+        data={
+            CONF_LOCKS: ["lock.departed"],
+            CONF_SLOTS: {1: {"enabled": True, "name": "Raman", "pin": "1111"}},
+        },
+        version=3,
+        minor_version=1,
+    )
+    entry.add_to_hass(hass)
+    ent_reg = er.async_get(hass)
+    ent_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        f"{entry.entry_id}|1|{ATTR_CODE}|lock.departed",
+        config_entry=entry,
+        suggested_object_id="departed_code_slot_1",
+        original_name="Code slot 1",
+    )
+    assert ent_reg.async_get("lock.departed") is None
+
+    # Setup itself cannot succeed without the lock, but the migration runs
+    # ahead of it, so the rename still has to do something sensible.
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    assert entry.version == 4
+
+    assert (
+        ent_reg.async_get_entity_id(
+            "sensor", DOMAIN, f"{entry.entry_id}|1|{ATTR_CODE}|lock.departed"
+        )
+        == "sensor.raman_departed_pin"
+    )

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2367,10 +2367,10 @@ async def test_migration_of_a_real_world_entry_shape(
             "slots": {
                 1: {"enabled": True, "name": "Raman and Sherene", "pin": "1111"},
                 2: {"enabled": True, "name": "Housekeeper", "pin": "2222"},
-                3: {"enabled": False, "name": "", "pin": "3333"},
+                3: {"enabled": False, "name": ""},
                 4: {"enabled": False},
                 5: {"enabled": False},
-                6: {"enabled": False, "name": "", "pin": "6666"},
+                6: {"enabled": False, "name": ""},
             },
         },
         version=3,
@@ -2407,18 +2407,11 @@ async def test_migration_of_a_real_world_entry_shape(
     config = get_entry_config(entry)
     assert entry.version == 4
     # Nobody lost, and nobody renumbered: the number is the entities' key.
-    # 4 and 5 held nothing and named nobody, so they are gone. 3 and 6 had
-    # no name but did have a PIN, so they stayed and were given one.
-    assert sorted(config.assignment.slots.values()) == [1, 2, 3, 6]
+    # Only the two people. Everything else held nothing and named nobody.
+    assert sorted(config.assignment.slots.values()) == [1, 2]
     assert config.name_for(1) == "Raman and Sherene"
     assert config.name_for(2) == "Housekeeper"
-    assert config.name_for(3) == "User 3"
-    assert config.name_for(6) == "User 6"
-    assert not config.has_slot(4)
-    assert not config.has_slot(5)
-    # A disabled slot's PIN is still its PIN.
-    assert config.slot(3)[CONF_PIN] == "3333"
-    assert config.slot(6)[CONF_PIN] == "6666"
+    assert not any(config.has_slot(slot) for slot in (3, 4, 5, 6))
 
     # The entity IDs move onto the users, but the registry ENTRIES are the
     # same rows: everything hanging off them -- settings, area, and the
@@ -2438,7 +2431,7 @@ async def test_migration_of_a_real_world_entry_shape(
                 is None
             )
             continue
-        assert moved == f"text.{slugify(config.name_for(slot))}_pin"
+        assert moved == f"text.{slugify(f'{entry.title} {config.name_for(slot)}')}_pin"
         assert ent_reg.async_get(moved).id == entry_before.id
 
     await hass.config_entries.async_unload(entry.entry_id)
@@ -2457,7 +2450,12 @@ async def test_a_slot_device_is_named_for_the_user_who_holds_it(
     for slot_num in config.slot_numbers:
         device = dev_reg.async_get_device({(DOMAIN, f"{entry_id}|{slot_num}")})
         assert device is not None
-        assert device.name == config.name_for(slot_num)
+        # Prefixed with the entry title, which is what makes the entity IDs
+        # derived from it unique across entries.
+        assert (
+            device.name
+            == f"{lock_code_manager_config_entry.title} {config.name_for(slot_num)}"
+        )
 
 
 async def test_renaming_a_user_renames_their_device(
@@ -2476,7 +2474,7 @@ async def test_renaming_a_user_renames_their_device(
     dev_reg = dr.async_get(hass)
     identifiers = {(DOMAIN, f"{entry_id}|1")}
     before = get_entry_config(lock_code_manager_config_entry).name_for(1)
-    assert dev_reg.async_get_device(identifiers).name == before
+    assert dev_reg.async_get_device(identifiers).name == f"Mock Title {before}"
 
     await hass.services.async_call(
         TEXT_DOMAIN,
@@ -2488,7 +2486,7 @@ async def test_renaming_a_user_renames_their_device(
     await hass.async_block_till_done()
 
     assert get_entry_config(lock_code_manager_config_entry).name_for(1) == "Sherene"
-    assert dev_reg.async_get_device(identifiers).name == "Sherene"
+    assert dev_reg.async_get_device(identifiers).name == "Mock Title Sherene"
 
 
 async def test_migration_reslugs_entity_ids_onto_the_user_name(
@@ -2531,7 +2529,7 @@ async def test_migration_reslugs_entity_ids_onto_the_user_name(
     after = ent_reg.async_get_entity_id(
         "text", DOMAIN, f"{entry.entry_id}|1|{CONF_PIN}"
     )
-    assert after == "text.raman_pin"
+    assert after == "text.all_locks_raman_pin"
     # Same registry entry, so everything hanging off it came along.
     assert ent_reg.async_get(after).id == before.id
     assert ent_reg.async_get(after).area_id == "kitchen"
@@ -2594,10 +2592,13 @@ async def test_migration_renames_even_after_the_entry_was_retitled(
     The entry's title is not a way back to an existing entity ID.
 
     An entity is slugged from the title in force when it was created, so
-    rebuilding the old ID from today's title matches nothing once the entry
-    has been renamed -- and silently renamed nothing at all. The registry's
+    rebuilding the OLD ID from today's title matches nothing once the entry
+    has been renamed -- and silently renames nothing at all. The registry's
     own ``original_name`` is what a released version left behind, and it does
     not depend on the title.
+
+    The NEW ID does use today's title, because that is what the device is
+    named and what a fresh install would generate.
     """
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -2625,7 +2626,7 @@ async def test_migration_renames_even_after_the_entry_was_retitled(
 
     assert (
         ent_reg.async_get_entity_id("text", DOMAIN, f"{entry.entry_id}|1|{CONF_PIN}")
-        == "text.raman_pin"
+        == "text.renamed_since_raman_pin"
     )
 
     await hass.config_entries.async_unload(entry.entry_id)
@@ -2653,16 +2654,16 @@ async def test_migration_leaves_an_entity_that_already_has_the_right_id(
         f"{entry.entry_id}|1|{CONF_PIN}",
         config_entry=entry,
         original_name="PIN",
-        suggested_object_id="raman_pin",
+        suggested_object_id="all_locks_raman_pin",
     )
-    assert before.entity_id == "text.raman_pin"
+    assert before.entity_id == "text.all_locks_raman_pin"
 
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
     assert (
         ent_reg.async_get_entity_id("text", DOMAIN, f"{entry.entry_id}|1|{CONF_PIN}")
-        == "text.raman_pin"
+        == "text.all_locks_raman_pin"
     )
     # Nothing moved, so the user is not told anything moved.
     assert ir.async_get(hass).async_get_issue(DOMAIN, ENTITY_IDS_RENAMED_ISSUE) is None
@@ -2877,7 +2878,10 @@ async def test_a_per_lock_entity_id_names_the_lock_it_belongs_to(
     ]
     # The user, then the lock, then the credential type -- no slot number and
     # no collision suffix.
-    assert moved == ["sensor.raman_test_1_pin", "sensor.raman_test_2_pin"]
+    assert moved == [
+        "sensor.all_locks_raman_test_1_pin",
+        "sensor.all_locks_raman_test_2_pin",
+    ]
 
     await hass.config_entries.async_unload(entry.entry_id)
 
@@ -2926,5 +2930,49 @@ async def test_a_per_lock_entity_survives_its_lock_leaving_the_registry(
         ent_reg.async_get_entity_id(
             "sensor", DOMAIN, f"{entry.entry_id}|1|{ATTR_CODE}|lock.departed"
         )
-        == "sensor.raman_departed_pin"
+        == "sensor.all_locks_raman_departed_pin"
     )
+
+
+@pytest.mark.parametrize("enabled", [True, False])
+async def test_a_slot_with_a_pin_but_no_name_survives_being_migrated(
+    hass: HomeAssistant, mock_lock_config_entry, enabled: bool
+) -> None:
+    """
+    Constructed, not captured: a PIN with no name, which only 4.x could make.
+
+    Its schema left both the name and the PIN optional and only required a
+    PIN when the slot was enabled, so a nameless slot could hold one -- and
+    could be switched on, putting a live code on the lock belonging to
+    nobody. The user-centric shape cannot express this at all, because the
+    name is the key a user is stored under, so it arrives only by migration.
+
+    Either way the slot survives and is named after its number, but for
+    different reasons: enabled, there is a credential on the lock and
+    somebody has to own it; disabled, the PIN is only stored configuration,
+    and dropping it would delete something the owner typed.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="All Locks",
+        data={
+            CONF_LOCKS: [LOCK_1_ENTITY_ID],
+            CONF_SLOTS: {
+                1: {"enabled": True, "name": "Raman", "pin": "1111"},
+                2: {"enabled": enabled, "name": "", "pin": "2222"},
+            },
+        },
+        version=3,
+        minor_version=1,
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    config = get_entry_config(entry)
+    assert sorted(config.assignment.slots.values()) == [1, 2]
+    assert config.name_for(2) == "User 2"
+    assert config.slot(2)[CONF_PIN] == "2222"
+
+    await hass.config_entries.async_unload(entry.entry_id)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -54,6 +54,7 @@ from custom_components.lock_code_manager.const import (
     CONF_SLOTS,
     CONF_USERS,
     DOMAIN,
+    ENTITY_IDS_RENAMED_ISSUE,
     EVENT_CREDENTIAL_USED,
     SERVICE_DEOBFUSCATE_LOG,
     SERVICE_HARD_REFRESH_USERCODES,
@@ -2339,11 +2340,15 @@ async def test_migration_of_a_real_world_entry_shape(
 ) -> None:
     """A shape taken from a production entry, not invented for the test.
 
-    Real configurations carry things a hand-written case tends not to: slots
-    whose name is the empty string, slots with no name key at all, and
-    disabled slots still holding a PIN. All three have to survive naming and
-    keep their number, because the number is what their entities are keyed
-    on.
+    Real configurations carry things a hand-written case tends not to:
+    slots whose name is the empty string, slots with no name key at all,
+    and disabled slots still holding a PIN.
+
+    A slot holding a PIN survives however it was named, keeping its number,
+    because the number is what its entities are keyed on and the credential
+    is on the lock. A slot with neither a name nor a PIN was never a user --
+    just an unused position from picking how many slots to create -- and is
+    dropped rather than turned into somebody.
     """
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -2364,6 +2369,15 @@ async def test_migration_of_a_real_world_entry_shape(
     )
     entry.add_to_hass(hass)
     ent_reg = er.async_get(hass)
+    dev_reg = dr.async_get(hass)
+    # Devices as a released version left them, so the teardown of a dropped
+    # slot has one to remove.
+    for slot in range(1, 7):
+        dev_reg.async_get_or_create(
+            config_entry_id=entry.entry_id,
+            identifiers={(DOMAIN, build_slot_device_identifier(entry.entry_id, slot))},
+            name=f"All Locks Code slot {slot}",
+        )
 
     # The registry as a released version leaves it: entity IDs slugged from
     # the entry title and the slot number, keyed on the slot number.
@@ -2384,12 +2398,15 @@ async def test_migration_of_a_real_world_entry_shape(
     config = get_entry_config(entry)
     assert entry.version == 4
     # Nobody lost, and nobody renumbered: the number is the entities' key.
-    assert sorted(config.assignment.slots.values()) == [1, 2, 3, 4, 5, 6]
+    # 4 and 5 held nothing and named nobody, so they are gone. 3 and 6 had
+    # no name but did have a PIN, so they stayed and were given one.
+    assert sorted(config.assignment.slots.values()) == [1, 2, 3, 6]
     assert config.name_for(1) == "Raman and Sherene"
     assert config.name_for(2) == "Housekeeper"
-    # Named, rather than left without an identity the new model needs.
     assert config.name_for(3) == "User 3"
-    assert config.name_for(4) == "User 4"
+    assert config.name_for(6) == "User 6"
+    assert not config.has_slot(4)
+    assert not config.has_slot(5)
     # A disabled slot's PIN is still its PIN.
     assert config.slot(3)[CONF_PIN] == "3333"
     assert config.slot(6)[CONF_PIN] == "6666"
@@ -2401,6 +2418,17 @@ async def test_migration_of_a_real_world_entry_shape(
         moved = ent_reg.async_get_entity_id(
             "text", DOMAIN, f"{entry.entry_id}|{slot}|{CONF_PIN}"
         )
+        if not config.has_slot(slot):
+            # A dropped slot's entities and device go with it, rather than
+            # lingering under a name for a user who does not exist.
+            assert moved is None
+            assert (
+                dev_reg.async_get_device(
+                    {(DOMAIN, build_slot_device_identifier(entry.entry_id, slot))}
+                )
+                is None
+            )
+            continue
         assert moved == f"text.{slugify(config.name_for(slot))}_pin"
         assert ent_reg.async_get(moved).id == entry_before.id
 
@@ -2501,9 +2529,7 @@ async def test_migration_reslugs_entity_ids_onto_the_user_name(
 
     # Nothing rewrites an entity id stored inside an automation, so the user
     # is handed the mapping rather than left to discover it.
-    issue = ir.async_get(hass).async_get_issue(
-        DOMAIN, f"entity_ids_renamed_{entry.entry_id}"
-    )
+    issue = ir.async_get(hass).async_get_issue(DOMAIN, ENTITY_IDS_RENAMED_ISSUE)
     assert issue is not None
     assert before.entity_id in issue.translation_placeholders["renames"]
     assert after in issue.translation_placeholders["renames"]
@@ -2630,12 +2656,7 @@ async def test_migration_leaves_an_entity_that_already_has_the_right_id(
         == "text.raman_pin"
     )
     # Nothing moved, so the user is not told anything moved.
-    assert (
-        ir.async_get(hass).async_get_issue(
-            DOMAIN, f"entity_ids_renamed_{entry.entry_id}"
-        )
-        is None
-    )
+    assert ir.async_get(hass).async_get_issue(DOMAIN, ENTITY_IDS_RENAMED_ISSUE) is None
 
     await hass.config_entries.async_unload(entry.entry_id)
 
@@ -2738,7 +2759,7 @@ def test_migration_keeps_the_condition_already_set() -> None:
     release's changes, but taking the legacy value would quietly undo
     whatever set the new one.
     """
-    migrated, _ = migrate_to_users(
+    migrated, _, _dropped = migrate_to_users(
         {
             CONF_LOCKS: [LOCK_1_ENTITY_ID],
             CONF_USERS: {

--- a/tests/test_repairs_references.py
+++ b/tests/test_repairs_references.py
@@ -22,7 +22,7 @@ from custom_components.lock_code_manager.repairs import async_create_fix_flow
 from .common import LOCK_1_ENTITY_ID
 
 OLD_PIN_ENTITY = "text.all_locks_code_slot_1_pin"
-NEW_PIN_ENTITY = "text.raman_pin"
+NEW_PIN_ENTITY = "text.all_locks_raman_pin"
 
 
 async def _migrated_entry(hass: HomeAssistant) -> MockConfigEntry:

--- a/tests/test_repairs_references.py
+++ b/tests/test_repairs_references.py
@@ -12,7 +12,10 @@ from homeassistant.helpers import entity_registry as er, issue_registry as ir
 from homeassistant.setup import async_setup_component
 from homeassistant.util.yaml import save_yaml
 
-from custom_components.lock_code_manager.const import DOMAIN
+from custom_components.lock_code_manager.const import (
+    DOMAIN,
+    ENTITY_IDS_RENAMED_ISSUE,
+)
 from custom_components.lock_code_manager.domain import references
 from custom_components.lock_code_manager.repairs import async_create_fix_flow
 
@@ -56,7 +59,7 @@ async def _migrated_entry(hass: HomeAssistant) -> MockConfigEntry:
 
 async def _open_repair(hass: HomeAssistant, entry: MockConfigEntry):
     """Open the repair the migration raised, and hand back its flow."""
-    issue_id = f"entity_ids_renamed_{entry.entry_id}"
+    issue_id = ENTITY_IDS_RENAMED_ISSUE
     issue = ir.async_get(hass).async_get_issue(DOMAIN, issue_id)
     assert issue is not None
     flow = await async_create_fix_flow(hass, issue_id, issue.data)
@@ -166,7 +169,7 @@ async def test_a_lookalike_id_is_not_reported(
     )
 
     entry = await _migrated_entry(hass)
-    issue_id = f"entity_ids_renamed_{entry.entry_id}"
+    issue_id = ENTITY_IDS_RENAMED_ISSUE
     issue = ir.async_get(hass).async_get_issue(DOMAIN, issue_id)
     flow = await async_create_fix_flow(hass, issue_id, issue.data)
     flow.hass = hass
@@ -286,8 +289,8 @@ async def test_nothing_is_written_to_the_config_files(
     (config_dir / "secrets.yaml").write_text("my_token: shhh\n", encoding="utf-8")
     before = automations.read_text(encoding="utf-8")
 
-    entry = await _migrated_entry(hass)
-    issue_id = f"entity_ids_renamed_{entry.entry_id}"
+    await _migrated_entry(hass)
+    issue_id = ENTITY_IDS_RENAMED_ISSUE
     issue = ir.async_get(hass).async_get_issue(DOMAIN, issue_id)
     flow = await async_create_fix_flow(hass, issue_id, issue.data)
     flow.hass = hass


### PR DESCRIPTION
## Proposed change

Findings from running the v3 migration against a copy of a real installation — full backup, deploy, restart, observe, restore. The revert was verified: entity IDs came back byte-identical to the pre-test snapshot.

Five defects, none of which the 1,700-test suite could have found, because each needed a real installation's shape.

### 1. Empty slots became people

A slot with neither a name nor a PIN was an unused position left over from being asked how many slots to create. Naming it invented a user who never existed. Two production entries produced **six** of them (`User 3`–`User 6`, `User 2`, `User 3`).

They're dropped now. Anything holding a PIN still survives, named after its number — 4.x allowed a PIN with a blank name, and could even have it *enabled*, meaning a live code on a lock belonging to nobody.

### 2. Dropped slots left their entities and device behind

Exposed by fixing #1, and invisible until the assertion was written. The update listener tears down a removed slot's entities by diffing data against options — but the migration writes the new shape to **both**, so from its point of view those slots were never there. The migration now purges the registry rows itself.

### 3. Per-lock entity IDs came out worse than they went in

They sit one-per-lock on a single slot device, so naming them after the user alone made three identical slugs and Home Assistant separated them with `_2`/`_3` — assigned in rename order, identifying nothing:

```
sensor.raman_and_sherene_code_slot_1     ← front door
sensor.raman_and_sherene_code_slot_1_2   ← back door
sensor.raman_and_sherene_code_slot_1_3   ← basement
```

The old `sensor.back_door_lock_code_slot_1` at least named the lock. Fresh installs were **already correct** — per-lock entities take their name from a translation carrying `{lock_name}`. Only the migration was wrong, because it reused the registry's `original_name`, which on an upgraded install is text stored under 4.4.6 ("Code slot 1") with no lock in it. It's rebuilt from the user, the lock and the credential type instead.

### 4. Entity IDs now name the entry too

A user's name is unique within its config entry and nowhere else. Two entries each holding a "Raman" collided into the same arbitrary `_2`. The slot device is `<entry title> <user>` again — what the old scheme did with the slot number, and what HA derives every entity ID from.

### 5. Two rename repairs, and a deprecation

One repair per config entry, saying the same thing twice — now a single accumulated issue. And `entity_registry.async_generate_entity_id` is removed in HA 2027.2; `async_get_available_entity_id` takes the same arguments.

## Also

`sensor.code` is now `{lock_name} PIN` rather than `{lock_name} code`, settling the spec's deferred question about non-PIN types. It's accurate today, it matches the `text.pin` beside it, and these IDs are moving anyway — leaving it meant a second rename migration when a second credential type arrives.

`test_migration_of_a_real_world_entry_shape` claimed to be a production entry while inventing PINs on two slots that never had any. That claim is what stopped the values being checked, and it made me misreport the migration result. It now holds the captured shape; the constructed case moved to its own test that says so.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

Wants a second live smoke test before merging — the whole point is that these only appear against real data.

## Checklist

- [x] The code change is tested and works locally. 1788 passed, 3 skipped, **100% coverage**.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XDxiHpQJkRKWctS9BfQmbY