### PR TITLE
feat(repairs): quote link health when an unmanaged-code clear fails

### DIFF
--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -551,7 +551,8 @@ class BaseLock:
         Describe how reliably the integration is reaching this lock, if it can.
 
         Purely descriptive: the returned sentence is appended to the repair
-        raised when a slot suspends, and nothing reads it to make a decision.
+        raised when a slot suspends and to the abort shown when an
+        unmanaged-code clear fails, and nothing reads it to make a decision.
         A provider that cannot measure its transport returns None and the
         repair keeps its generic wording.
 

--- a/custom_components/lock_code_manager/repairs.py
+++ b/custom_components/lock_code_manager/repairs.py
@@ -63,9 +63,8 @@ class UnmanagedCodeRepairFlow(RepairsFlow):
         self, user_input: dict[str, str] | None = None
     ) -> data_entry_flow.FlowResult:
         """Clear the code off the lock."""
-        lock = None
+        lock = get_managed_lock(self.hass, self._lock_entity_id)
         try:
-            lock = get_managed_lock(self.hass, self._lock_entity_id)
             await lock.async_internal_clear_usercode(self._slot)
         except LockCodeManagerError as err:
             _LOGGER.warning(
@@ -77,8 +76,9 @@ class UnmanagedCodeRepairFlow(RepairsFlow):
             # The error alone cannot distinguish a lock that rejected the
             # clear from a link that dropped the reply. Whatever the
             # provider can measure about its transport goes in verbatim so
-            # the reader can settle it at a glance (issue #1307).
-            link_health = lock.describe_link_health() if lock else None
+            # the reader can settle it at a glance (issue #1397, resurfaced
+            # by #1307's failed clear).
+            link_health = lock.describe_link_health()
             # Left standing deliberately: the code is still on the lock, so
             # resolving the issue would report a clear that did not happen.
             return self.async_abort(

--- a/custom_components/lock_code_manager/repairs.py
+++ b/custom_components/lock_code_manager/repairs.py
@@ -63,6 +63,7 @@ class UnmanagedCodeRepairFlow(RepairsFlow):
         self, user_input: dict[str, str] | None = None
     ) -> data_entry_flow.FlowResult:
         """Clear the code off the lock."""
+        lock = None
         try:
             lock = get_managed_lock(self.hass, self._lock_entity_id)
             await lock.async_internal_clear_usercode(self._slot)
@@ -73,6 +74,11 @@ class UnmanagedCodeRepairFlow(RepairsFlow):
                 self._lock_entity_id,
                 err,
             )
+            # The error alone cannot distinguish a lock that rejected the
+            # clear from a link that dropped the reply. Whatever the
+            # provider can measure about its transport goes in verbatim so
+            # the reader can settle it at a glance (issue #1307).
+            link_health = lock.describe_link_health() if lock else None
             # Left standing deliberately: the code is still on the lock, so
             # resolving the issue would report a clear that did not happen.
             return self.async_abort(
@@ -80,6 +86,7 @@ class UnmanagedCodeRepairFlow(RepairsFlow):
                 description_placeholders={
                     **self.description_placeholders,
                     "error": str(err),
+                    "link_health": f"\n\n{link_health}" if link_health else "",
                 },
             )
         return self.async_create_entry(title="", data={})

--- a/custom_components/lock_code_manager/strings.json
+++ b/custom_components/lock_code_manager/strings.json
@@ -366,7 +366,7 @@
         },
         "abort": {
           "unmanaged_code_kept": "The code in slot {slot} on {lock} was left alone. Lock Code Manager will not ask about this slot again, and will not assign a user to it.",
-          "unmanaged_code_clear_failed": "The code in slot {slot} on {lock} could not be cleared: {error}\n\nIt is still on the lock, so this repair stays open."
+          "unmanaged_code_clear_failed": "The code in slot {slot} on {lock} could not be cleared: {error}{link_health}\n\nIt is still on the lock, so this repair stays open."
         }
       }
     }

--- a/custom_components/lock_code_manager/translations/en.json
+++ b/custom_components/lock_code_manager/translations/en.json
@@ -366,7 +366,7 @@
         },
         "abort": {
           "unmanaged_code_kept": "The code in slot {slot} on {lock} was left alone. Lock Code Manager will not ask about this slot again, and will not assign a user to it.",
-          "unmanaged_code_clear_failed": "The code in slot {slot} on {lock} could not be cleared: {error}\n\nIt is still on the lock, so this repair stays open."
+          "unmanaged_code_clear_failed": "The code in slot {slot} on {lock} could not be cleared: {error}{link_health}\n\nIt is still on the lock, so this repair stays open."
         }
       }
     }

--- a/tests/test_unmanaged_codes.py
+++ b/tests/test_unmanaged_codes.py
@@ -173,5 +173,44 @@ async def test_a_clear_that_fails_leaves_the_repair_standing(
 
     assert result["type"] == "abort"
     assert result["reason"] == "unmanaged_code_clear_failed"
+    assert result["description_placeholders"]["link_health"] == ""
     assert (await lock.async_get_usercodes())[STRANDED_SLOT].pin == STRANDED_PIN
     assert ir.async_get(hass).async_get_issue(DOMAIN, issue_id) is not None
+
+
+async def test_a_failed_clear_quotes_the_lock_link_health(
+    hass: HomeAssistant, stranded
+) -> None:
+    """
+    A failed clear carries the provider's transport counters.
+
+    The failure message alone cannot distinguish a lock that rejected the
+    clear from a link that dropped the reply; whatever the provider can
+    measure about its transport goes in so the reader can settle it.
+    """
+    lock = stranded.runtime_data.locks[LOCK_1_ENTITY_ID]
+    issue_id = unmanaged_issue_id(LOCK_1_ENTITY_ID, STRANDED_SLOT)
+    flow = await async_create_fix_flow(
+        hass, issue_id, {"lock_entity_id": LOCK_1_ENTITY_ID, "slot": STRANDED_SLOT}
+    )
+    flow.hass = hass
+    with (
+        patch.object(
+            lock,
+            "async_internal_clear_usercode",
+            AsyncMock(side_effect=LockDisconnected("lock is asleep")),
+        ),
+        patch.object(
+            lock,
+            "describe_link_health",
+            return_value="39 read requests went unanswered",
+        ),
+    ):
+        result = await flow.async_step_clear()
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "unmanaged_code_clear_failed"
+    assert (
+        result["description_placeholders"]["link_health"]
+        == "\n\n39 read requests went unanswered"
+    )


### PR DESCRIPTION
## Proposed change

When the unmanaged-code repair's "Clear the code" option fails, the abort message only relayed the provider error — which cannot distinguish a lock that rejected the clear from a link that dropped the reply. In #1307 the reporter hit exactly this: their two `slot_suspended` repairs quoted the Z-Wave transport counters (added in #1410) and pointed at a mesh problem, while the failed clear on the same lossy link showed a bare "The device rejected the credential without giving a reason."

This appends `describe_link_health()`'s sentence to the `unmanaged_code_clear_failed` abort, mirroring what the slot-suspension repair has done since #1410, so the same failure self-diagnoses the same way in both repairs. Providers that cannot measure their transport contribute nothing and the message is unchanged.

Also hoists `get_managed_lock` out of the `try` in `async_step_clear`: it raises `ServiceValidationError`, which the `except LockCodeManagerError` never caught, so binding it inside the `try` implied a recovery path that could not occur.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #1307, #1397

🤖 Generated with [Claude Code](https://claude.com/claude-code)