### PR TITLE
refactor: thread the config entry into build_lock_instance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,10 @@ entities.
 - `zha.py`: Zigbee Home Automation lock implementation
 - `zigbee2mqtt.py`: Zigbee2MQTT lock implementation (via MQTT)
 - `zwave_js_ui.py`: zwave-js-ui lock implementation (via MQTT, api-driven)
-- `virtual.py`: Virtual lock implementation for testing
+- `virtual.py`: Virtual lock implementation -- a credential store rather than a device.
+  Advertises every credential type with no limits, and reports code slot events so it can be
+  the recording surface for credentials used where Lock Code Manager observes nothing
+  (`use_credential`). Also the way to try Lock Code Manager without a real lock.
 - Each provider implements: `async_get_users()`, `async_set_credential()`, `async_delete_credential()`,
   `async_is_integration_connected()`, `async_hard_refresh_codes()`
 - Providers listen for lock-specific events and translate them to LCM events via `async_fire_code_slot_event()`

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Supported lock integrations:
 | [Matter][wiki-matter] | ❌ | ✅ | ✅ | PINs write-only per spec |
 | [Schlage WiFi][wiki-schlage] | ❌ | ❌ | ❌ | Cloud-based, PINs masked |
 | [Akuvox][wiki-akuvox]¹ | ✅ | ❌ | ❌ | Local API, polling-based |
-| [Virtual][wiki-virtual]¹ | ✅ | ❌ | ❌ | For testing only |
+| [Virtual][wiki-virtual]¹ | ✅ | ❌ | ✅ | A credential store rather than a device: records uses reported by the `use_credential` action, and lets you try Lock Code Manager without a real lock |
 
 ¹ Custom integration required ([Local Akuvox][local-akuvox],
 [hass-virtual][hass-virtual])

--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -338,7 +338,8 @@ class LockCodeManagerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             # Settled before a single name is collected. Which users get
             # configured does not change which numbers allocation issues, so
             # the count alone decides whether they fit -- and a refusal here
-            # is one the user can still act on.
+            # is one the user can still act on. The ``None`` is the entry the
+            # lock reads are made for: this flow is what creates it.
             (
                 unavailable,
                 errors,
@@ -461,7 +462,9 @@ class LockCodeManagerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 assert users is not None
                 # Same allocation the guided path uses, against the same
                 # occupancy: nobody picks a number on either route, so
-                # neither can land on one a lock already holds.
+                # neither can land on one a lock already holds. The ``None``
+                # is the entry the lock reads are made for, which this flow
+                # has not created yet.
                 (
                     unavailable,
                     allocation_errors,

--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -171,6 +171,7 @@ def _check_common_slots(
 
 async def _async_validate_users_yaml(
     hass: HomeAssistant,
+    config_entry: ConfigEntry | None,
     raw_users: dict[Any, Any],
     locks: Iterable[str],
 ) -> tuple[dict | None, dict, dict]:
@@ -181,6 +182,10 @@ async def _async_validate_users_yaml(
     and the numbers are allocated afterwards from whatever the locks leave
     free. What can still fail is a name that is empty or that means the same
     person as another, and a count of users no lock could hold.
+
+    ``config_entry`` is the entry the submission is for, or ``None`` from
+    the flow that is still creating one; it is what the lock reads this
+    performs are made on behalf of.
 
     Returns the parsed users -- or ``None`` when validation failed -- with the
     accumulated errors and description placeholders.
@@ -224,7 +229,7 @@ async def _async_validate_users_yaml(
 
     # The count is what a lock has to hold, now that nobody picks a number.
     try:
-        await async_check_slot_capacity(hass, locks, [len(parsed_users)])
+        await async_check_slot_capacity(hass, config_entry, locks, [len(parsed_users)])
     except SlotAllocationError as err:
         return (
             None,
@@ -236,21 +241,23 @@ async def _async_validate_users_yaml(
 
 async def _allocate_for(
     hass: HomeAssistant,
+    config_entry: ConfigEntry | None,
     locks: Sequence[str],
     num_users: int,
-    *,
-    excluding: ConfigEntry | None = None,
 ) -> tuple[frozenset[int] | None, dict[str, str], dict[str, Any]]:
     """
     Find numbers for ``num_users``, or say why it could not.
 
     Allocation itself lives in ``domain.allocation``, which the services call
     too; this only turns its refusals into the form errors a flow renders.
+
+    ``config_entry`` is the entry being allocated for, whose own numbers do
+    not constrain it: kept ones are held by tenure, released ones are free
+    for whoever comes next. A flow that is still creating its entry passes
+    ``None``, which by the same rule holds nothing.
     """
     try:
-        unavailable = await async_allocate_for(
-            hass, locks, num_users, excluding=excluding
-        )
+        unavailable = await async_allocate_for(hass, config_entry, locks, num_users)
     except SlotAllocationError as err:
         return None, {"base": err.translation_key}, err.placeholders
     return unavailable, {}, {}
@@ -336,7 +343,7 @@ class LockCodeManagerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 unavailable,
                 errors,
                 description_placeholders,
-            ) = await _allocate_for(self.hass, self.data[CONF_LOCKS], num_users)
+            ) = await _allocate_for(self.hass, None, self.data[CONF_LOCKS], num_users)
             if unavailable is not None:
                 self._users_to_configure = num_users
                 self._unavailable = unavailable
@@ -445,7 +452,7 @@ class LockCodeManagerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 validation_errors,
                 validation_placeholders,
             ) = await _async_validate_users_yaml(
-                self.hass, user_input[CONF_USERS], self.data[CONF_LOCKS]
+                self.hass, None, user_input[CONF_USERS], self.data[CONF_LOCKS]
             )
             errors.update(validation_errors)
             description_placeholders.update(validation_placeholders)
@@ -459,7 +466,9 @@ class LockCodeManagerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     unavailable,
                     allocation_errors,
                     allocation_placeholders,
-                ) = await _allocate_for(self.hass, self.data[CONF_LOCKS], len(users))
+                ) = await _allocate_for(
+                    self.hass, None, self.data[CONF_LOCKS], len(users)
+                )
                 if unavailable is None:
                     return self.async_show_form(
                         step_id="yaml",
@@ -545,7 +554,7 @@ class LockCodeManagerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 # already-valid slot set can become too large for the new lock.
                 try:
                     await async_check_slot_capacity(
-                        self.hass, user_input[CONF_LOCKS], existing_slots
+                        self.hass, config_entry, user_input[CONF_LOCKS], existing_slots
                     )
                 except SlotAllocationError as err:
                     additional_errors = {"base": err.translation_key}
@@ -626,7 +635,10 @@ class LockCodeManagerOptionsFlow(config_entries.OptionsFlow):
                 validation_errors,
                 validation_placeholders,
             ) = await _async_validate_users_yaml(
-                self.hass, user_input[CONF_USERS], user_input[CONF_LOCKS]
+                self.hass,
+                self.config_entry,
+                user_input[CONF_USERS],
+                user_input[CONF_LOCKS],
             )
             errors.update(validation_errors)
             description_placeholders.update(validation_placeholders)
@@ -639,11 +651,9 @@ class LockCodeManagerOptionsFlow(config_entries.OptionsFlow):
                     allocation_placeholders,
                 ) = await _allocate_for(
                     self.hass,
+                    self.config_entry,
                     user_input[CONF_LOCKS],
                     len(users),
-                    # Its own numbers do not constrain it: kept ones are held
-                    # by tenure, released ones are free for whoever comes next.
-                    excluding=self.config_entry,
                 )
                 if unavailable is None:
                     errors.update(allocation_errors)

--- a/custom_components/lock_code_manager/domain/allocation.py
+++ b/custom_components/lock_code_manager/domain/allocation.py
@@ -69,6 +69,7 @@ def build_lock_instance(
     hass: HomeAssistant,
     dev_reg: dr.DeviceRegistry,
     ent_reg: er.EntityRegistry,
+    config_entry: ConfigEntry | None,
     lock_entity_id: str,
 ) -> Any:
     """
@@ -77,11 +78,22 @@ def build_lock_instance(
     Performs setup-time checks (entity in registry, a provider claims it,
     parent config entry exists) and instantiates the provider class.
     Raises ``LockQuerySkipped`` if any setup-time check fails.
+
+    ``config_entry`` is the Lock Code Manager entry the lock is being read
+    for, and is ``None`` only while the entry that will own it is still
+    being created. What this factory decides about a lock -- above all
+    whether an unbuildable one is still one credentials get written to --
+    is a question about that entry's configuration, not about the lock
+    alone, so the entry has to be reachable from here.
     """
+    # Locks are shared between entries, so a skipped read names the entry
+    # that asked as well as the lock it gave up on.
+    asked_by = config_entry.entry_id if config_entry else "New entry"
     lock_entry = ent_reg.async_get(lock_entity_id)
     if not lock_entry:
         _LOGGER.warning(
-            "Entity %s not found in registry; skipping usercode check",
+            "%s: entity %s not found in registry; skipping usercode check",
+            asked_by,
             lock_entity_id,
         )
         raise LockQuerySkipped(lock_entity_id, managed=True)
@@ -91,7 +103,8 @@ def build_lock_instance(
         # no provider speaks: either way nothing is ever written there, so
         # the lock constrains no numbering.
         _LOGGER.debug(
-            "No provider claims lock %s (platform %s); skipping usercode check",
+            "%s: no provider claims lock %s (platform %s); skipping usercode check",
+            asked_by,
             lock_entity_id,
             lock_entry.platform,
         )
@@ -99,7 +112,8 @@ def build_lock_instance(
     lock_config_entry = hass.config_entries.async_get_entry(lock_entry.config_entry_id)
     if lock_config_entry is None:
         _LOGGER.warning(
-            "Config entry for lock %s not found; skipping usercode check",
+            "%s: config entry for lock %s not found; skipping usercode check",
+            asked_by,
             lock_entity_id,
         )
         raise LockQuerySkipped(lock_entity_id, managed=True)
@@ -109,6 +123,7 @@ def build_lock_instance(
 
 async def async_check_slot_capacity(
     hass: HomeAssistant,
+    config_entry: ConfigEntry | None,
     locks: Iterable[str],
     slots_list: Iterable[int | str],
 ) -> None:
@@ -132,7 +147,9 @@ async def async_check_slot_capacity(
     for lock_entity_id in locks:
         try:
             async with borrowed_lock_instance(
-                build_lock_instance(hass, dev_reg, ent_reg, lock_entity_id)
+                build_lock_instance(
+                    hass, dev_reg, ent_reg, config_entry, lock_entity_id
+                )
             ) as lock_instance:
                 if not lock_instance.credential_index_follows_slot:
                     continue
@@ -169,10 +186,9 @@ async def async_check_slot_capacity(
 
 async def async_read_occupancy(
     hass: HomeAssistant,
+    config_entry: ConfigEntry | None,
     locks: Sequence[str],
     indices: Collection[int],
-    *,
-    excluding: ConfigEntry | None = None,
 ) -> Occupancy:
     """
     Ask every lock in ``locks`` which of ``indices`` it holds.
@@ -183,16 +199,20 @@ async def async_read_occupancy(
     to answer has to arrive that way, including the ones no provider
     promised.
 
-    ``excluding`` is the entry being edited, whose own numbers do not
-    constrain it: kept ones are held by tenure, released ones are free for
-    whoever comes next.
+    ``config_entry`` is the entry being allocated for, which is also the
+    one entry whose numbers do not constrain the answer: kept ones are held
+    by tenure, released ones are free for whoever comes next. ``None`` is
+    an entry still being created, which by the same rule holds nothing and
+    so excludes nothing.
     """
     dev_reg = dr.async_get(hass)
     ent_reg = er.async_get(hass)
     lock_occupancies: list[LockOccupancy] = []
     for lock_entity_id in locks:
         try:
-            lock_instance = build_lock_instance(hass, dev_reg, ent_reg, lock_entity_id)
+            lock_instance = build_lock_instance(
+                hass, dev_reg, ent_reg, config_entry, lock_entity_id
+            )
         except LockQuerySkipped as skipped:
             lock_occupancies.append(
                 LockOccupancy(
@@ -255,7 +275,7 @@ async def async_read_occupancy(
         claimed_by_other_entries=frozenset(
             slot
             for lock_entity_id in locks
-            for slot in get_managed_slots(hass, lock_entity_id, excluding=excluding)
+            for slot in get_managed_slots(hass, lock_entity_id, excluding=config_entry)
         ),
     )
 
@@ -305,7 +325,7 @@ def _too_far(
 
 
 async def async_max_slot(
-    hass: HomeAssistant, locks: Sequence[str]
+    hass: HomeAssistant, config_entry: ConfigEntry | None, locks: Sequence[str]
 ) -> tuple[int, str | None]:
     """
     Return how far a search for free numbers may go across these locks.
@@ -326,7 +346,9 @@ async def async_max_slot(
     for lock_entity_id in locks:
         try:
             async with borrowed_lock_instance(
-                build_lock_instance(hass, dev_reg, ent_reg, lock_entity_id)
+                build_lock_instance(
+                    hass, dev_reg, ent_reg, config_entry, lock_entity_id
+                )
             ) as lock_instance:
                 if not lock_instance.credential_index_follows_slot:
                     continue
@@ -352,10 +374,9 @@ async def async_max_slot(
 
 async def async_allocate_for(
     hass: HomeAssistant,
+    config_entry: ConfigEntry | None,
     locks: Sequence[str],
     num_users: int,
-    *,
-    excluding: ConfigEntry | None = None,
 ) -> frozenset[int]:
     """
     Find numbers for ``num_users``, reading only as far as it has to.
@@ -376,13 +397,13 @@ async def async_allocate_for(
     once they have names.
     """
     try:
-        await async_check_slot_capacity(hass, locks, [num_users])
+        await async_check_slot_capacity(hass, config_entry, locks, [num_users])
     except SlotAllocationError as err:
         raise SlotAllocationError(
             "too_many_users", {**err.placeholders, "num_users": str(num_users)}
         ) from err
 
-    max_slot, limiting_lock = await async_max_slot(hass, locks)
+    max_slot, limiting_lock = await async_max_slot(hass, config_entry, locks)
     if num_users > max_slot:
         # Before the first read, not just before each widening: a count
         # past the range walks off the end of the lock on the way in, and
@@ -397,7 +418,7 @@ async def async_allocate_for(
         # each pass would cost a nearly-full lock several times its own
         # capacity to place a couple of users.
         occupancy = await async_read_occupancy(
-            hass, locks, range(read_up_to + 1, window + 1), excluding=excluding
+            hass, config_entry, locks, range(read_up_to + 1, window + 1)
         )
         if not occupancy.is_known:
             # Unreadable is not free: issuing a number could overwrite a
@@ -415,7 +436,7 @@ async def async_allocate_for(
         # Every number in the way pushes the last user one further out.
         wider = num_users + taken_in_window
         try:
-            await async_check_slot_capacity(hass, locks, [wider])
+            await async_check_slot_capacity(hass, config_entry, locks, [wider])
         except SlotAllocationError as err:
             # Distinct from the count being too large: the count fits,
             # and the numbers needed to reach around what is already

--- a/custom_components/lock_code_manager/domain/allocation.py
+++ b/custom_components/lock_code_manager/domain/allocation.py
@@ -140,6 +140,9 @@ async def async_check_slot_capacity(
     capabilities need the lock awake, and a sleeping battery lock must not
     make the config flow unusable. The same check runs at write time, where
     it can suspend the affected slot precisely.
+
+    ``config_entry`` is the entry the locks are being read for, on the terms
+    ``build_lock_instance`` describes.
     """
     dev_reg = dr.async_get(hass)
     ent_reg = er.async_get(hass)
@@ -339,6 +342,9 @@ async def async_max_slot(
     A lock of ``None`` means nothing here could say and the limit is this
     integration's own -- which a message must not describe as a capacity
     some lock reported.
+
+    ``config_entry`` is the entry the locks are being read for, on the terms
+    ``build_lock_instance`` describes.
     """
     dev_reg = dr.async_get(hass)
     ent_reg = er.async_get(hass)
@@ -395,6 +401,9 @@ async def async_allocate_for(
     Returns the numbers allocation must avoid, verified across a window
     wide enough to hold everyone. The users are numbered from it later,
     once they have names.
+
+    ``config_entry`` is the entry the numbers are being allocated for, on the
+    terms ``build_lock_instance`` describes.
     """
     try:
         await async_check_slot_capacity(hass, config_entry, locks, [num_users])

--- a/custom_components/lock_code_manager/domain/services.py
+++ b/custom_components/lock_code_manager/domain/services.py
@@ -241,7 +241,7 @@ async def async_add_user(
 
     try:
         unavailable = await async_allocate_for(
-            hass, config.locks, len(config.users) + 1, excluding=config_entry
+            hass, config_entry, config.locks, len(config.users) + 1
         )
     except SlotAllocationError as err:
         raise ServiceValidationError(

--- a/tests/common.py
+++ b/tests/common.py
@@ -37,28 +37,6 @@ from custom_components.lock_code_manager.domain.credentials import WriteResult
 from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers import BaseLock
 
-
-@contextmanager
-def reading_for():
-    """
-    Record the entry every lock read allocation performs is made on behalf of.
-
-    The real factory still runs, so the caller under test behaves exactly as
-    it would unwatched; only the entry it was handed is captured.
-    """
-    read_for: list[ConfigEntry | None] = []
-
-    def _spy(hass, dev_reg, ent_reg, config_entry, lock_entity_id):
-        read_for.append(config_entry)
-        return build_lock_instance(hass, dev_reg, ent_reg, config_entry, lock_entity_id)
-
-    with patch(
-        "custom_components.lock_code_manager.domain.allocation.build_lock_instance",
-        _spy,
-    ):
-        yield read_for
-
-
 LOCK_1_ENTITY_ID = "lock.test_1"
 LOCK_2_ENTITY_ID = "lock.test_2"
 
@@ -80,6 +58,27 @@ BASE_CONFIG = {
 
 UNCLAIMED_IDENTIFIER = "somebridge_1"
 UNCLAIMED_UNIQUE_ID = f"{UNCLAIMED_IDENTIFIER}_lock"
+
+
+@contextmanager
+def reading_for():
+    """
+    Record the entry every lock read allocation performs is made on behalf of.
+
+    The real factory still runs, so the caller under test behaves exactly as
+    it would unwatched; only the entry it was handed is captured.
+    """
+    read_for: list[ConfigEntry | None] = []
+
+    def _spy(hass, dev_reg, ent_reg, config_entry, lock_entity_id):
+        read_for.append(config_entry)
+        return build_lock_instance(hass, dev_reg, ent_reg, config_entry, lock_entity_id)
+
+    with patch(
+        "custom_components.lock_code_manager.domain.allocation.build_lock_instance",
+        _spy,
+    ):
+        yield read_for
 
 
 async def async_discover_unclaimed_mqtt_lock(

--- a/tests/common.py
+++ b/tests/common.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 from collections import defaultdict
 from collections.abc import Collection
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 import json
 from typing import Literal
+from unittest.mock import patch
 
 from pytest_homeassistant_custom_component.common import async_fire_mqtt_message
 
@@ -29,10 +31,33 @@ from custom_components.lock_code_manager.const import (
     CONF_SLOTS,
     DOMAIN,
 )
+from custom_components.lock_code_manager.domain.allocation import build_lock_instance
 from custom_components.lock_code_manager.domain.config import build_slot_unique_id
 from custom_components.lock_code_manager.domain.credentials import WriteResult
 from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers import BaseLock
+
+
+@contextmanager
+def reading_for():
+    """
+    Record the entry every lock read allocation performs is made on behalf of.
+
+    The real factory still runs, so the caller under test behaves exactly as
+    it would unwatched; only the entry it was handed is captured.
+    """
+    read_for: list[ConfigEntry | None] = []
+
+    def _spy(hass, dev_reg, ent_reg, config_entry, lock_entity_id):
+        read_for.append(config_entry)
+        return build_lock_instance(hass, dev_reg, ent_reg, config_entry, lock_entity_id)
+
+    with patch(
+        "custom_components.lock_code_manager.domain.allocation.build_lock_instance",
+        _spy,
+    ):
+        yield read_for
+
 
 LOCK_1_ENTITY_ID = "lock.test_1"
 LOCK_2_ENTITY_ID = "lock.test_2"

--- a/tests/providers/test_dispatch.py
+++ b/tests/providers/test_dispatch.py
@@ -222,7 +222,7 @@ async def test_allocation_skips_unclaimed_mqtt_lock(
 
     with pytest.raises(LockQuerySkipped) as raised:
         build_lock_instance(
-            hass, dr.async_get(hass), er.async_get(hass), lock_entry.entity_id
+            hass, dr.async_get(hass), er.async_get(hass), None, lock_entry.entity_id
         )
 
     assert raised.value.managed is False

--- a/tests/providers/zwave_js_ui/test_borrowed.py
+++ b/tests/providers/zwave_js_ui/test_borrowed.py
@@ -73,7 +73,9 @@ async def test_the_occupancy_read_returns_the_transport_it_borrowed(
     allocation refuses to issue numbers it could not verify are free.
     """
     with track_zui_transport() as transport:
-        occupancy = await async_read_occupancy(hass, [zui_lock_answering], range(1, 3))
+        occupancy = await async_read_occupancy(
+            hass, None, [zui_lock_answering], range(1, 3)
+        )
 
     assert occupancy.is_known
     assert transport.opened
@@ -93,7 +95,7 @@ async def test_the_capacity_check_returns_the_transport_it_borrowed(
     does not have to remember to add a teardown.
     """
     with track_zui_transport() as transport:
-        await async_check_slot_capacity(hass, [zui_lock_answering], [2])
+        await async_check_slot_capacity(hass, None, [zui_lock_answering], [2])
 
     assert transport.disposed == [zui_lock_answering]
 
@@ -103,7 +105,7 @@ async def test_the_slot_range_query_returns_the_transport_it_borrowed(
 ) -> None:
     """Asking how far the slot numbers go opens the same transport, and closes it."""
     with track_zui_transport() as transport:
-        assert await async_max_slot(hass, [zui_lock_answering]) == (
+        assert await async_max_slot(hass, None, [zui_lock_answering]) == (
             LOCK_CAPACITY,
             zui_lock_answering,
         )
@@ -154,7 +156,7 @@ async def test_a_returned_provider_stops_reporting_keypad_use(
     assert [event.data[ATTR_CODE_SLOT] for event in events] == [1]
 
     # What an options flow does on its way to re-numbering the users.
-    await async_read_occupancy(hass, [zui_lock.lock.entity_id], range(1, 3))
+    await async_read_occupancy(hass, None, [zui_lock.lock.entity_id], range(1, 3))
 
     fire_zui_node_value(hass, KEYPAD_UNLOCK, {"userId": 1})
     await hass.async_block_till_done()

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,6 +1,7 @@
 """Config flow tests."""
 
 import json
+import logging
 from pathlib import Path
 import re
 from unittest.mock import AsyncMock, PropertyMock, patch
@@ -1980,6 +1981,45 @@ async def test_a_lock_that_cannot_be_built_says_whether_it_is_ours(
         build_lock_instance(hass, dr.async_get(hass), ent_reg, None, entity_id)
 
     assert raised.value.managed is managed
+
+
+async def test_a_skipped_lock_read_names_the_entry_that_asked(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    Giving up on a lock has to say who gave up on it.
+
+    Locks are shared between entries, so the lock alone does not identify
+    the read that stopped: whoever reads the log has to be able to tell
+    which entry's configuration to go and look at. Setup is the one caller
+    with honestly nobody to name.
+    """
+    dev_reg = dr.async_get(hass)
+    ent_reg = er.async_get(hass)
+
+    def _asked_by(config_entry) -> str:
+        caplog.clear()
+        with caplog.at_level(logging.WARNING), pytest.raises(LockQuerySkipped):
+            build_lock_instance(
+                hass, dev_reg, ent_reg, config_entry, "lock.never_registered"
+            )
+        [record] = [
+            record
+            for record in caplog.records
+            if record.name.endswith("domain.allocation")
+        ]
+        asked_by, lock_entity_id = record.args
+        assert lock_entity_id == "lock.never_registered"
+        return asked_by
+
+    assert (
+        _asked_by(lock_code_manager_config_entry)
+        == lock_code_manager_config_entry.entry_id
+    )
+    assert _asked_by(None) == "New entry"
 
 
 async def test_setup_refuses_when_a_lock_cannot_be_read(

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -47,6 +47,7 @@ from .common import (
     LOCK_2_ENTITY_ID,
     MockLCMLock,
     async_discover_unclaimed_mqtt_lock,
+    reading_for,
 )
 from .providers.zigbee2mqtt.conftest import async_discover_z2m_lock
 
@@ -935,6 +936,76 @@ async def test_setup_ignores_a_lock_on_an_unsupported_platform(
 
     assert result["type"] == "form"
     assert result["step_id"] == "code_slot"
+
+
+async def test_setup_reads_the_locks_for_no_entry_at_all(
+    hass: HomeAssistant, mock_lock_config_entry
+):
+    """
+    The flow that creates an entry has none yet, and its reads say so.
+
+    What allocation makes of a lock -- above all whether one it cannot build
+    a provider for is still one credentials get written to -- is settled by
+    the owning entry's configuration, so every read has to carry the entry it
+    is made for. Setup is the one case where there is honestly nobody to
+    name.
+    """
+    flow_id = await _start_config_flow(hass)
+    await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
+
+    with reading_for() as read_for:
+        result = await hass.config_entries.flow.async_configure(
+            flow_id, {CONF_NUM_USERS: 2}
+        )
+
+    assert result["step_id"] == "code_slot"
+    assert read_for, "allocation issued numbers without reading a lock"
+    assert all(entry is None for entry in read_for)
+
+
+async def test_editing_reads_the_locks_for_the_entry_being_edited(
+    hass: HomeAssistant, mock_lock_config_entry
+):
+    """The editor names the entry whose locks it is reading."""
+    flow_id, entry = await _start_options_flow(hass)
+
+    with reading_for() as read_for:
+        result = await hass.config_entries.options.async_configure(
+            flow_id,
+            {
+                CONF_LOCKS: [LOCK_1_ENTITY_ID],
+                CONF_USERS: {
+                    "User 1": {CONF_ENABLED: True, CONF_PIN: "1234"},
+                    "Newcomer": {CONF_ENABLED: True, CONF_PIN: "9999"},
+                },
+            },
+        )
+
+    assert result["type"] == "create_entry"
+    assert read_for, "the editor allocated numbers without reading a lock"
+    assert all(read is entry for read in read_for)
+
+
+async def test_reauth_reads_the_locks_for_the_entry_it_is_repairing(
+    hass: HomeAssistant, mock_lock_config_entry, lock_code_manager_config_entry
+):
+    """Swapping a lock is still a read the entry being repaired asked for."""
+    lock_code_manager_config_entry.async_start_reauth(
+        hass, context={"lock_entity_id": LOCK_1_ENTITY_ID}
+    )
+    await hass.async_block_till_done()
+    [flow] = lock_code_manager_config_entry.async_get_active_flows(
+        hass, {SOURCE_REAUTH}
+    )
+
+    with reading_for() as read_for:
+        result = await hass.config_entries.flow.async_configure(
+            flow["flow_id"], {CONF_LOCKS: [LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID]}
+        )
+
+    assert result["reason"] == "locks_updated"
+    assert read_for, "reauth accepted the new locks without reading them"
+    assert all(read is lock_code_manager_config_entry for read in read_for)
 
 
 async def test_setup_reads_only_as_far_as_it_has_to(
@@ -1906,7 +1977,7 @@ async def test_a_lock_that_cannot_be_built_says_whether_it_is_ours(
         ).entity_id
 
     with pytest.raises(LockQuerySkipped) as raised:
-        build_lock_instance(hass, dr.async_get(hass), ent_reg, entity_id)
+        build_lock_instance(hass, dr.async_get(hass), ent_reg, None, entity_id)
 
     assert raised.value.managed is managed
 
@@ -1971,7 +2042,7 @@ async def test_a_lock_whose_config_entry_is_gone_is_skipped(
     ent_reg.async_update_entity(orphan.entity_id, config_entry_id=None)
 
     with pytest.raises(LockQuerySkipped) as raised:
-        build_lock_instance(hass, dr.async_get(hass), ent_reg, orphan.entity_id)
+        build_lock_instance(hass, dr.async_get(hass), ent_reg, None, orphan.entity_id)
 
     # Ours, so it still bounds the numbers even unread.
     assert raised.value.managed is True

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -80,7 +80,7 @@ from custom_components.lock_code_manager.providers.schlage import (
 )
 from tests.providers.helpers import register_mock_service
 
-from .common import LOCK_1_ENTITY_ID
+from .common import LOCK_1_ENTITY_ID, reading_for
 
 
 async def test_set_usercode_service(
@@ -510,6 +510,36 @@ async def test_add_user_service(
     assert config.assignment.slot("test1") == 1
     assert config.assignment.slot("test2") == 2
     assert config.assignment.slot("Newcomer") not in (1, 2)
+
+
+async def test_add_user_service_reads_the_locks_for_its_own_entry(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+) -> None:
+    """
+    The entry named in the call is the one its lock reads are made for.
+
+    What allocation makes of a lock is settled by the owning entry's
+    configuration, so a read made for nobody would consult the wrong one --
+    and the service and the editor would stop agreeing about which numbers
+    are free.
+    """
+    with reading_for() as read_for:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_ADD_USER,
+            {
+                "config_entry_id": lock_code_manager_config_entry.entry_id,
+                CONF_NAME: "Newcomer",
+                CONF_PIN: "9876",
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    assert read_for, "the service allocated a number without reading a lock"
+    assert all(read is lock_code_manager_config_entry for read in read_for)
 
 
 async def test_add_user_service_returns_once_the_entities_exist(


### PR DESCRIPTION
## Proposed change

`domain/allocation.py`'s `build_lock_instance` never received the Lock Code
Manager entry it was reading locks on behalf of, unlike its sibling factory
`domain/locks.py`'s `async_create_lock_instance`. This threads it through, so a
later PR's per-member declaration is reachable there.

Plumbing only — nothing reads the entry to decide anything yet; the only new use
is naming it in the "skipping usercode check" log lines, which previously named
just the lock even though locks are shared between entries.

- `build_lock_instance` and the four surfaces above it
  (`async_check_slot_capacity`, `async_read_occupancy`, `async_max_slot`,
  `async_allocate_for`) take `config_entry` immediately after `hass`. Required,
  not defaulted, so a caller can't omit it by accident.
- `excluding` folds into that same parameter. Every caller already passed the same
  entry for both, and the roles coincide: the entry being allocated for is the one
  whose own numbers must not constrain it. `LockOccupancy.claimed_by_other_entries`
  already named it that way.

Also corrects docs that still called the Virtual provider testing-only — it has
recorded credential-use events and advertised capabilities since 5.2.0.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue: #1480

PR 1 of 5. 2248 passing, 100% coverage. One test per call site, each verified by
mutation — the `add_user` path had no detector at all before.
