### PR TITLE
fix: tear down shared locks when the only sibling entry is unloaded

### DIFF
--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -789,9 +789,43 @@ def _lock_managed_by_other_entry(
     config_entry: LockCodeManagerConfigEntry,
     lock_entity_id: str,
 ) -> bool:
-    """Return True if another (non-disabled, non-ignored) LCM entry manages the lock."""
+    """
+    Return True if another (non-disabled, non-ignored) LCM entry manages the lock.
+
+    This asks about entry *presence*, which is what the persistent per-lock
+    repair issues care about: they outlive unloads and reloads, so an entry
+    that is merely between loads still needs its issue kept. Anything that
+    tears down live objects wants ``_lock_managed_by_other_loaded_entry``
+    instead.
+    """
     return any(
         entry.entry_id != config_entry.entry_id
+        and get_entry_config(entry).has_lock(lock_entity_id)
+        for entry in hass.config_entries.async_entries(
+            DOMAIN, include_disabled=False, include_ignore=False
+        )
+    )
+
+
+def _lock_managed_by_other_loaded_entry(
+    hass: HomeAssistant,
+    config_entry: LockCodeManagerConfigEntry,
+    lock_entity_id: str,
+) -> bool:
+    """
+    Return True if another *loaded* LCM entry manages the lock.
+
+    Teardown has to match ``_find_shared_lock_instance``, which only reuses
+    an instance from a loaded entry. An entry that exists but is unloaded
+    (setup retrying, mid-reload, disabled entry re-added) will build its own
+    instance when it next loads, so keeping this one alive on its behalf
+    leaves an ownerless BaseLock whose push subscription and config-entry
+    state listener both keep firing -- and a second instance alongside it
+    once anything reloads, which doubles every code-slot event.
+    """
+    return any(
+        entry.entry_id != config_entry.entry_id
+        and entry.state is ConfigEntryState.LOADED
         and get_entry_config(entry).has_lock(lock_entity_id)
         for entry in hass.config_entries.async_entries(
             DOMAIN, include_disabled=False, include_ignore=False
@@ -841,7 +875,7 @@ async def async_unload_lock(
         lock = runtime_data.locks.pop(_lock_entity_id, None)
         if lock is None:
             continue
-        if not _lock_managed_by_other_entry(hass, config_entry, _lock_entity_id):
+        if not _lock_managed_by_other_loaded_entry(hass, config_entry, _lock_entity_id):
             await lock.async_unload(remove_permanently)
             if lock.coordinator is not None:
                 await lock.coordinator.async_shutdown()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -691,6 +691,107 @@ async def test_overlapping_locks_both_entries_get_entities(
     await hass.config_entries.async_unload(entry_2.entry_id)
 
 
+def _entry_with_shared_lock(unique_id: str, slot_num: int) -> MockConfigEntry:
+    """Build an unloaded LCM entry managing LOCK_1 on its own slot."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_LOCKS: [LOCK_1_ENTITY_ID],
+            CONF_SLOTS: {
+                slot_num: {
+                    CONF_NAME: f"shared{slot_num}",
+                    CONF_PIN: "0123",
+                    CONF_ENABLED: True,
+                },
+            },
+        },
+        unique_id=unique_id,
+        title=unique_id,
+    )
+
+
+async def test_shared_lock_unloads_when_only_sibling_is_unloaded(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+):
+    """The last loaded entry tears the shared lock down, ignoring unloaded siblings."""
+    entry_a = _entry_with_shared_lock("Shared A", 1)
+    entry_b = _entry_with_shared_lock("Shared B", 3)
+    for entry in (entry_a, entry_b):
+        entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    shared_lock = entry_a.runtime_data.locks[LOCK_1_ENTITY_ID]
+    assert shared_lock is entry_b.runtime_data.locks[LOCK_1_ENTITY_ID]
+
+    # B goes away while A still uses the lock: the instance must survive.
+    await hass.config_entries.async_unload(entry_b.entry_id)
+    await hass.async_block_till_done()
+    assert shared_lock._config_entry_state_unsub is not None
+
+    # Now nothing loaded uses the lock. B merely *existing* must not keep the
+    # provider's listeners alive with no owner.
+    await hass.config_entries.async_unload(entry_a.entry_id)
+    await hass.async_block_till_done()
+    assert shared_lock._config_entry_state_unsub is None
+
+
+async def test_reload_with_unloaded_sibling_does_not_leave_two_instances(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+):
+    """Reloading past an unloaded sibling replaces the shared lock, not duplicates it."""
+    entry_a = _entry_with_shared_lock("Reload A", 1)
+    entry_b = _entry_with_shared_lock("Reload B", 3)
+    for entry in (entry_a, entry_b):
+        entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    original_lock = entry_a.runtime_data.locks[LOCK_1_ENTITY_ID]
+
+    await hass.config_entries.async_unload(entry_b.entry_id)
+    await hass.async_block_till_done()
+
+    await hass.config_entries.async_reload(entry_a.entry_id)
+    await hass.async_block_till_done()
+
+    # The reload builds a fresh instance because no loaded entry holds one, so
+    # the pre-reload instance must have been torn down -- two live instances
+    # means two push subscriptions and duplicate events per physical code use.
+    assert entry_a.runtime_data.locks[LOCK_1_ENTITY_ID] is not original_lock
+    assert original_lock._config_entry_state_unsub is None
+
+    await hass.config_entries.async_unload(entry_a.entry_id)
+    await hass.async_block_till_done()
+
+
+async def test_reload_with_loaded_sibling_keeps_sharing_the_instance(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+):
+    """A loaded sibling still keeps the shared lock alive across a reload."""
+    entry_a = _entry_with_shared_lock("Keep A", 1)
+    entry_b = _entry_with_shared_lock("Keep B", 3)
+    for entry in (entry_a, entry_b):
+        entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    shared_lock = entry_b.runtime_data.locks[LOCK_1_ENTITY_ID]
+
+    await hass.config_entries.async_reload(entry_a.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry_a.runtime_data.locks[LOCK_1_ENTITY_ID] is shared_lock
+    assert shared_lock._config_entry_state_unsub is not None
+
+    for entry in (entry_a, entry_b):
+        await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+
 @pytest.mark.parametrize("config", [{}])
 async def test_reload_after_started_no_listener_error(
     hass: HomeAssistant,


### PR DESCRIPTION
## Proposed change

`_lock_managed_by_other_entry` answers "does another Lock Code Manager entry
manage this lock?" by scanning `hass.config_entries.async_entries(...)` — that
tests config-entry **presence**, not whether the entry is **loaded**.

`async_unload_lock` used that predicate to decide whether to call
`lock.async_unload()`. So when a second entry merely *exists* — unloaded, in
`SETUP_RETRY`, mid-reload — the shared `BaseLock` was never torn down even
though no loaded entry was using it. Three consequences:

1. The provider's listeners survive with no loaded entry owning them.
2. **Duplicate events.** `_find_shared_lock_instance` *correctly* requires
   `LOADED`, so the next setup found nothing to reuse and built a **second**
   provider instance with a second subscription. Both fire — two events per
   physical code use. Reachable via an options change on entry A while entry B
   is in `SETUP_RETRY`, or a reload-all.
3. The skip also leaves the provider's config-entry-state listener registered,
   so a later provider reload re-runs `async_setup` against an unloaded entry.

This adds `_lock_managed_by_other_loaded_entry` and uses it at the unload site
only, so teardown asks the same question `_find_shared_lock_instance` asks when
deciding to share.

The other two call sites keep presence semantics deliberately. Both clean up
per-lock repair issues (`async_remove_entry` and the options-flow lock removal),
and those issues are flagged `is_persistent=True` — they outlive unloads and
reloads by design. An entry that is merely between loads still needs its issue
kept, so presence is the correct question there.

### Tests

Three tests in `tests/test_init.py`, all driven through the real config-entry
lifecycle with two entries sharing `lock.test_1`:

- `test_shared_lock_unloads_when_only_sibling_is_unloaded` — the sibling
  unloads first, then the last loaded entry must tear the lock down. Also
  asserts the instance *survives* the first unload, which is the HA-shutdown
  ordering.
- `test_reload_with_unloaded_sibling_does_not_leave_two_instances` — reload
  past an unloaded sibling; the pre-reload instance must be torn down rather
  than left alongside the new one.
- `test_reload_with_loaded_sibling_keeps_sharing_the_instance` — guard against
  over-fixing: a genuinely loaded sibling still keeps the shared instance.

The observable is `BaseLock._config_entry_state_unsub`, which `async_unload`
clears — it is both a faithful "did teardown run?" witness and consequence 3
itself. Mutation-checked both ways: dropping the `LOADED` clause fails the
first two tests, restoring it passes all three.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #1476
- This PR is related to issue:

🤖 Generated with [Claude Code](https://claude.com/claude-code)