### PR TITLE
fix: label the config flow fields the 5.0.0 rename left behind

### DIFF
--- a/custom_components/lock_code_manager/strings.json
+++ b/custom_components/lock_code_manager/strings.json
@@ -31,7 +31,7 @@
       },
       "code_slot": {
         "data": {
-          "entity_id": "Condition Entity",
+          "condition": "Condition Entity",
           "enabled": "Enabled",
           "name": "Name",
           "pin": "PIN Code"
@@ -56,10 +56,10 @@
       },
       "yaml": {
         "data": {
-          "slots": "Slots YAML"
+          "users": "Users YAML"
         },
-        "description": "The config is expected to be a dictionary where the key is the slot number. For more information, check the docs.",
-        "title": "Configure slots"
+        "description": "The config is expected to be a dictionary where the key is the user's name. Lock Code Manager picks the code slot each user occupies. For more information, check the docs.",
+        "title": "Configure users"
       },
       "reauth_confirm": {
         "data": {
@@ -143,9 +143,9 @@
       "init": {
         "data": {
           "locks": "Locks",
-          "slots": "Slots YAML"
+          "users": "Users YAML"
         },
-        "description": "Update the locks that are associated with this config entry and/or the slot configurations.",
+        "description": "Update the locks that are associated with this config entry and/or the users.",
         "title": "Lock Code Manager"
       }
     }

--- a/custom_components/lock_code_manager/translations/en.json
+++ b/custom_components/lock_code_manager/translations/en.json
@@ -31,7 +31,7 @@
       },
       "code_slot": {
         "data": {
-          "entity_id": "Condition Entity",
+          "condition": "Condition Entity",
           "enabled": "Enabled",
           "name": "Name",
           "pin": "PIN Code"
@@ -56,10 +56,10 @@
       },
       "yaml": {
         "data": {
-          "slots": "Slots YAML"
+          "users": "Users YAML"
         },
-        "description": "The config is expected to be a dictionary where the key is the slot number. For more information, check the docs.",
-        "title": "Configure slots"
+        "description": "The config is expected to be a dictionary where the key is the user's name. Lock Code Manager picks the code slot each user occupies. For more information, check the docs.",
+        "title": "Configure users"
       },
       "reauth_confirm": {
         "data": {
@@ -143,9 +143,9 @@
       "init": {
         "data": {
           "locks": "Locks",
-          "slots": "Slots YAML"
+          "users": "Users YAML"
         },
-        "description": "Update the locks that are associated with this config entry and/or the slot configurations.",
+        "description": "Update the locks that are associated with this config entry and/or the users.",
         "title": "Lock Code Manager"
       }
     }

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -161,6 +161,92 @@ async def _init_flow_to_user_step(hass: HomeAssistant) -> str:
     return result["flow_id"]
 
 
+def _assert_fields_are_labelled(result, category: str) -> None:
+    """
+    Assert a form's fields and its labels name the same set of keys.
+
+    ``ha-form`` falls back to the raw key when a field has no label, so a
+    field the strings do not name reaches the user as ``condition`` rather
+    than "Condition Entity". Comparing as sets catches the other half of the
+    same mistake: a label still filed under the key a rename left behind
+    names nothing, and is the only trace that the rename was half-done.
+
+    The schema comes off the form the flow actually returned rather than
+    from an import, so a step that builds its schema inline is covered the
+    same as one that reuses a module constant.
+    """
+    strings = json.loads(
+        Path("custom_components/lock_code_manager/strings.json").read_text()
+    )
+    step_id = result["step_id"]
+    labelled = set(strings[category]["step"][step_id].get("data", {}))
+    fields = {str(key.schema) for key in result["data_schema"].schema}
+    assert fields == labelled, (
+        f"{category} step {step_id}: fields {sorted(fields)} "
+        f"but labels {sorted(labelled)}"
+    )
+
+
+async def test_every_config_flow_field_has_a_label(
+    hass: HomeAssistant, mock_lock_config_entry
+):
+    """Every field the setup flow shows is named by the strings."""
+    flow_id = await _init_flow_to_user_step(hass)
+    result = await hass.config_entries.flow.async_configure(flow_id)
+    _assert_fields_are_labelled(result, "config")
+
+    result = await hass.config_entries.flow.async_configure(
+        flow_id, {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        flow_id, {"next_step_id": "ui"}
+    )
+    _assert_fields_are_labelled(result, "config")
+
+    result = await hass.config_entries.flow.async_configure(
+        flow_id, {CONF_NUM_USERS: 1}
+    )
+    _assert_fields_are_labelled(result, "config")
+
+    # The yaml path is the ui path's sibling, so reaching it takes a second
+    # flow -- under a second name, because the first one holds the unique id.
+    flow_id = await _init_flow_to_user_step(hass)
+    await hass.config_entries.flow.async_configure(
+        flow_id, {CONF_NAME: "test2", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        flow_id, {"next_step_id": "yaml"}
+    )
+    _assert_fields_are_labelled(result, "config")
+
+
+async def test_every_options_flow_field_has_a_label(
+    hass: HomeAssistant, mock_lock_config_entry
+):
+    """Every field the options flow shows is named by the strings."""
+    entry = MockConfigEntry(domain=DOMAIN, data=BASE_CONFIG, unique_id="Mock Title")
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    _assert_fields_are_labelled(result, "options")
+
+
+async def test_every_reauth_field_has_a_label(
+    hass: HomeAssistant, mock_lock_config_entry, lock_code_manager_config_entry
+):
+    """Every field the reauth flow shows is named by the strings."""
+    lock_code_manager_config_entry.async_start_reauth(
+        hass, context={"lock_entity_id": LOCK_1_ENTITY_ID}
+    )
+    await hass.async_block_till_done()
+    [flow] = lock_code_manager_config_entry.async_get_active_flows(
+        hass, {SOURCE_REAUTH}
+    )
+    # The in-progress flow carries no schema, so render the form to get one.
+    result = await hass.config_entries.flow.async_configure(flow["flow_id"])
+    _assert_fields_are_labelled(result, "config")
+
+
 async def test_config_flow_ui(hass: HomeAssistant, mock_lock_config_entry):
     """Test UI based config flow with slot number incrementing correctly."""
     flow_id = await _start_ui_config_flow(hass)

--- a/tests/test_frontend_contract.py
+++ b/tests/test_frontend_contract.py
@@ -224,11 +224,14 @@ def test_every_entity_key_has_a_name() -> None:
 
 def test_every_translation_matches_the_strings_it_translates() -> None:
     """
-    A name added to one file and not the other ships untranslated.
+    A string added to one file and not the other ships untranslated.
 
     ``strings.json`` is what Home Assistant uploads for translation and
     ``translations/en.json`` is what it actually renders for an English
-    install, so a name that reaches only the first is a name nobody sees.
+    install, so a string that reaches only the first is one nobody sees.
+    The whole document is compared, not just the entity names: the config
+    flow reads its field labels from here too, and a rename that lands in
+    one file leaves the other naming a key that no longer exists.
     """
     root = (
         pathlib.Path(__file__).resolve().parent.parent
@@ -240,4 +243,4 @@ def test_every_translation_matches_the_strings_it_translates() -> None:
         (root / "translations" / "en.json").read_text(encoding="utf-8")
     )
 
-    assert strings["entity"] == english["entity"]
+    assert strings == english


### PR DESCRIPTION
## Proposed change

Three config flow fields have been rendering as raw, lowercase keys in every 5.x release. The user-centric rename in #1462 changed the schema keys and left every one of their labels behind:

| Step | Schema key | Label key in `strings.json` | Rendered |
|---|---|---|---|
| `config.code_slot` | `condition` | `entity_id` | `condition` |
| `config.yaml` | `users` | `slots` | `users` |
| `options.init` | `users` | `slots` | `users` |

`ha-form` falls back to `schema.name` when a field has no label, so nothing errored — the field just quietly lost its name. It is visible in the screenshot on #1474 as a bare `condition` under the PIN field.

The copy in the same two steps was stale for the same reason: the YAML editor still described "a dictionary where the key is the slot number", sitting directly next to the `users_keyed_by_slot` error that rejects exactly that shape.

### The guard

Each flow surface now renders its form and asserts that the schema and the strings name the same set of keys. Two things make it catch this class rather than just this instance:

- The schema is read off `result["data_schema"]` — the form the flow actually returned — so the steps that build theirs inline inside `async_show_form` (`yaml`, `options.init`) are covered the same as the ones that reuse a module constant.
- It compares as **sets**, not "no unlabelled fields". A label still filed under the key a rename left behind names nothing, and is the only trace that the rename was half-done. Asserting equality caught both halves; all three failures above were red before the fix.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #1474

Note that this does **not** fix the `MISSING_VALUE`/`slot_num` error #1474 was filed about. That string was removed in 5.0.0 and 5.1.1 ships `"User {user_num} of {num_users}"`, so the reporter is running 5.1.1 code against pre-5.0.0 strings held by HA's process-lifetime translation cache: `_TranslationCache._async_load` never re-reads a component off disk once loaded, and `_validate_placeholders` actively *drops* an updated string whose placeholders differ from the cached one. A restart clears it. The screenshot is what led here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)