### PR TITLE
feat: per-member config shape on the entry

### DIFF
--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -664,6 +664,7 @@ class LockCodeManagerOptionsFlow(config_entries.OptionsFlow):
                         title="",
                         data=EntryConfig(
                             locks=tuple(user_input[CONF_LOCKS]),
+                            members=config.members,
                             users=users,
                             assignment=assignment,
                             extra=config.extra,

--- a/custom_components/lock_code_manager/const.py
+++ b/custom_components/lock_code_manager/const.py
@@ -146,8 +146,8 @@ CONF_CONFIG_ENTRY = "config_entry"
 CONF_CONDITIONS = "conditions"
 CONF_ENTITIES = "entities"
 CONF_LOCKS = "locks"
-# Per-member declarations, keyed by entity id, alongside the CONF_LOCKS
-# roster. See EntryConfig.member().
+# Per-member declarations, keyed by entity registry entry id, alongside the
+# CONF_LOCKS roster. See EntryConfig.member().
 CONF_MEMBERS = "members"
 CONF_SLOTS = "slots"
 CONF_USERS = "users"

--- a/custom_components/lock_code_manager/const.py
+++ b/custom_components/lock_code_manager/const.py
@@ -146,6 +146,9 @@ CONF_CONFIG_ENTRY = "config_entry"
 CONF_CONDITIONS = "conditions"
 CONF_ENTITIES = "entities"
 CONF_LOCKS = "locks"
+# Per-member declarations, keyed by entity id, alongside the CONF_LOCKS
+# roster. See EntryConfig.member().
+CONF_MEMBERS = "members"
 CONF_SLOTS = "slots"
 CONF_USERS = "users"
 CONF_NUM_USERS = "num_users"

--- a/custom_components/lock_code_manager/domain/config.py
+++ b/custom_components/lock_code_manager/domain/config.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass, field
+import logging
 from types import MappingProxyType
 from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME, CONF_PIN
+from homeassistant.helpers import entity_registry as er
 
 from ..const import CONF_LOCKS, CONF_MEMBERS, CONF_SLOTS, CONF_USERS
 from .names import normalize_name
@@ -18,6 +20,8 @@ from .slot_assignment import (
     identity,
     users_from_slots,
 )
+
+_LOGGER = logging.getLogger(__name__)
 
 _EMPTY_USERS: Mapping[str, Mapping[str, Any]] = MappingProxyType({})
 _EMPTY_MEMBERS: Mapping[str, Mapping[str, Any]] = MappingProxyType({})
@@ -58,22 +62,50 @@ def _member_declarations(raw: Any) -> Mapping[str, Mapping[str, Any]]:
     """
     Return the per-member declarations a stored value carries.
 
-    Malformed storage -- hand-edited ``.storage``, a restored backup, a key
-    written by a version that spelled it differently -- is dropped rather than
-    raised on, at both levels: the whole key if it is not a mapping, and any
-    single member whose declaration is not one. Every field then reads as its
-    own default, where raising would make the entry unloadable over a key no
-    member has to have.
+    Malformed storage -- hand-edited ``.storage``, a restored backup -- is
+    dropped rather than raised on, at both levels: the whole key if it is not
+    a mapping, and any single member whose key is not a registry id or whose
+    declaration is not a mapping. Every field then reads as its own default,
+    where raising would make the entry unloadable over a key no member has to
+    have.
+
+    Whatever is dropped is named in the log. The symptom otherwise is a member
+    silently reverting to defaults, which is indistinguishable from never
+    having been declared about, and the next write erases the evidence.
     """
     if not isinstance(raw, Mapping):
+        _LOGGER.warning(
+            "Ignoring the stored member declarations: expected a mapping of "
+            "entity registry ids, got %s (%r). Nothing is declared about any "
+            "member until this key is repaired",
+            type(raw).__name__,
+            raw,
+        )
         return _EMPTY_MEMBERS
-    return MappingProxyType(
-        {
-            entity_id: MappingProxyType(dict(declared))
-            for entity_id, declared in raw.items()
-            if isinstance(declared, Mapping)
-        }
-    )
+    declarations: dict[str, Mapping[str, Any]] = {}
+    for registry_id, declared in raw.items():
+        if not isinstance(registry_id, str):
+            _LOGGER.warning(
+                "Ignoring a stored member declaration: expected an entity "
+                "registry id, got %s (%r) as the key. The declaration %r is "
+                "dropped",
+                type(registry_id).__name__,
+                registry_id,
+                declared,
+            )
+            continue
+        if not isinstance(declared, Mapping):
+            _LOGGER.warning(
+                "Ignoring the stored declaration for member %s: expected a "
+                "mapping, got %s (%r). That member takes every default until "
+                "this is repaired",
+                registry_id,
+                type(declared).__name__,
+                declared,
+            )
+            continue
+        declarations[registry_id] = MappingProxyType(dict(declared))
+    return MappingProxyType(declarations)
 
 
 @dataclass(frozen=True, slots=True)
@@ -97,10 +129,10 @@ class EntryConfig:
     """
 
     locks: tuple[str, ...]
-    # What the entry declares ABOUT each member, keyed by entity id, next to
-    # the `locks` roster rather than inside it: the roster is read raw in
-    # several places that would all have to learn a new element shape. No
-    # default, for the same reason `extra` has none.
+    # What the entry declares ABOUT each member, keyed by entity registry
+    # entry id, next to the `locks` roster rather than inside it: the roster
+    # is read raw in several places that would all have to learn a new
+    # element shape. No default, for the same reason `extra` has none.
     members: Mapping[str, Mapping[str, Any]]
     users: Mapping[str, Mapping[str, Any]]
     assignment: SlotAssignment
@@ -162,11 +194,12 @@ class EntryConfig:
             **{k: v for k, v in entry.data.items() if k not in _CONFIG_KEYS},
             **{k: v for k, v in entry.options.items() if k not in _CONFIG_KEYS},
             CONF_LOCKS: entry.options.get(CONF_LOCKS, entry.data.get(CONF_LOCKS, [])),
-            # Read per key rather than from the side the users came from, like
-            # the roster beside it. Both are keyed by entity id, so a side that
-            # lags describes members by name and the entries for members this
-            # entry no longer has are simply never read -- where a lagging
-            # assignment would silently renumber the users it is paired with.
+            # Read per key rather than from the side the users came from,
+            # like the roster beside it: a declaration names the member it is
+            # about, so a side that lags describes those same members and the
+            # ones this entry no longer has are simply never read -- where a
+            # lagging assignment would silently renumber the users it is
+            # paired with.
             CONF_MEMBERS: entry.options.get(
                 CONF_MEMBERS, entry.data.get(CONF_MEMBERS, {})
             ),
@@ -211,7 +244,7 @@ class EntryConfig:
             assignment = SlotAssignment.from_mapping(mapping)
         return cls(
             locks=tuple(mapping.get(CONF_LOCKS, [])),
-            members=_member_declarations(mapping.get(CONF_MEMBERS)),
+            members=_member_declarations(mapping.get(CONF_MEMBERS, _EMPTY_MEMBERS)),
             users=MappingProxyType(
                 {
                     name: MappingProxyType(_normalized_user(user))
@@ -253,7 +286,7 @@ class EntryConfig:
         """Return True if this entry manages the given lock."""
         return lock_entity_id in self.locks
 
-    def member(self, entity_id: str) -> Mapping[str, Any]:
+    def member(self, lock_entry: er.RegistryEntry) -> Mapping[str, Any]:
         """
         Return what this entry declares about one of its members.
 
@@ -263,14 +296,31 @@ class EntryConfig:
         member actuates anything, or that the credentials live on the device
         at all.
 
+        Takes the registry entry, not an entity id, because the declarations
+        are keyed by ``RegistryEntry.id`` -- the handle Home Assistant keeps
+        stable across a rename. Nothing in this integration listens for
+        registry updates, so keying by entity id would strand a declaration
+        the moment somebody renamed their lock, with no repair path; the
+        roster IS keyed by entity id, but a stale roster fails setup and the
+        reauth that follows rewrites it, so the two would disagree exactly
+        where it mattered. Every provider already holds its ``lock``
+        registry entry, and the entry cannot load while a roster member has
+        none, so there is no unresolvable case to handle. Passing the entry
+        rather than its id also keeps a caller holding the wrong string out:
+        an entity id would look up nothing and be reported as "nothing
+        declared".
+
         Declaring nothing is the normal case and returns an empty mapping, so
         every field a caller reads takes its own default. Membership itself is
         the ``locks`` roster; this records only what somebody said about a
         member, which is why an entity absent from the roster still answers
-        rather than raising -- a declaration is keyed by entity id and outlives
-        the member's removal, so re-adding them restores what was declared.
+        rather than raising. A declaration outlives both a rename and the
+        member's removal from the roster -- re-adding the same entity finds it
+        again -- but not the entity's removal from the entity registry, since
+        anything recreated afterwards is a new registry entry with a new id
+        and nothing declared about it.
         """
-        return self.members.get(entity_id, _EMPTY_MEMBER)
+        return self.members.get(lock_entry.id, _EMPTY_MEMBER)
 
     def name_for(self, slot_num: int | str) -> str | None:
         """Return the user occupying a slot, or None if it is unoccupied."""
@@ -420,8 +470,8 @@ class EntryConfig:
             **dict(self.extra),
             CONF_LOCKS: list(self.locks),
             CONF_MEMBERS: {
-                entity_id: dict(declared)
-                for entity_id, declared in self.members.items()
+                registry_id: dict(declared)
+                for registry_id, declared in self.members.items()
             },
             CONF_USERS: {name: dict(user) for name, user in self.users.items()},
             CONF_SLOT_ASSIGNMENT: dict(self.assignment.slots),

--- a/custom_components/lock_code_manager/domain/config.py
+++ b/custom_components/lock_code_manager/domain/config.py
@@ -10,7 +10,7 @@ from typing import Any
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME, CONF_PIN
 
-from ..const import CONF_LOCKS, CONF_SLOTS, CONF_USERS
+from ..const import CONF_LOCKS, CONF_MEMBERS, CONF_SLOTS, CONF_USERS
 from .names import normalize_name
 from .slot_assignment import (
     CONF_SLOT_ASSIGNMENT,
@@ -20,11 +20,15 @@ from .slot_assignment import (
 )
 
 _EMPTY_USERS: Mapping[str, Mapping[str, Any]] = MappingProxyType({})
+_EMPTY_MEMBERS: Mapping[str, Mapping[str, Any]] = MappingProxyType({})
+_EMPTY_MEMBER: Mapping[str, Any] = MappingProxyType({})
 _EMPTY_EXTRA: Mapping[str, Any] = MappingProxyType({})
 
 # The keys EntryConfig models directly. Everything else in the entry is
 # internal bookkeeping and rides along in `extra`.
-_CONFIG_KEYS = frozenset({CONF_LOCKS, CONF_SLOTS, CONF_USERS, CONF_SLOT_ASSIGNMENT})
+_CONFIG_KEYS = frozenset(
+    {CONF_LOCKS, CONF_MEMBERS, CONF_SLOTS, CONF_USERS, CONF_SLOT_ASSIGNMENT}
+)
 
 
 def _normalized_user(user: Mapping[str, Any]) -> dict[str, Any]:
@@ -50,6 +54,28 @@ def _normalized_user(user: Mapping[str, Any]) -> dict[str, Any]:
     return normalized
 
 
+def _member_declarations(raw: Any) -> Mapping[str, Mapping[str, Any]]:
+    """
+    Return the per-member declarations a stored value carries.
+
+    Malformed storage -- hand-edited ``.storage``, a restored backup, a key
+    written by a version that spelled it differently -- is dropped rather than
+    raised on, at both levels: the whole key if it is not a mapping, and any
+    single member whose declaration is not one. Every field then reads as its
+    own default, where raising would make the entry unloadable over a key no
+    member has to have.
+    """
+    if not isinstance(raw, Mapping):
+        return _EMPTY_MEMBERS
+    return MappingProxyType(
+        {
+            entity_id: MappingProxyType(dict(declared))
+            for entity_id, declared in raw.items()
+            if isinstance(declared, Mapping)
+        }
+    )
+
+
 @dataclass(frozen=True, slots=True)
 class EntryConfig:
     """
@@ -71,6 +97,11 @@ class EntryConfig:
     """
 
     locks: tuple[str, ...]
+    # What the entry declares ABOUT each member, keyed by entity id, next to
+    # the `locks` roster rather than inside it: the roster is read raw in
+    # several places that would all have to learn a new element shape. No
+    # default, for the same reason `extra` has none.
+    members: Mapping[str, Mapping[str, Any]]
     users: Mapping[str, Mapping[str, Any]]
     assignment: SlotAssignment
     # Every other top-level key in the entry, carried through verbatim. No
@@ -100,6 +131,7 @@ class EntryConfig:
         """Return a config for an entry with no locks and no users."""
         return cls(
             locks=(),
+            members=_EMPTY_MEMBERS,
             users=_EMPTY_USERS,
             assignment=SlotAssignment.empty(),
             extra=_EMPTY_EXTRA,
@@ -130,6 +162,14 @@ class EntryConfig:
             **{k: v for k, v in entry.data.items() if k not in _CONFIG_KEYS},
             **{k: v for k, v in entry.options.items() if k not in _CONFIG_KEYS},
             CONF_LOCKS: entry.options.get(CONF_LOCKS, entry.data.get(CONF_LOCKS, [])),
+            # Read per key rather than from the side the users came from, like
+            # the roster beside it. Both are keyed by entity id, so a side that
+            # lags describes members by name and the entries for members this
+            # entry no longer has are simply never read -- where a lagging
+            # assignment would silently renumber the users it is paired with.
+            CONF_MEMBERS: entry.options.get(
+                CONF_MEMBERS, entry.data.get(CONF_MEMBERS, {})
+            ),
         }
         # The assignment comes from the SAME side as the users it numbers, or
         # it could pair users with numbering that predates them.
@@ -171,6 +211,7 @@ class EntryConfig:
             assignment = SlotAssignment.from_mapping(mapping)
         return cls(
             locks=tuple(mapping.get(CONF_LOCKS, [])),
+            members=_member_declarations(mapping.get(CONF_MEMBERS)),
             users=MappingProxyType(
                 {
                     name: MappingProxyType(_normalized_user(user))
@@ -211,6 +252,25 @@ class EntryConfig:
     def has_lock(self, lock_entity_id: str) -> bool:
         """Return True if this entry manages the given lock."""
         return lock_entity_id in self.locks
+
+    def member(self, entity_id: str) -> Mapping[str, Any]:
+        """
+        Return what this entry declares about one of its members.
+
+        A member is an entity this entry keeps credentials on. Deliberately
+        not "a lock": a provider is a credential store, and only some stores
+        are also the thing that gets locked. Nothing here may assume the
+        member actuates anything, or that the credentials live on the device
+        at all.
+
+        Declaring nothing is the normal case and returns an empty mapping, so
+        every field a caller reads takes its own default. Membership itself is
+        the ``locks`` roster; this records only what somebody said about a
+        member, which is why an entity absent from the roster still answers
+        rather than raising -- a declaration is keyed by entity id and outlives
+        the member's removal, so re-adding them restores what was declared.
+        """
+        return self.members.get(entity_id, _EMPTY_MEMBER)
 
     def name_for(self, slot_num: int | str) -> str | None:
         """Return the user occupying a slot, or None if it is unoccupied."""
@@ -276,6 +336,7 @@ class EntryConfig:
         }
         return EntryConfig(
             locks=self.locks,
+            members=self.members,
             users=MappingProxyType(
                 {k: MappingProxyType(v) for k, v in new_users.items()}
             ),
@@ -305,6 +366,7 @@ class EntryConfig:
         new_users[stored][key] = value
         return EntryConfig(
             locks=self.locks,
+            members=self.members,
             users=MappingProxyType(
                 {k: MappingProxyType(v) for k, v in new_users.items()}
             ),
@@ -323,6 +385,7 @@ class EntryConfig:
         new_users[stored].pop(key, None)
         return EntryConfig(
             locks=self.locks,
+            members=self.members,
             users=MappingProxyType(
                 {k: MappingProxyType(v) for k, v in new_users.items()}
             ),
@@ -356,6 +419,10 @@ class EntryConfig:
         return {
             **dict(self.extra),
             CONF_LOCKS: list(self.locks),
+            CONF_MEMBERS: {
+                entity_id: dict(declared)
+                for entity_id, declared in self.members.items()
+            },
             CONF_USERS: {name: dict(user) for name, user in self.users.items()},
             CONF_SLOT_ASSIGNMENT: dict(self.assignment.slots),
         }

--- a/custom_components/lock_code_manager/domain/services.py
+++ b/custom_components/lock_code_manager/domain/services.py
@@ -263,6 +263,7 @@ async def async_add_user(
         config_entry,
         EntryConfig(
             locks=config.locks,
+            members=config.members,
             users={**config.users, name: user},
             assignment=assignment,
             extra=config.extra,
@@ -312,6 +313,7 @@ async def async_delete_user(
         config_entry,
         EntryConfig(
             locks=config.locks,
+            members=config.members,
             users=remaining,
             assignment=config.assignment.reconcile(remaining, start=1),
             extra=config.extra,

--- a/tests/properties/test_slot_assignment.py
+++ b/tests/properties/test_slot_assignment.py
@@ -449,6 +449,7 @@ def test_a_rename_keeps_the_users_number(
     assignment = SlotAssignment.empty().reconcile(names, start=start)
     config = EntryConfig(
         locks=(),
+        members={},
         users={name: {} for name in names},
         assignment=assignment,
         extra={},

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,6 +8,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.lock_code_manager.const import (
     CONF_LOCKS,
+    CONF_MEMBERS,
     CONF_SLOTS,
     CONF_USERS,
     DOMAIN,
@@ -838,3 +839,207 @@ def test_a_non_string_stored_pin_is_left_alone() -> None:
     )
     assert config.slot(1)["pin"] == 1234
     assert not isinstance(config.slot(1)["pin"], str)
+
+
+# --- Per-member declarations (issue #1480) ---
+
+# There is no declared field yet: this PR adds the shape the first one will
+# live in. A placeholder stands in so the tests assert what the shape
+# guarantees -- that it carries whatever is put in it, unchanged -- rather
+# than the meaning of a key that does not exist.
+_DECLARED = {"placeholder": True}
+
+
+def test_nothing_declared_is_the_default() -> None:
+    """
+    An entry with no member key declares nothing about anybody.
+
+    Absence is the normal case for every entry that exists today, so it has
+    to read as "take the defaults" rather than as missing data.
+    """
+    config = EntryConfig.from_mapping({CONF_LOCKS: ["lock.a"], CONF_SLOTS: {}})
+
+    assert dict(config.members) == {}
+    assert config.member("lock.a") == {}
+    assert EntryConfig.empty().member("lock.a") == {}
+
+
+def test_a_member_absent_from_the_roster_still_answers() -> None:
+    """
+    Declarations are keyed by entity id and outlive membership.
+
+    Removing a lock from the entry does not erase what was declared about it,
+    so re-adding it restores the declaration instead of silently reverting to
+    defaults.
+    """
+    config = EntryConfig.from_mapping(
+        {CONF_LOCKS: [], CONF_MEMBERS: {"lock.gone": _DECLARED}}
+    )
+
+    assert not config.has_lock("lock.gone")
+    assert config.member("lock.gone") == _DECLARED
+
+
+def test_member_declarations_round_trip() -> None:
+    """
+    to_dict -> from_mapping preserves declarations verbatim.
+
+    to_dict feeds async_update_entry, so anything this does not preserve is
+    dropped from storage on the next write of any other field.
+    """
+    original = EntryConfig.from_mapping(
+        {
+            CONF_LOCKS: ["lock.a", "lock.b"],
+            CONF_MEMBERS: {"lock.a": _DECLARED},
+            CONF_SLOTS: {1: _slot()},
+        }
+    )
+
+    round_tripped = EntryConfig.from_mapping(original.to_dict())
+
+    assert dict(round_tripped.members) == {"lock.a": _DECLARED}
+    assert round_tripped.member("lock.a") == _DECLARED
+    # The member nobody declared anything about is still defaulted, not
+    # invented as an empty declaration.
+    assert "lock.b" not in round_tripped.members
+
+
+def test_a_partially_populated_declaration_round_trips() -> None:
+    """
+    Members may declare some fields, no fields, or not appear at all.
+
+    All three are legal and distinct on the way in, and all three have to
+    survive the write: a declaration is not a fixed record, so the shape can
+    never fill in what was left out.
+    """
+    original = EntryConfig.from_mapping(
+        {
+            CONF_LOCKS: ["lock.a", "lock.b", "lock.c"],
+            CONF_MEMBERS: {"lock.a": {"one": 1, "two": 2}, "lock.b": {}},
+        }
+    )
+
+    round_tripped = EntryConfig.from_mapping(original.to_dict())
+
+    assert dict(round_tripped.members) == {"lock.a": {"one": 1, "two": 2}, "lock.b": {}}
+    assert round_tripped.member("lock.c") == {}
+
+
+def test_an_unrelated_edit_preserves_member_declarations() -> None:
+    """
+    Editing a user does not erase what was declared about the members.
+
+    Every copy helper rebuilds the whole EntryConfig, and to_dict writes the
+    result straight to the entry, so a field one of them forgets to carry is
+    gone from storage with no error anywhere.
+    """
+    original = EntryConfig.from_mapping(
+        {
+            CONF_LOCKS: ["lock.a"],
+            CONF_MEMBERS: {"lock.a": _DECLARED},
+            CONF_SLOTS: {1: _slot(name="Somebody")},
+        }
+    )
+
+    edited = (
+        original.with_user_field_set("Somebody", "pin", "9999")
+        .with_user_field_removed("Somebody", "enabled")
+        .with_user_renamed("Somebody", "Somebody Else")
+    )
+    saved = EntryConfig.from_mapping(edited.to_dict())
+
+    assert saved.member("lock.a") == _DECLARED
+    # The edit itself landed, so the guarantee is not vacuous.
+    assert saved.users["Somebody Else"]["pin"] == "9999"
+
+
+def test_member_declarations_are_deeply_immutable() -> None:
+    """The declarations share EntryConfig's read-only guarantee."""
+    config = EntryConfig.from_mapping(
+        {CONF_LOCKS: ["lock.a"], CONF_MEMBERS: {"lock.a": dict(_DECLARED)}}
+    )
+
+    with pytest.raises(TypeError):
+        config.members["lock.b"] = {}  # type: ignore[index]
+
+    with pytest.raises(TypeError):
+        config.member("lock.a")["placeholder"] = False  # type: ignore[index]
+
+
+def test_to_dict_produces_plain_member_dicts() -> None:
+    """
+    The written declarations are plain dicts HA can serialize.
+
+    The read-only wrappers EntryConfig uses internally do not survive storage.
+    """
+    config = EntryConfig.from_mapping(
+        {CONF_LOCKS: ["lock.a"], CONF_MEMBERS: {"lock.a": dict(_DECLARED)}}
+    )
+
+    result = config.to_dict()
+
+    assert isinstance(result[CONF_MEMBERS], dict)
+    assert isinstance(result[CONF_MEMBERS]["lock.a"], dict)
+    result[CONF_MEMBERS]["lock.a"]["placeholder"] = False
+    assert config.member("lock.a") == _DECLARED
+
+
+@pytest.mark.parametrize(
+    ("stored", "expected"),
+    [
+        (["lock.a"], {}),
+        ("lock.a", {}),
+        (None, {}),
+        ({"lock.a": "not a mapping"}, {}),
+        ({"lock.a": None}, {}),
+        ({"lock.a": _DECLARED, "lock.b": 5}, {"lock.a": _DECLARED}),
+    ],
+)
+def test_malformed_member_storage_is_dropped_not_raised(
+    stored: object, expected: dict
+) -> None:
+    """
+    A member key that is not the shape it should be reads as nothing declared.
+
+    Reachable from hand-edited storage or a restored backup. Raising here
+    would take entry setup down over a key no member has to have, and the
+    members that ARE well-formed still have to load.
+    """
+    config = EntryConfig.from_mapping({CONF_LOCKS: ["lock.a"], CONF_MEMBERS: stored})
+
+    assert dict(config.members) == expected
+
+
+def test_from_entry_reads_member_declarations_options_preferred() -> None:
+    """
+    Options wins over data, matching the roster beside it.
+
+    During an options-flow update the new configuration is in options while
+    data still holds the old one.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_LOCKS: ["lock.a"], CONF_MEMBERS: {"lock.a": {"which": "data"}}},
+        options={
+            CONF_LOCKS: ["lock.a"],
+            CONF_MEMBERS: {"lock.a": {"which": "options"}},
+        },
+    )
+
+    assert EntryConfig.from_entry(entry).member("lock.a") == {"which": "options"}
+
+
+def test_from_entry_falls_back_to_data_for_member_declarations() -> None:
+    """
+    A side carrying no declarations does not erase the other side's.
+
+    Setup moves the configuration from data into options and the listener
+    moves it back, so either side may be the one holding it.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_LOCKS: ["lock.a"], CONF_MEMBERS: {"lock.a": _DECLARED}},
+        options={CONF_SLOTS: {1: _slot()}},
+    )
+
+    assert EntryConfig.from_entry(entry).member("lock.a") == _DECLARED

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,10 +1,14 @@
 """Tests for data helpers (EntryConfig, EntryConfigDiff, etc)."""
 
 from dataclasses import FrozenInstanceError
+import logging
 from types import SimpleNamespace
+from typing import cast
 
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from homeassistant.helpers import entity_registry as er
 
 from custom_components.lock_code_manager.const import (
     CONF_LOCKS,
@@ -849,6 +853,23 @@ def test_a_non_string_stored_pin_is_left_alone() -> None:
 # than the meaning of a key that does not exist.
 _DECLARED = {"placeholder": True}
 
+# Declarations are keyed by entity registry entry id, which is opaque: these
+# stand in for the ids a real registry hands out, and look nothing like an
+# entity id on purpose.
+_MEMBER_A = "0aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+_MEMBER_B = "0bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+_MEMBER_C = "0cccccccccccccccccccccccccccccccc"
+
+
+def _member_entry(registry_id: str) -> er.RegistryEntry:
+    """
+    Stand in for the registry entry a caller passes to ``member()``.
+
+    Only ``id`` is ever read, and building a real RegistryEntry takes twenty
+    more keyword arguments. The integration tests pass the real thing.
+    """
+    return cast(er.RegistryEntry, SimpleNamespace(id=registry_id))
+
 
 def test_nothing_declared_is_the_default() -> None:
     """
@@ -860,24 +881,24 @@ def test_nothing_declared_is_the_default() -> None:
     config = EntryConfig.from_mapping({CONF_LOCKS: ["lock.a"], CONF_SLOTS: {}})
 
     assert dict(config.members) == {}
-    assert config.member("lock.a") == {}
-    assert EntryConfig.empty().member("lock.a") == {}
+    assert config.member(_member_entry(_MEMBER_A)) == {}
+    assert EntryConfig.empty().member(_member_entry(_MEMBER_A)) == {}
 
 
 def test_a_member_absent_from_the_roster_still_answers() -> None:
     """
-    Declarations are keyed by entity id and outlive membership.
+    Declarations outlive membership.
 
     Removing a lock from the entry does not erase what was declared about it,
     so re-adding it restores the declaration instead of silently reverting to
     defaults.
     """
     config = EntryConfig.from_mapping(
-        {CONF_LOCKS: [], CONF_MEMBERS: {"lock.gone": _DECLARED}}
+        {CONF_LOCKS: [], CONF_MEMBERS: {_MEMBER_A: _DECLARED}}
     )
 
     assert not config.has_lock("lock.gone")
-    assert config.member("lock.gone") == _DECLARED
+    assert config.member(_member_entry(_MEMBER_A)) == _DECLARED
 
 
 def test_member_declarations_round_trip() -> None:
@@ -890,18 +911,18 @@ def test_member_declarations_round_trip() -> None:
     original = EntryConfig.from_mapping(
         {
             CONF_LOCKS: ["lock.a", "lock.b"],
-            CONF_MEMBERS: {"lock.a": _DECLARED},
+            CONF_MEMBERS: {_MEMBER_A: _DECLARED},
             CONF_SLOTS: {1: _slot()},
         }
     )
 
     round_tripped = EntryConfig.from_mapping(original.to_dict())
 
-    assert dict(round_tripped.members) == {"lock.a": _DECLARED}
-    assert round_tripped.member("lock.a") == _DECLARED
+    assert dict(round_tripped.members) == {_MEMBER_A: _DECLARED}
+    assert round_tripped.member(_member_entry(_MEMBER_A)) == _DECLARED
     # The member nobody declared anything about is still defaulted, not
     # invented as an empty declaration.
-    assert "lock.b" not in round_tripped.members
+    assert _MEMBER_B not in round_tripped.members
 
 
 def test_a_partially_populated_declaration_round_trips() -> None:
@@ -915,14 +936,17 @@ def test_a_partially_populated_declaration_round_trips() -> None:
     original = EntryConfig.from_mapping(
         {
             CONF_LOCKS: ["lock.a", "lock.b", "lock.c"],
-            CONF_MEMBERS: {"lock.a": {"one": 1, "two": 2}, "lock.b": {}},
+            CONF_MEMBERS: {_MEMBER_A: {"one": 1, "two": 2}, _MEMBER_B: {}},
         }
     )
 
     round_tripped = EntryConfig.from_mapping(original.to_dict())
 
-    assert dict(round_tripped.members) == {"lock.a": {"one": 1, "two": 2}, "lock.b": {}}
-    assert round_tripped.member("lock.c") == {}
+    assert dict(round_tripped.members) == {
+        _MEMBER_A: {"one": 1, "two": 2},
+        _MEMBER_B: {},
+    }
+    assert round_tripped.member(_member_entry(_MEMBER_C)) == {}
 
 
 def test_an_unrelated_edit_preserves_member_declarations() -> None:
@@ -936,7 +960,7 @@ def test_an_unrelated_edit_preserves_member_declarations() -> None:
     original = EntryConfig.from_mapping(
         {
             CONF_LOCKS: ["lock.a"],
-            CONF_MEMBERS: {"lock.a": _DECLARED},
+            CONF_MEMBERS: {_MEMBER_A: _DECLARED},
             CONF_SLOTS: {1: _slot(name="Somebody")},
         }
     )
@@ -948,7 +972,7 @@ def test_an_unrelated_edit_preserves_member_declarations() -> None:
     )
     saved = EntryConfig.from_mapping(edited.to_dict())
 
-    assert saved.member("lock.a") == _DECLARED
+    assert saved.member(_member_entry(_MEMBER_A)) == _DECLARED
     # The edit itself landed, so the guarantee is not vacuous.
     assert saved.users["Somebody Else"]["pin"] == "9999"
 
@@ -956,14 +980,14 @@ def test_an_unrelated_edit_preserves_member_declarations() -> None:
 def test_member_declarations_are_deeply_immutable() -> None:
     """The declarations share EntryConfig's read-only guarantee."""
     config = EntryConfig.from_mapping(
-        {CONF_LOCKS: ["lock.a"], CONF_MEMBERS: {"lock.a": dict(_DECLARED)}}
+        {CONF_LOCKS: ["lock.a"], CONF_MEMBERS: {_MEMBER_A: dict(_DECLARED)}}
     )
 
     with pytest.raises(TypeError):
-        config.members["lock.b"] = {}  # type: ignore[index]
+        config.members[_MEMBER_B] = {}  # type: ignore[index]
 
     with pytest.raises(TypeError):
-        config.member("lock.a")["placeholder"] = False  # type: ignore[index]
+        config.member(_member_entry(_MEMBER_A))["placeholder"] = False  # type: ignore[index]
 
 
 def test_to_dict_produces_plain_member_dicts() -> None:
@@ -973,41 +997,76 @@ def test_to_dict_produces_plain_member_dicts() -> None:
     The read-only wrappers EntryConfig uses internally do not survive storage.
     """
     config = EntryConfig.from_mapping(
-        {CONF_LOCKS: ["lock.a"], CONF_MEMBERS: {"lock.a": dict(_DECLARED)}}
+        {CONF_LOCKS: ["lock.a"], CONF_MEMBERS: {_MEMBER_A: dict(_DECLARED)}}
     )
 
     result = config.to_dict()
 
     assert isinstance(result[CONF_MEMBERS], dict)
-    assert isinstance(result[CONF_MEMBERS]["lock.a"], dict)
-    result[CONF_MEMBERS]["lock.a"]["placeholder"] = False
-    assert config.member("lock.a") == _DECLARED
+    assert isinstance(result[CONF_MEMBERS][_MEMBER_A], dict)
+    result[CONF_MEMBERS][_MEMBER_A]["placeholder"] = False
+    assert config.member(_member_entry(_MEMBER_A)) == _DECLARED
 
 
 @pytest.mark.parametrize(
-    ("stored", "expected"),
+    ("stored", "expected", "discarded"),
     [
-        (["lock.a"], {}),
-        ("lock.a", {}),
-        (None, {}),
-        ({"lock.a": "not a mapping"}, {}),
-        ({"lock.a": None}, {}),
-        ({"lock.a": _DECLARED, "lock.b": 5}, {"lock.a": _DECLARED}),
+        # The whole key is the wrong shape, so nobody is declared about.
+        (["lock.a"], {}, ["lock.a"]),
+        ("lock.a", {}, "lock.a"),
+        (None, {}, None),
+        # One member's declaration is the wrong shape.
+        ({_MEMBER_A: "not a mapping"}, {}, "not a mapping"),
+        ({_MEMBER_A: None}, {}, None),
+        ({_MEMBER_A: _DECLARED, _MEMBER_B: 5}, {_MEMBER_A: _DECLARED}, 5),
+        # One member's KEY is not a registry id.
+        ({5: _DECLARED}, {}, 5),
+        ({5: _DECLARED, _MEMBER_A: _DECLARED}, {_MEMBER_A: _DECLARED}, 5),
     ],
 )
 def test_malformed_member_storage_is_dropped_not_raised(
-    stored: object, expected: dict
+    stored: object,
+    expected: dict,
+    discarded: object,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """
     A member key that is not the shape it should be reads as nothing declared.
 
     Reachable from hand-edited storage or a restored backup. Raising here
     would take entry setup down over a key no member has to have, and the
-    members that ARE well-formed still have to load.
+    members that ARE well-formed still have to load. Silence would be worse
+    than either: the symptom is a member taking every default, which is what
+    declaring nothing about it looks like, and the next write erases the
+    evidence -- so whatever was discarded goes in the warning.
     """
-    config = EntryConfig.from_mapping({CONF_LOCKS: ["lock.a"], CONF_MEMBERS: stored})
+    with caplog.at_level(logging.WARNING):
+        config = EntryConfig.from_mapping(
+            {CONF_LOCKS: ["lock.a"], CONF_MEMBERS: stored}
+        )
 
     assert dict(config.members) == expected
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    assert discarded in warnings[0].args
+
+
+def test_nothing_is_warned_about_when_nothing_is_declared(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    The absent key is the normal case, not a malformed one.
+
+    Every entry written before this key existed omits it, so warning here
+    would fire for all of them on every load, which is how a warning stops
+    being read.
+    """
+    with caplog.at_level(logging.WARNING):
+        config = EntryConfig.from_mapping({CONF_LOCKS: ["lock.a"], CONF_SLOTS: {}})
+        assert dict(EntryConfig.empty().members) == {}
+
+    assert dict(config.members) == {}
+    assert [r for r in caplog.records if r.levelno == logging.WARNING] == []
 
 
 def test_from_entry_reads_member_declarations_options_preferred() -> None:
@@ -1019,14 +1078,16 @@ def test_from_entry_reads_member_declarations_options_preferred() -> None:
     """
     entry = MockConfigEntry(
         domain=DOMAIN,
-        data={CONF_LOCKS: ["lock.a"], CONF_MEMBERS: {"lock.a": {"which": "data"}}},
+        data={CONF_LOCKS: ["lock.a"], CONF_MEMBERS: {_MEMBER_A: {"which": "data"}}},
         options={
             CONF_LOCKS: ["lock.a"],
-            CONF_MEMBERS: {"lock.a": {"which": "options"}},
+            CONF_MEMBERS: {_MEMBER_A: {"which": "options"}},
         },
     )
 
-    assert EntryConfig.from_entry(entry).member("lock.a") == {"which": "options"}
+    assert EntryConfig.from_entry(entry).member(_member_entry(_MEMBER_A)) == {
+        "which": "options"
+    }
 
 
 def test_from_entry_falls_back_to_data_for_member_declarations() -> None:
@@ -1038,8 +1099,8 @@ def test_from_entry_falls_back_to_data_for_member_declarations() -> None:
     """
     entry = MockConfigEntry(
         domain=DOMAIN,
-        data={CONF_LOCKS: ["lock.a"], CONF_MEMBERS: {"lock.a": _DECLARED}},
+        data={CONF_LOCKS: ["lock.a"], CONF_MEMBERS: {_MEMBER_A: _DECLARED}},
         options={CONF_SLOTS: {1: _slot()}},
     )
 
-    assert EntryConfig.from_entry(entry).member("lock.a") == _DECLARED
+    assert EntryConfig.from_entry(entry).member(_member_entry(_MEMBER_A)) == _DECLARED

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -2432,9 +2432,12 @@ async def test_options_flow_preserves_member_declarations(
     it never asks about members, so anything it does not carry forward is
     erased by the one write a user reaches from the UI.
     """
+    ent_reg = er.async_get(hass)
+    lock_1 = ent_reg.async_get(LOCK_1_ENTITY_ID)
+    assert lock_1
     entry = MockConfigEntry(
         domain=DOMAIN,
-        data={**BASE_CONFIG, CONF_MEMBERS: {LOCK_1_ENTITY_ID: {"placeholder": True}}},
+        data={**BASE_CONFIG, CONF_MEMBERS: {lock_1.id: {"placeholder": True}}},
         unique_id="Mock Title",
     )
     entry.add_to_hass(hass)
@@ -2450,6 +2453,6 @@ async def test_options_flow_preserves_member_declarations(
         )
 
     assert result["type"] == "create_entry"
-    assert result["data"][CONF_MEMBERS] == {LOCK_1_ENTITY_ID: {"placeholder": True}}
+    assert result["data"][CONF_MEMBERS] == {lock_1.id: {"placeholder": True}}
     # The edit the declaration had to survive actually landed.
     assert set(result["data"][CONF_USERS]) == {"test1"}

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -16,6 +16,7 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 from custom_components.lock_code_manager.config_flow import _check_common_slots
 from custom_components.lock_code_manager.const import (
     CONF_LOCKS,
+    CONF_MEMBERS,
     CONF_NUM_USERS,
     CONF_USERS,
     DOMAIN,
@@ -2419,3 +2420,36 @@ async def test_reauth_completes_around_a_grandfathered_unclaimed_lock(
 
     assert result["type"] == "abort"
     assert result["reason"] == "locks_updated"
+
+
+async def test_options_flow_preserves_member_declarations(
+    hass: HomeAssistant, mock_lock_config_entry
+):
+    """
+    Editing users through the options flow keeps the member declarations.
+
+    The flow rebuilds the whole entry from an EntryConfig and writes it, and
+    it never asks about members, so anything it does not carry forward is
+    erased by the one write a user reaches from the UI.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={**BASE_CONFIG, CONF_MEMBERS: {LOCK_1_ENTITY_ID: {"placeholder": True}}},
+        unique_id="Mock Title",
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    with _holding():
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_LOCKS: list(BASE_CONFIG[CONF_LOCKS]),
+                CONF_USERS: {"test1": {CONF_PIN: "1234", CONF_ENABLED: True}},
+            },
+        )
+
+    assert result["type"] == "create_entry"
+    assert result["data"][CONF_MEMBERS] == {LOCK_1_ENTITY_ID: {"placeholder": True}}
+    # The edit the declaration had to survive actually landed.
+    assert set(result["data"][CONF_USERS]) == {"test1"}

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -3090,6 +3090,7 @@ async def test_removing_a_slot_clears_its_code_off_the_lock(
         entry,
         options=EntryConfig(
             locks=config.locks,
+            members=config.members,
             users=remaining,
             assignment=config.assignment.reconcile(remaining, start=1),
             extra=config.extra,

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -70,7 +70,10 @@ from custom_components.lock_code_manager.const import (
 )
 from custom_components.lock_code_manager.domain import services
 from custom_components.lock_code_manager.domain.allocation import SlotAllocationError
-from custom_components.lock_code_manager.domain.config import build_slot_unique_id
+from custom_components.lock_code_manager.domain.config import (
+    EntryConfig,
+    build_slot_unique_id,
+)
 from custom_components.lock_code_manager.domain.pin_generator import is_unsafe_pin
 from custom_components.lock_code_manager.domain.queries import get_entry_config
 from custom_components.lock_code_manager.domain.services import async_set_usercode
@@ -1747,7 +1750,9 @@ async def test_a_write_preserves_member_declarations(
     through real setup and a real service call because those are the writes
     that would do the erasing.
     """
-    declared = {LOCK_1_ENTITY_ID: {"placeholder": True}}
+    lock_1 = er.async_get(hass).async_get(LOCK_1_ENTITY_ID)
+    assert lock_1
+    declared = {lock_1.id: {"placeholder": True}}
     entry = MockConfigEntry(
         domain=DOMAIN,
         title="Member Declarations",
@@ -1775,7 +1780,7 @@ async def test_a_write_preserves_member_declarations(
     await hass.async_block_till_done()
 
     config = get_entry_config(hass.config_entries.async_get_entry(entry.entry_id))
-    assert config.member(LOCK_1_ENTITY_ID) == {"placeholder": True}
+    assert config.member(lock_1) == {"placeholder": True}
     # The write it had to survive actually happened.
     assert "Newcomer" in config.users
 
@@ -1788,7 +1793,40 @@ async def test_a_write_preserves_member_declarations(
     await hass.async_block_till_done()
 
     config = get_entry_config(hass.config_entries.async_get_entry(entry.entry_id))
-    assert config.member(LOCK_1_ENTITY_ID) == {"placeholder": True}
+    assert config.member(lock_1) == {"placeholder": True}
     assert "Newcomer" not in config.users
 
     await hass.config_entries.async_unload(entry.entry_id)
+
+
+async def test_a_declaration_survives_renaming_its_member(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+) -> None:
+    """
+    Renaming the lock entity does not lose what was declared about it.
+
+    This is the whole reason declarations are keyed by registry entry id
+    rather than entity id. Nothing in this integration listens for entity
+    registry updates, so a declaration keyed by entity id would be stranded
+    the moment somebody renamed their lock -- and stranded permanently, since
+    the roster beside it gets rewritten by the reauth a stale roster
+    triggers, leaving the two describing different entities. Renamed through
+    the real registry because the guarantee being relied on is Home
+    Assistant's, not this integration's.
+    """
+    ent_reg = er.async_get(hass)
+    lock_1 = ent_reg.async_get(LOCK_1_ENTITY_ID)
+    assert lock_1
+    config = EntryConfig.from_mapping(
+        {**BASE_CONFIG, CONF_MEMBERS: {lock_1.id: {"placeholder": True}}}
+    )
+
+    renamed = ent_reg.async_update_entity(
+        LOCK_1_ENTITY_ID, new_entity_id="lock.renamed_by_the_user"
+    )
+
+    assert renamed.entity_id != lock_1.entity_id
+    assert config.member(renamed) == {"placeholder": True}
+    # The roster, which is keyed by entity id, is the half that goes stale.
+    assert not config.has_lock(renamed.entity_id)

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -50,6 +50,7 @@ from custom_components.lock_code_manager.const import (
     ATTR_VALID,
     BUS_EVENT_CREDENTIAL_USED,
     CONF_LOCKS,
+    CONF_MEMBERS,
     CONF_SLOTS,
     DOMAIN,
     EVENT_CREDENTIAL_USED,
@@ -80,7 +81,7 @@ from custom_components.lock_code_manager.providers.schlage import (
 )
 from tests.providers.helpers import register_mock_service
 
-from .common import LOCK_1_ENTITY_ID
+from .common import BASE_CONFIG, LOCK_1_ENTITY_ID
 
 
 async def test_set_usercode_service(
@@ -1731,3 +1732,63 @@ async def test_use_credential_requires_both_attribution_fields(
         await hass.services.async_call(
             DOMAIN, SERVICE_USE_CREDENTIAL, data, blocking=True
         )
+
+
+async def test_a_write_preserves_member_declarations(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+) -> None:
+    """
+    What the entry declares about a member survives a write about a user.
+
+    The declaration is stored on the entry, and every write rewrites the
+    whole entry from an EntryConfig, so a construction site that does not
+    carry it erases it -- silently, and only for users who set it. Driven
+    through real setup and a real service call because those are the writes
+    that would do the erasing.
+    """
+    declared = {LOCK_1_ENTITY_ID: {"placeholder": True}}
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Member Declarations",
+        data={**BASE_CONFIG, CONF_MEMBERS: declared},
+        unique_id="test_member_declarations",
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Setup moves the configuration from data into options, which is already
+    # a full rewrite of the entry.
+    assert dict(get_entry_config(entry).members) == declared
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_ADD_USER,
+        {
+            ATTR_CONFIG_ENTRY_ID: entry.entry_id,
+            CONF_NAME: "Newcomer",
+            CONF_PIN: "9876",
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    config = get_entry_config(hass.config_entries.async_get_entry(entry.entry_id))
+    assert config.member(LOCK_1_ENTITY_ID) == {"placeholder": True}
+    # The write it had to survive actually happened.
+    assert "Newcomer" in config.users
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_DELETE_USER,
+        {ATTR_CONFIG_ENTRY_ID: entry.entry_id, CONF_NAME: "Newcomer"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    config = get_entry_config(hass.config_entries.async_get_entry(entry.entry_id))
+    assert config.member(LOCK_1_ENTITY_ID) == {"placeholder": True}
+    assert "Newcomer" not in config.users
+
+    await hass.config_entries.async_unload(entry.entry_id)


### PR DESCRIPTION
## Proposed change

**What this is for.** Today the config flow refuses a lock no provider claims —
*"No Lock Code Manager provider claims `lock.garage`"*. The plan (#1484) is to
accept it and ask instead:

> Lock Code Manager can't read or write codes on `lock.garage`. It can still
> manage codes for it — storing them itself and checking codes you report with
> `use_credential`. The lock won't be written to.

The user answers, and the answer has to live somewhere. **This PR is that
somewhere.** No UI and no behavior yet — the flow step that writes it is #1484.

There is nowhere to record anything *about* a member of a config entry —
`EntryConfig.locks` is a `tuple[str, ...]` and nothing hangs off an individual
entity. #1484 needs somewhere to say "this lock has no code storage".

Adds an optional `members` mapping **alongside** the `locks` roster rather than
restructuring it (the roster is read raw in `unmanaged.py`, serialized in
`config.py` and consumed twice in `websocket.py`). `EntryConfig.member(lock_entry)`
returns what the entry declares about one member, or an empty mapping.

Shape only — no config-flow field, no UI, no behavior. Deliberately not named for
locks: per #1480 a provider is a credential store and only sometimes the thing
that gets locked, so nothing reading a declaration may assume the member actuates
anything.

**Keyed by `RegistryEntry.id`, and the accessor takes the registry entry.** Entity
IDs are mutable and this integration has no registry-update listener, so keying by
entity ID meant a rename stranded the declaration — reauth repairs the roster but
nothing repairs `members`. Under #1484 that reads: rename your codeless lock, and
LCM forgets it is codeless. Taking the `RegistryEntry` rather than an ID string
also makes passing an entity ID a type error instead of a silent empty result.

**No migration, and the entry stays at VERSION 4.** Every stored v4 entry is
already valid under this shape — an unwritten key reads as "nothing declared",
which is what a v4 entry means. Verified round-trip, downgrade, and that no read
path indexes the key.

One on-disk effect: `to_dict()` emits `members` unconditionally, so every entry
gains `"members": {}` on its next write, making the first post-upgrade
`async_update_entry` return `True`. That costs one extra update-listener pass,
which early-returns on empty options.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue: #1480, and unblocks #1484

PR 3 of 5. 2264 passing, 100% coverage. Every write path that could silently drop
a declaration is mutation-tested — the options flow, the write a user actually
reaches, had no coverage until one survived.
