### PR TITLE
fix(pbt): follow Bombadil 0.7's click schema

### DIFF
--- a/ts/pbt/spec.ts
+++ b/ts/pbt/spec.ts
@@ -7,7 +7,7 @@
  */
 /* eslint-disable no-underscore-dangle -- window.__lcmHarness is the harness's fixed extractor surface */
 import { always, eventually, now } from '@antithesishq/bombadil';
-import { actions, extract } from '@antithesishq/bombadil/browser';
+import { actions, extract, getFingerprint } from '@antithesishq/bombadil/browser';
 
 export * from '@antithesishq/bombadil/browser/defaults';
 
@@ -117,24 +117,38 @@ export const suspendedStateEventuallyShowsBanner = always(() =>
     )
 );
 
-/** Click chaos-panel buttons and card-internal (shadow DOM) buttons. */
+/**
+ * Click chaos-panel buttons and card-internal (shadow DOM) buttons.
+ *
+ * A click carries a fingerprint of the element it came from, not just a
+ * point, so a replay can tell whether the thing it is about to click is
+ * still the thing the run originally clicked. Built with the library's own
+ * ``getFingerprint`` rather than by hand, so it keeps matching whatever the
+ * schema asks for next.
+ */
 const clickablePoints = extract((state) => {
-    const points: { name: string; x: number; y: number }[] = [];
+    const points: { fingerprint: ReturnType<typeof getFingerprint>; x: number; y: number }[] = [];
+    const view = state.document.defaultView;
+    const width = view?.innerWidth ?? 0;
+    const height = view?.innerHeight ?? 0;
     for (const el of deepQueryAll(state.document, 'button')) {
         const rect = el.getBoundingClientRect();
-        if (rect.width > 0 && rect.height > 0) {
-            points.push({
-                name: el.id || el.textContent?.trim().slice(0, 24) || 'button',
-                x: rect.left + rect.width / 2,
-                y: rect.top + rect.height / 2
-            });
+        const x = rect.left + rect.width / 2;
+        const y = rect.top + rect.height / 2;
+        // Rects are relative to the viewport, so anything scrolled past has
+        // negative coordinates -- which the action schema rejects outright.
+        // Offer only what is on screen right now; scrolling is its own
+        // action, and what it reveals becomes clickable on the next state.
+        const onScreen = x >= 0 && y >= 0 && x < width && y < height;
+        if (rect.width > 0 && rect.height > 0 && onScreen) {
+            points.push({ fingerprint: getFingerprint(el), x, y });
         }
     }
     return points;
 });
 
 export const clickButtons = actions(() =>
-    clickablePoints.current.map(({ name, x, y }) => {
-        return { Click: { name, point: { x, y } } };
+    clickablePoints.current.map(({ fingerprint, x, y }) => {
+        return { Click: { fingerprint, point: { x, y } } };
     })
 );


### PR DESCRIPTION
## Proposed change

The nightly property run has failed **every night since 2026-08-14**, when
Dependabot took Bombadil from 0.6.1 to 0.7.0 (#1409). Not a 5.0.0 regression —
it predates the release by a week, and the last green run was 2026-08-13.

Two schema changes, the second visible only once the first was fixed:

1. **`Click` carries a `fingerprint`, not a `name`.** 0.7's `Action` type is
   `{ Click: { fingerprint: Fingerprint; point: Point } }`, so a replay can
   tell whether the element it is about to click is still the one the original
   run clicked. Built with the library's exported `getFingerprint` rather than
   assembling the struct by hand, so it keeps matching whatever the schema asks
   for next. Failure was `failed to convert generated action from clickButtons:
   missing field 'fingerprint'`.

2. **Negative coordinates are rejected.** With the first fixed, the run got as
   far as its first scroll and died on `value must not be negative`. Bounding
   rects are relative to the viewport, so anything scrolled past reports
   negative coordinates. Only on-screen elements are offered now — scrolling is
   its own action, and what it reveals becomes clickable in the next state.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #1409

Verified locally rather than by waiting for the nightly: a 60-second headless
exploration completes and reports no violations, having clicked buttons, inputs
and spans throughout. Before the fix it died in under a second.

Worth noting the failure mode — a scheduled job that only runs at 08:17 UTC and
notifies nobody was broken for eight days without anyone noticing. Might be
worth having it open an issue on failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XDxiHpQJkRKWctS9BfQmbY