### PR TITLE
fix: harden the MQTT providers against review findings from #1466

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -305,15 +305,28 @@ If you test with stale JavaScript, the Lovelace strategy will fail with:
 
 Provider tests live in dedicated modules mirroring the integration's test patterns:
 
+Each provider has its own package with a `conftest.py`, a `test_provider.py`
+covering its credential operations, and a `test_e2e.py` driving it through a
+real LCM config entry. Anything further is split by what it is about, not by
+size — the MQTT bridges each carry a `test_topic_resolution.py` because
+addressing the device is a separate problem from talking to it.
+
 ```text
 tests/providers/
-  akuvox/          # conftest.py, test_akuvox.py
-  matter/          # conftest.py, helpers.py, fixtures/, test_matter.py
-  schlage/         # conftest.py, test_schlage.py
-  virtual/         # conftest.py, test_virtual.py
-  zwave_js/        # conftest.py, fixtures/, test_zwave_js.py
-  test_zigbee2mqtt.py
+  akuvox/          # conftest, test_provider, test_e2e
+  matter/          # + helpers, fixtures/, test_sdk_exception_translation
+  schlage/         # conftest, test_provider, test_e2e
+  virtual/         # conftest, test_provider, test_e2e
+  zha/             # conftest, test_provider
+  zigbee2mqtt/     # + test_payload, test_topic_resolution
+  zwave_js/        # + helpers, fixtures/, test_events
+  zwave_js_ui/     # + test_api, test_borrowed, test_payload, test_push,
+                   #   test_topic_resolution
   helpers.py       # Shared test mixins (ServiceProviderConnectionTests, etc.)
+  test_base.py     # BaseLock lifecycle, setup deferral, rate limiting
+  test_dispatch.py # Entity/device -> provider class resolution
+  test_seam.py     # The user/credential seam over the provider primitives
+  test_util.py     # Shared provider helpers (masked codes, discovery payloads)
 ```
 
 ### Test conventions
@@ -399,7 +412,8 @@ with a comment citing the contract. Never silence one by rerunning.
    integration connectivity and device availability.
 6. Override `async_setup()` to register event listeners
 7. Call `async_fire_code_slot_event()` when lock events indicate PIN usage
-8. Add tests in `tests/providers/<provider>/test_<provider>.py`
+8. Add tests in `tests/providers/<provider>/` — at minimum `conftest.py`,
+   `test_provider.py`, and `test_e2e.py`, matching the layout above
 9. Use `self.managed_slots` (property) to get managed slot numbers
 10. Use `self.async_call_service()` for HA service calls — it wraps `HomeAssistantError`
    as `LockDisconnected` automatically

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -305,28 +305,22 @@ If you test with stale JavaScript, the Lovelace strategy will fail with:
 
 Provider tests live in dedicated modules mirroring the integration's test patterns:
 
-Each provider has its own package with a `conftest.py`, a `test_provider.py`
-covering its credential operations, and a `test_e2e.py` driving it through a
-real LCM config entry. Anything further is split by what it is about, not by
-size — the MQTT bridges each carry a `test_topic_resolution.py` because
-addressing the device is a separate problem from talking to it.
+Each provider package has a `conftest.py`, a `test_provider.py`, and (except
+`zha`) a `test_e2e.py`; anything further is split by subject.
 
 ```text
 tests/providers/
   akuvox/          # conftest, test_provider, test_e2e
   matter/          # + helpers, fixtures/, test_sdk_exception_translation
-  schlage/         # conftest, test_provider, test_e2e
-  virtual/         # conftest, test_provider, test_e2e
+  schlage/
+  virtual/
   zha/             # conftest, test_provider
   zigbee2mqtt/     # + test_payload, test_topic_resolution
   zwave_js/        # + helpers, fixtures/, test_events
   zwave_js_ui/     # + test_api, test_borrowed, test_payload, test_push,
                    #   test_topic_resolution
   helpers.py       # Shared test mixins (ServiceProviderConnectionTests, etc.)
-  test_base.py     # BaseLock lifecycle, setup deferral, rate limiting
-  test_dispatch.py # Entity/device -> provider class resolution
-  test_seam.py     # The user/credential seam over the provider primitives
-  test_util.py     # Shared provider helpers (masked codes, discovery payloads)
+  test_base.py, test_dispatch.py, test_seam.py, test_util.py
 ```
 
 ### Test conventions
@@ -412,8 +406,8 @@ with a comment citing the contract. Never silence one by rerunning.
    integration connectivity and device availability.
 6. Override `async_setup()` to register event listeners
 7. Call `async_fire_code_slot_event()` when lock events indicate PIN usage
-8. Add tests in `tests/providers/<provider>/` — at minimum `conftest.py`,
-   `test_provider.py`, and `test_e2e.py`, matching the layout above
+8. Add tests in `tests/providers/<provider>/` (`conftest.py`,
+   `test_provider.py`, `test_e2e.py`)
 9. Use `self.managed_slots` (property) to get managed slot numbers
 10. Use `self.async_call_service()` for HA service calls — it wraps `HomeAssistantError`
    as `LockDisconnected` automatically

--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -100,7 +100,11 @@ from .domain.config import (
     parse_slot_device_identifier,
     parse_slot_unique_id,
 )
-from .domain.exceptions import LockDisconnected, LockOperationFailed
+from .domain.exceptions import (
+    LockDisconnected,
+    LockOperationFailed,
+    UnclaimedLockError,
+)
 from .domain.locks import async_create_lock_instance, get_locks_from_targets
 from .domain.models import (
     LockCodeManagerConfigEntry,
@@ -1339,10 +1343,10 @@ async def async_remove_config_entry_device(
 
 @callback
 def _async_report_dropped_lock(
-    hass: HomeAssistant, lock_entity_id: str, err: BaseException
+    hass: HomeAssistant, lock_entity_id: str, err: UnclaimedLockError
 ) -> None:
     """
-    Raise a repair for a configured lock that could not be set up at all.
+    Raise a repair for a configured lock no provider claims.
 
     Distinct from ``lock_setup_failed``, which describes a lock that is
     still in the entry with its entities present but unavailable. This
@@ -1354,6 +1358,11 @@ def _async_report_dropped_lock(
     before selection-time validation existed, holding an mqtt lock whose
     bridge no provider speaks. Nobody ever told those users, so the
     repair names the entity and quotes what refused it.
+
+    Narrowly typed on purpose. The text diagnoses an unsupported bridge and
+    asks the user to remove the entity, which is only the right advice for
+    that one failure; raised on any exception that escaped setup it told
+    users with a perfectly good lock and a provider bug to throw the lock out.
     """
     async_create_issue(
         hass,
@@ -1430,6 +1439,14 @@ async def _async_setup_new_locks(
 
     added_locks: list[BaseLock] = []
     for lock_entity_id, result in zip(locks_to_add, setup_results, strict=True):
+        if isinstance(result, asyncio.CancelledError):
+            # ``return_exceptions=True`` aggregates a cancelled child rather
+            # than propagating it, so cancellation has to be re-raised by hand
+            # or Home Assistant shutting down looks exactly like a lock that
+            # could not be set up -- and left a persistent repair blaming an
+            # unsupported bridge, surviving the restart that cleared the
+            # actual condition.
+            raise result
         if isinstance(result, BaseException):
             # Transport failures degrade inside async_setup_internal, and
             # structural validation failures are logged there and kept
@@ -1447,7 +1464,12 @@ async def _async_setup_new_locks(
                 exc_info=result,
             )
             runtime_data.locks.pop(lock_entity_id, None)
-            _async_report_dropped_lock(hass, lock_entity_id, result)
+            if isinstance(result, UnclaimedLockError):
+                # Only this failure has a diagnosis and an action to offer.
+                # Any other exception is a bug in a provider LCM does speak,
+                # and a repair telling that user their bridge is unsupported
+                # sends them to remove a lock that works.
+                _async_report_dropped_lock(hass, lock_entity_id, result)
             continue
 
         added_locks.append(result)

--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Container, Iterable, Mapping, Sequence
 import logging
 from typing import Any
 
@@ -98,21 +98,33 @@ POSITIVE_INT = vol.All(vol.Coerce(int), vol.Range(min=1))
 
 
 def _check_unclaimed_mqtt_locks(
-    hass: HomeAssistant, lock_entity_ids: Iterable[str]
+    hass: HomeAssistant,
+    lock_entity_ids: Iterable[str],
+    already_configured: Container[str] = (),
 ) -> tuple[dict[str, str], dict[str, Any]]:
     """
-    Turn any unclaimed mqtt selection into the form error that names it.
+    Turn any newly selected unclaimed mqtt lock into the form error that names it.
 
     The entity selector filter can only express integration+domain, so
     per-device dispatch has to be enforced here at submit time -- otherwise
     an unclaimed mqtt lock is accepted and only refused at setup.
+
+    ``already_configured`` is what the entry holds now, and locks in it are
+    waved through. An entry configured before this check existed can be
+    carrying an unclaimed lock, and every options and reauth submission
+    re-renders that entry's whole lock list -- so validating all of it made
+    one grandfathered lock refuse every subsequent edit: no PIN could be
+    changed and no reauth could complete, for a lock the form was not being
+    asked to add. That lock is not silently accepted either; it is dropped at
+    setup and says so in its own repair.
     """
     ent_reg = er.async_get(hass)
     dev_reg = dr.async_get(hass)
     unclaimed = [
         entity_id
         for entity_id in lock_entity_ids
-        if (entry := ent_reg.async_get(entity_id)) is not None
+        if entity_id not in already_configured
+        and (entry := ent_reg.async_get(entity_id)) is not None
         and entry.platform == MQTT_DOMAIN
         and resolve_provider_class_for_entity(dev_reg, entry) is None
     ]
@@ -510,9 +522,10 @@ class LockCodeManagerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             # selector from the entry's current config either way.
             user_input = {CONF_LOCKS: list(get_entry_config(config_entry).locks)}
         else:
-            existing_slots = get_entry_config(config_entry).slot_numbers
+            entry_config = get_entry_config(config_entry)
+            existing_slots = entry_config.slot_numbers
             additional_errors, additional_placeholders = _check_unclaimed_mqtt_locks(
-                self.hass, user_input[CONF_LOCKS]
+                self.hass, user_input[CONF_LOCKS], entry_config.locks
             )
             if not additional_errors:
                 additional_errors, additional_placeholders = _check_common_slots(
@@ -595,7 +608,9 @@ class LockCodeManagerOptionsFlow(config_entries.OptionsFlow):
             # short-circuiting it: both refusals render together, so one round
             # trip shows everything wrong with the submission.
             lock_errors, lock_placeholders = _check_unclaimed_mqtt_locks(
-                self.hass, user_input[CONF_LOCKS]
+                self.hass,
+                user_input[CONF_LOCKS],
+                get_entry_config(self.config_entry).locks,
             )
             errors.update(lock_errors)
             description_placeholders.update(lock_placeholders)

--- a/custom_components/lock_code_manager/domain/coordinator.py
+++ b/custom_components/lock_code_manager/domain/coordinator.py
@@ -440,22 +440,17 @@ class LockUsercodeUpdateCoordinator(
         """
         Re-read whether the lock pushes, once its provider setup has succeeded.
 
-        A bridged provider derives push support from discovery data that
-        arrives on the broker's schedule, so a lock whose setup was deferred
-        was very likely constructed before the answer existed -- and kept the
-        poll cadence chosen for a lock that has none. That polled a lock which
-        does push, indefinitely, at one api round trip per slot per five
-        minutes on a mesh this provider goes out of its way not to fill.
+        A bridged provider derives push support from discovery data arriving
+        on the broker's schedule, so a lock whose setup was deferred was built
+        before the answer existed and kept the poll cadence chosen for a lock
+        that has none -- polling a pushing lock forever, one api round trip
+        per slot every five minutes.
 
-        Only the gaining direction is acted on, and only once. Losing push is
-        not a transition worth chasing: discovery data going transiently
-        missing is not a lock that stopped pushing, and the poll cadence would
-        thrash with it.
-
-        The live interval is left alone while a probe arm owns it -- the
-        breaker's backoff, or the cold-start retry for a lock that has never
-        been reached. Both restore ``_original_update_interval`` when they let
-        go, which is what has just been updated.
+        Only the gaining direction, and only once: discovery data going
+        transiently missing is not a lock that stopped pushing, and the
+        cadence would thrash with it. The live interval is left alone while a
+        probe arm owns it (breaker backoff, or the cold-start retry); both
+        restore ``_original_update_interval``, which has just been updated.
         """
         if self._is_push or not self._lock.supports_push:
             return

--- a/custom_components/lock_code_manager/domain/coordinator.py
+++ b/custom_components/lock_code_manager/domain/coordinator.py
@@ -76,17 +76,12 @@ class LockUsercodeUpdateCoordinator(
         # Disable periodic polling when push updates are supported.
         # Polling is still used for initial load.
         #
-        # Read once, and a bridged provider may not know the answer yet: it
-        # derives push support from discovery data that arrives on the
-        # broker's schedule. A lock that gains push after this therefore
-        # keeps the poll cadence chosen for a lock without it. That is
-        # redundant rather than wrong -- push updates do arrive, because the
-        # deferred-setup retry re-runs the provider's own subscribe -- and it
-        # lasts until the next reload. Re-deriving it live means reaching
-        # into the interval state machine below, whose three arms (breaker
-        # backoff, cold-start probe, restore-on-recovery) all own this value
-        # at different times.
-        update_interval = None if lock.supports_push else lock.usercode_scan_interval
+        # A bridged provider may not know the answer yet: it derives push
+        # support from discovery data that arrives on the broker's schedule,
+        # so a lock constructed before that lands looks like a poll lock.
+        # ``note_push_capability`` is the one place that answer is revisited.
+        self._is_push = lock.supports_push
+        update_interval = None if self._is_push else lock.usercode_scan_interval
         super().__init__(
             hass,
             _LOGGER,
@@ -395,7 +390,7 @@ class LockUsercodeUpdateCoordinator(
                     self._lock.lock.entity_id,
                     new_interval.total_seconds(),
                 )
-        elif self._original_update_interval is None and not self._reached_once:
+        elif self._is_push and not self._reached_once:
             # A push provider polls on no timer, so the recovery probe above
             # can never start from a cold start: tripping the breaker takes
             # repeated polls and nothing is scheduling them. One failed first
@@ -439,6 +434,42 @@ class LockUsercodeUpdateCoordinator(
                     "lock_entity_id": self._lock.lock.entity_id,
                 },
             )
+
+    @callback
+    def note_push_capability(self) -> None:
+        """
+        Re-read whether the lock pushes, once its provider setup has succeeded.
+
+        A bridged provider derives push support from discovery data that
+        arrives on the broker's schedule, so a lock whose setup was deferred
+        was very likely constructed before the answer existed -- and kept the
+        poll cadence chosen for a lock that has none. That polled a lock which
+        does push, indefinitely, at one api round trip per slot per five
+        minutes on a mesh this provider goes out of its way not to fill.
+
+        Only the gaining direction is acted on, and only once. Losing push is
+        not a transition worth chasing: discovery data going transiently
+        missing is not a lock that stopped pushing, and the poll cadence would
+        thrash with it.
+
+        The live interval is left alone while a probe arm owns it -- the
+        breaker's backoff, or the cold-start retry for a lock that has never
+        been reached. Both restore ``_original_update_interval`` when they let
+        go, which is what has just been updated.
+        """
+        if self._is_push or not self._lock.supports_push:
+            return
+        self._is_push = True
+        self._original_update_interval = None
+        if not self._lock_breaker.tripped and self._reached_once:
+            # Same narrowing the restore-on-recovery arm needs: the base
+            # class annotates this as ``timedelta`` while treating None as
+            # "do not poll", which is exactly the state being entered.
+            self.update_interval = self._original_update_interval  # type: ignore[assignment]
+        _LOGGER.debug(
+            "Lock %s pushes after all; polling disabled",
+            self._lock.lock.entity_id,
+        )
 
     @property
     def unreachable(self) -> bool:

--- a/custom_components/lock_code_manager/domain/exceptions.py
+++ b/custom_components/lock_code_manager/domain/exceptions.py
@@ -14,6 +14,21 @@ class LockCodeManagerError(HomeAssistantError):
     """Base class for lock_code_manager exceptions."""
 
 
+class UnclaimedLockError(LockCodeManagerError):
+    """
+    Raised when no provider recognizes a configured lock entity.
+
+    Deliberately its own type rather than a message on the generic error:
+    dropping a lock raises a repair that tells the user their bridge is
+    unsupported and to remove the entity, and that diagnosis is only true for
+    this one failure. Matching on the text instead would put it on every
+    unrelated provider bug that happened to escape setup.
+
+    Not a ``LockCodeManagerProviderError``: there is no provider here to have
+    failed. That is the whole condition.
+    """
+
+
 class LockCodeManagerProviderError(LockCodeManagerError):
     """
     Base class for exceptions raised by lock providers.

--- a/custom_components/lock_code_manager/domain/locks.py
+++ b/custom_components/lock_code_manager/domain/locks.py
@@ -11,7 +11,7 @@ from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_AREA_ID, ATTR_DEVICE_ID, ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant, callback, split_entity_id
-from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import (
     config_validation as cv,
     device_registry as dr,
@@ -19,6 +19,7 @@ from homeassistant.helpers import (
 )
 
 from ..providers import BaseLock, resolve_provider_class_for_entity
+from .exceptions import UnclaimedLockError
 from .queries import iter_loaded_lcm_entries
 
 _LOGGER = logging.getLogger(__name__)
@@ -40,7 +41,7 @@ def async_create_lock_instance(
     if lock_cls is None:
         # Selection-time validation and this guard share one rule: never
         # guess a provider for an unclaimed lock.
-        raise HomeAssistantError(
+        raise UnclaimedLockError(
             f"No Lock Code Manager provider claims {lock_entity_id} "
             f"(platform {lock_entry.platform})"
         )

--- a/custom_components/lock_code_manager/providers/__init__.py
+++ b/custom_components/lock_code_manager/providers/__init__.py
@@ -44,19 +44,28 @@ def resolve_provider_class(
         return INTEGRATIONS_CLASS_MAP.get(platform)
     if device_entry is None:
         return None
-    for identifier in device_entry.identifiers:
-        if len(identifier) < 2:
-            continue
-        value = str(identifier[1])
-        # Zigbee2MQTT is tested first, and has to be: its own prefix is
-        # fixed, while the zwave-js-ui identifier is recognized by its tail
-        # alone (the head is operator-configurable), so a Zigbee2MQTT device
-        # whose address happened to end ``0x<hex>_node<n>`` would be claimed
-        # by the wrong provider if the order were reversed.
-        if value.startswith(Z2M_IDENTIFIER_PREFIX):
-            return Zigbee2MQTTLock
-        if parse_zwave_js_ui_identifier(value):
-            return ZWaveJSUILock
+    values = [
+        str(identifier[1])
+        for identifier in device_entry.identifiers
+        if len(identifier) >= 2
+    ]
+    # Zigbee2MQTT is tested first, and has to be: its own prefix is fixed,
+    # while the zwave-js-ui identifier is recognized by its tail alone (the
+    # head is operator-configurable), so a device whose address happened to
+    # end ``0x<hex>_node<n>`` would be claimed by the wrong provider if the
+    # order were reversed.
+    #
+    # Two passes over the whole set, rather than both rules per identifier,
+    # because ``identifiers`` is a SET and its iteration order is arbitrary.
+    # A device carrying both shapes -- which is what a stale registry row
+    # from a re-paired device looks like -- resolved to whichever one the
+    # hash happened to yield first, so the same device could dispatch
+    # differently across restarts. The precedence has to hold over the
+    # device, not over one identifier at a time.
+    if any(value.startswith(Z2M_IDENTIFIER_PREFIX) for value in values):
+        return Zigbee2MQTTLock
+    if any(parse_zwave_js_ui_identifier(value) for value in values):
+        return ZWaveJSUILock
     return None
 
 

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -898,6 +898,17 @@ class BaseLock:
 
         Operations are chained sequentially so setup completes before
         the coordinator refresh or push subscription begins.
+
+        A connectivity failure here re-arms the deferred flag. That flag is
+        the only thing that arms another attempt for a lock whose integration
+        was loaded all along, and ``_async_run_provider_setup`` clears it on
+        the way in -- so a blip during the retry spent the retry, and the lock
+        stayed un-set-up with sync, gated on that, refusing to write anything
+        until the integration was reloaded by hand. A validation failure
+        deliberately does not re-arm: that lock is known-degraded with a
+        diagnosis and its own revalidation path, and re-probing it from every
+        connection check would put a capability read on the wire every thirty
+        seconds to learn what it already knows.
         """
         if (
             self._lcm_config_entry is None
@@ -911,6 +922,7 @@ class BaseLock:
         try:
             await self._async_run_provider_setup(self._lcm_config_entry)
         except LockDisconnected, LockOperationFailed:
+            self._setup_deferred = True
             LOGGER.debug(
                 "Provider setup failed for %s, will retry on next reconnect",
                 self.lock.entity_id,

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -947,6 +947,11 @@ class BaseLock:
                 )
             self._setup_succeeded = True
             self._clear_setup_validation_issue()
+            if self.coordinator:
+                # A bridged provider only learns it can push once its
+                # discovery data lands, which for a deferred setup is after
+                # the coordinator picked its cadence.
+                self.coordinator.note_push_capability()
         finally:
             self._setup_running = False
 

--- a/custom_components/lock_code_manager/providers/_mqtt.py
+++ b/custom_components/lock_code_manager/providers/_mqtt.py
@@ -48,14 +48,6 @@ from ..domain.models import SlotCredential
 from ._base import BaseLock
 from .const import LOGGER
 
-# How many all-silent multi-slot reads in a row are an outage rather than a
-# bad patch of mesh. Two, because the reads of one poll fail together far more
-# often than independently -- a node that drops half its replies loses both
-# ends of a two-slot poll about a quarter of the time -- while two whole polls
-# in a row silent, with the bridge's own status topic still reporting up, is
-# not a pattern a merely lossy link produces at any comparable rate.
-SILENT_READS_BEFORE_DISCONNECT = 2
-
 
 @dataclass(repr=False, eq=False)
 class BaseMqttLock(BaseLock):
@@ -66,8 +58,6 @@ class BaseMqttLock(BaseLock):
     # records is a property of the bridge and the lock's firmware, and neither
     # stops being able to answer reads because a poll went badly.
     _reads_have_succeeded: bool = field(init=False, default=False)
-    # Consecutive multi-slot reads where nothing at all came back.
-    _silent_reads: int = field(init=False, default=0)
 
     @property
     def domain(self) -> str:
@@ -254,7 +244,7 @@ class BaseMqttLock(BaseLock):
         what silence means on its own bridge.
 
         Silence is only evidence of an outage against a transport that has
-        been shown capable of the opposite, so three conditions all have to
+        been shown capable of the opposite, so two conditions both have to
         hold before this raises.
 
         Two slots is the smallest read it can judge. Asking about one and
@@ -278,12 +268,11 @@ class BaseMqttLock(BaseLock):
         absence of one, and a lock that can never prove it is left exactly as
         it was before this rule existed.
 
-        And the silence must be the second in a row. The reads of a single
-        poll fail together far more often than independently -- one node, one
-        route, one busy gateway queue -- so a two-slot poll on a #1397-class
-        link comes back entirely empty a good fraction of the time. Absorbing
-        the first costs one poll interval of delayed detection and buys not
-        suspending a lock that is merely slow.
+        One silent poll is not by itself an outage, and does not need to be
+        one here: raising records a single connectivity failure, and the
+        coordinator's breaker takes three in a row before it suspends
+        anything. A #1397-class link that loses both replies of one poll is
+        absorbed there, by the mechanism that already exists for it.
 
         Nothing about a transport that is genuinely gone rests on this
         signal. Every public operation runs ``_async_ensure_operational``
@@ -299,21 +288,10 @@ class BaseMqttLock(BaseLock):
         reads = {slot_num: await read_slot(slot_num) for slot_num in sorted(code_slots)}
         if any(state is not None for state in reads.values()):
             self._reads_have_succeeded = True
-            self._silent_reads = 0
         elif len(reads) > 1 and self._reads_have_succeeded:
-            self._silent_reads += 1
-            if self._silent_reads >= SILENT_READS_BEFORE_DISCONNECT:
-                raise LockDisconnected(
-                    f"{self.lock.entity_id}: every one of the {len(reads)} requested "
-                    f"slot reads {transport_failure}, on "
-                    f"{self._silent_reads} consecutive polls"
-                )
-            LOGGER.debug(
-                "Lock %s: every one of the %s requested slot reads %s; absorbing "
-                "one silent poll before treating it as an outage",
-                self.lock.entity_id,
-                len(reads),
-                transport_failure,
+            raise LockDisconnected(
+                f"{self.lock.entity_id}: every one of the {len(reads)} requested "
+                f"slot reads {transport_failure}"
             )
         return [
             user_from_slot(

--- a/custom_components/lock_code_manager/providers/_mqtt.py
+++ b/custom_components/lock_code_manager/providers/_mqtt.py
@@ -34,7 +34,7 @@ its own lifetime), the payload projections, and the api client.
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable, Collection
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import timedelta
 from typing import NoReturn, final
 
@@ -48,10 +48,26 @@ from ..domain.models import SlotCredential
 from ._base import BaseLock
 from .const import LOGGER
 
+# How many all-silent multi-slot reads in a row are an outage rather than a
+# bad patch of mesh. Two, because the reads of one poll fail together far more
+# often than independently -- a node that drops half its replies loses both
+# ends of a two-slot poll about a quarter of the time -- while two whole polls
+# in a row silent, with the bridge's own status topic still reporting up, is
+# not a pattern a merely lossy link produces at any comparable rate.
+SILENT_READS_BEFORE_DISCONNECT = 2
+
 
 @dataclass(repr=False, eq=False)
 class BaseMqttLock(BaseLock):
     """Base class for a lock addressed through an MQTT bridge."""
+
+    # Whether any slot read on this instance has ever come back with something
+    # the lock said, rather than silence. Latched on, never cleared: what it
+    # records is a property of the bridge and the lock's firmware, and neither
+    # stops being able to answer reads because a poll went badly.
+    _reads_have_succeeded: bool = field(init=False, default=False)
+    # Consecutive multi-slot reads where nothing at all came back.
+    _silent_reads: int = field(init=False, default=0)
 
     @property
     def domain(self) -> str:
@@ -224,7 +240,7 @@ class BaseMqttLock(BaseLock):
         -- but only the silences decide whether the read was worth anything.
 
         Every slot failing at the transport is a different thing from every
-        slot reading unreadable, and only the first raises. An all-unreadable
+        slot reading unreadable, and only the first can raise. An all-unreadable
         return is a successful poll as far as the coordinator is concerned:
         it resets the connectivity breaker, un-suspends the slots, and lets
         them re-fail on the next tick -- an oscillation on the order of
@@ -237,14 +253,37 @@ class BaseMqttLock(BaseLock):
         lost transport, and the caller's ``transport_failure`` phrase names
         what silence means on its own bridge.
 
-        Which is why two slots is the smallest read this can judge. Asking
-        about one and hearing nothing is a single lost reply, and on a lossy
-        mesh that is routine -- issue #1397 had a node dropping roughly half
-        its responses. Raising there would trip the connectivity breaker on
+        Silence is only evidence of an outage against a transport that has
+        been shown capable of the opposite, so three conditions all have to
+        hold before this raises.
+
+        Two slots is the smallest read it can judge. Asking about one and
+        hearing nothing is a single lost reply, and on a lossy mesh that is
+        routine -- issue #1397 had a node dropping roughly half its
+        responses. Raising there would trip the connectivity breaker on
         ordinary noise for an entry with one user, while an entry with two on
-        the same lock, losing replies at the same rate, polled on
-        untroubled. How many people a household has must not decide whether
-        its lock is reported unreachable.
+        the same lock, losing replies at the same rate, polled on untroubled.
+        How many people a household has must not decide whether its lock is
+        reported unreachable.
+
+        This instance must also have read something successfully at least
+        once. Some bridges cannot answer a read at all and never could: a
+        Zigbee2MQTT converter that exposes the PIN as write-only, a node whose
+        firmware implements User Code Set without Get. Those locks worked --
+        every poll came back all-unreadable and every write landed -- until an
+        all-silent rule that did not ask whether reading was ever possible
+        started declaring them gone, tripping the breaker and suspending the
+        writes along with the reads that were never going to work. Until the
+        lock proves it can be read, silence is the answer rather than the
+        absence of one, and a lock that can never prove it is left exactly as
+        it was before this rule existed.
+
+        And the silence must be the second in a row. The reads of a single
+        poll fail together far more often than independently -- one node, one
+        route, one busy gateway queue -- so a two-slot poll on a #1397-class
+        link comes back entirely empty a good fraction of the time. Absorbing
+        the first costs one poll interval of delayed detection and buys not
+        suspending a lock that is merely slow.
 
         Nothing about a transport that is genuinely gone rests on this
         signal. Every public operation runs ``_async_ensure_operational``
@@ -258,10 +297,23 @@ class BaseMqttLock(BaseLock):
             return []
 
         reads = {slot_num: await read_slot(slot_num) for slot_num in sorted(code_slots)}
-        if len(reads) > 1 and all(state is None for state in reads.values()):
-            raise LockDisconnected(
-                f"{self.lock.entity_id}: every one of the {len(reads)} requested "
-                f"slot reads {transport_failure}"
+        if any(state is not None for state in reads.values()):
+            self._reads_have_succeeded = True
+            self._silent_reads = 0
+        elif len(reads) > 1 and self._reads_have_succeeded:
+            self._silent_reads += 1
+            if self._silent_reads >= SILENT_READS_BEFORE_DISCONNECT:
+                raise LockDisconnected(
+                    f"{self.lock.entity_id}: every one of the {len(reads)} requested "
+                    f"slot reads {transport_failure}, on "
+                    f"{self._silent_reads} consecutive polls"
+                )
+            LOGGER.debug(
+                "Lock %s: every one of the %s requested slot reads %s; absorbing "
+                "one silent poll before treating it as an outage",
+                self.lock.entity_id,
+                len(reads),
+                transport_failure,
             )
         return [
             user_from_slot(

--- a/custom_components/lock_code_manager/providers/zha.py
+++ b/custom_components/lock_code_manager/providers/zha.py
@@ -37,6 +37,7 @@ from ..domain.credentials import (
 from ..domain.exceptions import CodeRejectedError, LockDisconnected
 from ..domain.models import SlotCredential
 from ._base import BaseLock
+from ._util import is_masked_code
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -401,9 +402,19 @@ class ZHALock(BaseLock):
             # Everything else holds something untrustworthy: claiming its
             # value would read as in sync while the code does not open the
             # door, and claiming it empty would hand it to allocation.
+            #
+            # An Enabled slot whose code comes back masked is untrustworthy
+            # in the same way: a lock withholding its codes answers with an
+            # asterisk per digit, which can never equal the configured PIN,
+            # so confirming it makes sync reprogram the slot on every tick
+            # forever.
             if user_status == DoorLock.UserStatus.Available:
                 slot_states[slot_num] = SlotCredential.empty()
-            elif user_status == DoorLock.UserStatus.Enabled and pin_code:
+            elif (
+                user_status == DoorLock.UserStatus.Enabled
+                and pin_code
+                and not is_masked_code(pin_code)
+            ):
                 slot_states[slot_num] = SlotCredential.known(pin_code)
             else:
                 slot_states[slot_num] = SlotCredential.unreadable()

--- a/custom_components/lock_code_manager/providers/zwave_js_ui.py
+++ b/custom_components/lock_code_manager/providers/zwave_js_ui.py
@@ -368,6 +368,11 @@ class ZWaveJSUILock(BaseMqttLock):
     _api_subscription_lock: asyncio.Lock = field(
         init=False, default_factory=asyncio.Lock
     )
+    # Event-loop time the live subscription is settled enough to publish
+    # into, or 0.0 when nothing is pending. Recorded rather than slept
+    # through, so the cost lands on the first caller that actually publishes
+    # and on nobody else.
+    _settle_deadline: float = field(init=False, default=0.0)
     # Outstanding api calls by nonce. The single response handler resolves
     # whichever future the gateway's echoed nonce names.
     _pending_api_calls: dict[str, asyncio.Future[dict[str, Any]]] = field(
@@ -821,8 +826,19 @@ class ZWaveJSUILock(BaseMqttLock):
             # responses (getNodes) are large. With nothing outstanding there
             # is nothing to correlate, so skip the parse entirely.
             return
+        raw = msg.payload
+        # The key only exists because this provider adds it to its own
+        # requests, and it comes back only in the echo of one. A substring
+        # scan of the undecoded payload rejects every other client's traffic
+        # -- the gateway's own user interface polls getNodes, which can run
+        # to megabytes -- without building a dict out of it first. Whatever
+        # survives is still parsed and correlated properly: the scan can only
+        # let too much through, and the nonce lookup below rejects that.
+        marker = REQUEST_ID_KEY.encode() if isinstance(raw, bytes) else REQUEST_ID_KEY
+        if marker not in raw:
+            return
         try:
-            payload = json.loads(msg.payload)
+            payload = json.loads(raw)
         except ValueError:
             LOGGER.debug("Ignoring non-JSON payload on %s", msg.topic)
             return
@@ -858,10 +874,14 @@ class ZWaveJSUILock(BaseMqttLock):
         this logs and returns, leaving any live subscription alone: discovery
         data going transiently missing is not a prefix that moved.
 
-        Every subscribe is followed by ``SUBSCRIBE_SETTLE_DELAY``, so a
-        subscription is settled by the time this returns and no caller has to
-        remember whether it made one. That is what lets the same call publish
-        into it safely.
+        Every subscribe records a settle deadline rather than sleeping to it.
+        What has to be true is that nothing is published into a subscription
+        the broker has not been told about yet, and that is the publisher's
+        constraint, not the subscriber's: ``_async_api_call_at`` waits out
+        whatever remains before its first publish. Sleeping here instead
+        charged the whole delay to every caller that only wanted a
+        subscription -- setup, and every borrowed instance that turns out to
+        need no call at all -- while buying them nothing.
 
         Serialized on its own lock, because the idempotence guard reads a
         field the subscribe below sets and there is an await in between. Two
@@ -894,7 +914,29 @@ class ZWaveJSUILock(BaseMqttLock):
                 response_topic, self._api_response_received
             )
             self._api_response_topic = response_topic
-            await asyncio.sleep(SUBSCRIBE_SETTLE_DELAY)
+            self._settle_deadline = (
+                asyncio.get_running_loop().time() + SUBSCRIBE_SETTLE_DELAY
+            )
+
+    async def _async_await_settle(self) -> None:
+        """
+        Wait out whatever remains of a fresh subscription's settling window.
+
+        Called immediately before a publish, which is the only operation the
+        window protects. Time already spent elsewhere -- resolving a gateway,
+        waiting on the operation pacing lock -- counts towards it, so a call
+        that took the slow road pays nothing here.
+
+        The deadline is cleared once reached, so it is spent once per
+        subscription rather than consulted forever. A caller that arrives
+        while another is still waiting sees it still set and waits too, which
+        is correct: the window has not elapsed for either of them.
+        """
+        if not (deadline := self._settle_deadline):
+            return
+        if (remaining := deadline - asyncio.get_running_loop().time()) > 0:
+            await asyncio.sleep(remaining)
+        self._settle_deadline = 0.0
 
     async def _async_resolve_api_base(self) -> str:
         """
@@ -1140,6 +1182,7 @@ class ZWaveJSUILock(BaseMqttLock):
         self._pending_api_calls[nonce] = future
         try:
             try:
+                await self._async_await_settle()
                 await async_publish(
                     self.hass,
                     f"{response_topic}/set",

--- a/custom_components/lock_code_manager/providers/zwave_js_ui.py
+++ b/custom_components/lock_code_manager/providers/zwave_js_ui.py
@@ -165,13 +165,31 @@ def _state_topic_from_payload(payload: dict[str, Any]) -> str | None:
 
 def _split_state_topic(state_topic: str) -> tuple[str, str] | None:
     """
-    Split a gateway-built value topic into ``(gateway prefix, node topic)``.
+    Split a gateway-built value topic into ``(first prefix segment, node topic)``.
 
-    The first segment is always the gateway's own topic prefix, and the last
-    three are the value's ``<cc>/<endpoint>/<property>``. A topic with fewer
-    than five segments leaves no room for both plus a node topic, so it can
-    only be a MANUAL-gateway custom topic, whose shape says nothing about the
-    node — unresolvable, never guessed.
+    The last three segments are the value's ``<cc>/<endpoint>/<property>``,
+    and everything before them is the node topic -- exactly, because the node
+    topic is whatever the gateway put there and this does not have to parse
+    it. A topic with fewer than five segments leaves no room for a prefix, a
+    node topic, and the value, so it can only be a MANUAL-gateway custom
+    topic, whose shape says nothing about the node -- unresolvable, never
+    guessed.
+
+    The prefix is the FIRST segment only, and that is a guess this cannot
+    improve on. zwave-js-ui permits ``/`` inside ``mqtt.prefix``: the settings
+    UI's ``validPrefix`` rule lists ``/`` among the allowed characters
+    (``src/views/Settings.vue``), ``sanitizeTopic`` keeps it unless a caller
+    asks for it to be stripped (``api/lib/utils.ts``), the settings POST
+    handler validates nothing at all (``api/app.ts``), and every topic is
+    built by plain concatenation (``api/lib/MqttClient.ts``). A prefix of
+    ``home/zwave`` therefore produces real multi-level topics, and in
+    ``home/zwave/nodeID_5/98/0/currentMode`` nothing distinguishes the
+    prefix's second segment from a NAMED gateway's location segment.
+
+    So a multi-level prefix is only recoverable from the availability list,
+    which names the gateway's client topic outright. Callers that fall back
+    to this must say so when they find nothing, rather than searching under
+    ``home`` and reporting an empty broker.
     """
     parts = state_topic.split("/")
     if len(parts) < MIN_VALUE_TOPIC_SEGMENTS:
@@ -945,6 +963,12 @@ class ZWaveJSUILock(BaseMqttLock):
         applied client-side on the received topic segment; retained statuses
         arrive immediately after subscribing and the window exists only to
         collect them all before deciding.
+
+        Reaching here at all means the discovery payload named no gateway, so
+        ``prefix`` is the first segment of the state topic -- which is only
+        the whole prefix if the gateway's is single-level. Finding nothing is
+        therefore two different diagnoses at once, and the one the operator
+        cannot guess is named in the refusal: see ``_split_state_topic``.
         """
         gateways: set[str] = set()
 
@@ -982,9 +1006,21 @@ class ZWaveJSUILock(BaseMqttLock):
             unsub()
 
         if not gateways:
+            LOGGER.debug(
+                "Lock %s: nothing answered under %s/_CLIENTS; that prefix was "
+                "derived from state topic %s",
+                self.lock.entity_id,
+                prefix,
+                self._resolve_state_topic(),
+            )
             raise LockDisconnected(
                 f"No zwave-js-ui gateway published a client status under "
-                f"{prefix}/_CLIENTS"
+                f"{prefix}/_CLIENTS. That prefix was taken from the first "
+                f"segment of {self.lock.entity_id}'s state topic, which is "
+                f"wrong if the gateway's mqtt prefix contains a '/': a "
+                f"multi-level prefix is only recoverable from the gateway's "
+                f"discovery availability entry, so enable Home Assistant "
+                f"discovery on the gateway if it is configured that way"
             )
 
         # Ask each candidate which network it runs and keep the one whose home

--- a/custom_components/lock_code_manager/providers/zwave_js_ui.py
+++ b/custom_components/lock_code_manager/providers/zwave_js_ui.py
@@ -289,27 +289,6 @@ def _published_code(value: Any) -> str | None:
     return None
 
 
-def _interpret_user_id_status(value: Any) -> CodeSlotStatus | None:
-    """
-    Read a published ``userIdStatus`` value as a slot status; None when it is not one.
-
-    Booleans are rejected before anything else: ``CodeSlotStatus`` members are
-    ints and ``True == 1`` in Python, so a JSON ``true`` would otherwise be
-    admitted as Enabled and a ``false`` as Available. Same guard
-    ``_project_user_code_result`` and ``homeid`` apply.
-
-    A value that names no member -- a manufacturer-specific status, a string,
-    a float -- is not "some status we do not act on", it is no reading at all,
-    and the caller must not record it as one.
-    """
-    if isinstance(value, bool):
-        return None
-    try:
-        return CodeSlotStatus(value)
-    except ValueError:
-        return None
-
-
 def _project_user_code_result(result: Any) -> SlotCredential:
     """
     Project a User Code CC ``get`` result to a SlotCredential.
@@ -361,17 +340,14 @@ class ZWaveJSUILock(BaseMqttLock):
     # Topic the live subscription covers, or None when there is none.
     _api_response_topic: str | None = field(init=False, default=None)
     # Serializes ``_async_ensure_api_response_subscription``. Deliberately not
-    # the base's ``_aio_lock``, which is held for the whole of every rate-
-    # limited provider operation -- and those operations resolve the api base,
-    # which ensures this subscription, so sharing it would deadlock on the
-    # first read.
+    # the base's ``_aio_lock``: that is held across every rate-limited
+    # operation, and those resolve the api base, which ensures this
+    # subscription -- sharing it would deadlock on the first read.
     _api_subscription_lock: asyncio.Lock = field(
         init=False, default_factory=asyncio.Lock
     )
     # Event-loop time the live subscription is settled enough to publish
-    # into, or 0.0 when nothing is pending. Recorded rather than slept
-    # through, so the cost lands on the first caller that actually publishes
-    # and on nobody else.
+    # into, or 0.0 when nothing is pending.
     _settle_deadline: float = field(init=False, default=0.0)
     # Outstanding api calls by nonce. The single response handler resolves
     # whichever future the gateway's echoed nonce names.
@@ -382,13 +358,13 @@ class ZWaveJSUILock(BaseMqttLock):
     # none. Unlike the api subscription above, this one IS the push lifecycle,
     # so its unsub goes in the base's push-unsub registry.
     _subscribed_node_topic: str | None = field(init=False, default=None)
-    # Last ``userIdStatus`` seen per slot on the node subscription. The two
-    # User Code CC properties are published as separate retained topics, so a
-    # code publication has to be read against whatever the status topic last
-    # said. Lives and dies with the node subscription it was observed on.
-    _last_user_id_status: dict[int, CodeSlotStatus] = field(
-        init=False, default_factory=dict
-    )
+    # Whether each slot's last published ``userIdStatus`` was Enabled. A
+    # missing entry means no usable status has been seen, which admits the
+    # slot's code -- see ``_process_user_code_value``. Cleared alongside
+    # ``_subscribed_node_topic`` because it describes the node that
+    # subscription covered: kept across a teardown, a status seen before an
+    # unload would gate codes published after the resubscribe.
+    _slot_enabled: dict[int, bool] = field(init=False, default_factory=dict)
     _min_operation_delay: float = field(init=False, default=ZWAVE_JS_UI_OPERATION_DELAY)
 
     @property
@@ -611,89 +587,60 @@ class ZWaveJSUILock(BaseMqttLock):
         """
         Confirm a slot from a User Code Command Class value publication.
 
-        The two properties are published separately, so each has to stand on
-        its own -- and neither means anything without the other, which is what
-        ``_last_user_id_status`` is for.
+        The two properties are separate retained topics, so each arrives on
+        its own and neither means anything without the other.
+
+        A ``userCode`` carrying no usable code says nothing at all: empty is
+        how the gateway spells both a withheld code and a cleared slot, and
+        reading it as cleared would tell sync the code is gone. A code is only
+        an active credential on an Enabled slot -- a Disabled one keeps its
+        digits, and ``_project_user_code_result`` already refuses to report
+        them, so confirming one here would make the same slot read in sync
+        over push and unreadable over poll, decided by which retained topic
+        the broker replayed first. A slot no status has been seen for keeps
+        its code (hence the ``True`` default): a gateway that publishes codes
+        and never statuses would otherwise leave every slot permanently
+        unconfirmed, and an over-confirmed code is corrected by the next poll
+        while a muted one has nothing to correct it.
+
+        ``userIdStatus`` carries occupancy, and only Available means the slot
+        holds nothing. A value naming no status at all is recorded as nothing,
+        because "unreadable status" must not gate codes the way a real
+        Disabled does; booleans are rejected first, since ``True == 1`` in
+        Python would otherwise pass for Enabled and ``False`` for Available.
         """
         if (slot_num := parse_slot_num(slot_segment)) is None:
             return
         value = _unwrap_mqtt_value(payload)
         if property_name == "userCode":
-            self._process_published_code(slot_num, value)
-        elif property_name == "userIdStatus":
-            self._process_published_status(slot_num, value)
-
-    @callback
-    def _process_published_code(self, slot_num: int, value: Any) -> None:
-        """
-        Confirm a slot from a published ``userCode``, if its status admits one.
-
-        A ``userCode`` carrying no usable code says nothing at all: empty is
-        how the gateway spells both a withheld code and a cleared slot, and
-        reading it as cleared would tell sync the code is gone.
-
-        A code is only an active credential on an Enabled slot. A Disabled
-        slot keeps its digits, and the poll projection
-        (``_project_user_code_result``) already refuses to report them, so
-        confirming them here would make the same slot read in sync over push
-        and unreadable over poll -- decided by which transport spoke last, and
-        for retained messages that is arrival order rather than lock state.
-
-        Never having heard a status is deliberately NOT treated as "not
-        Enabled". A gateway that publishes a slot's code and never its status
-        would otherwise leave that slot permanently unconfirmed, so the
-        unknown case keeps the code, which is what this did before there was
-        any tracking at all. If the slot turns out to be Disabled, the next
-        poll reads it unreadable and corrects the record; the reverse -- muting
-        a real code until some future republication of a retained topic -- has
-        no such correction.
-        """
-        if (code := _published_code(value)) is None:
-            return
-        status = self._last_user_id_status.get(slot_num)
-        if status is not None and status is not CodeSlotStatus.ENABLED:
-            LOGGER.debug(
-                "Lock %s: ignoring published code for slot %s; its last status "
-                "was %s rather than Enabled",
-                self.lock.entity_id,
-                slot_num,
-                status.name,
-            )
-            return
-        self._confirm_slot(slot_num, SlotCredential.known(code))
-
-    @callback
-    def _process_published_status(self, slot_num: int, value: Any) -> None:
-        """
-        Record a published ``userIdStatus`` and act on it when it is Available.
-
-        ``userIdStatus`` is what carries occupancy, and only Available means
-        the slot holds nothing -- any other status leaves the code to the
-        paired ``userCode`` publication. A value that is not a status at all is
-        recorded as nothing, because "unreadable status" must not gate codes
-        the way a genuine Disabled does.
-
-        Available is ignored when Lock Code Manager expects a PIN on this
-        slot. Some locks send stale AVAILABLE events after a code was set,
-        which would cause infinite sync loops.
-        """
-        if (status := _interpret_user_id_status(value)) is None:
-            return
-        self._last_user_id_status[slot_num] = status
-        if status is not CodeSlotStatus.AVAILABLE:
-            return
-        if (
-            self.coordinator is not None
-            and self.coordinator.desired_credential(pin_address(slot_num)).is_present
-        ):
-            LOGGER.debug(
-                "Lock %s: ignoring userIdStatus=AVAILABLE for slot %s "
-                "(LCM expects PIN on this slot)",
-                self.lock.entity_id,
-                slot_num,
-            )
-            return
-        self._confirm_slot(slot_num, SlotCredential.empty())
+            if (code := _published_code(value)) is not None and self._slot_enabled.get(
+                slot_num, True
+            ):
+                self._confirm_slot(slot_num, SlotCredential.known(code))
+        elif property_name == "userIdStatus" and not isinstance(value, bool):
+            if value == CodeSlotStatus.ENABLED:
+                self._slot_enabled[slot_num] = True
+            elif value == CodeSlotStatus.DISABLED:
+                self._slot_enabled[slot_num] = False
+            elif value == CodeSlotStatus.AVAILABLE:
+                self._slot_enabled[slot_num] = False
+                # Ignore AVAILABLE when Lock Code Manager expects a PIN on
+                # this slot. Some locks send stale AVAILABLE events after a
+                # code was set, which would cause infinite sync loops.
+                if (
+                    self.coordinator is not None
+                    and self.coordinator.desired_credential(
+                        pin_address(slot_num)
+                    ).is_present
+                ):
+                    LOGGER.debug(
+                        "Lock %s: ignoring userIdStatus=AVAILABLE for slot %s "
+                        "(LCM expects PIN on this slot)",
+                        self.lock.entity_id,
+                        slot_num,
+                    )
+                else:
+                    self._confirm_slot(slot_num, SlotCredential.empty())
 
     @callback
     def _process_notification(
@@ -735,20 +682,6 @@ class ZWaveJSUILock(BaseMqttLock):
         )
 
     @callback
-    def _forget_node_subscription_state(self) -> None:
-        """
-        Drop everything that was only true while the node subscription was live.
-
-        The tracked slot statuses go with it: they describe the node that
-        subscription covered, and after a rename or a teardown that is either
-        a different node or one nobody is watching. Keeping them would let a
-        status observed before an unload gate codes published after the
-        resubscribe, with nothing in between to correct it.
-        """
-        self._subscribed_node_topic = None
-        self._last_user_id_status.clear()
-
-    @callback
     def _node_subscription_current(self, node_topic: str | None) -> bool:
         """
         Return whether the live subscription already covers what is wanted.
@@ -781,7 +714,8 @@ class ZWaveJSUILock(BaseMqttLock):
         # puts in the push-unsub registry -- the api transport is tracked
         # separately -- so clearing all of them clears exactly this one.
         self._clear_push_unsubs()
-        self._forget_node_subscription_state()
+        self._subscribed_node_topic = None
+        self._slot_enabled.clear()
 
         @callback
         def message_received(msg: ReceiveMessage) -> None:
@@ -875,21 +809,17 @@ class ZWaveJSUILock(BaseMqttLock):
         data going transiently missing is not a prefix that moved.
 
         Every subscribe records a settle deadline rather than sleeping to it.
-        What has to be true is that nothing is published into a subscription
-        the broker has not been told about yet, and that is the publisher's
-        constraint, not the subscriber's: ``_async_api_call_at`` waits out
-        whatever remains before its first publish. Sleeping here instead
-        charged the whole delay to every caller that only wanted a
-        subscription -- setup, and every borrowed instance that turns out to
-        need no call at all -- while buying them nothing.
+        Nothing may be published into a subscription the broker has not been
+        told about yet, but that is the publisher's constraint, not the
+        subscriber's, so ``_async_api_call_at`` waits out whatever remains
+        before its first publish. Sleeping here charged the whole delay to
+        setup and to every borrowed instance that turns out to need no call
+        at all.
 
-        Serialized on its own lock, because the idempotence guard reads a
-        field the subscribe below sets and there is an await in between. Two
-        callers that reach it together -- the deferred-setup retry task and an
-        in-flight poll, say -- both passed the guard and both subscribed, and
-        whichever finished second overwrote the other's unsub. Nothing else
-        held a reference to the loser, so the broker went on delivering into
-        it for the rest of the run.
+        Serialized on its own lock: the idempotence guard reads a field the
+        subscribe below sets, with an await in between, so two callers
+        reaching it together both subscribed and the loser's unsub was
+        overwritten and leaked.
         """
         async with self._api_subscription_lock:
             if (prefix := self._gateway_prefix()) is None:
@@ -917,26 +847,6 @@ class ZWaveJSUILock(BaseMqttLock):
             self._settle_deadline = (
                 asyncio.get_running_loop().time() + SUBSCRIBE_SETTLE_DELAY
             )
-
-    async def _async_await_settle(self) -> None:
-        """
-        Wait out whatever remains of a fresh subscription's settling window.
-
-        Called immediately before a publish, which is the only operation the
-        window protects. Time already spent elsewhere -- resolving a gateway,
-        waiting on the operation pacing lock -- counts towards it, so a call
-        that took the slow road pays nothing here.
-
-        The deadline is cleared once reached, so it is spent once per
-        subscription rather than consulted forever. A caller that arrives
-        while another is still waiting sees it still set and waits too, which
-        is correct: the window has not elapsed for either of them.
-        """
-        if not (deadline := self._settle_deadline):
-            return
-        if (remaining := deadline - asyncio.get_running_loop().time()) > 0:
-            await asyncio.sleep(remaining)
-        self._settle_deadline = 0.0
 
     async def _async_resolve_api_base(self) -> str:
         """
@@ -1182,7 +1092,17 @@ class ZWaveJSUILock(BaseMqttLock):
         self._pending_api_calls[nonce] = future
         try:
             try:
-                await self._async_await_settle()
+                # Wait out whatever remains of a fresh subscription's
+                # settling window before the first publish -- the only
+                # operation it protects. Time already spent resolving the
+                # gateway counts towards it, and a deadline of 0.0 (nothing
+                # pending) lands far in the past, so it costs nothing.
+                if (
+                    remaining := self._settle_deadline
+                    - asyncio.get_running_loop().time()
+                ) > 0:
+                    await asyncio.sleep(remaining)
+                self._settle_deadline = 0.0
                 await async_publish(
                     self.hass,
                     f"{response_topic}/set",
@@ -1239,75 +1159,44 @@ class ZWaveJSUILock(BaseMqttLock):
         """
         Call an api on this lock's resolved gateway.
 
-        A disconnect against the cached base drops it, so the next attempt
-        rediscovers. The gateway can be renamed, replaced, or moved to
-        another broker, and without this a base that nobody answers on any
-        more would stick until the integration reloads.
+        A disconnect drops this instance's binding, so the next attempt
+        re-resolves: the gateway can be renamed, replaced, or moved to another
+        broker, and a base nobody answers on would otherwise stick until the
+        integration reloads.
+
+        Whether the SHARED scan result goes too is a separate question. Every
+        api sent to a lock is a ``sendCommand`` that waits on the mesh, so a
+        FLiRS lock missing its wake window times one out routinely -- a slow
+        node, not a gateway at the wrong address. Dropping the scan for that
+        sent every lock on the prefix rescanning into the same command queue
+        that was already too slow to answer. So the gateway is asked directly:
+        ``getInfo`` is served from its own cached driver state, off the mesh,
+        and one still answering for this lock's network keeps its binding. An
+        answer from another network is as stale as no answer -- that address
+        now belongs to somebody else, and writing there would program a
+        neighbouring network's node of the same number. With no response
+        subscription there is nothing to ask over, so nothing shared is
+        touched.
         """
+        home_hex, _ = self._require_node()
         api_base = await self._async_resolve_api_base()
         try:
             return await self._async_api_call_at(api_base, api_name, args)
         except LockDisconnected:
-            await self._async_reappraise_binding(api_base)
+            self._api_base = None
+            if self._api_response_topic is not None and await self._async_probe_home_id(
+                api_base
+            ) != int(home_hex, 16):
+                self._invalidate_gateway_scan()
             raise
-
-    async def _async_reappraise_binding(self, api_base: str) -> None:
-        """
-        Decide how much of a failed call's binding to throw away.
-
-        Every api this provider makes for a lock is a ``sendCommand`` that
-        waits on the mesh, so a FLiRS lock missing its wake window times one
-        out routinely -- the very reason the budget is a minute. That is a
-        slow node, not a gateway at the wrong address, and the two were
-        indistinguishable here: any disconnect dropped the SHARED scan result
-        every lock on the prefix binds from, sending all of them rescanning
-        into the same command queue that was already too slow to answer.
-
-        So the gateway is asked directly. ``getInfo`` is served from its own
-        cached driver state on the local budget, puts nothing on the mesh, and
-        a gateway that answers with this lock's network is exactly the gateway
-        the binding names -- it keeps it. An answer from some other network
-        means the address now belongs to somebody else, which is as stale as
-        no answer at all.
-
-        The instance's own base goes either way. Re-resolving it is a
-        dictionary read while the shared answer stands, and the correct thing
-        to do when it does not.
-
-        With no response subscription there is nothing to probe with, and a
-        transport released out from under a call says nothing about the
-        gateway, so nothing shared is touched.
-        """
-        self._forget_api_base()
-        if self._api_response_topic is None:
-            return
-        home_hex, _ = self._require_node()
-        if await self._async_probe_home_id(api_base) == int(home_hex, 16):
-            LOGGER.debug(
-                "Lock %s: gateway %s still answers for network %s, so the call "
-                "failed on the node rather than the binding",
-                self.lock.entity_id,
-                api_base,
-                home_hex,
-            )
-            return
-        self._invalidate_gateway_scan()
-
-    @callback
-    def _forget_api_base(self) -> None:
-        """Drop this instance's resolved gateway, leaving any shared scan intact."""
-        self._api_base = None
 
     @callback
     def _invalidate_gateway_scan(self) -> None:
         """
         Drop the scan result that produced this binding, for every lock sharing it.
 
-        Reserved for evidence about the GATEWAY rather than about one call:
-        they were all told the same gateway sits at the same address, so once
-        that stops being true the scan has to run again rather than be
-        replayed. Anything short of that leaves it alone -- a wiped scan costs
-        every lock behind the gateway a fresh discovery window.
+        Only ever called on evidence about the GATEWAY, never about one call:
+        a wiped scan costs every lock behind it a fresh discovery window.
         """
         self._api_base = None
         if (key := self._scan_key) is None:
@@ -1464,8 +1353,8 @@ class ZWaveJSUILock(BaseMqttLock):
         every borrowed provider does it on the way out -- so wiping the
         cross-lock answer here made an unmanaged sweep of N locks pay N full
         discovery windows instead of one, and made a connection blip cost the
-        same. Only ``_async_reappraise_binding``, which has actually asked the
-        gateway, invalidates that. Idempotent.
+        same. Only ``_async_api_call``, which has actually asked the gateway,
+        invalidates that. Idempotent.
         """
         if (unsub := self._api_response_unsub) is not None:
             self._api_response_unsub = None
@@ -1481,7 +1370,7 @@ class ZWaveJSUILock(BaseMqttLock):
                     err,
                 )
         self._api_response_topic = None
-        self._forget_api_base()
+        self._api_base = None
         for future in self._pending_api_calls.values():
             if not future.done():
                 future.cancel()
@@ -1498,7 +1387,8 @@ class ZWaveJSUILock(BaseMqttLock):
         both paths, so teardown owns both. Idempotent.
         """
         self._clear_push_unsubs()
-        self._forget_node_subscription_state()
+        self._subscribed_node_topic = None
+        self._slot_enabled.clear()
         self._release_api_subscription()
 
     async def async_unload(self, remove_permanently: bool) -> None:

--- a/custom_components/lock_code_manager/providers/zwave_js_ui.py
+++ b/custom_components/lock_code_manager/providers/zwave_js_ui.py
@@ -1152,17 +1152,66 @@ class ZWaveJSUILock(BaseMqttLock):
         try:
             return await self._async_api_call_at(api_base, api_name, args)
         except LockDisconnected:
-            self._forget_api_base()
+            await self._async_reappraise_binding(api_base)
             raise
+
+    async def _async_reappraise_binding(self, api_base: str) -> None:
+        """
+        Decide how much of a failed call's binding to throw away.
+
+        Every api this provider makes for a lock is a ``sendCommand`` that
+        waits on the mesh, so a FLiRS lock missing its wake window times one
+        out routinely -- the very reason the budget is a minute. That is a
+        slow node, not a gateway at the wrong address, and the two were
+        indistinguishable here: any disconnect dropped the SHARED scan result
+        every lock on the prefix binds from, sending all of them rescanning
+        into the same command queue that was already too slow to answer.
+
+        So the gateway is asked directly. ``getInfo`` is served from its own
+        cached driver state on the local budget, puts nothing on the mesh, and
+        a gateway that answers with this lock's network is exactly the gateway
+        the binding names -- it keeps it. An answer from some other network
+        means the address now belongs to somebody else, which is as stale as
+        no answer at all.
+
+        The instance's own base goes either way. Re-resolving it is a
+        dictionary read while the shared answer stands, and the correct thing
+        to do when it does not.
+
+        With no response subscription there is nothing to probe with, and a
+        transport released out from under a call says nothing about the
+        gateway, so nothing shared is touched.
+        """
+        self._forget_api_base()
+        if self._api_response_topic is None:
+            return
+        home_hex, _ = self._require_node()
+        if await self._async_probe_home_id(api_base) == int(home_hex, 16):
+            LOGGER.debug(
+                "Lock %s: gateway %s still answers for network %s, so the call "
+                "failed on the node rather than the binding",
+                self.lock.entity_id,
+                api_base,
+                home_hex,
+            )
+            return
+        self._invalidate_gateway_scan()
 
     @callback
     def _forget_api_base(self) -> None:
-        """
-        Drop the resolved gateway, and any scan result that produced it.
+        """Drop this instance's resolved gateway, leaving any shared scan intact."""
+        self._api_base = None
 
-        A binding that stopped answering is stale for every lock that shares
-        it: they were all told the same gateway sits at the same address, and
-        the scan that said so has to run again rather than be replayed.
+    @callback
+    def _invalidate_gateway_scan(self) -> None:
+        """
+        Drop the scan result that produced this binding, for every lock sharing it.
+
+        Reserved for evidence about the GATEWAY rather than about one call:
+        they were all told the same gateway sits at the same address, so once
+        that stops being true the scan has to run again rather than be
+        replayed. Anything short of that leaves it alone -- a wiped scan costs
+        every lock behind the gateway a fresh discovery window.
         """
         self._api_base = None
         if (key := self._scan_key) is None:
@@ -1309,10 +1358,18 @@ class ZWaveJSUILock(BaseMqttLock):
         """
         Drop the api response subscription and everything that depended on it.
 
-        The resolved gateway goes too: whatever brought us here (a reconnect,
-        an unload) can be followed by a renamed gateway, a different broker,
-        or a rebuilt topology, so the next api call rediscovers rather than
-        publishing at a base nobody listens on. Idempotent.
+        This instance's resolved gateway goes too: whatever brought us here (a
+        reconnect, an unload) can be followed by a renamed gateway, a
+        different broker, or a rebuilt topology, so the next api call
+        re-resolves rather than publishing at a base nobody listens on.
+
+        The SHARED scan result deliberately does not. Releasing a transport
+        is something this instance did, not something the gateway did, and
+        every borrowed provider does it on the way out -- so wiping the
+        cross-lock answer here made an unmanaged sweep of N locks pay N full
+        discovery windows instead of one, and made a connection blip cost the
+        same. Only ``_async_reappraise_binding``, which has actually asked the
+        gateway, invalidates that. Idempotent.
         """
         if (unsub := self._api_response_unsub) is not None:
             self._api_response_unsub = None

--- a/custom_components/lock_code_manager/providers/zwave_js_ui.py
+++ b/custom_components/lock_code_manager/providers/zwave_js_ui.py
@@ -360,6 +360,14 @@ class ZWaveJSUILock(BaseMqttLock):
     _api_response_unsub: Callable[[], None] | None = field(init=False, default=None)
     # Topic the live subscription covers, or None when there is none.
     _api_response_topic: str | None = field(init=False, default=None)
+    # Serializes ``_async_ensure_api_response_subscription``. Deliberately not
+    # the base's ``_aio_lock``, which is held for the whole of every rate-
+    # limited provider operation -- and those operations resolve the api base,
+    # which ensures this subscription, so sharing it would deadlock on the
+    # first read.
+    _api_subscription_lock: asyncio.Lock = field(
+        init=False, default_factory=asyncio.Lock
+    )
     # Outstanding api calls by nonce. The single response handler resolves
     # whichever future the gateway's echoed nonce names.
     _pending_api_calls: dict[str, asyncio.Future[dict[str, Any]]] = field(
@@ -854,30 +862,39 @@ class ZWaveJSUILock(BaseMqttLock):
         subscription is settled by the time this returns and no caller has to
         remember whether it made one. That is what lets the same call publish
         into it safely.
-        """
-        if (prefix := self._gateway_prefix()) is None:
-            if self._api_response_topic is None:
-                LOGGER.info(
-                    "Lock %s: no zwave-js-ui topic prefix in discovery data yet; "
-                    "the api response subscription will be established once it "
-                    "arrives",
-                    self.lock.entity_id,
-                )
-            return
-        response_topic = f"{prefix}/_CLIENTS/+/api/+"
-        if self._api_response_topic == response_topic:
-            return
 
-        # Moved, or first subscribe. The release drops the cached base along
-        # with the subscription, which is what a new prefix requires: the old
-        # base named a gateway at an address that no longer carries this
-        # lock's traffic.
-        self._release_api_subscription()
-        self._api_response_unsub = await self._async_subscribe(
-            response_topic, self._api_response_received
-        )
-        self._api_response_topic = response_topic
-        await asyncio.sleep(SUBSCRIBE_SETTLE_DELAY)
+        Serialized on its own lock, because the idempotence guard reads a
+        field the subscribe below sets and there is an await in between. Two
+        callers that reach it together -- the deferred-setup retry task and an
+        in-flight poll, say -- both passed the guard and both subscribed, and
+        whichever finished second overwrote the other's unsub. Nothing else
+        held a reference to the loser, so the broker went on delivering into
+        it for the rest of the run.
+        """
+        async with self._api_subscription_lock:
+            if (prefix := self._gateway_prefix()) is None:
+                if self._api_response_topic is None:
+                    LOGGER.info(
+                        "Lock %s: no zwave-js-ui topic prefix in discovery data "
+                        "yet; the api response subscription will be established "
+                        "once it arrives",
+                        self.lock.entity_id,
+                    )
+                return
+            response_topic = f"{prefix}/_CLIENTS/+/api/+"
+            if self._api_response_topic == response_topic:
+                return
+
+            # Moved, or first subscribe. The release drops the cached base
+            # along with the subscription, which is what a new prefix
+            # requires: the old base named a gateway at an address that no
+            # longer carries this lock's traffic.
+            self._release_api_subscription()
+            self._api_response_unsub = await self._async_subscribe(
+                response_topic, self._api_response_received
+            )
+            self._api_response_topic = response_topic
+            await asyncio.sleep(SUBSCRIBE_SETTLE_DELAY)
 
     async def _async_resolve_api_base(self) -> str:
         """

--- a/custom_components/lock_code_manager/providers/zwave_js_ui.py
+++ b/custom_components/lock_code_manager/providers/zwave_js_ui.py
@@ -23,7 +23,13 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import CALLBACK_TYPE, callback
 from homeassistant.exceptions import HomeAssistantError
 
-from ..domain.credentials import Credential, CredentialRef, User, WriteResult
+from ..domain.credentials import (
+    Credential,
+    CredentialRef,
+    User,
+    WriteResult,
+    pin_address,
+)
 from ..domain.exceptions import LockDisconnected, LockOperationFailed
 from ..domain.models import SlotCredential
 from ._mqtt import BaseMqttLock
@@ -265,6 +271,27 @@ def _published_code(value: Any) -> str | None:
     return None
 
 
+def _interpret_user_id_status(value: Any) -> CodeSlotStatus | None:
+    """
+    Read a published ``userIdStatus`` value as a slot status; None when it is not one.
+
+    Booleans are rejected before anything else: ``CodeSlotStatus`` members are
+    ints and ``True == 1`` in Python, so a JSON ``true`` would otherwise be
+    admitted as Enabled and a ``false`` as Available. Same guard
+    ``_project_user_code_result`` and ``homeid`` apply.
+
+    A value that names no member -- a manufacturer-specific status, a string,
+    a float -- is not "some status we do not act on", it is no reading at all,
+    and the caller must not record it as one.
+    """
+    if isinstance(value, bool):
+        return None
+    try:
+        return CodeSlotStatus(value)
+    except ValueError:
+        return None
+
+
 def _project_user_code_result(result: Any) -> SlotCredential:
     """
     Project a User Code CC ``get`` result to a SlotCredential.
@@ -324,6 +351,13 @@ class ZWaveJSUILock(BaseMqttLock):
     # none. Unlike the api subscription above, this one IS the push lifecycle,
     # so its unsub goes in the base's push-unsub registry.
     _subscribed_node_topic: str | None = field(init=False, default=None)
+    # Last ``userIdStatus`` seen per slot on the node subscription. The two
+    # User Code CC properties are published as separate retained topics, so a
+    # code publication has to be read against whatever the status topic last
+    # said. Lives and dies with the node subscription it was observed on.
+    _last_user_id_status: dict[int, CodeSlotStatus] = field(
+        init=False, default_factory=dict
+    )
     _min_operation_delay: float = field(init=False, default=ZWAVE_JS_UI_OPERATION_DELAY)
 
     @property
@@ -547,26 +581,88 @@ class ZWaveJSUILock(BaseMqttLock):
         Confirm a slot from a User Code Command Class value publication.
 
         The two properties are published separately, so each has to stand on
-        its own. A ``userCode`` carrying no usable code says nothing at all:
-        empty is how the gateway spells both a withheld code and a cleared
-        slot, and reading it as cleared would tell sync the code is gone.
-        ``userIdStatus`` is what carries occupancy, and only Available means
-        the slot holds nothing -- any other status leaves the code unknown.
+        its own -- and neither means anything without the other, which is what
+        ``_last_user_id_status`` is for.
         """
         if (slot_num := parse_slot_num(slot_segment)) is None:
             return
         value = _unwrap_mqtt_value(payload)
-        if property_name == "userCode" and (code := _published_code(value)) is not None:
-            self._confirm_slot(slot_num, SlotCredential.known(code))
-        elif (
-            property_name == "userIdStatus"
-            # ``True == 1`` and ``False == 0`` in Python, so a JSON boolean
-            # would otherwise report an occupied slot as Available. Same
-            # guard ``_project_user_code_result`` and ``homeid`` apply.
-            and not isinstance(value, bool)
-            and value == CodeSlotStatus.AVAILABLE
+        if property_name == "userCode":
+            self._process_published_code(slot_num, value)
+        elif property_name == "userIdStatus":
+            self._process_published_status(slot_num, value)
+
+    @callback
+    def _process_published_code(self, slot_num: int, value: Any) -> None:
+        """
+        Confirm a slot from a published ``userCode``, if its status admits one.
+
+        A ``userCode`` carrying no usable code says nothing at all: empty is
+        how the gateway spells both a withheld code and a cleared slot, and
+        reading it as cleared would tell sync the code is gone.
+
+        A code is only an active credential on an Enabled slot. A Disabled
+        slot keeps its digits, and the poll projection
+        (``_project_user_code_result``) already refuses to report them, so
+        confirming them here would make the same slot read in sync over push
+        and unreadable over poll -- decided by which transport spoke last, and
+        for retained messages that is arrival order rather than lock state.
+
+        Never having heard a status is deliberately NOT treated as "not
+        Enabled". A gateway that publishes a slot's code and never its status
+        would otherwise leave that slot permanently unconfirmed, so the
+        unknown case keeps the code, which is what this did before there was
+        any tracking at all. If the slot turns out to be Disabled, the next
+        poll reads it unreadable and corrects the record; the reverse -- muting
+        a real code until some future republication of a retained topic -- has
+        no such correction.
+        """
+        if (code := _published_code(value)) is None:
+            return
+        status = self._last_user_id_status.get(slot_num)
+        if status is not None and status is not CodeSlotStatus.ENABLED:
+            LOGGER.debug(
+                "Lock %s: ignoring published code for slot %s; its last status "
+                "was %s rather than Enabled",
+                self.lock.entity_id,
+                slot_num,
+                status.name,
+            )
+            return
+        self._confirm_slot(slot_num, SlotCredential.known(code))
+
+    @callback
+    def _process_published_status(self, slot_num: int, value: Any) -> None:
+        """
+        Record a published ``userIdStatus`` and act on it when it is Available.
+
+        ``userIdStatus`` is what carries occupancy, and only Available means
+        the slot holds nothing -- any other status leaves the code to the
+        paired ``userCode`` publication. A value that is not a status at all is
+        recorded as nothing, because "unreadable status" must not gate codes
+        the way a genuine Disabled does.
+
+        Available is ignored when Lock Code Manager expects a PIN on this
+        slot. Some locks send stale AVAILABLE events after a code was set,
+        which would cause infinite sync loops.
+        """
+        if (status := _interpret_user_id_status(value)) is None:
+            return
+        self._last_user_id_status[slot_num] = status
+        if status is not CodeSlotStatus.AVAILABLE:
+            return
+        if (
+            self.coordinator is not None
+            and self.coordinator.desired_credential(pin_address(slot_num)).is_present
         ):
-            self._confirm_slot(slot_num, SlotCredential.empty())
+            LOGGER.debug(
+                "Lock %s: ignoring userIdStatus=AVAILABLE for slot %s "
+                "(LCM expects PIN on this slot)",
+                self.lock.entity_id,
+                slot_num,
+            )
+            return
+        self._confirm_slot(slot_num, SlotCredential.empty())
 
     @callback
     def _process_notification(
@@ -608,6 +704,20 @@ class ZWaveJSUILock(BaseMqttLock):
         )
 
     @callback
+    def _forget_node_subscription_state(self) -> None:
+        """
+        Drop everything that was only true while the node subscription was live.
+
+        The tracked slot statuses go with it: they describe the node that
+        subscription covered, and after a rename or a teardown that is either
+        a different node or one nobody is watching. Keeping them would let a
+        status observed before an unload gate codes published after the
+        resubscribe, with nothing in between to correct it.
+        """
+        self._subscribed_node_topic = None
+        self._last_user_id_status.clear()
+
+    @callback
     def _node_subscription_current(self, node_topic: str | None) -> bool:
         """
         Return whether the live subscription already covers what is wanted.
@@ -640,7 +750,7 @@ class ZWaveJSUILock(BaseMqttLock):
         # puts in the push-unsub registry -- the api transport is tracked
         # separately -- so clearing all of them clears exactly this one.
         self._clear_push_unsubs()
-        self._subscribed_node_topic = None
+        self._forget_node_subscription_state()
 
         @callback
         def message_received(msg: ReceiveMessage) -> None:
@@ -1235,7 +1345,7 @@ class ZWaveJSUILock(BaseMqttLock):
         both paths, so teardown owns both. Idempotent.
         """
         self._clear_push_unsubs()
-        self._subscribed_node_topic = None
+        self._forget_node_subscription_state()
         self._release_api_subscription()
 
     async def async_unload(self, remove_permanently: bool) -> None:

--- a/tests/common.py
+++ b/tests/common.py
@@ -58,7 +58,7 @@ UNCLAIMED_UNIQUE_ID = f"{UNCLAIMED_IDENTIFIER}_lock"
 
 
 async def async_discover_unclaimed_mqtt_lock(
-    hass: HomeAssistant,
+    hass: HomeAssistant, suffix: str = ""
 ) -> er.RegistryEntry:
     """
     Discover an mqtt lock whose device identifier no provider recognizes.
@@ -66,26 +66,31 @@ async def async_discover_unclaimed_mqtt_lock(
     Going through real discovery is what puts the bridge's identifier on the
     device registry entry -- the very field dispatch reads -- so a hand-built
     registry row would be testing this test's idea of the payload.
+
+    ``suffix`` distinguishes a second such lock from the first, for the tests
+    that need to tell one the entry already holds from one being added now.
     """
+    identifier = f"{UNCLAIMED_IDENTIFIER}{suffix}"
+    unique_id = f"{identifier}_lock"
     async_fire_mqtt_message(
         hass,
-        f"homeassistant/lock/{UNCLAIMED_IDENTIFIER}/lock/config",
+        f"homeassistant/lock/{identifier}/lock/config",
         json.dumps(
             {
                 "name": None,
-                "command_topic": "somebridge/lock1/set",
-                "state_topic": "somebridge/lock1",
-                "unique_id": UNCLAIMED_UNIQUE_ID,
+                "command_topic": f"somebridge/lock1{suffix}/set",
+                "state_topic": f"somebridge/lock1{suffix}",
+                "unique_id": unique_id,
                 "device": {
-                    "identifiers": [UNCLAIMED_IDENTIFIER],
-                    "name": "Unclaimed Bridge Lock",
+                    "identifiers": [identifier],
+                    "name": f"Unclaimed Bridge Lock{suffix}",
                 },
             }
         ),
     )
     await hass.async_block_till_done()
     ent_reg = er.async_get(hass)
-    entity_id = ent_reg.async_get_entity_id("lock", "mqtt", UNCLAIMED_UNIQUE_ID)
+    entity_id = ent_reg.async_get_entity_id("lock", "mqtt", unique_id)
     assert entity_id is not None, "discovery did not create the lock entity"
     lock_entry = ent_reg.async_get(entity_id)
     assert lock_entry is not None

--- a/tests/providers/test_base.py
+++ b/tests/providers/test_base.py
@@ -2301,6 +2301,44 @@ async def test_deferred_setup_is_retried_once_the_lock_becomes_reachable(
     await lock.async_unload(False)
 
 
+async def test_a_deferred_retry_that_hits_a_blip_gets_another_one(
+    hass: HomeAssistant,
+):
+    """
+    One transient failure during the retry must not consume the only retry.
+
+    The deferred flag was cleared before the retried setup ran, so a
+    LockDisconnected on the way through spent it: nothing armed another
+    attempt, and the lock stayed un-set-up -- sync gated off it, no writes --
+    until the whole integration was reloaded by hand. A connectivity failure
+    is precisely the condition this retry exists for, so it re-arms.
+    """
+    lock = _make_base_test_lock(hass, "test_lock_blip_during_retry")
+    lock.set_connected(False)
+    await lock.async_setup_internal(lock.lock_config_entry)
+    assert lock.provider_setup_succeeded is False
+
+    lock.set_connected(True)
+    loaded_entry = MagicMock()
+    loaded_entry.state = ConfigEntryState.LOADED
+    lock.lock_config_entry = loaded_entry
+
+    with patch.object(
+        lock, "async_setup", AsyncMock(side_effect=LockDisconnected("blip"))
+    ):
+        assert await lock.async_internal_is_reachable() is True
+        await hass.async_block_till_done()
+    assert lock.provider_setup_succeeded is False
+
+    assert await lock.async_internal_is_reachable() is True
+    await hass.async_block_till_done()
+
+    assert lock.provider_setup_succeeded is True
+
+    await lock.coordinator.async_shutdown()
+    await lock.async_unload(False)
+
+
 async def test_a_lock_that_was_set_up_is_not_set_up_again_on_every_check(
     hass: HomeAssistant,
 ):

--- a/tests/providers/test_dispatch.py
+++ b/tests/providers/test_dispatch.py
@@ -123,6 +123,37 @@ async def test_mqtt_dispatch_prefers_zigbee2mqtt_over_the_zui_tail(
     assert resolve_provider_class("mqtt", device) is Zigbee2MQTTLock
 
 
+async def test_precedence_holds_across_separate_identifiers(
+    hass: HomeAssistant,
+) -> None:
+    """
+    The order is over the device, not over one identifier at a time.
+
+    A device can carry both shapes in separate identifiers -- a stale
+    registry row left by a re-paired device, or a bridge that publishes more
+    than one address. ``identifiers`` is a SET, so testing both rules against
+    each entry in turn resolved to whichever the hash happened to yield
+    first, and the same device could dispatch differently across restarts.
+    Two passes over the whole set is what makes the documented precedence
+    mean anything.
+    """
+    mqtt_entry = MockConfigEntry(domain="mqtt")
+    mqtt_entry.add_to_hass(hass)
+    mqtt_entry._async_set_state(hass, mqtt_entry.state, None)
+
+    device = dr.async_get(hass).async_get_or_create(
+        config_entry_id=mqtt_entry.entry_id,
+        connections=set(),
+        identifiers={
+            ("mqtt", "zwavejs2mqtt_0xd4ee5a7a_node20"),
+            ("mqtt", "zigbee2mqtt_0x00124b0021fb1234"),
+        },
+        name="BothShapesLock",
+    )
+
+    assert resolve_provider_class("mqtt", device) is Zigbee2MQTTLock
+
+
 async def test_mqtt_dispatch_skips_malformed_identifier(hass: HomeAssistant) -> None:
     """A malformed short identifier tuple is skipped, not treated as a crash."""
     mqtt_entry = MockConfigEntry(domain="mqtt")

--- a/tests/providers/zha/test_provider.py
+++ b/tests/providers/zha/test_provider.py
@@ -1045,6 +1045,47 @@ async def test_only_available_means_the_slot_is_free(
     assert not codes[2].is_readable
 
 
+@pytest.mark.parametrize(
+    ("code", "readable"),
+    [
+        pytest.param("****", False, id="masked"),
+        pytest.param("1234", True, id="digits"),
+        # Asterisks mixed with digits are not a shape any lock produces, and
+        # guessing at partial masking would discard a code that is there.
+        pytest.param("12**", True, id="partially_masked"),
+    ],
+)
+async def test_a_masked_code_is_unreadable_not_known(
+    hass: HomeAssistant,
+    zha_lock: ZHALock,
+    simple_lcm_config_entry: MockConfigEntry,
+    code: str,
+    readable: bool,
+) -> None:
+    """
+    A lock withholding its codes answers with an asterisk per digit.
+
+    The reply arrives and the slot is plainly Enabled, but the asterisks can
+    never equal the configured PIN -- confirming them as the code makes sync
+    reprogram the slot on every tick, forever. Same Zigbee hardware, same
+    behaviour, and the same guard the Zigbee2MQTT read path applies.
+    """
+    cluster = zha_lock._get_door_lock_cluster()
+    assert cluster is not None
+    cluster.get_pin_code = AsyncMock(
+        return_value=type(
+            "Response",
+            (),
+            {"user_status": DoorLock.UserStatus.Enabled, "code": code},
+        )()
+    )
+
+    codes = await zha_lock.async_get_usercodes(range(1, 2))
+
+    assert codes[1].is_present
+    assert codes[1].is_readable is readable
+
+
 async def test_available_is_an_empty_slot(
     hass: HomeAssistant,
     zha_lock: ZHALock,

--- a/tests/providers/zigbee2mqtt/test_provider.py
+++ b/tests/providers/zigbee2mqtt/test_provider.py
@@ -475,16 +475,13 @@ class TestAsyncGetUsers:
         )
 
         # The rule only arms once this bridge has proven it answers reads at
-        # all, and only fires on the second consecutive silence, so the outage
-        # has to be preceded by a good poll and reached by two bad ones.
+        # all, so the outage has to be preceded by a poll that worked.
         with (
             managed,
             patch(
                 _PUBLISH, side_effect=_answering_publish(lock, {1: "1234", 2: "5678"})
             ),
         ):
-            await lock.async_get_users()
-        with managed, silence():
             await lock.async_get_users()
         with (
             managed,

--- a/tests/providers/zigbee2mqtt/test_provider.py
+++ b/tests/providers/zigbee2mqtt/test_provider.py
@@ -469,12 +469,25 @@ class TestAsyncGetUsers:
         the lock unreachable so its backoff governs the next attempt.
         """
         lock = zigbee2mqtt_lock_connected
+        managed = patch(
+            "custom_components.lock_code_manager.providers._base.get_managed_slots",
+            return_value={1, 2},
+        )
 
+        # The rule only arms once this bridge has proven it answers reads at
+        # all, and only fires on the second consecutive silence, so the outage
+        # has to be preceded by a good poll and reached by two bad ones.
         with (
+            managed,
             patch(
-                "custom_components.lock_code_manager.providers._base.get_managed_slots",
-                return_value={1, 2},
+                _PUBLISH, side_effect=_answering_publish(lock, {1: "1234", 2: "5678"})
             ),
+        ):
+            await lock.async_get_users()
+        with managed, silence():
+            await lock.async_get_users()
+        with (
+            managed,
             silence(),
             pytest.raises(LockDisconnected, match="every one of the 2"),
         ):

--- a/tests/providers/zwave_js_ui/test_api.py
+++ b/tests/providers/zwave_js_ui/test_api.py
@@ -1219,6 +1219,53 @@ async def test_the_response_subscription_is_established_by_setup(
     assert lock._api_response_unsub is not None
 
 
+async def test_two_concurrent_ensures_make_one_subscription(
+    hass: HomeAssistant, zui_lock_provider: ZWaveJSUILock
+) -> None:
+    """
+    Two callers arriving together must not both subscribe.
+
+    The idempotence guard reads the live topic and the subscribe that follows
+    awaits, so a second caller entering that window passes the guard too:
+    both subscribe, and whichever finishes second overwrites the other's
+    unsub. The lost one is leaked -- nothing else holds a reference to it --
+    so the broker keeps delivering into a handler for the rest of the run. It
+    is reachable in ordinary operation: the deferred-setup retry task and an
+    in-flight poll both re-ensure.
+    """
+    lock = zui_lock_provider
+    opened: list[str] = []
+    released: list[str] = []
+    real_subscribe = ZWaveJSUILock._async_subscribe
+
+    async def _spy(self: ZWaveJSUILock, topic: str, *args: Any, **kw: Any) -> Any:
+        # Home Assistant's own subscribe awaits, which is what opens the
+        # window. Yielding here makes the interleaving deterministic instead
+        # of dependent on how the mocked broker happens to schedule.
+        await asyncio.sleep(0)
+        unsub = await real_subscribe(self, topic, *args, **kw)
+        opened.append(topic)
+
+        def _release() -> None:
+            released.append(topic)
+            unsub()
+
+        return _release
+
+    with patch.object(ZWaveJSUILock, "_async_subscribe", _spy):
+        await asyncio.gather(
+            lock._async_ensure_api_response_subscription(),
+            lock._async_ensure_api_response_subscription(),
+        )
+
+    assert opened == [f"{ZUI_PREFIX}/_CLIENTS/+/api/+"]
+
+    # Teardown can only release the one unsub the instance kept, so anything
+    # opened beyond it is unreachable for the rest of the run.
+    lock.teardown_push_subscription()
+    assert released == opened
+
+
 async def test_the_response_subscription_is_established_at_most_once(
     hass: HomeAssistant, zui_lock_provider: ZWaveJSUILock
 ) -> None:

--- a/tests/providers/zwave_js_ui/test_api.py
+++ b/tests/providers/zwave_js_ui/test_api.py
@@ -1390,25 +1390,27 @@ async def test_a_subscription_nobody_publishes_into_costs_no_settle(
 
 
 async def test_time_already_spent_counts_towards_the_settle(
-    hass: HomeAssistant, zui_lock_provider: ZWaveJSUILock
+    hass: HomeAssistant,
+    zui_lock_provider: ZWaveJSUILock,
+    zui_api_responder: ZWaveJSUIApiResponder,
 ) -> None:
     """
     A deadline already in the past is nothing left to wait for.
 
-    Resolution can spend a whole discovery window between subscribing and
-    the first publish, and re-sleeping the full delay on top of that is time
-    the broker did not need.
+    Resolution can spend a whole discovery window between subscribing and the
+    first publish, and re-sleeping the full delay on top of that is time the
+    broker did not need.
     """
     lock = zui_lock_provider
+    zui_api_responder.set_result("sendCommand", 30)
     await lock._async_ensure_api_response_subscription()
     lock._settle_deadline = asyncio.get_running_loop().time() - 1
 
     with record_transport_events(0.0123) as events:
-        await lock._async_await_settle()
+        assert await lock.async_get_max_slot() == 30
 
-    assert events == []
-    # Spent, so a second call does not reconsider it.
-    assert lock._settle_deadline == 0.0
+    assert "publish" in events
+    assert "settle" not in events
 
 
 async def test_other_clients_traffic_is_rejected_before_it_is_parsed(
@@ -1449,18 +1451,17 @@ async def test_other_clients_traffic_is_rejected_before_it_is_parsed(
     assert lock._pending_api_calls["nonce"].done()
 
 
-@pytest.mark.parametrize("encode", [False, True], ids=["text", "bytes"])
-async def test_the_prefilter_reads_either_payload_type(
-    hass: HomeAssistant, zui_lock_provider: ZWaveJSUILock, encode: bool
+async def test_the_prefilter_reads_a_bytes_payload(
+    hass: HomeAssistant, zui_lock_provider: ZWaveJSUILock
 ) -> None:
     """
     Home Assistant hands a subscriber either text or raw bytes.
 
     Which one depends on the subscription's encoding, and a marker compared
-    against the wrong type never matches -- so a provider that assumed one
-    would silently correlate nothing on a broker serving the other. Delivered
+    against the wrong type never matches -- so a provider that assumed text
+    would silently correlate nothing on a broker serving bytes. Delivered
     straight to the handler, because the type is exactly what the mocked
-    broker normalizes away.
+    broker normalizes away; every other test here covers the text side.
     """
     lock = zui_lock_provider
     loop = asyncio.get_running_loop()
@@ -1470,7 +1471,7 @@ async def test_the_prefilter_reads_either_payload_type(
     lock._api_response_received(
         ReceiveMessage(
             topic=f"{ZUI_API_BASE}/api/getInfo",
-            payload=body.encode() if encode else body,
+            payload=body.encode(),
             qos=0,
             retain=False,
             subscribed_topic=f"{ZUI_PREFIX}/_CLIENTS/+/api/+",

--- a/tests/providers/zwave_js_ui/test_api.py
+++ b/tests/providers/zwave_js_ui/test_api.py
@@ -399,6 +399,35 @@ async def test_silent_prefix_is_disconnected(
         await zui_scan_lock_provider._async_resolve_api_base()
 
 
+async def test_a_multi_level_prefix_fails_with_its_own_diagnosis(
+    hass: HomeAssistant, mqtt_mock, mqtt_teardown
+) -> None:
+    """
+    A prefix containing a slash cannot be recovered from the state topic.
+
+    zwave-js-ui permits one: its settings UI lists '/' among the allowed
+    prefix characters and its server validates the field not at all. In
+    ``home/zwave/nodeID_20/98/0/currentMode`` nothing distinguishes the
+    prefix's second segment from a NAMED gateway's location segment, so the
+    scan searches under ``home`` and finds an empty broker. That refusal is
+    indistinguishable from a gateway that is simply down, and the operator
+    cannot guess which -- so the message names the one they can act on.
+    """
+    lock = build_zui_lock(
+        hass,
+        await async_discover_zui_lock(
+            hass, prefix="home/zwave", include_availability=False
+        ),
+    )
+    await lock._async_ensure_api_response_subscription()
+
+    with pytest.raises(LockDisconnected, match="multi-level prefix") as caught:
+        await lock._async_resolve_api_base()
+
+    # The prefix it actually searched, so the wrong guess is visible.
+    assert "home/_CLIENTS" in str(caught.value)
+
+
 async def test_non_gateway_clients_on_the_prefix_are_ignored(
     hass: HomeAssistant, zui_scan_lock_provider: ZWaveJSUILock
 ) -> None:

--- a/tests/providers/zwave_js_ui/test_api.py
+++ b/tests/providers/zwave_js_ui/test_api.py
@@ -595,10 +595,10 @@ async def test_a_gateway_that_stops_answering_sends_the_scan_round_again(
     zui_api_responder: ZWaveJSUIApiResponder,
 ) -> None:
     """
-    A dropped binding drops the shared scan result with it.
+    A gateway that has stopped answering anything drops the shared scan result.
 
-    Keeping the scan's answer past the disconnect that invalidated the
-    instance's would hand the very next call the address nobody answered on,
+    Keeping the scan's answer past a disconnect the gateway itself could not
+    contradict would hand the very next call the address nobody answered on,
     and no lock behind that gateway could ever rediscover it.
     """
     lock = zui_scan_lock_provider
@@ -607,8 +607,9 @@ async def test_a_gateway_that_stops_answering_sends_the_scan_round_again(
     fire_zui_gateway_status(hass)
     assert await task == ZUI_API_BASE
 
-    # The gateway goes quiet: an api call times out, which is what drops the
-    # binding on the real path.
+    # The gateway goes quiet altogether: neither the node command nor the
+    # gateway-local probe that follows it comes back.
+    zui_api_responder.handlers.clear()
     with pytest.raises(LockDisconnected, match="Timed out waiting"):
         await lock.async_get_max_slot()
 
@@ -616,6 +617,90 @@ async def test_a_gateway_that_stops_answering_sends_the_scan_round_again(
     # nothing to find -- which is the proof that it did reopen.
     with pytest.raises(LockDisconnected, match="published a client status"):
         await lock._async_resolve_api_base()
+
+
+async def test_a_slow_node_behind_a_live_gateway_keeps_the_shared_binding(
+    hass: HomeAssistant,
+    zui_scan_lock_provider: ZWaveJSUILock,
+    zui_api_responder: ZWaveJSUIApiResponder,
+) -> None:
+    """
+    A node timing out says nothing about the gateway that relayed the command.
+
+    ``sendCommand`` waits on the mesh, so a FLiRS lock that misses its wake
+    window times it out routinely. Treating that as a stale gateway binding
+    threw away the scan every lock on the broker shares and sent them all
+    rescanning into the same queue that was already too slow to answer. The
+    gateway is asked directly instead, out of its own memory, and a gateway
+    that answers keeps its binding.
+    """
+    lock = zui_scan_lock_provider
+    zui_api_responder.set_result("getInfo", {"homeid": ZUI_HOME_ID})
+    task = await async_start_gateway_resolution(hass, lock)
+    fire_zui_gateway_status(hass)
+    assert await task == ZUI_API_BASE
+
+    with pytest.raises(LockDisconnected, match="Timed out waiting"):
+        await lock.async_get_max_slot()
+
+    # No status is published now, so re-resolving would fail outright if the
+    # shared scan result had been thrown away.
+    assert await lock._async_resolve_api_base() == ZUI_API_BASE
+
+
+async def test_a_released_transport_leaves_the_shared_scan_alone(
+    hass: HomeAssistant,
+    zui_scan_lock_provider: ZWaveJSUILock,
+    zui_api_responder: ZWaveJSUIApiResponder,
+) -> None:
+    """
+    Releasing one instance's transport is not evidence about the gateway.
+
+    Every borrowed provider -- a config flow read, the unmanaged sweep --
+    releases on the way out, and a connection blip releases too. Wiping the
+    cross-lock scan on each of those made a sweep of N locks pay N full
+    three-second scan windows instead of one.
+    """
+    lock = zui_scan_lock_provider
+    zui_api_responder.set_result("getInfo", {"homeid": ZUI_HOME_ID})
+    task = await async_start_gateway_resolution(hass, lock)
+    fire_zui_gateway_status(hass)
+    assert await task == ZUI_API_BASE
+
+    lock.teardown_push_subscription()
+    assert lock._api_base is None
+
+    # Nothing publishes a status, so binding at all proves the scan survived.
+    await lock._async_ensure_api_response_subscription()
+    assert await lock._async_resolve_api_base() == ZUI_API_BASE
+
+
+async def test_a_disconnect_with_no_transport_left_invalidates_nothing_shared(
+    hass: HomeAssistant,
+    zui_scan_lock_provider: ZWaveJSUILock,
+    zui_api_responder: ZWaveJSUIApiResponder,
+) -> None:
+    """
+    With the response channel gone there is no probe, and so no evidence.
+
+    A call whose transport is released under it fails as a disconnect, and
+    the gateway cannot be asked about it -- so the shared answer is left for
+    whoever can ask.
+    """
+    lock = zui_scan_lock_provider
+    zui_api_responder.set_result("getInfo", {"homeid": ZUI_HOME_ID})
+    task = await async_start_gateway_resolution(hass, lock)
+    fire_zui_gateway_status(hass)
+    assert await task == ZUI_API_BASE
+
+    pending = asyncio.create_task(lock._async_api_call("getUsersCount", []))
+    await hass.async_block_till_done()
+    lock._release_api_subscription()
+    with pytest.raises(LockDisconnected, match="transport released"):
+        await pending
+
+    await lock._async_ensure_api_response_subscription()
+    assert await lock._async_resolve_api_base() == ZUI_API_BASE
 
 
 async def test_lock_without_an_identifier_cannot_be_resolved() -> None:
@@ -890,12 +975,18 @@ async def test_node_commands_wait_on_the_mesh_budget(
     UsersNumberGet addressed to the lock (node-zwave-js
     ``UserCodeCCAPI.getUsersCount``), so it queues behind the same wake
     schedule as a code read and must not be cut short.
+
+    Asserted as an ordering rather than as an absence: the timeout is
+    followed by the gateway-local probe that decides whether the binding or
+    only the node is at fault, so both budgets are spent and which came first
+    is what says the node command got the mesh one.
     """
     with record_wait_budgets() as budgets, pytest.raises(LockDisconnected):
         await zui_gateway_resolved._async_user_code_command(method, [])
 
-    assert FAST_API_CALL_TIMEOUT in budgets
-    assert FAST_GATEWAY_LOCAL_TIMEOUT not in budgets
+    assert budgets.index(FAST_API_CALL_TIMEOUT) < budgets.index(
+        FAST_GATEWAY_LOCAL_TIMEOUT
+    )
 
 
 def test_operations_are_paced_wider_than_the_base_default() -> None:

--- a/tests/providers/zwave_js_ui/test_api.py
+++ b/tests/providers/zwave_js_ui/test_api.py
@@ -14,6 +14,7 @@ import pytest
 from pytest_homeassistant_custom_component.common import async_fire_mqtt_message
 
 from homeassistant.components.mqtt import debug_info as mqtt_debug_info
+from homeassistant.components.mqtt.models import ReceiveMessage
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
@@ -25,6 +26,7 @@ from custom_components.lock_code_manager.domain.exceptions import (
 from custom_components.lock_code_manager.providers import zwave_js_ui
 from custom_components.lock_code_manager.providers._base import MIN_OPERATION_DELAY
 from custom_components.lock_code_manager.providers.zwave_js_ui import (
+    REQUEST_ID_KEY,
     ZWAVE_JS_UI_OPERATION_DELAY,
     ZWaveJSUILock,
 )
@@ -84,10 +86,13 @@ def record_transport_events(settle_delay: float) -> Iterator[list[str]]:
     """
     Record subscribes, settle waits, and publishes in the order they happen.
 
-    The settle wait is recognized by its exact duration: ``asyncio.sleep`` is
-    patched process-wide for the block, so Home Assistant's own sleeps would
-    otherwise be indistinguishable from it. ``settle_delay`` therefore has to
-    be a value nothing else passes.
+    The settle wait is recognized by its duration falling in ``(0,
+    settle_delay]``: ``asyncio.sleep`` is patched process-wide for the block,
+    so Home Assistant's own sleeps would otherwise be indistinguishable from
+    it. ``settle_delay`` therefore has to be a value nothing else sleeps at or
+    below. A range rather than an exact match because the provider sleeps out
+    the REMAINDER of a recorded deadline, so whatever it spent between
+    subscribing and publishing has already come off.
     """
     module = "custom_components.lock_code_manager.providers.zwave_js_ui"
     events: list[str] = []
@@ -104,7 +109,7 @@ def record_transport_events(settle_delay: float) -> Iterator[list[str]]:
         return await real_publish(hass, topic, *args, **kw)
 
     async def _sleep(delay: float, *args: Any, **kw: Any) -> Any:
-        if delay == settle_delay:
+        if 0 < delay <= settle_delay:
             events.append("settle")
         return await real_sleep(delay, *args, **kw)
 
@@ -781,21 +786,36 @@ async def test_responses_for_other_callers_are_ignored(
     zwave-js-ui UI and other automations publish their own answers onto it.
     The trailing duplicate is the gateway retransmitting an answer already
     delivered, which must not disturb the settled call.
+
+    Every decoy carries the request id somewhere, because the bytes prefilter
+    would otherwise drop it before any of these guards ran -- and a decoy
+    that never reaches the guard it is aimed at proves nothing about it.
     """
     topic = f"{ZUI_API_BASE}/api/getInfo"
 
     def _handler(_api_base: str, request: dict[str, Any]) -> dict[str, Any]:
         answer = {"success": True, "result": "ours", "origin": request}
         for payload in (
-            "not json at all",
-            json.dumps([1, 2, 3]),
-            json.dumps({"success": True, "result": "no origin at all"}),
-            json.dumps({"success": True, "result": "origin with no id", "origin": {}}),
+            f"not json at all, but mentions {REQUEST_ID_KEY}",
+            json.dumps([REQUEST_ID_KEY, 2, 3]),
+            json.dumps(
+                {"success": True, "result": f"no origin, only {REQUEST_ID_KEY}"}
+            ),
+            json.dumps(
+                {"success": True, "result": REQUEST_ID_KEY, "origin": {}},
+            ),
+            json.dumps(
+                {
+                    "success": True,
+                    "result": "a nonce that is not a string",
+                    "origin": {REQUEST_ID_KEY: 7},
+                }
+            ),
             json.dumps(
                 {
                     "success": True,
                     "result": "somebody else's",
-                    "origin": {"lcmRequestId": "not-our-nonce"},
+                    "origin": {REQUEST_ID_KEY: "not-our-nonce"},
                 }
             ),
             json.dumps(answer),
@@ -1346,6 +1366,119 @@ async def test_a_fresh_subscription_settles_before_anything_is_published(
         assert await lock.async_get_max_slot() == 30
 
     assert events.index("subscribe") < events.index("settle") < events.index("publish")
+
+
+async def test_a_subscription_nobody_publishes_into_costs_no_settle(
+    hass: HomeAssistant, zui_lock_provider: ZWaveJSUILock
+) -> None:
+    """
+    The settling window is the publisher's cost, so a non-publisher pays none.
+
+    Setup subscribes and returns, and every borrowed instance -- a config
+    flow allocation read, the unmanaged sweep -- may turn out to need no call
+    at all. Sleeping the whole window at subscribe time charged all of them
+    for a guarantee only a publish needs.
+    """
+    lock = zui_lock_provider
+
+    with record_transport_events(0.0123) as events:
+        await lock.async_setup(MagicMock())
+
+    assert "subscribe" in events
+    assert "settle" not in events
+    assert "publish" not in events
+
+
+async def test_time_already_spent_counts_towards_the_settle(
+    hass: HomeAssistant, zui_lock_provider: ZWaveJSUILock
+) -> None:
+    """
+    A deadline already in the past is nothing left to wait for.
+
+    Resolution can spend a whole discovery window between subscribing and
+    the first publish, and re-sleeping the full delay on top of that is time
+    the broker did not need.
+    """
+    lock = zui_lock_provider
+    await lock._async_ensure_api_response_subscription()
+    lock._settle_deadline = asyncio.get_running_loop().time() - 1
+
+    with record_transport_events(0.0123) as events:
+        await lock._async_await_settle()
+
+    assert events == []
+    # Spent, so a second call does not reconsider it.
+    assert lock._settle_deadline == 0.0
+
+
+async def test_other_clients_traffic_is_rejected_before_it_is_parsed(
+    hass: HomeAssistant, zui_lock_provider: ZWaveJSUILock
+) -> None:
+    """
+    The api topics carry every client's traffic, and some of it is enormous.
+
+    The gateway's own user interface polls ``getNodes``, whose response can
+    run to megabytes, on the same wildcard this correlates its calls on.
+    Building a dict out of each one to discover it was never ours is work
+    proportional to somebody else's payload; the request id only ever appears
+    in the echo of one of our own requests, so a substring scan settles it.
+    """
+    lock = zui_lock_provider
+    await lock._async_ensure_api_response_subscription()
+    loop = asyncio.get_running_loop()
+    lock._pending_api_calls["nonce"] = loop.create_future()
+
+    with patch.object(zwave_js_ui.json, "loads", side_effect=AssertionError) as parse:
+        async_fire_mqtt_message(
+            hass,
+            f"{ZUI_API_BASE}/api/getNodes",
+            json.dumps({"success": True, "result": [{"id": 20}]}),
+        )
+        await hass.async_block_till_done()
+
+    parse.assert_not_called()
+
+    # And an echo of one of our own still gets through to correlation.
+    async_fire_mqtt_message(
+        hass,
+        f"{ZUI_API_BASE}/api/getInfo",
+        json.dumps({"success": True, "origin": {REQUEST_ID_KEY: "nonce"}}),
+    )
+    await hass.async_block_till_done()
+
+    assert lock._pending_api_calls["nonce"].done()
+
+
+@pytest.mark.parametrize("encode", [False, True], ids=["text", "bytes"])
+async def test_the_prefilter_reads_either_payload_type(
+    hass: HomeAssistant, zui_lock_provider: ZWaveJSUILock, encode: bool
+) -> None:
+    """
+    Home Assistant hands a subscriber either text or raw bytes.
+
+    Which one depends on the subscription's encoding, and a marker compared
+    against the wrong type never matches -- so a provider that assumed one
+    would silently correlate nothing on a broker serving the other. Delivered
+    straight to the handler, because the type is exactly what the mocked
+    broker normalizes away.
+    """
+    lock = zui_lock_provider
+    loop = asyncio.get_running_loop()
+    lock._pending_api_calls["nonce"] = loop.create_future()
+    body = json.dumps({"success": True, "origin": {REQUEST_ID_KEY: "nonce"}})
+
+    lock._api_response_received(
+        ReceiveMessage(
+            topic=f"{ZUI_API_BASE}/api/getInfo",
+            payload=body.encode() if encode else body,
+            qos=0,
+            retain=False,
+            subscribed_topic=f"{ZUI_PREFIX}/_CLIENTS/+/api/+",
+            timestamp=0.0,
+        )
+    )
+
+    assert lock._pending_api_calls["nonce"].done()
 
 
 async def test_resolution_fails_loud_when_no_subscription_can_be_established(

--- a/tests/providers/zwave_js_ui/test_e2e.py
+++ b/tests/providers/zwave_js_ui/test_e2e.py
@@ -61,7 +61,6 @@ CC_USER_CODE_ID = 99
 # zwave-js UserIDStatus: 0 Available, 1 Enabled.
 STATUS_AVAILABLE = 0
 STATUS_ENABLED = 1
-STATUS_DISABLED = 2
 
 E2E_SLOT_PINS = {1: "1234", 2: "5678"}
 LOCK_CAPACITY = 20
@@ -409,29 +408,6 @@ class TestPushUpdates:
 
         assert zui_lock.coordinator.data.get(pin_address(2)) == SlotCredential.known(
             E2E_SLOT_PINS[2]
-        )
-
-    async def test_a_disabled_slots_code_is_not_a_confirmation(
-        self,
-        hass: HomeAssistant,
-        synced_lcm_config_entry: MockConfigEntry,
-        zui_lock: ZWaveJSUILock,
-    ) -> None:
-        """
-        A Disabled slot keeps its digits, and they are not an active code.
-
-        The status and the code are separate retained topics, so the push path
-        has to read one against the other or it reports the same slot in sync
-        while a poll of it reads unreadable.
-        """
-        fire_zui_node_value(
-            hass, "user_code/endpoint_0/userIdStatus/1", STATUS_DISABLED
-        )
-        fire_zui_node_value(hass, "user_code/endpoint_0/userCode/1", "9999")
-        await hass.async_block_till_done()
-
-        assert zui_lock.coordinator.data.get(pin_address(1)) == SlotCredential.known(
-            E2E_SLOT_PINS[1]
         )
 
 

--- a/tests/providers/zwave_js_ui/test_e2e.py
+++ b/tests/providers/zwave_js_ui/test_e2e.py
@@ -61,6 +61,7 @@ CC_USER_CODE_ID = 99
 # zwave-js UserIDStatus: 0 Available, 1 Enabled.
 STATUS_AVAILABLE = 0
 STATUS_ENABLED = 1
+STATUS_DISABLED = 2
 
 E2E_SLOT_PINS = {1: "1234", 2: "5678"}
 LOCK_CAPACITY = 20
@@ -368,13 +369,70 @@ class TestPushUpdates:
         synced_lcm_config_entry: MockConfigEntry,
         zui_lock: ZWaveJSUILock,
     ) -> None:
-        """Available is the one status that confirms the slot holds nothing."""
+        """
+        Available is the one status that confirms the slot holds nothing.
+
+        Asserted on a slot the entry configures nothing for, because a slot it
+        does expect a code on is the stale-AVAILABLE case below.
+        """
+        unconfigured_slot = max(E2E_SLOT_PINS) + 1
+        fire_zui_node_value(
+            hass,
+            f"user_code/endpoint_0/userIdStatus/{unconfigured_slot}",
+            STATUS_AVAILABLE,
+        )
+        await hass.async_block_till_done()
+
+        assert (
+            zui_lock.coordinator.data.get(pin_address(unconfigured_slot))
+            is SlotCredential.empty()
+        )
+
+    async def test_stale_available_does_not_unwind_a_synced_slot(
+        self,
+        hass: HomeAssistant,
+        synced_lcm_config_entry: MockConfigEntry,
+        zui_lock: ZWaveJSUILock,
+    ) -> None:
+        """
+        A lock re-announcing AVAILABLE after a write must not restart sync.
+
+        Some locks send a stale AVAILABLE once a code lands. Believed, it
+        marks the slot cleared, sync rewrites it, the lock re-announces, and
+        the entry never settles -- so the assertion is that a fully synced
+        slot survives one.
+        """
         fire_zui_node_value(
             hass, "user_code/endpoint_0/userIdStatus/2", STATUS_AVAILABLE
         )
         await hass.async_block_till_done()
 
-        assert zui_lock.coordinator.data.get(pin_address(2)) is SlotCredential.empty()
+        assert zui_lock.coordinator.data.get(pin_address(2)) == SlotCredential.known(
+            E2E_SLOT_PINS[2]
+        )
+
+    async def test_a_disabled_slots_code_is_not_a_confirmation(
+        self,
+        hass: HomeAssistant,
+        synced_lcm_config_entry: MockConfigEntry,
+        zui_lock: ZWaveJSUILock,
+    ) -> None:
+        """
+        A Disabled slot keeps its digits, and they are not an active code.
+
+        The status and the code are separate retained topics, so the push path
+        has to read one against the other or it reports the same slot in sync
+        while a poll of it reads unreadable.
+        """
+        fire_zui_node_value(
+            hass, "user_code/endpoint_0/userIdStatus/1", STATUS_DISABLED
+        )
+        fire_zui_node_value(hass, "user_code/endpoint_0/userCode/1", "9999")
+        await hass.async_block_till_done()
+
+        assert zui_lock.coordinator.data.get(pin_address(1)) == SlotCredential.known(
+            E2E_SLOT_PINS[1]
+        )
 
 
 class TestKeypadEvents:

--- a/tests/providers/zwave_js_ui/test_provider.py
+++ b/tests/providers/zwave_js_ui/test_provider.py
@@ -219,6 +219,9 @@ class TestAsyncGetUsers:
         them re-fail on the next tick, oscillating on a seconds-scale loop
         that flips every slot in and out of sync. Raising leaves the lock
         unreachable so its backoff governs the next attempt.
+
+        Preceded by a poll that answered, because the rule only arms once
+        this transport has shown it can be read at all.
         """
         lock = zui_gateway_resolved
         zui_api_responder.set_handler("sendCommand", _answering_handler())
@@ -228,8 +231,6 @@ class TestAsyncGetUsers:
         zui_api_responder.set_result(
             "sendCommand", None, success=False, message="Node 20 is not alive"
         )
-        with patch(MANAGED_SLOTS, return_value={1, 2}):
-            await lock.async_get_users()
         with (
             patch(MANAGED_SLOTS, return_value={1, 2}),
             pytest.raises(LockDisconnected, match="every one of the 2"),
@@ -257,63 +258,7 @@ class TestAsyncGetUsers:
             "sendCommand", None, success=False, message="Command not supported"
         )
 
-        for _ in range(4):
-            with patch(MANAGED_SLOTS, return_value={1, 2}):
-                users = await lock.async_get_users()
-            assert _slot_state(users, 1) is SlotCredential.unreadable()
-            assert _slot_state(users, 2) is SlotCredential.unreadable()
-
-    async def test_one_silent_poll_after_a_good_one_is_absorbed(
-        self,
-        hass: HomeAssistant,
-        zui_gateway_resolved: ZWaveJSUILock,
-        zui_api_responder: ZWaveJSUIApiResponder,
-    ) -> None:
-        """
-        A lossy mesh drops correlated bursts, and two slots is a small sample.
-
-        Issue #1397 had a node timing out roughly half its responses, which
-        loses both replies of a two-slot poll about a quarter of the time.
-        Tripping the breaker there suspends a lock that is merely slow, so
-        one silent poll is absorbed and only a second consecutive one is
-        treated as an outage.
-        """
-        lock = zui_gateway_resolved
-        zui_api_responder.set_handler("sendCommand", _answering_handler())
-        with patch(MANAGED_SLOTS, return_value={1, 2}):
-            await lock.async_get_users()
-
-        zui_api_responder.set_result(
-            "sendCommand", None, success=False, message="Node 20 is not alive"
-        )
-        with patch(MANAGED_SLOTS, return_value={1, 2}):
-            users = await lock.async_get_users()
-
-        assert _slot_state(users, 1) is SlotCredential.unreadable()
-
-    async def test_an_answered_poll_between_two_silent_ones_resets_the_count(
-        self,
-        hass: HomeAssistant,
-        zui_gateway_resolved: ZWaveJSUILock,
-        zui_api_responder: ZWaveJSUIApiResponder,
-    ) -> None:
-        """
-        Only consecutive silence is an outage; alternating is a weak link.
-
-        Without the reset a lock that answers every other poll accumulates
-        silences forever and is eventually declared gone while it is plainly
-        still talking.
-        """
-        lock = zui_gateway_resolved
-        answering = _answering_handler()
-
         for _ in range(3):
-            zui_api_responder.set_handler("sendCommand", answering)
-            with patch(MANAGED_SLOTS, return_value={1, 2}):
-                await lock.async_get_users()
-            zui_api_responder.set_result(
-                "sendCommand", None, success=False, message="Node 20 is not alive"
-            )
             with patch(MANAGED_SLOTS, return_value={1, 2}):
                 users = await lock.async_get_users()
             assert _slot_state(users, 1) is SlotCredential.unreadable()

--- a/tests/providers/zwave_js_ui/test_provider.py
+++ b/tests/providers/zwave_js_ui/test_provider.py
@@ -51,6 +51,21 @@ def _user_code_handler(
     return _handler
 
 
+def _answering_handler() -> Callable[[str, dict[str, Any]], dict[str, Any] | None]:
+    """
+    Answer every slot with a real enabled code, whichever slot is asked about.
+
+    What the code is does not matter to the tests that use this; that the
+    transport answered at all does, because that is what proves the lock can
+    be read and arms the all-silent rule.
+    """
+
+    def _handler(_api_base: str, _request: dict[str, Any]) -> dict[str, Any]:
+        return {"success": True, "result": {"userIdStatus": 1, "userCode": "1234"}}
+
+    return _handler
+
+
 def _slot_state(users: list[User], slot: int) -> SlotCredential:
     """Pull one slot's projected Personal Identification Number state."""
     return next(user for user in users if user.user_id == slot).pin_credentials[0].state
@@ -206,15 +221,102 @@ class TestAsyncGetUsers:
         unreachable so its backoff governs the next attempt.
         """
         lock = zui_gateway_resolved
+        zui_api_responder.set_handler("sendCommand", _answering_handler())
+        with patch(MANAGED_SLOTS, return_value={1, 2}):
+            await lock.async_get_users()
+
         zui_api_responder.set_result(
             "sendCommand", None, success=False, message="Node 20 is not alive"
         )
-
+        with patch(MANAGED_SLOTS, return_value={1, 2}):
+            await lock.async_get_users()
         with (
             patch(MANAGED_SLOTS, return_value={1, 2}),
             pytest.raises(LockDisconnected, match="every one of the 2"),
         ):
             await lock.async_get_users()
+
+    async def test_a_transport_that_never_answered_a_read_never_disconnects(
+        self,
+        hass: HomeAssistant,
+        zui_gateway_resolved: ZWaveJSUILock,
+        zui_api_responder: ZWaveJSUIApiResponder,
+    ) -> None:
+        """
+        Silence only means "gone" once this transport has proven it can speak.
+
+        A bridge that accepts writes but answers no reads at all -- the
+        write-only Zigbee2MQTT converter, a gateway whose node has User Code
+        Set but not Get -- worked before this rule existed: every poll came
+        back all-unreadable and every write landed. Raising on it instead
+        trips the breaker, suspends the slots, and takes the writes down with
+        the reads that were never going to work.
+        """
+        lock = zui_gateway_resolved
+        zui_api_responder.set_result(
+            "sendCommand", None, success=False, message="Command not supported"
+        )
+
+        for _ in range(4):
+            with patch(MANAGED_SLOTS, return_value={1, 2}):
+                users = await lock.async_get_users()
+            assert _slot_state(users, 1) is SlotCredential.unreadable()
+            assert _slot_state(users, 2) is SlotCredential.unreadable()
+
+    async def test_one_silent_poll_after_a_good_one_is_absorbed(
+        self,
+        hass: HomeAssistant,
+        zui_gateway_resolved: ZWaveJSUILock,
+        zui_api_responder: ZWaveJSUIApiResponder,
+    ) -> None:
+        """
+        A lossy mesh drops correlated bursts, and two slots is a small sample.
+
+        Issue #1397 had a node timing out roughly half its responses, which
+        loses both replies of a two-slot poll about a quarter of the time.
+        Tripping the breaker there suspends a lock that is merely slow, so
+        one silent poll is absorbed and only a second consecutive one is
+        treated as an outage.
+        """
+        lock = zui_gateway_resolved
+        zui_api_responder.set_handler("sendCommand", _answering_handler())
+        with patch(MANAGED_SLOTS, return_value={1, 2}):
+            await lock.async_get_users()
+
+        zui_api_responder.set_result(
+            "sendCommand", None, success=False, message="Node 20 is not alive"
+        )
+        with patch(MANAGED_SLOTS, return_value={1, 2}):
+            users = await lock.async_get_users()
+
+        assert _slot_state(users, 1) is SlotCredential.unreadable()
+
+    async def test_an_answered_poll_between_two_silent_ones_resets_the_count(
+        self,
+        hass: HomeAssistant,
+        zui_gateway_resolved: ZWaveJSUILock,
+        zui_api_responder: ZWaveJSUIApiResponder,
+    ) -> None:
+        """
+        Only consecutive silence is an outage; alternating is a weak link.
+
+        Without the reset a lock that answers every other poll accumulates
+        silences forever and is eventually declared gone while it is plainly
+        still talking.
+        """
+        lock = zui_gateway_resolved
+        answering = _answering_handler()
+
+        for _ in range(3):
+            zui_api_responder.set_handler("sendCommand", answering)
+            with patch(MANAGED_SLOTS, return_value={1, 2}):
+                await lock.async_get_users()
+            zui_api_responder.set_result(
+                "sendCommand", None, success=False, message="Node 20 is not alive"
+            )
+            with patch(MANAGED_SLOTS, return_value={1, 2}):
+                users = await lock.async_get_users()
+            assert _slot_state(users, 1) is SlotCredential.unreadable()
 
     async def test_a_lone_slot_losing_its_reply_is_not_a_dead_transport(
         self,

--- a/tests/providers/zwave_js_ui/test_push.py
+++ b/tests/providers/zwave_js_ui/test_push.py
@@ -347,20 +347,6 @@ class TestStatusGatedCodes:
 
         lock.coordinator.push_update.assert_not_called()
 
-    async def test_a_code_after_an_enabled_status_confirms_the_slot(
-        self, hass: HomeAssistant, zui_lock_subscribed: ZWaveJSUILock
-    ) -> None:
-        """An enabled slot's code is exactly what the poll would report."""
-        lock = zui_lock_subscribed
-
-        fire_node_value(hass, f"{USER_ID_STATUS_VALUEID}/3", wrapped(1))
-        fire_node_value(hass, f"{USER_CODE_VALUEID}/3", wrapped("1234"))
-        await hass.async_block_till_done()
-
-        lock.coordinator.push_update.assert_called_once_with(
-            {3: SlotCredential.known("1234")}
-        )
-
     async def test_a_code_before_any_status_confirms_the_slot(
         self, hass: HomeAssistant, zui_lock_subscribed: ZWaveJSUILock
     ) -> None:
@@ -379,55 +365,6 @@ class TestStatusGatedCodes:
         lock.coordinator.push_update.assert_called_once_with(
             {3: SlotCredential.known("1234")}
         )
-
-    @pytest.mark.parametrize(
-        ("status", "code_first", "expected"),
-        [
-            pytest.param(
-                1, False, SlotCredential.known("1234"), id="enabled_then_code"
-            ),
-            pytest.param(1, True, SlotCredential.known("1234"), id="code_then_enabled"),
-            pytest.param(2, False, None, id="disabled_then_code"),
-            # The one permutation the last-seen rule cannot settle: with no
-            # status yet the code is taken at face value. Pinned so the
-            # asymmetry is a decision rather than a surprise.
-            pytest.param(
-                2, True, SlotCredential.known("1234"), id="code_then_disabled"
-            ),
-        ],
-    )
-    async def test_retained_arrival_order(
-        self,
-        hass: HomeAssistant,
-        zui_lock_subscribed: ZWaveJSUILock,
-        status: int,
-        code_first: bool,
-        expected: SlotCredential | None,
-    ) -> None:
-        """
-        Retained messages arrive in the broker's order, not a meaningful one.
-
-        Every permutation is pinned because the gateway retains both topics
-        and replays them on subscribe, so which one lands first is not a
-        property of the lock's state.
-        """
-        lock = zui_lock_subscribed
-        code_message = (f"{USER_CODE_VALUEID}/3", wrapped("1234"))
-        status_message = (f"{USER_ID_STATUS_VALUEID}/3", wrapped(status))
-        order = (
-            (code_message, status_message)
-            if code_first
-            else (status_message, code_message)
-        )
-
-        for suffix, payload in order:
-            fire_node_value(hass, suffix, payload)
-        await hass.async_block_till_done()
-
-        if expected is None:
-            lock.coordinator.push_update.assert_not_called()
-        else:
-            lock.coordinator.push_update.assert_called_once_with({3: expected})
 
     async def test_a_disabled_slot_does_not_gate_another_slot(
         self, hass: HomeAssistant, zui_lock_subscribed: ZWaveJSUILock

--- a/tests/providers/zwave_js_ui/test_push.py
+++ b/tests/providers/zwave_js_ui/test_push.py
@@ -64,10 +64,20 @@ def keypad_payload(user_id: Any) -> str:
 async def zui_lock_subscribed(
     hass: HomeAssistant, zui_lock_provider: ZWaveJSUILock
 ) -> ZWaveJSUILock:
-    """A provider subscribed to its node topic through the real setup path."""
+    """
+    A provider subscribed to its node topic through the real setup path.
+
+    ``desired_credential`` is seeded empty because that is what a lock with no
+    Lock Code Manager configuration wants everywhere, and a bare MagicMock
+    would answer every ``is_present`` truthily -- silently arming the
+    stale-AVAILABLE guard in every test that never mentions it.
+    """
     await zui_lock_provider.async_setup(MagicMock())
     await hass.async_block_till_done()
     zui_lock_provider.coordinator = MagicMock()
+    zui_lock_provider.coordinator.desired_credential.return_value = (
+        SlotCredential.empty()
+    )
     return zui_lock_provider
 
 
@@ -256,6 +266,241 @@ class TestUserCodeValues:
         await hass.async_block_till_done()
 
         lock.coordinator.push_update.assert_not_called()
+
+
+class TestStaleAvailable:
+    """The AVAILABLE status a lock re-sends after a code was written."""
+
+    async def test_available_is_ignored_when_a_pin_is_expected(
+        self, hass: HomeAssistant, zui_lock_subscribed: ZWaveJSUILock
+    ) -> None:
+        """
+        A slot Lock Code Manager wants a code on never reads empty from a push.
+
+        Some locks re-announce AVAILABLE after a successful write. Taken at
+        face value it tells sync the slot was cleared, sync rewrites it, the
+        lock re-announces, and the loop never ends. Same hardware signal, same
+        guard as the zwave_js provider applies.
+        """
+        lock = zui_lock_subscribed
+        lock.coordinator.desired_credential.return_value = SlotCredential.known("1234")
+
+        fire_node_value(hass, f"{USER_ID_STATUS_VALUEID}/4", wrapped(0))
+        await hass.async_block_till_done()
+
+        lock.coordinator.push_update.assert_not_called()
+
+    async def test_available_confirms_empty_when_no_pin_is_expected(
+        self, hass: HomeAssistant, zui_lock_subscribed: ZWaveJSUILock
+    ) -> None:
+        """The guard is about a contradicted clear, not about clears at all."""
+        lock = zui_lock_subscribed
+        lock.coordinator.desired_credential.return_value = SlotCredential.empty()
+
+        fire_node_value(hass, f"{USER_ID_STATUS_VALUEID}/4", wrapped(0))
+        await hass.async_block_till_done()
+
+        lock.coordinator.push_update.assert_called_once_with(
+            {4: SlotCredential.empty()}
+        )
+
+    async def test_available_confirms_empty_without_a_coordinator(
+        self, hass: HomeAssistant, zui_lock_provider: ZWaveJSUILock
+    ) -> None:
+        """
+        With nothing to ask, the observation stands rather than being dropped.
+
+        A provider answering queries outside an entry has no coordinator, so a
+        guard that treated "cannot ask" as "a PIN is expected" would suppress
+        every clear it ever saw.
+        """
+        lock = zui_lock_provider
+        await lock.async_setup(MagicMock())
+        await hass.async_block_till_done()
+        assert lock.coordinator is None
+
+        with patch.object(ZWaveJSUILock, "_confirm_slot") as confirm:
+            fire_node_value(hass, f"{USER_ID_STATUS_VALUEID}/4", wrapped(0))
+            await hass.async_block_till_done()
+
+        confirm.assert_called_once_with(4, SlotCredential.empty())
+
+
+class TestStatusGatedCodes:
+    """A published code is only a confirmation when the slot is enabled."""
+
+    async def test_a_code_after_a_disabled_status_confirms_nothing(
+        self, hass: HomeAssistant, zui_lock_subscribed: ZWaveJSUILock
+    ) -> None:
+        """
+        A Disabled slot keeps its digits, and they are not an active code.
+
+        The poll projection already requires ENABLED before it reports a code,
+        so a push that confirmed one regardless would make the same slot read
+        in-sync or unreadable depending on which transport spoke last.
+        """
+        lock = zui_lock_subscribed
+
+        fire_node_value(hass, f"{USER_ID_STATUS_VALUEID}/3", wrapped(2))
+        fire_node_value(hass, f"{USER_CODE_VALUEID}/3", wrapped("1234"))
+        await hass.async_block_till_done()
+
+        lock.coordinator.push_update.assert_not_called()
+
+    async def test_a_code_after_an_enabled_status_confirms_the_slot(
+        self, hass: HomeAssistant, zui_lock_subscribed: ZWaveJSUILock
+    ) -> None:
+        """An enabled slot's code is exactly what the poll would report."""
+        lock = zui_lock_subscribed
+
+        fire_node_value(hass, f"{USER_ID_STATUS_VALUEID}/3", wrapped(1))
+        fire_node_value(hass, f"{USER_CODE_VALUEID}/3", wrapped("1234"))
+        await hass.async_block_till_done()
+
+        lock.coordinator.push_update.assert_called_once_with(
+            {3: SlotCredential.known("1234")}
+        )
+
+    async def test_a_code_before_any_status_confirms_the_slot(
+        self, hass: HomeAssistant, zui_lock_subscribed: ZWaveJSUILock
+    ) -> None:
+        """
+        Never having heard a status is not the same as having heard a bad one.
+
+        A gateway that publishes a slot's code and never its status would
+        otherwise go permanently unconfirmed, so the unknown case keeps the
+        pre-existing behaviour and the poll corrects it if it was wrong.
+        """
+        lock = zui_lock_subscribed
+
+        fire_node_value(hass, f"{USER_CODE_VALUEID}/3", wrapped("1234"))
+        await hass.async_block_till_done()
+
+        lock.coordinator.push_update.assert_called_once_with(
+            {3: SlotCredential.known("1234")}
+        )
+
+    @pytest.mark.parametrize(
+        ("status", "code_first", "expected"),
+        [
+            pytest.param(
+                1, False, SlotCredential.known("1234"), id="enabled_then_code"
+            ),
+            pytest.param(1, True, SlotCredential.known("1234"), id="code_then_enabled"),
+            pytest.param(2, False, None, id="disabled_then_code"),
+            # The one permutation the last-seen rule cannot settle: with no
+            # status yet the code is taken at face value. Pinned so the
+            # asymmetry is a decision rather than a surprise.
+            pytest.param(
+                2, True, SlotCredential.known("1234"), id="code_then_disabled"
+            ),
+        ],
+    )
+    async def test_retained_arrival_order(
+        self,
+        hass: HomeAssistant,
+        zui_lock_subscribed: ZWaveJSUILock,
+        status: int,
+        code_first: bool,
+        expected: SlotCredential | None,
+    ) -> None:
+        """
+        Retained messages arrive in the broker's order, not a meaningful one.
+
+        Every permutation is pinned because the gateway retains both topics
+        and replays them on subscribe, so which one lands first is not a
+        property of the lock's state.
+        """
+        lock = zui_lock_subscribed
+        code_message = (f"{USER_CODE_VALUEID}/3", wrapped("1234"))
+        status_message = (f"{USER_ID_STATUS_VALUEID}/3", wrapped(status))
+        order = (
+            (code_message, status_message)
+            if code_first
+            else (status_message, code_message)
+        )
+
+        for suffix, payload in order:
+            fire_node_value(hass, suffix, payload)
+        await hass.async_block_till_done()
+
+        if expected is None:
+            lock.coordinator.push_update.assert_not_called()
+        else:
+            lock.coordinator.push_update.assert_called_once_with({3: expected})
+
+    async def test_a_disabled_slot_does_not_gate_another_slot(
+        self, hass: HomeAssistant, zui_lock_subscribed: ZWaveJSUILock
+    ) -> None:
+        """Statuses are per slot; one disabled user must not mute the rest."""
+        lock = zui_lock_subscribed
+
+        fire_node_value(hass, f"{USER_ID_STATUS_VALUEID}/3", wrapped(2))
+        fire_node_value(hass, f"{USER_CODE_VALUEID}/4", wrapped("5678"))
+        await hass.async_block_till_done()
+
+        lock.coordinator.push_update.assert_called_once_with(
+            {4: SlotCredential.known("5678")}
+        )
+
+    async def test_re_enabling_a_slot_re_admits_its_code(
+        self, hass: HomeAssistant, zui_lock_subscribed: ZWaveJSUILock
+    ) -> None:
+        """The gate follows the latest status, not the first one seen."""
+        lock = zui_lock_subscribed
+
+        fire_node_value(hass, f"{USER_ID_STATUS_VALUEID}/3", wrapped(2))
+        fire_node_value(hass, f"{USER_ID_STATUS_VALUEID}/3", wrapped(1))
+        fire_node_value(hass, f"{USER_CODE_VALUEID}/3", wrapped("1234"))
+        await hass.async_block_till_done()
+
+        lock.coordinator.push_update.assert_called_once_with(
+            {3: SlotCredential.known("1234")}
+        )
+
+    async def test_an_uninterpretable_status_does_not_gate(
+        self, hass: HomeAssistant, zui_lock_subscribed: ZWaveJSUILock
+    ) -> None:
+        """
+        A status nobody can read tells us nothing, including "not enabled".
+
+        Recording it would mute the slot's codes until the gateway happened to
+        republish a real status, which for a retained topic may be never.
+        """
+        lock = zui_lock_subscribed
+
+        fire_node_value(hass, f"{USER_ID_STATUS_VALUEID}/3", wrapped(True))
+        fire_node_value(hass, f"{USER_ID_STATUS_VALUEID}/3", wrapped("nonsense"))
+        fire_node_value(hass, f"{USER_CODE_VALUEID}/3", wrapped("1234"))
+        await hass.async_block_till_done()
+
+        lock.coordinator.push_update.assert_called_once_with(
+            {3: SlotCredential.known("1234")}
+        )
+
+    async def test_teardown_forgets_the_tracked_statuses(
+        self, hass: HomeAssistant, zui_lock_subscribed: ZWaveJSUILock
+    ) -> None:
+        """
+        A released subscription's statuses describe a node we stopped watching.
+
+        Keeping them across a teardown would let a status seen before an
+        unload gate codes published after the resubscribe, with nothing in
+        between to correct it.
+        """
+        lock = zui_lock_subscribed
+
+        fire_node_value(hass, f"{USER_ID_STATUS_VALUEID}/3", wrapped(2))
+        await hass.async_block_till_done()
+        lock.teardown_push_subscription()
+        await lock._async_ensure_node_subscription()
+
+        fire_node_value(hass, f"{USER_CODE_VALUEID}/3", wrapped("1234"))
+        await hass.async_block_till_done()
+
+        lock.coordinator.push_update.assert_called_once_with(
+            {3: SlotCredential.known("1234")}
+        )
 
 
 class TestKeypadEvents:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -2077,6 +2077,87 @@ async def test_options_flow_rejects_unclaimed_mqtt_lock(
     assert result["data"][CONF_LOCKS] == [LOCK_1_ENTITY_ID]
 
 
+async def test_options_flow_saves_around_a_grandfathered_unclaimed_lock(
+    hass: HomeAssistant, mock_lock_config_entry, mqtt_mock, mqtt_teardown
+) -> None:
+    """
+    An entry that already holds an unclaimed lock can still be edited.
+
+    Entries configured before selection-time validation existed can be
+    carrying one, and the options form re-renders the whole lock list every
+    time -- so validating all of it meant the entry could never be saved
+    again. Changing a PIN was refused because of a lock the user was not
+    touching, with no way out but hand-editing storage.
+    """
+    unclaimed = await async_discover_unclaimed_mqtt_lock(hass)
+    locks = [LOCK_1_ENTITY_ID, unclaimed.entity_id]
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="test",
+        data={
+            CONF_LOCKS: locks,
+            CONF_USERS: {"User 1": {CONF_ENABLED: True, CONF_PIN: "1234"}},
+            CONF_SLOT_ASSIGNMENT: {"user 1": 1},
+        },
+    )
+    entry.add_to_hass(hass)
+    started = await hass.config_entries.options.async_init(entry.entry_id)
+
+    with _holding():
+        result = await hass.config_entries.options.async_configure(
+            started["flow_id"],
+            user_input={
+                CONF_LOCKS: locks,
+                CONF_USERS: {"User 1": {CONF_ENABLED: True, CONF_PIN: "9999"}},
+            },
+        )
+
+    assert result["type"] == "create_entry"
+    assert result["data"][CONF_LOCKS] == locks
+    assert result["data"][CONF_USERS]["User 1"][CONF_PIN] == "9999"
+
+
+async def test_options_flow_still_refuses_a_newly_added_unclaimed_lock(
+    hass: HomeAssistant, mock_lock_config_entry, mqtt_mock, mqtt_teardown
+) -> None:
+    """
+    Grandfathering is per lock, not per entry.
+
+    An entry already carrying one unclaimed lock must not become a place
+    where any other one can be added unchecked.
+    """
+    grandfathered = await async_discover_unclaimed_mqtt_lock(hass)
+    newcomer = await async_discover_unclaimed_mqtt_lock(hass, suffix="_two")
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="test",
+        data={
+            CONF_LOCKS: [LOCK_1_ENTITY_ID, grandfathered.entity_id],
+            CONF_USERS: {"User 1": {CONF_ENABLED: True, CONF_PIN: "1234"}},
+            CONF_SLOT_ASSIGNMENT: {"user 1": 1},
+        },
+    )
+    entry.add_to_hass(hass)
+    started = await hass.config_entries.options.async_init(entry.entry_id)
+
+    with _holding():
+        result = await hass.config_entries.options.async_configure(
+            started["flow_id"],
+            user_input={
+                CONF_LOCKS: [
+                    LOCK_1_ENTITY_ID,
+                    grandfathered.entity_id,
+                    newcomer.entity_id,
+                ],
+                CONF_USERS: {"User 1": {CONF_ENABLED: True, CONF_PIN: "1234"}},
+            },
+        )
+
+    assert result["type"] == "form"
+    assert result["errors"] == {CONF_LOCKS: "unsupported_mqtt_lock"}
+    assert result["description_placeholders"]["locks"] == newcomer.entity_id
+
+
 async def test_options_flow_renders_lock_and_users_errors_together(
     hass: HomeAssistant, mock_lock_config_entry, mqtt_mock, mqtt_teardown
 ) -> None:
@@ -2131,3 +2212,39 @@ async def test_reauth_rejects_unclaimed_mqtt_lock(
     assert result["step_id"] == "reauth_confirm"
     assert result["errors"] == {CONF_LOCKS: "unsupported_mqtt_lock"}
     assert result["description_placeholders"]["locks"] == unclaimed.entity_id
+
+
+async def test_reauth_completes_around_a_grandfathered_unclaimed_lock(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    mqtt_mock,
+    mqtt_teardown,
+) -> None:
+    """
+    Reauth is the recovery path, so an old unclaimed lock must not block it.
+
+    The form is pre-filled with the entry's whole lock list, so re-validating
+    all of it meant an entry carrying one unclaimed lock could never finish a
+    reauth -- the exact entry most likely to be in reauth, and the swap it is
+    asking for is on a different lock entirely.
+    """
+    unclaimed = await async_discover_unclaimed_mqtt_lock(hass)
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            **BASE_CONFIG,
+            CONF_LOCKS: [LOCK_1_ENTITY_ID, unclaimed.entity_id],
+        },
+        unique_id="grandfathered_reauth",
+    )
+    entry.add_to_hass(hass)
+    entry.async_start_reauth(hass, context={"lock_entity_id": LOCK_1_ENTITY_ID})
+    await hass.async_block_till_done()
+
+    [flow] = entry.async_get_active_flows(hass, {SOURCE_REAUTH})
+    result = await hass.config_entries.flow.async_configure(
+        flow["flow_id"], {CONF_LOCKS: [LOCK_2_ENTITY_ID, unclaimed.entity_id]}
+    )
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "locks_updated"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -901,6 +901,95 @@ async def test_backoff_init_push_stores_none_interval(
     assert push_coordinator._lock_breaker.failure_count == 0
 
 
+class TestLatePushCapability:
+    """A bridged lock that only learns it can push after the coordinator exists."""
+
+    @staticmethod
+    def _coordinator_for_a_lock_that_gains_push(
+        hass: HomeAssistant,
+        push_lock: MockLCMPushLock,
+        lcm_config_entry: MockConfigEntry,
+    ) -> LockUsercodeUpdateCoordinator:
+        """
+        Build a coordinator that picked a poll cadence, then grant push.
+
+        A push provider that does not know it yet, which is exactly the
+        bridged case: the capability is derived from discovery data that has
+        not landed at construction time.
+        """
+        push_lock._supports_push = False
+        coordinator = _make_coordinator(hass, push_lock, lcm_config_entry)
+        assert coordinator.update_interval == push_lock.usercode_scan_interval
+        push_lock._supports_push = True
+        return coordinator
+
+    async def test_polling_stops_once_the_lock_turns_out_to_push(
+        self,
+        hass: HomeAssistant,
+        push_lock: MockLCMPushLock,
+        lcm_config_entry: MockConfigEntry,
+    ) -> None:
+        """
+        A bridged provider derives push from discovery data that lands late.
+
+        A lock whose setup was deferred was very likely built before that
+        answer existed, so it kept the cadence chosen for a lock with no push
+        -- and then polled forever, at one api round trip per slot every five
+        minutes, on a mesh this provider goes out of its way not to fill.
+        """
+        coordinator = self._coordinator_for_a_lock_that_gains_push(
+            hass, push_lock, lcm_config_entry
+        )
+        coordinator._reached_once = True
+
+        coordinator.note_push_capability()
+
+        assert coordinator.update_interval is None
+        assert coordinator._original_update_interval is None
+
+    async def test_a_probe_arm_keeps_the_interval_it_owns(
+        self,
+        hass: HomeAssistant,
+        push_lock: MockLCMPushLock,
+        lcm_config_entry: MockConfigEntry,
+    ) -> None:
+        """
+        The cadence is only applied when nothing else is currently driving it.
+
+        A lock that has never been reached is being probed on the cold-start
+        retry, and clearing the interval out from under that leaves it with
+        nothing scheduling the poll that would seed it. The arm restores
+        ``_original_update_interval`` when it lets go, and that is what has
+        just been updated.
+        """
+        coordinator = self._coordinator_for_a_lock_that_gains_push(
+            hass, push_lock, lcm_config_entry
+        )
+        coordinator._apply_backoff()
+        probe_interval = coordinator.update_interval
+
+        coordinator.note_push_capability()
+
+        assert coordinator.update_interval == probe_interval
+        assert coordinator._original_update_interval is None
+
+    async def test_losing_push_is_not_chased(
+        self, push_coordinator: LockUsercodeUpdateCoordinator, push_lock
+    ) -> None:
+        """
+        Discovery data going transiently missing is not a lock that stopped pushing.
+
+        Acting on it would restore a poll cadence, and the next publication
+        would take it away again -- so the cadence thrashes with the broker.
+        """
+        push_lock._supports_push = False
+
+        push_coordinator.note_push_capability()
+
+        assert push_coordinator.update_interval is None
+        assert push_coordinator._original_update_interval is None
+
+
 async def test_push_update_resets_backoff(
     push_coordinator: LockUsercodeUpdateCoordinator,
     push_lock: MockLCMPushLock,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -3,7 +3,7 @@
 import asyncio
 import copy
 import logging
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -40,6 +40,7 @@ from homeassistant.util import slugify
 
 from custom_components.lock_code_manager import (
     _async_reclaim_entities_from_foreign_devices,
+    _async_setup_new_locks,
     _setup_entry_after_start,
     async_remove_config_entry_device,
     async_remove_entry,
@@ -74,6 +75,7 @@ from custom_components.lock_code_manager.domain.slot_assignment import (
     CONF_SLOT_ASSIGNMENT,
 )
 from custom_components.lock_code_manager.domain.user_migration import migrate_to_users
+from custom_components.lock_code_manager.providers import BaseLock
 from custom_components.lock_code_manager.repairs import (
     AcknowledgeRepairFlow,
     async_create_fix_flow,
@@ -3112,6 +3114,82 @@ async def test_a_lock_no_provider_claims_raises_its_own_repair(
     assert unclaimed.entity_id in issue.translation_placeholders["error"]
     # The rest of the entry is untouched: one bad lock is not a failed setup.
     assert list(entry.runtime_data.locks) == [LOCK_1_ENTITY_ID]
+
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+
+async def test_a_provider_bug_during_setup_raises_no_repair(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """
+    Only an unclaimed lock gets the repair that says the bridge is unsupported.
+
+    Every other exception escaping setup is a bug in a provider LCM does
+    speak, and that repair is persistent, survives restarts, and tells the
+    user to remove a lock that works. The log line it already had is the
+    right amount of noise for a bug.
+    """
+    config = {CONF_LOCKS: [LOCK_1_ENTITY_ID], CONF_SLOTS: BASE_CONFIG[CONF_SLOTS]}
+    entry = MockConfigEntry(domain=DOMAIN, data=config, unique_id="provider_bug")
+    entry.add_to_hass(hass)
+
+    with patch.object(
+        BaseLock, "async_setup_internal", side_effect=ValueError("provider bug")
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert (
+        ir.async_get(hass).async_get_issue(DOMAIN, f"lock_dropped_{LOCK_1_ENTITY_ID}")
+        is None
+    )
+    assert list(entry.runtime_data.locks) == []
+
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+
+async def test_cancellation_during_setup_is_never_swallowed(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """
+    Shutting Home Assistant down must not look like a lock that could not load.
+
+    ``asyncio.gather(return_exceptions=True)`` hands a cancelled child back as
+    a result rather than propagating it, so cancellation reached the same
+    branch as a real failure: the lock was dropped and a persistent repair
+    blamed an unsupported bridge -- outliving the restart that ended the
+    condition, on a lock that was never unsupported at all.
+    """
+    config = {CONF_LOCKS: [LOCK_1_ENTITY_ID], CONF_SLOTS: BASE_CONFIG[CONF_SLOTS]}
+    entry = MockConfigEntry(domain=DOMAIN, data=config, unique_id="cancelled")
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Driven through the setup pass directly: Home Assistant's own config
+    # entry machinery absorbs whatever a setup raises, so going through it
+    # would assert on that absorption rather than on this loop.
+    with (
+        patch.object(
+            BaseLock, "async_setup_internal", side_effect=asyncio.CancelledError
+        ),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await _async_setup_new_locks(
+            hass,
+            entry,
+            [LOCK_2_ENTITY_ID],
+            get_entry_config(entry),
+            MagicMock(),
+            er.async_get(hass),
+        )
+
+    assert (
+        ir.async_get(hass).async_get_issue(DOMAIN, f"lock_dropped_{LOCK_2_ENTITY_ID}")
+        is None
+    )
 
     await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()


### PR DESCRIPTION
## Proposed change

Follow-up to #1466 (merged/released): a second full-PR review found defects that per-commit review could not see — several were interactions between individually-correct fixes. This PR addresses all of them, slimmed to the minimal mechanism per finding (417 production insertions):

**Correctness**
- Push classification now respects status semantics: the stale-AVAILABLE guard the `zwave_js` provider applies to the identical hardware signal (documented infinite reprogram loop) now also guards the zwave-js-ui push path, and a `userCode` publication no longer confirms a slot whose last-seen `userIdStatus` was non-ENABLED (retained-message order no longer makes state nondeterministic).
- The all-silent-read disconnect only fires once reads have ever succeeded on that lock — a Zigbee2MQTT converter that supports setting PINs but never answers a get (worked pre-5.1) polls all-unreadable again instead of tripping the breaker and suspending writes. A redundant consecutive-poll counter was deleted after analysis showed it *reset the breaker it was meant to feed*.
- Borrowed/throwaway instance releases no longer wipe the shared per-gateway scan cache; a node-level command timeout only invalidates the shared binding after a gateway-level probe (home-id checked) also fails — a slow FLiRS node no longer forces every lock behind a healthy gateway to rescan into the jammed queue.
- The `lock_dropped` repair fires only for a genuinely unclaimed lock (new `UnclaimedLockError`); `CancelledError` propagates out of setup instead of minting a persistent misdirecting repair at shutdown; other setup errors keep the log-only path.
- Options flow and reauth validate only locks a submission *adds* — a grandfathered pre-upgrade unclaimed lock no longer blocks unrelated PIN edits or reauth completion.
- A connectivity blip during the deferred-setup retry re-arms the retry instead of stranding writes until reload; ZHA gains the masked-code guard every other provider got; the ensure-api-subscription path is serialized (double-subscribe leak); MQTT-provider dispatch precedence is enforced across the whole identifier set (was hash-order-dependent for a device carrying both identifier shapes).
- Multi-level gateway prefixes (upstream permits `/` in the prefix — verified in zwave-js-ui source) now fail loud with a diagnosable message in the scan fallback, pointing at the discovery availability entry that handles them correctly.

**Efficiency**
- The 1s subscribe-settle sleep became a recorded deadline awaited only before the first publish (entry setup and config-flow allocation no longer stack sleeps); foreign api payloads are skipped by a bytes-level nonce prefilter before JSON parsing; a lock that gains push support from late-arriving discovery stops its now-redundant polling at the deferred-setup transition.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue: #1466 (follow-up review round)
- Full suite: 2153 passed / 3 skipped; total coverage 100%; every fix landed fail-first with targeted mutations (15 re-verified against the final slimmed code, each killed by a uniquely identifiable test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)