### PR TITLE
docs: point the README at 5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,13 @@ Features:
   - `binary_sensor` / `switch` / `input_boolean` — active when on
   - `schedule` — active during scheduled times
 - [Services and actions](https://github.com/raman325/lock_code_manager/wiki/Services-and-Actions)
-  for setting/clearing PINs, attaching condition entities, hard-refreshing
-  from the lock, and generating safe random PINs from automations
+  for adding and removing users, setting/clearing PINs, attaching condition
+  entities, hard-refreshing from the lock, and generating safe random PINs
+  from automations
 - [Blueprints](https://github.com/raman325/lock_code_manager/wiki/Blueprints)
   for advanced use cases like usage limiting, calendar-driven PINs, and more
+- [Guest and rental workflows](https://github.com/raman325/lock_code_manager/wiki/Managing-Guests-and-Rentals)
+  — rotate a standing user per booking, or add and remove them per stay
 - Dashboard strategies and custom cards for managing codes and viewing lock
   status — from one-line auto-generated dashboards to fully hand-composed
   layouts
@@ -124,6 +127,11 @@ input tables, and import buttons.
 Visit the [Wiki](https://github.com/raman325/lock_code_manager/wiki) for detailed
 documentation including configuration, troubleshooting, dashboard setup, and development guides.
 
+**Upgrading from 4.x?** 5.0 is configured by user rather than by slot number,
+and migrating renames every entity ID. Read
+[Upgrading to 5.0](https://github.com/raman325/lock_code_manager/wiki/Upgrading-to-5.0)
+first — the migration is one-way.
+
 ## UI & Dashboards
 
 Lock Code Manager ships custom Lovelace **strategies** (which auto-generate UI
@@ -135,7 +143,7 @@ you want where you want it.
 
 - [UI overview & decision guide][wiki-ui-overview] — start here
 - [UI Strategies][wiki-ui-strategies] — dashboard, view, and section strategies
-- [Custom Cards][wiki-ui-cards] — slot card, lock-codes card, and code-display modes
+- [Custom Cards][wiki-ui-cards] — user card, add-user card, lock-codes card, and code-display modes
 
 [wiki-ui-overview]: https://github.com/raman325/lock_code_manager/wiki/Add-a-UI-for-lock-code-management
 [wiki-ui-strategies]: https://github.com/raman325/lock_code_manager/wiki/UI-Strategies


### PR DESCRIPTION
## Proposed change

The README still described the pre-5.0 shape in three places:

- The features list did not mention `add_user` or `delete_user`.
- The UI section advertised a "slot card"; that card is the user card now.
- Nothing told an upgrading user that the migration is one-way, or where
  to read about it first.

Adds those, plus a link to the new guest and rental workflows page.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

Companion to the wiki pass already published, which added
[Upgrading to 5.0](https://github.com/raman325/lock_code_manager/wiki/Upgrading-to-5.0)
and [Managing Guests and Rentals](https://github.com/raman325/lock_code_manager/wiki/Managing-Guests-and-Rentals).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XDxiHpQJkRKWctS9BfQmbY