### PR TITLE
feat: credential kinds as event types, and one recording path for every use

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,7 +102,11 @@ entities.
 - `text.py`: Name and PIN configuration entities
 - `number.py`: Number of uses tracking (decrements on PIN use)
 - `switch.py`: Slot enabled/disabled toggle
-- `event.py`: PIN usage events (fires when code slot is used to lock/unlock)
+- `event.py`: per-user `credential_used` event entity. One fixed event type,
+  `credential_used`; it records from `BUS_EVENT_CREDENTIAL_USED` alone and
+  publishes that payload (`name`, `config_entry_id`, `config_entry_title`,
+  `source`, `target`) as its state attributes, alongside `code_slot` and
+  `slot_field`. Where the credential was used is `target`, not `event_type`
 
 ### Data Flow
 
@@ -121,7 +125,9 @@ entities.
    (`lock_code_manager_lock_state_changed`), the older lock-shaped event. It is
    retained for backward compatibility while consumers migrate to the unified
    event above, with no removal version set and no runtime deprecation
-   warning; the per-slot `credential_used` event entity still listens to it.
+   warning. Nothing inside the integration listens to it -- the per-slot
+   `credential_used` event entity records from the unified event only, which
+   is what lets it record a use whose target is not a lock at all.
 
 ### Sync State Machine (`sync.py`)
 
@@ -428,7 +434,7 @@ with a comment citing the contract. Never silence one by rerunning.
 | `hard_refresh_interval` | None | Interval for full code refresh (detects out-of-band changes) |
 | `connection_check_interval` | 30 seconds | Interval for connection state checks |
 | `supports_push` | False | Enable push-based updates instead of polling |
-| `supports_code_slot_events` | True | Whether lock fires code slot used events |
+| `supports_code_slot_events` | True | Whether lock reports which code slot was used. Diagnostics only; nothing gates on it |
 
 ### Push Support
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,11 +102,14 @@ entities.
 - `text.py`: Name and PIN configuration entities
 - `number.py`: Number of uses tracking (decrements on PIN use)
 - `switch.py`: Slot enabled/disabled toggle
-- `event.py`: per-user `credential_used` event entity. One fixed event type,
-  `credential_used`; it records from `BUS_EVENT_CREDENTIAL_USED` alone and
-  publishes that payload (`name`, `config_entry_id`, `config_entry_title`,
-  `source`, `target`) as its state attributes, alongside `code_slot` and
-  `slot_field`. Where the credential was used is `target`, not `event_type`
+- `event.py`: per-user `credential_used` event entity. Its `event_types` are
+  credential kinds -- `MANAGED_CREDENTIAL_TYPES` unioned with everything the
+  entry's locks advertise -- and a recorded use fires with the kind it was.
+  It records from `BUS_EVENT_CREDENTIAL_USED` alone and publishes that
+  payload (`name`, `config_entry_id`, `config_entry_title`, `source`,
+  `target`, `credential_type`, `operation`) as its state attributes,
+  alongside `code_slot` and `slot_field`. Where the credential was used is
+  `target`, not `event_type`
 
 ### Data Flow
 

--- a/BLUEPRINTS.md
+++ b/BLUEPRINTS.md
@@ -22,6 +22,9 @@ for additional setup guides and examples.
    - [Credential Used](#credential-used) *(automation)*
 1. Setup Helpers
    - [Condition Linker](#condition-linker) *(automation)*
+1. Reference
+   - [Finding a slot number](#finding-a-slot-number)
+   - [Credential used entity attributes](#credential-used-entity-attributes)
 
 ---
 
@@ -35,14 +38,16 @@ Optionally resets the counter when the user is re-enabled.
 
 - Set counter to **-1** for unlimited uses
 - Set counter to **0** to disable on next use
-- Requires a lock that reports credential use
+- The optional lock filter matches the use's `target` — the lock that
+  reported it, or whatever `lock_code_manager.use_credential` was told the
+  credential acted on
 
 [![Import Blueprint](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Framan325%2Flock_code_manager%2Fblob%2Fmain%2Fblueprints%2Fautomation%2Flock_code_manager%2Fslot_usage_limiter.yaml)
 
 | Input | Description | Default |
 | ----- | ----------- | ------- |
 | Credential used event entity | The user's event entity, which fires when their credential is used | Required |
-| Locks (optional) | Only count uses on these locks | All locks |
+| Locks (optional) | Only count uses whose target is one of these | All targets |
 | Slot enabled switch | The user's Enabled switch, turned off when the counter runs out | Required |
 | Uses counter | `input_number` helper tracking remaining uses | Required |
 | Initial uses on re-enable | Number of uses to reset to when the user is re-enabled (0 = no reset) | 0 |
@@ -57,6 +62,19 @@ their PIN is active.
 
 - Filter by event title, description, or location using Jinja2 templates
 - Supports any HA calendar integration (local, Google, CalDAV, etc.)
+- Template variables: `message`, `description`, `location`, `start_time`,
+  `end_time`, `all_day`, `slot_number`, `config_entry_title`, `name_state`
+
+> **Breaking: `lock_entity_ids` is gone.** It came from the credential used
+> event entity, which no longer lists the config entry's locks as its event
+> types, and nothing else exposes a config entry's locks to a template. A
+> condition template that still references it fails to render and the binary
+> sensor goes unavailable — visibly, rather than silently flipping
+> `{{ 'lock.front_door' in lock_entity_ids }}` to false and quietly
+> deactivating the PIN. The list was identical for every slot in the config
+> entry, so that example could only ever be constantly true or constantly
+> false: a condition entity gates a *user* across every lock in the entry, and
+> never one lock. Delete the reference to fix the sensor.
 
 [![Import Blueprint](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Framan325%2Flock_code_manager%2Fblob%2Fmain%2Fblueprints%2Ftemplate%2Flock_code_manager%2Fcalendar_condition.yaml)
 
@@ -153,8 +171,10 @@ has closed while the lock is unlocked.
 Runs actions when a user's credential is used on a lock. Use it to
 send notifications, trigger scripts, or run any HA action.
 
-- Requires a lock that reports credential use
 - Template variables: `slot_name`, `slot_num`, `lock_name`, `timestamp`
+- `lock_name` and the optional lock filter both read the use's `target` —
+  the lock that reported it, or whatever `lock_code_manager.use_credential`
+  was told the credential acted on
 - Uses `mode: queued` to handle rapid successive uses
 
 [![Import Blueprint](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Framan325%2Flock_code_manager%2Fblob%2Fmain%2Fblueprints%2Fautomation%2Flock_code_manager%2Fslot_usage_notifier.yaml)
@@ -162,7 +182,7 @@ send notifications, trigger scripts, or run any HA action.
 | Input | Description | Default |
 | ----- | ----------- | ------- |
 | Credential used event entities | One or more users' event entities | Required |
-| Locks (optional) | Only run for uses on these locks | All locks |
+| Locks (optional) | Only run for uses whose target is one of these | All targets |
 | Actions | HA actions to run (notifications, scripts, etc.) | Required |
 
 ### Credential Used
@@ -176,13 +196,14 @@ Manager saw it happen on a lock or was told about it through the
 - Every filter is optional; leave them all empty to act on every use
 - Uses `mode: queued` to handle rapid successive uses
 
-Slot Usage Notifier and Slot Usage Limiter trigger on a user's
-credential used *entity*, so they only see uses recorded there — uses
-against a lock in the same configuration. A use reported through
-`lock_code_manager.use_credential` with any other target has no
-per-user entity to record against, so those two never see it. This
-blueprint triggers on the `lock_code_manager_credential_used` event
-instead and sees every credential use.
+Slot Usage Notifier and Slot Usage Limiter trigger on one user's
+credential used *entity*, so each automation covers the users you point
+it at. This blueprint triggers on the `lock_code_manager_credential_used`
+event instead, so one automation covers every user in every
+configuration, and its filters narrow from there. All three see the same
+uses: whether Lock Code Manager watched a lock report one or was told
+about it through `lock_code_manager.use_credential`, and whatever the
+use was against.
 
 [![Import Blueprint](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Framan325%2Flock_code_manager%2Fblob%2Fmain%2Fblueprints%2Fautomation%2Flock_code_manager%2Fcredential_used.yaml)
 
@@ -230,3 +251,31 @@ look at its `code_slot` attribute. In a template:
 ```jinja
 {{ state_attr('text.raman_pin', 'code_slot') }}
 ```
+
+---
+
+## Credential used entity attributes
+
+Every user has a `credential_used` event entity. Its state is the
+timestamp of their last recorded use, and its attributes are what a
+template or blueprint reads about that use:
+
+| Attribute | Meaning |
+| --------- | ------- |
+| `event_type` | Always `credential_used`. It says *what* happened, never where |
+| `name` | The user whose credential was used |
+| `target` | What the credential was used against — a lock that reported the use, or whatever `lock_code_manager.use_credential` was told it acted on |
+| `source` | Where the credential was entered. Same entity as `target` when a lock observed the use itself |
+| `config_entry_id` | The Lock Code Manager configuration holding the user |
+| `config_entry_title` | That configuration's title |
+| `code_slot` | The user's slot number |
+| `slot_field` | Always `credential_used` |
+
+> **Breaking:** the entity used to publish the older lock-shaped payload
+> and set `event_type` to the lock entity ID. Templates reading
+> `event_type` as a lock must read `target` instead, and
+> `lock_code_manager_config_entry_id`, `code_slot_name`, `action_text`,
+> `notification_source`, `from`, `to`, `state`, `entity_id`, `device_id`,
+> `extra_data`, `credential_type` and `lock_config_entry_id` are gone from
+> the entity. They all still travel on the deprecated
+> `lock_code_manager_lock_state_changed` bus event, which keeps firing.

--- a/BLUEPRINTS.md
+++ b/BLUEPRINTS.md
@@ -42,11 +42,30 @@ Optionally resets the counter when the user is re-enabled.
   reported it, or whatever `lock_code_manager.use_credential` was told the
   credential acted on
 
+- **Operations that spend a use** picks which recorded uses count, by what
+  the device did with the credential: `unlock` and `unknown` by default,
+  `lock` not
+
+> **Breaking: the entity now records more than unlocks.** It used to record
+> only unlocks; it records every use of the user's credential now, including
+> a lock reporting which slot *locked* it and every use reported through
+> `lock_code_manager.use_credential`. **Operations that spend a use** is what
+> keeps that from changing your counters: leaving it at its default spends a
+> use on `unlock` and `unknown` and not on `lock`, so a guest who unlocks
+> with their PIN and locks up behind them with the same PIN spends one use
+> rather than two — on a 1-use code, being polite would otherwise lock them
+> out. Uses reported through `lock_code_manager.use_credential` are always
+> `unknown`, since Lock Code Manager never actuates a lock and so never sees
+> what happened next; clear `unknown` and those stop counting entirely. Slot
+> Usage Notifier has no such filter and runs on every use, locking included;
+> its `operation` variable says which happened.
+
 [![Import Blueprint](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Framan325%2Flock_code_manager%2Fblob%2Fmain%2Fblueprints%2Fautomation%2Flock_code_manager%2Fslot_usage_limiter.yaml)
 
 | Input | Description | Default |
 | ----- | ----------- | ------- |
 | Credential used event entity | The user's event entity, which fires when their credential is used | Required |
+| Operations that spend a use | Which uses decrement the counter, by what the device did: `unlock`, `lock`, `unknown` | `unlock`, `unknown` |
 | Locks (optional) | Only count uses whose target is one of these | All targets |
 | Slot enabled switch | The user's Enabled switch, turned off when the counter runs out | Required |
 | Uses counter | `input_number` helper tracking remaining uses | Required |
@@ -67,14 +86,20 @@ their PIN is active.
 
 > **Breaking: `lock_entity_ids` is gone.** It came from the credential used
 > event entity, which no longer lists the config entry's locks as its event
-> types, and nothing else exposes a config entry's locks to a template. A
-> condition template that still references it fails to render and the binary
-> sensor goes unavailable — visibly, rather than silently flipping
-> `{{ 'lock.front_door' in lock_entity_ids }}` to false and quietly
-> deactivating the PIN. The list was identical for every slot in the config
-> entry, so that example could only ever be constantly true or constantly
-> false: a condition entity gates a *user* across every lock in the entry, and
-> never one lock. Delete the reference to fix the sensor.
+> types, and nothing else exposes a config entry's locks to a template.
+> **A condition template that still references it fails quietly.** Home
+> Assistant treats an undefined template variable as empty rather than as an
+> error, so the binary sensor stays available, reads `off`, and the PIN never
+> activates. The one signal is a log line — `Template variable warning:
+> 'lock_entity_ids' is undefined when rendering ...` — so check the Home
+> Assistant log after upgrading. Nothing can make that louder: the sensor
+> cannot tell an undefined variable from a condition that is honestly false.
+> There is no replacement and nothing worth stubbing it to. The list was
+> identical for every slot in the config entry, so
+> `{{ 'lock.front_door' in lock_entity_ids }}` could only ever be constantly
+> true or constantly false: a condition entity gates a *user* across every
+> lock in the entry, and never one lock. Delete the reference to fix the
+> sensor.
 
 [![Import Blueprint](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Framan325%2Flock_code_manager%2Fblob%2Fmain%2Fblueprints%2Ftemplate%2Flock_code_manager%2Fcalendar_condition.yaml)
 
@@ -171,11 +196,16 @@ has closed while the lock is unlocked.
 Runs actions when a user's credential is used on a lock. Use it to
 send notifications, trigger scripts, or run any HA action.
 
-- Template variables: `slot_name`, `slot_num`, `lock_name`, `timestamp`
+- Template variables: `slot_name`, `slot_num`, `lock_name`, `timestamp`,
+  `operation`, `credential_type`
 - `lock_name` and the optional lock filter both read the use's `target` —
   the lock that reported it, or whatever `lock_code_manager.use_credential`
   was told the credential acted on
 - Uses `mode: queued` to handle rapid successive uses
+- **Breaking:** it now runs on every recorded use, locking by code
+  included, where it used to run only on unlocks. `operation` says which
+  happened; put it in your message, or skip a kind with a condition inside
+  your actions
 
 [![Import Blueprint](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Framan325%2Flock_code_manager%2Fblob%2Fmain%2Fblueprints%2Fautomation%2Flock_code_manager%2Fslot_usage_notifier.yaml)
 
@@ -191,8 +221,8 @@ Runs actions every time a credential is used, whether Lock Code
 Manager saw it happen on a lock or was told about it through the
 `lock_code_manager.use_credential` action.
 
-- Template variables: `name`, `source`, `target`, `config_entry_id`,
-  `config_entry_title`, `timestamp`
+- Template variables: `name`, `source`, `target`, `credential_type`,
+  `operation`, `config_entry_id`, `config_entry_title`, `timestamp`
 - Every filter is optional; leave them all empty to act on every use
 - Uses `mode: queued` to handle rapid successive uses
 
@@ -262,20 +292,31 @@ template or blueprint reads about that use:
 
 | Attribute | Meaning |
 | --------- | ------- |
-| `event_type` | Always `credential_used`. It says *what* happened, never where |
+| `event_type` | The kind of credential presented — `pin` today. It says *what* was used, never where |
+| `event_types` | The kinds this user's uses can be: what Lock Code Manager manages, plus everything the configuration's locks advertise |
 | `name` | The user whose credential was used |
 | `target` | What the credential was used against — a lock that reported the use, or whatever `lock_code_manager.use_credential` was told it acted on |
 | `source` | Where the credential was entered. Same entity as `target` when a lock observed the use itself |
+| `credential_type` | The kind of credential presented, the same value as `event_type` |
+| `operation` | What the device did with it: `unlock`, `lock`, or `unknown` when nothing reported which. Always `unknown` for a use reported through `lock_code_manager.use_credential` |
 | `config_entry_id` | The Lock Code Manager configuration holding the user |
 | `config_entry_title` | That configuration's title |
 | `code_slot` | The user's slot number |
 | `slot_field` | Always `credential_used` |
 
-> **Breaking:** the entity used to publish the older lock-shaped payload
-> and set `event_type` to the lock entity ID. Templates reading
+Filtering by credential kind is a template away: `event_type` (or
+`credential_type`) is `pin` for a PIN and would be `rfid` for a card read at
+a lock's own reader, so an automation can act on one kind without acting on
+every other.
+
+> **Breaking:** the entity used to record only unlocks; it now records every
+> use of the user's credential, including a lock reporting which slot locked
+> it, and says which in `operation`. Its `event_type` used to be the lock
+> entity ID and is now the credential kind, so `event_types` is the kinds of
+> credential rather than a list of locks. It also used to publish the older
+> lock-shaped payload. Templates reading
 > `event_type` as a lock must read `target` instead, and
 > `lock_code_manager_config_entry_id`, `code_slot_name`, `action_text`,
 > `notification_source`, `from`, `to`, `state`, `entity_id`, `device_id`,
-> `extra_data`, `credential_type` and `lock_config_entry_id` are gone from
-> the entity. They all still travel on the deprecated
+> `extra_data` and `lock_config_entry_id` are gone from the entity. They all still travel on the deprecated
 > `lock_code_manager_lock_state_changed` bus event, which keeps firing.

--- a/blueprints/automation/lock_code_manager/credential_used.yaml
+++ b/blueprints/automation/lock_code_manager/credential_used.yaml
@@ -10,19 +10,18 @@ blueprint:
     **Which blueprint should I use?**
 
 
-    Slot Usage Notifier and Slot Usage Limiter trigger on a user's
-    credential used *entity*, so they only see uses that were recorded
-    there — which means uses against a lock in the same Lock Code Manager
-    configuration. A use reported through `lock_code_manager.use_credential`
-    with any other target (a cover, an alarm panel, an entity Lock Code
-    Manager does not manage) has no per-user entity to record against, so
-    those two blueprints never see it.
+    Slot Usage Notifier and Slot Usage Limiter trigger on one user's
+    credential used *entity*, so each automation covers the users you point
+    it at. All three see the same uses — whether Lock Code Manager watched
+    a lock report one or was told about it through
+    `lock_code_manager.use_credential`, and whatever the use was against.
 
 
     This blueprint triggers on the `lock_code_manager_credential_used`
-    event instead, so it sees every credential use with no exceptions.
-    Reach for the other two when you want the focused, per-user recipe;
-    reach for this one when you want the whole picture.
+    event instead, so one automation covers every user in every
+    configuration and its filters narrow from there. Reach for the other
+    two when you want the focused, per-user recipe; reach for this one when
+    you want the whole picture.
 
 
     **Available template variables**
@@ -35,6 +34,11 @@ blueprint:
     - `source` — the entity ID where the credential was entered
 
     - `target` — the entity ID it was used against
+
+    - `credential_type` — the kind of credential presented, `pin` today
+
+    - `operation` — what the device did with it: `unlock`, `lock`, or
+      `unknown` when nothing reported which
 
     - `config_entry_id` — the ID of the Lock Code Manager configuration
 
@@ -124,6 +128,8 @@ variables:
   name: "{{ trigger.event.data.name }}"
   source: "{{ trigger.event.data.source }}"
   target: "{{ trigger.event.data.target }}"
+  credential_type: "{{ trigger.event.data.credential_type }}"
+  operation: "{{ trigger.event.data.operation }}"
   config_entry_id: "{{ trigger.event.data.config_entry_id }}"
   config_entry_title: "{{ trigger.event.data.config_entry_title }}"
   timestamp: >-

--- a/blueprints/automation/lock_code_manager/slot_usage_limiter.yaml
+++ b/blueprints/automation/lock_code_manager/slot_usage_limiter.yaml
@@ -131,10 +131,14 @@ actions:
       - conditions:
           - condition: trigger
             id: pin_used
+          # `target` is what the credential was used against. `event_type`
+          # is the fixed word `credential_used` and names nothing, so
+          # reading it here left every non-empty lock filter blocking
+          # everything.
           - condition: template
             value_template: >-
               {{ locks | count == 0
-                 or state_attr(trigger.entity_id, 'event_type') in locks }}
+                 or state_attr(trigger.entity_id, 'target') in locks }}
         sequence:
           - variables:
               current: >
@@ -175,7 +179,7 @@ actions:
                         {{ _config_entry_title }} code slot {{ _slot_number }}
                         has been disabled after reaching the usage limit.
                         Last used on lock
-                        {{ state_attr(trigger.entity_id, 'event_type')
+                        {{ state_attr(trigger.entity_id, 'target')
                            | default('unknown') }}
                         at {{ now().strftime('%Y-%m-%d %H:%M:%S') }}.
       - conditions:

--- a/blueprints/automation/lock_code_manager/slot_usage_limiter.yaml
+++ b/blueprints/automation/lock_code_manager/slot_usage_limiter.yaml
@@ -17,11 +17,23 @@ blueprint:
     - Set the counter to **0** to immediately disable the slot on next use.
 
 
-    **Requirements**
+    **What spends a use**
 
-    This blueprint requires at least one lock that supports code slot events
-    (i.e. produces credential-used events). If none of your locks
-    support this, the counter will never decrement.
+    The credential used event entity records every use of the user's
+    credential and says what the device did with it: `unlock`, `lock`, or
+    `unknown` when nothing reported which.
+
+
+    By default `unlock` and `unknown` spend a use and `lock` does not, so a
+    guest who unlocks with their PIN and locks up behind them with the same
+    PIN spends one use rather than two — on a 1-use code, being polite would
+    otherwise lock them out. Uses reported through the
+    `lock_code_manager.use_credential` action are always `unknown`, because
+    Lock Code Manager never actuates a lock and so never sees what happened
+    next; leaving `unknown` selected is what keeps those counting at all.
+
+
+    Widen or narrow that with **Operations that spend a use**.
 
 
     **Setup**
@@ -48,6 +60,35 @@ blueprint:
         entity:
           domain: event
           integration: lock_code_manager
+    counted_operations:
+      name: Operations that spend a use
+      description: >
+        Which recorded uses decrement the counter, by what the device did
+        with the credential.
+
+
+        `unlock` — the credential unlocked something.
+
+
+        `lock` — it locked something. Off by default: a guest who unlocks
+        with their PIN and locks up behind them with the same PIN would
+        otherwise spend two uses.
+
+
+        `unknown` — nothing reported what the device did. Every use reported
+        through `lock_code_manager.use_credential` is one of these, as is
+        any lock notification the provider could not classify, so clearing
+        this stops those counting entirely.
+      default:
+        - unlock
+        - unknown
+      selector:
+        select:
+          multiple: true
+          options:
+            - unlock
+            - lock
+            - unknown
     locks:
       name: Locks (optional)
       description: >
@@ -117,6 +158,7 @@ variables:
   uses_counter: !input uses_counter
   notify_target: !input notify_target
   locks: !input locks
+  counted_operations: !input counted_operations
   pin_used_entity_id: !input pin_used_entity
   _config_entry: >-
     {{ config_entry_id(pin_used_entity_id) }}
@@ -131,14 +173,18 @@ actions:
       - conditions:
           - condition: trigger
             id: pin_used
-          # `target` is what the credential was used against. `event_type`
-          # is the fixed word `credential_used` and names nothing, so
-          # reading it here left every non-empty lock filter blocking
-          # everything.
+          # Read off the trigger's own snapshot rather than the entity's
+          # live state: `mode: queued` runs this behind up to nine other
+          # uses, and a live read would judge this trigger by whatever use
+          # arrived last. `target` is what the credential was used against;
+          # `event_type` is the kind of credential and names no entity.
           - condition: template
             value_template: >-
-              {{ locks | count == 0
-                 or state_attr(trigger.entity_id, 'target') in locks }}
+              {{ trigger.to_state is not none
+                 and trigger.to_state.attributes.operation
+                     in counted_operations
+                 and (locks | count == 0
+                      or trigger.to_state.attributes.target in locks) }}
         sequence:
           - variables:
               current: >
@@ -179,7 +225,7 @@ actions:
                         {{ _config_entry_title }} code slot {{ _slot_number }}
                         has been disabled after reaching the usage limit.
                         Last used on lock
-                        {{ state_attr(trigger.entity_id, 'target')
+                        {{ trigger.to_state.attributes.target
                            | default('unknown') }}
                         at {{ now().strftime('%Y-%m-%d %H:%M:%S') }}.
       - conditions:

--- a/blueprints/automation/lock_code_manager/slot_usage_notifier.yaml
+++ b/blueprints/automation/lock_code_manager/slot_usage_notifier.yaml
@@ -27,11 +27,25 @@ blueprint:
 
     - `timestamp` — the date and time the event occurred
 
+    - `operation` — what the device did with the credential: `unlock`,
+      `lock`, or `unknown` when nothing reported which
 
-    **Requirements**
+    - `credential_type` — the kind of credential presented, `pin` today
 
-    This blueprint requires at least one lock that supports code slot
-    events (i.e. produces credential-used events).
+
+    **What runs the actions**
+
+    Every use recorded on the credential used event entity. That is a lock
+    reporting which code slot unlocked it, a lock reporting which code slot
+    *locked* it, and a use reported through the
+    `lock_code_manager.use_credential` action from a keypad or door
+    controller Home Assistant cannot watch.
+
+
+    Every one of them runs the actions, including locking by code — a guest
+    who unlocks with their PIN and locks up behind them with the same PIN
+    runs them twice. Use `operation` in your message to say which happened,
+    or to skip one kind with a condition inside your actions.
 
 
     **Setup**
@@ -101,8 +115,13 @@ variables:
   # `target` is what the credential was used against, which is a lock when
   # a lock observed the use and can be anything at all when the
   # `use_credential` action reported one.
+  #
+  # Read off the trigger's own snapshot rather than the entity's live state:
+  # `mode: queued` runs this behind up to nine other uses, and a live read
+  # would pair this trigger with whatever target arrived last.
   lock_entity_id: >-
-    {{ state_attr(trigger.entity_id, 'target') }}
+    {{ trigger.to_state.attributes.target | default(none, true)
+       if trigger.to_state is not none else none }}
   slot_name: >-
     {{ trigger.to_state.attributes.name | default('Unknown slot')
        if trigger.to_state is not none else 'Unknown slot' }}
@@ -120,6 +139,13 @@ variables:
     {{ (trigger.to_state.last_updated | as_local
         | as_timestamp | timestamp_custom('%Y-%m-%d %H:%M:%S'))
        if trigger.to_state is not none else '' }}
+  operation: >-
+    {{ trigger.to_state.attributes.operation | default('unknown', true)
+       if trigger.to_state is not none else 'unknown' }}
+  # The entity's event type is the kind of credential presented, not a place.
+  credential_type: >-
+    {{ trigger.to_state.attributes.event_type | default('unknown', true)
+       if trigger.to_state is not none else 'unknown' }}
 
 conditions:
   # Block transitions that aren't real PIN uses:

--- a/blueprints/automation/lock_code_manager/slot_usage_notifier.yaml
+++ b/blueprints/automation/lock_code_manager/slot_usage_notifier.yaml
@@ -96,20 +96,25 @@ variables:
   # `trigger.to_state` access against the entity-removal case
   # (`to_state is None`) — otherwise the variable rendering errors
   # out before the conditions below can block the action.
+
+  # `event_type` is the fixed word `credential_used` and names nothing;
+  # `target` is what the credential was used against, which is a lock when
+  # a lock observed the use and can be anything at all when the
+  # `use_credential` action reported one.
   lock_entity_id: >-
-    {{ state_attr(trigger.entity_id, 'event_type') }}
-  # A use the lock observed carries `code_slot_name`; one reported through
-  # the `use_credential` action carries the unified payload, which names the
-  # user in `name` instead.
+    {{ state_attr(trigger.entity_id, 'target') }}
   slot_name: >-
-    {{ trigger.to_state.attributes.code_slot_name
-       | default(trigger.to_state.attributes.name | default('Unknown slot'))
+    {{ trigger.to_state.attributes.name | default('Unknown slot')
        if trigger.to_state is not none else 'Unknown slot' }}
   slot_num: >-
     {{ trigger.to_state.attributes.code_slot | default('?')
        if trigger.to_state is not none else '?' }}
+  # A target can be an entity Home Assistant holds no state for at all --
+  # a gate, a door controller with no integration -- so falling back to the
+  # target's own id says more than 'Unknown lock' ever would.
   lock_name: >-
-    {{ state_attr(lock_entity_id, 'friendly_name') | default('Unknown lock')
+    {{ state_attr(lock_entity_id, 'friendly_name')
+       | default(lock_entity_id, true)
        if lock_entity_id is not none else 'Unknown lock' }}
   timestamp: >-
     {{ (trigger.to_state.last_updated | as_local

--- a/blueprints/template/lock_code_manager/calendar_condition.yaml
+++ b/blueprints/template/lock_code_manager/calendar_condition.yaml
@@ -29,14 +29,36 @@ blueprint:
 
     - `name_state` — the current name of the code slot
 
-    - `lock_entity_ids` — list of lock entity IDs that support code slot events for this slot
+
+    **Removed: `lock_entity_ids`**
+
+
+    This variable no longer exists. It was read off the credential used event
+    entity, which used to list the config entry's lock entity IDs as its event
+    types and now records one fixed event type instead. Nothing else in Home
+    Assistant exposes a config entry's locks to a template, so there is no
+    replacement.
+
+
+    A condition template that still references it will fail to render and the
+    binary sensor will go unavailable — loudly, on purpose. Silently handing
+    back an empty list would have flipped
+    `{{ 'lock.front_door' in lock_entity_ids }}` from always-true to
+    always-false and quietly stopped the PIN from ever activating.
+
+
+    That example was misleading anyway: the list was the same for every slot in
+    the config entry, so the template it appeared in could only ever be
+    constantly true or constantly false. A Lock Code Manager condition entity
+    gates a *user* across every lock in the entry; it cannot gate one lock.
+    Remove the reference to fix the sensor.
 
 
     **Example condition templates**
 
     - Allow when event title contains "Guest": `{{ 'Guest' in message }}`
 
-    - Allow only for a specific lock: `{{ 'lock.front_door' in lock_entity_ids }}`
+    - Allow when the slot is named for a known guest: `{{ name_state == 'Guest' }}`
 
 
     **Note:** The condition template and calendar attributes are evaluated when the
@@ -123,14 +145,6 @@ variables:
        | map(attribute='entity_id') | first | default('') }}
   name_state: >
     {{ states(_name_entity) if _name_entity else '' }}
-  _event_entity: >
-    {{ expand(_all_entities)
-       | selectattr('attributes.slot_field', 'defined')
-       | selectattr('attributes.slot_field', 'eq', 'credential_used')
-       | selectattr('attributes.code_slot', 'eq', slot_number | int)
-       | map(attribute='entity_id') | first | default('') }}
-  lock_entity_ids: >
-    {{ state_attr(_event_entity, 'event_types') | default([]) }}
   _condition_result: !input condition_template
 
 binary_sensor:

--- a/blueprints/template/lock_code_manager/calendar_condition.yaml
+++ b/blueprints/template/lock_code_manager/calendar_condition.yaml
@@ -40,18 +40,22 @@ blueprint:
     replacement.
 
 
-    A condition template that still references it will fail to render and the
-    binary sensor will go unavailable — loudly, on purpose. Silently handing
-    back an empty list would have flipped
-    `{{ 'lock.front_door' in lock_entity_ids }}` from always-true to
-    always-false and quietly stopped the PIN from ever activating.
+    A condition template that still references it fails quietly. Home
+    Assistant treats an undefined template variable as empty rather than as
+    an error, so the binary sensor stays available, reads `off`, and the PIN
+    never activates. The one signal is a line in the Home Assistant log:
+    `Template variable warning: 'lock_entity_ids' is undefined when rendering
+    ...`. Check the log after upgrading — nothing else will tell you.
 
 
-    That example was misleading anyway: the list was the same for every slot in
-    the config entry, so the template it appeared in could only ever be
-    constantly true or constantly false. A Lock Code Manager condition entity
-    gates a *user* across every lock in the entry; it cannot gate one lock.
-    Remove the reference to fix the sensor.
+    Nothing here can make that louder, and there is nothing worth stubbing
+    the variable to: the sensor cannot tell an undefined variable from a
+    condition that is honestly false. Nor was the variable worth keeping. The
+    list was the same for every slot in the config entry, so
+    `{{ 'lock.front_door' in lock_entity_ids }}` could only ever be constantly
+    true or constantly false. A Lock Code Manager condition entity gates a
+    *user* across every lock in the entry; it cannot gate one lock. Remove the
+    reference to fix the sensor.
 
 
     **Example condition templates**

--- a/custom_components/lock_code_manager/const.py
+++ b/custom_components/lock_code_manager/const.py
@@ -97,6 +97,8 @@ ATTR_SCHEDULE_NEXT_EVENT = "next_event"
 # and a caller with no natural entity for one of them is expected to make one.
 ATTR_SOURCE = "source"
 ATTR_TARGET = "target"
+# What the device did with the credential -- see ``CredentialOperation``.
+ATTR_OPERATION = "operation"
 
 # Bus events. The ``BUS_EVENT_`` prefix is load-bearing: ``EVENT_CREDENTIAL_USED``
 # further down is an entity key with a bare, undomained value, and firing that

--- a/custom_components/lock_code_manager/domain/credentials.py
+++ b/custom_components/lock_code_manager/domain/credentials.py
@@ -44,6 +44,21 @@ class CredentialType(StrEnum):
     NFC = "nfc"  # Near Field Communication tag.
 
 
+# The credential types Lock Code Manager itself manages -- the kinds it can
+# write to a lock. Only PIN today, because a slot holds one PIN per user, and
+# that is the only credential this integration knows how to produce.
+#
+# The single place to change when that stops being true. Do not restate the
+# set anywhere else: the point of naming it is that "PIN is the only one" is a
+# fact about today rather than an invariant, and every site that assumes it
+# has to move together.
+#
+# Distinct from what a lock can REPORT. A lock may advertise types Lock Code
+# Manager cannot write -- an RFID reader on the door is one -- and a use of
+# one of those is still a use worth recording.
+MANAGED_CREDENTIAL_TYPES: frozenset[CredentialType] = frozenset({CredentialType.PIN})
+
+
 class UserType(StrEnum):
     """
     How a user is constrained on the lock.

--- a/custom_components/lock_code_manager/domain/events.py
+++ b/custom_components/lock_code_manager/domain/events.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from enum import StrEnum
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_NAME
 from homeassistant.core import HomeAssistant, callback
@@ -9,10 +11,42 @@ from homeassistant.core import HomeAssistant, callback
 from ..const import (
     ATTR_CONFIG_ENTRY_ID,
     ATTR_CONFIG_ENTRY_TITLE,
+    ATTR_CREDENTIAL_TYPE,
+    ATTR_OPERATION,
     ATTR_SOURCE,
     ATTR_TARGET,
     BUS_EVENT_CREDENTIAL_USED,
 )
+from .credentials import CredentialType
+
+
+class CredentialOperation(StrEnum):
+    """
+    What the device did when the credential was accepted.
+
+    Reporting, not instruction. Lock Code Manager never actuates a lock, so
+    this is never an action anybody chose -- it is the observation a lock
+    passed on about what it did next, which is why the actuation vocabulary
+    deliberately kept out of this integration does not belong here either.
+
+    ``UNKNOWN`` is a first-class answer rather than a gap. A provider that
+    cannot classify a notification says so (Matter, ZHA and Z-Wave JS all
+    have such a path), and so does the ``use_credential`` action: the caller
+    told this integration a credential was used, not what happened
+    afterwards, and guessing on their behalf would put a fact in the payload
+    that nobody observed.
+    """
+
+    UNLOCK = "unlock"
+    LOCK = "lock"
+    UNKNOWN = "unknown"
+
+    @classmethod
+    def from_to_locked(cls, to_locked: bool | None) -> CredentialOperation:
+        """Read the operation off the lock-direction flag providers report."""
+        if to_locked is None:
+            return cls.UNKNOWN
+        return cls.LOCK if to_locked else cls.UNLOCK
 
 
 @callback
@@ -23,6 +57,8 @@ def async_fire_credential_used(
     name: str,
     source: str,
     target: str,
+    credential_type: CredentialType,
+    operation: CredentialOperation,
 ) -> None:
     """
     Announce that a credential belonging to ``name`` was used.
@@ -33,20 +69,28 @@ def async_fire_credential_used(
     slot number they happen to occupy -- that number is internal bookkeeping
     and putting it here would tie every consumer to it.
 
-    All five fields are always present and never empty. ``source`` (where the
-    credential was entered) and ``target`` (what it was used against) are the
-    same entity when a lock observed the use itself. Neither is restricted to
-    a domain: a use can target a lock, a cover, an alarm panel, anything the
-    caller associates it with. A caller with no natural entity for one of
-    them is expected to supply one -- a template entity as a source, a
-    Virtual lock as a target. That is the deliberate trade: a rigid payload
-    every consumer can read without key tests or null checks, with documented
-    escape hatches for the setups that need them. Do not add a default, a
-    fallback, or an optional field here.
+    All seven fields are always present and never empty. ``source`` (where
+    the credential was entered) and ``target`` (what it was used against) are
+    the same entity when a lock observed the use itself. Neither is
+    restricted to a domain: a use can target a lock, a cover, an alarm panel,
+    anything the caller associates it with. A caller with no natural entity
+    for one of them is expected to supply one -- a template entity as a
+    source, a Virtual lock as a target. That is the deliberate trade: a rigid
+    payload every consumer can read without key tests or null checks, with
+    documented escape hatches for the setups that need them. Do not add a
+    default, a fallback, or an optional field here.
 
-    Nothing dereferences ``source`` or ``target``: a code source's own state
-    can be the cleartext credential that was typed, so both travel as bare
-    identifiers and are never looked up or read.
+    ``credential_type`` is which kind of credential was presented and
+    ``operation`` is what the device did with it. Both are stated rather than
+    left to be inferred, which is what lets a consumer act on one kind of use
+    without acting on every other -- a usage limiter that spends a budget on
+    entries and not on the guest locking up behind them, say.
+
+    Nothing dereferences ``source``: a code source's own state can be the
+    cleartext credential that was typed, so it travels as a bare identifier
+    and is never looked up or read. ``target`` is read for its friendly name
+    -- the slot card names what a use happened against -- and for nothing
+    else.
     """
     hass.bus.async_fire(
         BUS_EVENT_CREDENTIAL_USED,
@@ -56,5 +100,7 @@ def async_fire_credential_used(
             ATTR_CONFIG_ENTRY_TITLE: config_entry.title,
             ATTR_SOURCE: source,
             ATTR_TARGET: target,
+            ATTR_CREDENTIAL_TYPE: credential_type,
+            ATTR_OPERATION: operation,
         },
     )

--- a/custom_components/lock_code_manager/domain/services.py
+++ b/custom_components/lock_code_manager/domain/services.py
@@ -21,7 +21,11 @@ from ..const import (
 )
 from .allocation import SlotAllocationError, async_allocate_for
 from .config import EntryConfig
-from .events import async_fire_credential_used
+from .credentials import CredentialType
+from .events import (
+    CredentialOperation,
+    async_fire_credential_used,
+)
 from .locks import get_managed_lock
 from .names import identity, name_error, normalize_name
 from .queries import get_entry_config, get_loaded_config_entry
@@ -125,15 +129,25 @@ async def async_use_credential(
     # rather than ``valid`` is also what tells the type checker it is there.
     if result.user is not None:
         # One event, whatever the target is. The entry's per-slot event
-        # entity reads this off the bus and records the use itself when the
-        # target is one of its event-capable locks, so nothing here has to
-        # know which targets are recordable.
+        # entity reads this off the bus and records every use it names, so
+        # nothing here has to know what a target is or whether Lock Code
+        # Manager manages it.
         #
         # ``source`` and ``target`` are data. Nothing here dereferences them,
         # looks them up in a registry, or reads their state: a code source's
         # state can be the cleartext credential that was just typed.
         async_fire_credential_used(
-            hass, config_entry, name=result.user, source=source, target=target
+            hass,
+            config_entry,
+            name=result.user,
+            source=source,
+            target=target,
+            # A PIN is what this action validates against.
+            credential_type=CredentialType.PIN,
+            # Nothing here observed a lock move. Lock Code Manager never
+            # actuates, so claiming an unlock would state a fact nobody saw;
+            # a caller that later needs to say gets a parameter for it.
+            operation=CredentialOperation.UNKNOWN,
         )
 
     return {

--- a/custom_components/lock_code_manager/entity.py
+++ b/custom_components/lock_code_manager/entity.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any, final
 
-from homeassistant.components.lock import LockState
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE
+from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import (
     Event,
     EventStateChangedData,
@@ -23,7 +22,6 @@ from homeassistant.helpers.event import TrackStates, async_track_state_change_fi
 from .const import (
     ATTR_CODE_SLOT,
     ATTR_SLOT_FIELD,
-    ATTR_TO,
     DOMAIN,
 )
 from .domain.config import build_slot_device_identifier, build_slot_unique_id
@@ -212,17 +210,6 @@ class BaseLockCodeManagerEntity(Entity):
         )
         self.async_on_remove(
             callbacks.register_lock_added_handler(self._handle_add_locks)
-        )
-
-    @callback
-    def _event_filter(self, event_data: dict[str, Any]) -> bool:
-        """Filter events."""
-        return (
-            any(
-                event_data[ATTR_ENTITY_ID] == lock.lock.entity_id for lock in self.locks
-            )
-            and event_data[ATTR_CODE_SLOT] == int(self.slot_num)
-            and event_data[ATTR_TO] == LockState.UNLOCKED
         )
 
     @callback

--- a/custom_components/lock_code_manager/event.py
+++ b/custom_components/lock_code_manager/event.py
@@ -2,31 +2,22 @@
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 from homeassistant.components.event import EventEntity
-from homeassistant.const import ATTR_ENTITY_ID, ATTR_NAME
+from homeassistant.const import ATTR_NAME
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import (
     ATTR_CONFIG_ENTRY_ID,
-    ATTR_SOURCE,
-    ATTR_TARGET,
     BUS_EVENT_CREDENTIAL_USED,
     EVENT_CREDENTIAL_USED,
-    EVENT_LOCK_STATE_CHANGED,
 )
 from .domain.models import LockCodeManagerConfigEntry
 from .domain.queries import get_entry_config
 from .entity import BaseLockCodeManagerEntity
-from .providers import BaseLock
-
-_LOGGER = logging.getLogger(__name__)
-
-ATTR_UNSUPPORTED_LOCKS = "unsupported_locks"
 
 
 async def async_setup_entry(
@@ -58,11 +49,14 @@ async def async_setup_entry(
 
 class LockCodeManagerCodeSlotEventEntity(BaseLockCodeManagerEntity, EventEntity):
     """
-    Code slot event entity for lock code manager.
+    Records every use of this user's credential, wherever it happened.
 
-    The event_types are the lock entity IDs that support code slot events.
-    When a PIN is used, the event type is the lock entity ID where it was used.
-    Locks that don't support code slot events are listed in unsupported_locks attribute.
+    One event type, ``credential_used``, always. Home Assistant refuses an
+    event type an entity did not declare, so a vocabulary that answered
+    "where" -- the entry's lock entity IDs, say -- makes a use against
+    anything outside it impossible to record at all. Keep it saying only
+    "what": where the credential was used is the payload's ``target``,
+    which nothing has to admit in advance.
     """
 
     _attr_entity_category = None
@@ -80,64 +74,7 @@ class LockCodeManagerCodeSlotEventEntity(BaseLockCodeManagerEntity, EventEntity)
         BaseLockCodeManagerEntity.__init__(
             self, hass, ent_reg, config_entry, slot_num, key
         )
-
-    def _get_supported_locks(self) -> list[BaseLock]:
-        """Get locks that support code slot events."""
-        return [lock for lock in self.locks if lock.supports_code_slot_events]
-
-    @property
-    def event_types(self) -> list[str]:
-        """Return supported event types (lock entity IDs)."""
-        return [lock.lock.entity_id for lock in self._get_supported_locks()]
-
-    @property
-    def available(self) -> bool:
-        """
-        Return True if entity is available.
-
-        The event entity is unavailable if no locks support code slot events.
-        """
-        if not self._get_supported_locks():
-            return False
-        return super().available
-
-    @property
-    def extra_state_attributes(self) -> dict[str, Any]:
-        """
-        Return extra state attributes.
-
-        Includes unsupported_locks list for locks that can't fire code slot events.
-        Computed dynamically to reflect any changes in lock capabilities.
-
-        Starts from what the base class publishes: a property shadows
-        ``_attr_extra_state_attributes`` outright, so building a fresh dict
-        here dropped this entity's slot identity and left it the one entity a
-        template could not find by slot.
-        """
-        attrs: dict[str, Any] = dict(self._attr_extra_state_attributes)
-        unsupported = [
-            lock.lock.entity_id
-            for lock in self.locks
-            if not lock.supports_code_slot_events
-        ]
-        if unsupported:
-            attrs[ATTR_UNSUPPORTED_LOCKS] = unsupported
-        return attrs
-
-    @callback
-    def _handle_event(self, event: Event) -> None:
-        """
-        Handle event.
-
-        The event type is the lock entity ID where the PIN was used.
-        _trigger_event stores the event type internally in EventEntity.
-        """
-        lock_entity_id = event.data.get(ATTR_ENTITY_ID)
-        if not lock_entity_id:
-            _LOGGER.warning("Received event without lock entity ID: %s", event.data)
-            return
-        self._trigger_event(lock_entity_id, event.data)
-        self.async_write_ha_state()
+        self._attr_event_types = [EVENT_CREDENTIAL_USED]
 
     @callback
     def _credential_used_filter(self, event_data: dict[str, Any]) -> bool:
@@ -148,55 +85,27 @@ class LockCodeManagerCodeSlotEventEntity(BaseLockCodeManagerEntity, EventEntity)
         occupy, so working out whose entity this is means asking the
         configuration who holds this slot right now.
 
-        A use a lock observed itself arrives here as well as on the
-        deprecated lock-state event, which carries the same use with the
-        richer payload this entity publishes as its attributes. Recording
-        both would fire the entity twice and leave it showing the thinner of
-        the two. ``source`` and ``target`` being the same entity is what
-        marks that case, and this guard retires with the deprecated event.
-
-        So a reported use is recorded only when both hold: the target is a
-        lock in this entry that can fire code slot events (checked in
-        :meth:`_handle_credential_used`), and ``source`` differs from
-        ``target``. Naming the same entity for both silently records
-        nothing, which is what the ``source`` field's description warns.
+        Deliberately says nothing about ``target``. A use against something
+        this integration does not manage -- a cover, an alarm panel, a
+        keypad with no integration of its own -- is still this user's
+        credential being used, and recording it is what this entity is for.
         """
+        slot_user = get_entry_config(self.config_entry).name_for(self.slot_num)
         return (
             event_data[ATTR_CONFIG_ENTRY_ID] == self.entry_id
-            and event_data[ATTR_SOURCE] != event_data[ATTR_TARGET]
-            and event_data[ATTR_NAME]
-            == get_entry_config(self.config_entry).name_for(self.slot_num)
+            and event_data[ATTR_NAME] == slot_user
         )
 
     @callback
     def _handle_credential_used(self, event: Event) -> None:
         """
-        Record a use reported against one of this entry's locks.
+        Record the use, publishing the unified payload as state attributes.
 
-        The target is the event type, the same as it is for a use a lock
-        observed. Anything else -- a cover, an alarm panel, a lock in the
-        entry that cannot fire code slot events -- is not one of this
-        entity's event types, and ``EventEntity`` raises on an event type it
-        was not told about. That is the ordinary case rather than a mistake:
-        the action's target is whatever the caller says the credential acted
-        on, and only some of those are things this entity can name.
+        The whole payload, unedited: a consumer reads ``target`` for where
+        the credential was used and ``source`` for where it was entered,
+        which for a use a lock observed itself are the same entity.
         """
-        target = event.data[ATTR_TARGET]
-        if target not in self.event_types:
-            return
-        self._trigger_event(target, event.data)
-        self.async_write_ha_state()
-
-    @callback
-    def _handle_add_locks(self, locks: list[BaseLock]) -> None:
-        """Handle lock entities being added."""
-        super()._handle_add_locks(locks)
-        self.async_write_ha_state()
-
-    @callback
-    def _handle_remove_lock(self, lock_entity_id: str) -> None:
-        """Handle lock entity being removed."""
-        super()._handle_remove_lock(lock_entity_id)
+        self._trigger_event(EVENT_CREDENTIAL_USED, event.data)
         self.async_write_ha_state()
 
     async def async_added_to_hass(self) -> None:
@@ -205,18 +114,10 @@ class LockCodeManagerCodeSlotEventEntity(BaseLockCodeManagerEntity, EventEntity)
         # EventEntity.async_added_to_hass restores __last_event_type from stored data
         await EventEntity.async_added_to_hass(self)
 
-        # Listen for lock state changed events
-        self.async_on_remove(
-            self.hass.bus.async_listen(
-                EVENT_LOCK_STATE_CHANGED,
-                self._handle_event,
-                self._event_filter,
-            )
-        )
-
-        # And for uses reported from outside, which reach this entity only as
-        # the unified event: the action that reports them fires nothing
-        # lock-shaped, because no lock observed anything.
+        # The unified event is the only source. Every use reaches it --
+        # observed by a lock or reported through the ``use_credential``
+        # action -- so there is one recording path and nothing to
+        # de-duplicate between two of them.
         self.async_on_remove(
             self.hass.bus.async_listen(
                 BUS_EVENT_CREDENTIAL_USED,

--- a/custom_components/lock_code_manager/event.py
+++ b/custom_components/lock_code_manager/event.py
@@ -12,9 +12,11 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import (
     ATTR_CONFIG_ENTRY_ID,
+    ATTR_CREDENTIAL_TYPE,
     BUS_EVENT_CREDENTIAL_USED,
     EVENT_CREDENTIAL_USED,
 )
+from .domain.credentials import MANAGED_CREDENTIAL_TYPES, CredentialType
 from .domain.models import LockCodeManagerConfigEntry
 from .domain.queries import get_entry_config
 from .entity import BaseLockCodeManagerEntity
@@ -51,12 +53,14 @@ class LockCodeManagerCodeSlotEventEntity(BaseLockCodeManagerEntity, EventEntity)
     """
     Records every use of this user's credential, wherever it happened.
 
-    One event type, ``credential_used``, always. Home Assistant refuses an
-    event type an entity did not declare, so a vocabulary that answered
-    "where" -- the entry's lock entity IDs, say -- makes a use against
-    anything outside it impossible to record at all. Keep it saying only
-    "what": where the credential was used is the payload's ``target``,
-    which nothing has to admit in advance.
+    The event type is the kind of credential that was presented, which is
+    what Home Assistant's ``event_types`` is for: telling kinds of event
+    apart. It is not where the use happened. A vocabulary of lock entity IDs
+    was tried and is what this replaces -- Home Assistant refuses an event
+    type an entity did not declare, so naming the entry's locks made a use
+    against anything else impossible to record at all. Where the credential
+    was used is the payload's ``target``, which nothing has to admit in
+    advance.
     """
 
     _attr_entity_category = None
@@ -74,7 +78,43 @@ class LockCodeManagerCodeSlotEventEntity(BaseLockCodeManagerEntity, EventEntity)
         BaseLockCodeManagerEntity.__init__(
             self, hass, ent_reg, config_entry, slot_num, key
         )
-        self._attr_event_types = [EVENT_CREDENTIAL_USED]
+        # Types this entity has actually recorded. A use is proof its kind is
+        # possible here, so recording one widens the vocabulary rather than
+        # being refused by it -- see :meth:`event_types`.
+        self._recorded_types: set[CredentialType] = set()
+
+    @property
+    def event_types(self) -> list[str]:
+        """
+        Return the credential kinds a use recorded here can be.
+
+        The union of what the entry's locks advertise and
+        ``MANAGED_CREDENTIAL_TYPES``, which is a floor rather than a cap.
+        Those two sets answer different questions and this entity spans
+        both: the constant is what Lock Code Manager can WRITE, and a lock's
+        advertised types are what it can REPORT. A lock with its own RFID
+        reader reports uses of a credential this integration never wrote,
+        and they are still this user's uses.
+
+        The floor is what makes the answer safe before anything is known.
+        Capabilities are probed lazily, so ``cached_capabilities`` reads
+        ``None`` for a lock that has not been asked yet or cannot be
+        reached, and an empty vocabulary would make ``_trigger_event``
+        refuse everything -- the entity would record nothing at all, for as
+        long as the probe took.
+
+        Read fresh on every state write, because it moves: a probe
+        completing or a lock being added changes it. Home Assistant re-reads
+        capability attributes each write, so a dynamic answer publishes
+        correctly; nothing caches it here, which is deliberate.
+        """
+        advertised = {
+            credential_type
+            for lock in self.locks
+            if (caps := lock.cached_capabilities) is not None
+            for credential_type in caps.credential_types
+        }
+        return sorted(advertised | MANAGED_CREDENTIAL_TYPES | self._recorded_types)
 
     @callback
     def _credential_used_filter(self, event_data: dict[str, Any]) -> bool:
@@ -90,10 +130,13 @@ class LockCodeManagerCodeSlotEventEntity(BaseLockCodeManagerEntity, EventEntity)
         keypad with no integration of its own -- is still this user's
         credential being used, and recording it is what this entity is for.
         """
-        slot_user = get_entry_config(self.config_entry).name_for(self.slot_num)
-        return (
-            event_data[ATTR_CONFIG_ENTRY_ID] == self.entry_id
-            and event_data[ATTR_NAME] == slot_user
+        # Every entry's entities see every entry's events, and resolving who
+        # holds this slot walks the configuration, so the entry has to be
+        # ruled out before that lookup rather than alongside it.
+        if event_data[ATTR_CONFIG_ENTRY_ID] != self.entry_id:
+            return False
+        return event_data[ATTR_NAME] == get_entry_config(self.config_entry).name_for(
+            self.slot_num
         )
 
     @callback
@@ -104,8 +147,17 @@ class LockCodeManagerCodeSlotEventEntity(BaseLockCodeManagerEntity, EventEntity)
         The whole payload, unedited: a consumer reads ``target`` for where
         the credential was used and ``source`` for where it was entered,
         which for a use a lock observed itself are the same entity.
+
+        A kind the vocabulary does not yet list widens it instead of being
+        dropped. ``_trigger_event`` raises on an undeclared type, and this
+        runs on a bus callback whose exceptions Home Assistant swallows, so
+        refusing would lose the use in silence -- and a use that arrived is
+        better evidence of what is possible here than a capability probe
+        that has not finished.
         """
-        self._trigger_event(EVENT_CREDENTIAL_USED, event.data)
+        credential_type = event.data[ATTR_CREDENTIAL_TYPE]
+        self._recorded_types.add(credential_type)
+        self._trigger_event(credential_type, event.data)
         self.async_write_ha_state()
 
     async def async_added_to_hass(self) -> None:

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -634,14 +634,12 @@ class BaseLock:
     @property
     def supports_code_slot_events(self) -> bool:
         """
-        Return whether this lock supports code slot events.
+        Return whether this lock reports which code slot was used.
 
-        When True, the lock can fire events indicating which code slot was used
-        to lock/unlock. This affects the event entity's event_types - locks that
-        support this will have their entity_id included in event_types.
-
-        Locks that don't support this will be listed in the unsupported_locks
-        attribute on the event entity.
+        Diagnostics only. Nothing gates on it: a use is recorded against the
+        user whose credential it was, and where it happened is payload rather
+        than capability, so a lock that never reports one costs nothing
+        anywhere else.
         """
         return True
 

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -60,7 +60,7 @@ from ..domain.credentials import (
     pin_address,
     user_from_slot,
 )
-from ..domain.events import async_fire_credential_used
+from ..domain.events import CredentialOperation, async_fire_credential_used
 from ..domain.exceptions import (
     CodeRejectedError,
     DuplicateCodeError,
@@ -2142,6 +2142,10 @@ class BaseLock:
 
         notification_source, extra_data = _serialize_source_data(source_data)
         slot_name = name_state.state if name_state else ""
+        # Only PIN is exercised today, but a consumer that reads it now keeps
+        # working when another kind arrives. Both payloads carry the same
+        # value, so they cannot drift.
+        credential_type = CredentialType.PIN
 
         event_data = {
             ATTR_NOTIFICATION_SOURCE: notification_source,
@@ -2153,9 +2157,7 @@ class BaseLock:
             ),
             ATTR_ACTION_TEXT: action_text,
             ATTR_CODE_SLOT: code_slot or 0,
-            # Only PIN is exercised today, but a consumer that reads it
-            # now keeps working when another kind arrives.
-            ATTR_CREDENTIAL_TYPE: CredentialType.PIN,
+            ATTR_CREDENTIAL_TYPE: credential_type,
             ATTR_CODE_SLOT_NAME: slot_name,
             ATTR_FROM: from_state,
             ATTR_TO: to_state,
@@ -2169,8 +2171,9 @@ class BaseLock:
         # what happened ("a credential belonging to this user was used") rather
         # than where. Retained for backward compatibility while consumers
         # migrate: both events fire, no removal version is set, and nothing
-        # warns at runtime. The per-slot event entity still listens to this
-        # one.
+        # warns at runtime. Nothing inside this integration reads it any
+        # more -- the per-slot event entity records off the unified event
+        # alone -- so it exists purely for consumers.
         self.hass.bus.async_fire(EVENT_LOCK_STATE_CHANGED, event_data=event_data)
 
         # Attribution is the whole content of the unified event, and every
@@ -2188,4 +2191,9 @@ class BaseLock:
                 # was entered and what it acted on.
                 source=lock_entity_id,
                 target=lock_entity_id,
+                credential_type=credential_type,
+                # The direction the lock reported moving, which every
+                # provider already hands this method. A provider that could
+                # not classify the notification passes None and says so.
+                operation=CredentialOperation.from_to_locked(to_locked),
             )

--- a/custom_components/lock_code_manager/providers/virtual.py
+++ b/custom_components/lock_code_manager/providers/virtual.py
@@ -50,15 +50,13 @@ class VirtualLock(BaseLock):
     @property
     def supports_code_slot_events(self) -> bool:
         """
-        Return True: a virtual lock is a recording surface for credential use.
+        Return False: a virtual lock observes nothing.
 
-        A virtual lock observes nothing on its own, but it is what somebody
-        adds when a credential is used somewhere Lock Code Manager cannot
-        watch -- an external keypad, a door controller with no integration.
-        The ``use_credential`` action records against it, so its per-slot
-        event entity has to accept events attributed to it.
+        It is a recording surface -- somewhere to point a use that happened
+        beyond Home Assistant's reach -- rather than a device that reports
+        one. Recording a use against it does not need this to say otherwise.
         """
-        return True
+        return False
 
     async def async_get_capabilities(self) -> LockCapabilities:
         """

--- a/custom_components/lock_code_manager/strings.json
+++ b/custom_components/lock_code_manager/strings.json
@@ -95,7 +95,12 @@
         "state_attributes": {
           "event_type": {
             "state": {
-              "credential_used": "PIN used"
+              "face": "Face",
+              "fingerprint": "Fingerprint",
+              "nfc": "NFC",
+              "password": "Password",
+              "pin": "PIN",
+              "rfid": "RFID"
             }
           }
         }
@@ -317,11 +322,11 @@
         },
         "source": {
           "name": "Source",
-          "description": "The entity where the credential was entered, such as a keypad. Required. If nothing in Home Assistant represents it, create a template entity to name here. Its state is never read, only its entity ID is reported. It should name a different entity from the target: a use whose source and target are the same entity is treated as one the lock observed itself, and is not recorded again."
+          "description": "The entity where the credential was entered, such as a keypad. Required. If nothing in Home Assistant represents it, create a template entity to name here. Its state is never read, only its entity ID is reported — a code source's state can be the code itself. Naming the same entity as the target is fine, and is what a credential entered and used in one place looks like."
         },
         "target": {
           "name": "Target",
-          "description": "The entity the credential was used against: a lock, a cover, an alarm panel, whatever the use applies to. Required. If nothing in Home Assistant represents it, create an entity to name here, such as a Virtual lock. Its state is never read, only its entity ID is reported. When it happens to be a lock in the chosen entry that can report code slot events, that user's credential used entity records the use as well."
+          "description": "The entity the credential was used against: a lock, a cover, an alarm panel, whatever the use applies to. Required. If nothing in Home Assistant represents it, create an entity to name here, such as a Virtual lock. Its entity ID is reported, and its friendly name is what the slot card shows for where the credential was last used. That user's credential used entity records the use whatever the target is."
         }
       }
     }

--- a/custom_components/lock_code_manager/translations/en.json
+++ b/custom_components/lock_code_manager/translations/en.json
@@ -95,7 +95,12 @@
         "state_attributes": {
           "event_type": {
             "state": {
-              "credential_used": "PIN used"
+              "face": "Face",
+              "fingerprint": "Fingerprint",
+              "nfc": "NFC",
+              "password": "Password",
+              "pin": "PIN",
+              "rfid": "RFID"
             }
           }
         }
@@ -317,11 +322,11 @@
         },
         "source": {
           "name": "Source",
-          "description": "The entity where the credential was entered, such as a keypad. Required. If nothing in Home Assistant represents it, create a template entity to name here. Its state is never read, only its entity ID is reported. It should name a different entity from the target: a use whose source and target are the same entity is treated as one the lock observed itself, and is not recorded again."
+          "description": "The entity where the credential was entered, such as a keypad. Required. If nothing in Home Assistant represents it, create a template entity to name here. Its state is never read, only its entity ID is reported — a code source's state can be the code itself. Naming the same entity as the target is fine, and is what a credential entered and used in one place looks like."
         },
         "target": {
           "name": "Target",
-          "description": "The entity the credential was used against: a lock, a cover, an alarm panel, whatever the use applies to. Required. If nothing in Home Assistant represents it, create an entity to name here, such as a Virtual lock. Its state is never read, only its entity ID is reported. When it happens to be a lock in the chosen entry that can report code slot events, that user's credential used entity records the use as well."
+          "description": "The entity the credential was used against: a lock, a cover, an alarm panel, whatever the use applies to. Required. If nothing in Home Assistant represents it, create an entity to name here, such as a Virtual lock. Its entity ID is reported, and its friendly name is what the slot card shows for where the credential was last used. That user's credential used entity records the use whatever the target is."
         }
       }
     }

--- a/custom_components/lock_code_manager/websocket.py
+++ b/custom_components/lock_code_manager/websocket.py
@@ -85,6 +85,7 @@ from .const import (
     ATTR_SLOT,
     ATTR_SLOT_NUM,
     ATTR_SYNC_STATUS,
+    ATTR_TARGET,
     ATTR_USER_ENTITY_ID,
     ATTR_USERCODE,
     CONDITION_ENTITY_DOMAINS,
@@ -857,11 +858,13 @@ def _get_last_used_info(
     hass: HomeAssistant, event_entity_id: str | None
 ) -> tuple[str | None, str | None]:
     """
-    Get last-used timestamp and lock name from an event entity.
+    Get the last-used timestamp and the name of what it was used against.
 
-    Returns a tuple of (last_used_timestamp, last_used_lock_name).
-    The event entity's state is the ISO timestamp of the last event,
-    and its event_type attribute is the lock entity ID where the PIN was used.
+    The event entity's state is the ISO timestamp of the last recorded use.
+    Where that use happened is the ``target`` attribute -- not ``event_type``,
+    which is the fixed word ``credential_used`` and names nothing. A target
+    with no state of its own (an entity outside Home Assistant's reach, or
+    one since removed) leaves the name unset and the card says only when.
     """
     if not event_entity_id:
         return None, None
@@ -870,11 +873,11 @@ def _get_last_used_info(
         return None, None
     last_used = event_state.state
     last_used_lock_name: str | None = None
-    if (last_used_lock_id := event_state.attributes.get("event_type")) and (
-        lock_state := hass.states.get(last_used_lock_id)
+    if (target_entity_id := event_state.attributes.get(ATTR_TARGET)) and (
+        target_state := hass.states.get(target_entity_id)
     ):
-        last_used_lock_name = lock_state.attributes.get(
-            ATTR_FRIENDLY_NAME, last_used_lock_id
+        last_used_lock_name = target_state.attributes.get(
+            ATTR_FRIENDLY_NAME, target_entity_id
         )
     return last_used, last_used_lock_name
 

--- a/custom_components/lock_code_manager/websocket.py
+++ b/custom_components/lock_code_manager/websocket.py
@@ -862,9 +862,10 @@ def _get_last_used_info(
 
     The event entity's state is the ISO timestamp of the last recorded use.
     Where that use happened is the ``target`` attribute -- not ``event_type``,
-    which is the fixed word ``credential_used`` and names nothing. A target
-    with no state of its own (an entity outside Home Assistant's reach, or
-    one since removed) leaves the name unset and the card says only when.
+    which is the kind of credential presented and names no entity at all. A
+    target with no state of its own (an entity outside Home Assistant's
+    reach, or one since removed) leaves the name unset and the card says
+    only when.
     """
     if not event_entity_id:
         return None, None

--- a/tests/providers/test_base.py
+++ b/tests/providers/test_base.py
@@ -29,8 +29,10 @@ from custom_components.lock_code_manager.const import (
     ATTR_CODE_SLOT_NAME,
     ATTR_CONFIG_ENTRY_ID,
     ATTR_CONFIG_ENTRY_TITLE,
+    ATTR_CREDENTIAL_TYPE,
     ATTR_EXTRA_DATA,
     ATTR_NOTIFICATION_SOURCE,
+    ATTR_OPERATION,
     ATTR_SOURCE,
     ATTR_TARGET,
     BUS_EVENT_CREDENTIAL_USED,
@@ -47,6 +49,7 @@ from custom_components.lock_code_manager.domain.credentials import (
     LockCapabilities,
     pin_address,
 )
+from custom_components.lock_code_manager.domain.events import CredentialOperation
 from custom_components.lock_code_manager.domain.exceptions import (
     DuplicateCodeError,
     LockCodeManagerProviderError,
@@ -923,6 +926,9 @@ async def test_fire_code_slot_event_fires_both_events(
         ATTR_CONFIG_ENTRY_TITLE: lock_code_manager_config_entry.title,
         ATTR_SOURCE: LOCK_1_ENTITY_ID,
         ATTR_TARGET: LOCK_1_ENTITY_ID,
+        ATTR_CREDENTIAL_TYPE: CredentialType.PIN,
+        # ``to_locked=False`` is the lock reporting that it opened.
+        ATTR_OPERATION: CredentialOperation.UNLOCK,
     }
 
 

--- a/tests/providers/virtual/test_e2e.py
+++ b/tests/providers/virtual/test_e2e.py
@@ -11,7 +11,7 @@ from pytest_homeassistant_custom_component.common import (
     async_fire_time_changed,
 )
 
-from homeassistant.components.event import ATTR_EVENT_TYPES
+from homeassistant.components.event import ATTR_EVENT_TYPE, ATTR_EVENT_TYPES
 from homeassistant.components.text import (
     ATTR_VALUE,
     DOMAIN as TEXT_DOMAIN,
@@ -28,7 +28,13 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
-from custom_components.lock_code_manager.const import CONF_LOCKS, CONF_SLOTS, DOMAIN
+from custom_components.lock_code_manager.const import (
+    ATTR_TARGET,
+    CONF_LOCKS,
+    CONF_SLOTS,
+    DOMAIN,
+    EVENT_CREDENTIAL_USED,
+)
 from custom_components.lock_code_manager.domain.credentials import (
     CredentialRef,
     CredentialType,
@@ -36,7 +42,6 @@ from custom_components.lock_code_manager.domain.credentials import (
 )
 from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.domain.sync import TICK_INTERVAL
-from custom_components.lock_code_manager.event import ATTR_UNSUPPORTED_LOCKS
 from custom_components.lock_code_manager.providers.virtual import VirtualLock
 
 from .conftest import VIRTUAL_LOCK_ENTITY_ID, get_virtual_lock
@@ -294,23 +299,33 @@ class TestStoredPaddingNeverReachesTheLock:
 class TestCredentialUseRecording:
     """A virtual lock is the surface for uses Lock Code Manager cannot watch."""
 
-    async def test_event_entity_accepts_the_virtual_lock(
+    async def test_event_entity_records_against_the_virtual_lock(
         self,
         hass: HomeAssistant,
         lcm_config_entry,
     ) -> None:
         """
-        The per-slot event entity lists the virtual lock and is available.
+        A virtual-only entry records a use without the lock claiming anything.
 
-        The entity refuses an event type it does not list, so a virtual-only
-        entry could not record a use at all until the lock advertised
-        support for code slot events.
+        The virtual lock observes nothing and says so
+        (``supports_code_slot_events`` is False). Recording a use against it
+        anyway is what a virtual lock is for: it is the surface somebody adds
+        for uses Lock Code Manager cannot watch.
         """
         state = hass.states.get(SLOT_1_EVENT_ENTITY)
         assert state
         assert state.state != STATE_UNAVAILABLE
-        assert state.attributes[ATTR_EVENT_TYPES] == [VIRTUAL_LOCK_ENTITY_ID]
-        assert ATTR_UNSUPPORTED_LOCKS not in state.attributes
+        assert state.attributes[ATTR_EVENT_TYPES] == [EVENT_CREDENTIAL_USED]
+        lock = get_virtual_lock(hass, lcm_config_entry)
+        assert lock.supports_code_slot_events is False
+
+        lock.async_fire_code_slot_event(1, False, "Keypad unlock")
+        await hass.async_block_till_done()
+
+        recorded = hass.states.get(SLOT_1_EVENT_ENTITY)
+        assert recorded.state != state.state
+        assert recorded.attributes[ATTR_EVENT_TYPE] == EVENT_CREDENTIAL_USED
+        assert recorded.attributes[ATTR_TARGET] == VIRTUAL_LOCK_ENTITY_ID
 
     @pytest.mark.parametrize("pin", ["1", "9" * 64])
     async def test_advertised_capabilities_reject_no_pin_length(

--- a/tests/providers/virtual/test_e2e.py
+++ b/tests/providers/virtual/test_e2e.py
@@ -33,9 +33,9 @@ from custom_components.lock_code_manager.const import (
     CONF_LOCKS,
     CONF_SLOTS,
     DOMAIN,
-    EVENT_CREDENTIAL_USED,
 )
 from custom_components.lock_code_manager.domain.credentials import (
+    MANAGED_CREDENTIAL_TYPES,
     CredentialRef,
     CredentialType,
     credential_from_slot,
@@ -315,7 +315,7 @@ class TestCredentialUseRecording:
         state = hass.states.get(SLOT_1_EVENT_ENTITY)
         assert state
         assert state.state != STATE_UNAVAILABLE
-        assert state.attributes[ATTR_EVENT_TYPES] == [EVENT_CREDENTIAL_USED]
+        assert state.attributes[ATTR_EVENT_TYPES] == sorted(MANAGED_CREDENTIAL_TYPES)
         lock = get_virtual_lock(hass, lcm_config_entry)
         assert lock.supports_code_slot_events is False
 
@@ -324,7 +324,7 @@ class TestCredentialUseRecording:
 
         recorded = hass.states.get(SLOT_1_EVENT_ENTITY)
         assert recorded.state != state.state
-        assert recorded.attributes[ATTR_EVENT_TYPE] == EVENT_CREDENTIAL_USED
+        assert recorded.attributes[ATTR_EVENT_TYPE] == CredentialType.PIN
         assert recorded.attributes[ATTR_TARGET] == VIRTUAL_LOCK_ENTITY_ID
 
     @pytest.mark.parametrize("pin", ["1", "9" * 64])

--- a/tests/providers/virtual/test_provider.py
+++ b/tests/providers/virtual/test_provider.py
@@ -147,16 +147,17 @@ async def test_async_unload_remove_permanently_removes_store(
     assert await _fresh_store().async_load() is None
 
 
-async def test_virtual_lock_supports_code_slot_events(
+async def test_virtual_lock_reports_no_code_slot_events(
     virtual_lock: VirtualLock,
 ):
-    """A virtual lock accepts credential-use events recorded against it.
+    """A virtual lock observes nothing, and says so.
 
-    It observes nothing itself, but it is the surface somebody adds to
-    record uses Lock Code Manager cannot watch, so the per-slot event
-    entity has to list it.
+    It is the surface somebody adds to record uses Lock Code Manager cannot
+    watch, not a device that reports them. Recording a use against it does
+    not need this to claim otherwise -- see the E2E test that does exactly
+    that with this answering False.
     """
-    assert virtual_lock.supports_code_slot_events is True
+    assert virtual_lock.supports_code_slot_events is False
 
 
 async def test_virtual_lock_capabilities_advertise_no_limits(

--- a/tests/providers/zigbee2mqtt/test_provider.py
+++ b/tests/providers/zigbee2mqtt/test_provider.py
@@ -106,6 +106,9 @@ def test_zigbee2mqtt_provider_properties_and_no_device_entry_resolves_no_topic()
     lock = _minimal_lock()
     assert lock.domain == MQTT_DOMAIN
     assert lock.supports_push is True
+    # Zigbee2MQTT publishes the used slot on the same device topic the push
+    # updates arrive on, so a lock that pushes also reports uses.
+    assert lock.supports_code_slot_events is True
     assert lock.usercode_scan_interval == timedelta(minutes=5)
     assert lock.hard_refresh_interval == timedelta(hours=1)
     assert lock.connection_check_interval == timedelta(seconds=30)

--- a/tests/providers/zwave_js_ui/test_e2e.py
+++ b/tests/providers/zwave_js_ui/test_e2e.py
@@ -32,6 +32,7 @@ from homeassistant.core import Event, HomeAssistant
 from custom_components.lock_code_manager.const import (
     ATTR_ACTION_TEXT,
     ATTR_CODE_SLOT,
+    ATTR_TARGET,
     CONF_LOCKS,
     CONF_NUM_USERS,
     CONF_SLOTS,
@@ -418,6 +419,7 @@ class TestKeypadEvents:
         self,
         hass: HomeAssistant,
         synced_lcm_config_entry: MockConfigEntry,
+        zui_lock: ZWaveJSUILock,
     ) -> None:
         """
         A keypad unlock names the slot that opened the lock, all the way out.
@@ -441,10 +443,13 @@ class TestKeypadEvents:
         await hass.async_block_till_done()
 
         assert [event.data[ATTR_CODE_SLOT] for event in events] == [1]
+        assert [event.data[ATTR_ACTION_TEXT] for event in events] == [
+            "Keypad_unlock_operation"
+        ]
         state = hass.states.get(event_entity_id)
         assert state.state != STATE_UNKNOWN
         assert state.attributes[ATTR_CODE_SLOT] == 1
-        assert state.attributes[ATTR_ACTION_TEXT] == "Keypad_unlock_operation"
+        assert state.attributes[ATTR_TARGET] == zui_lock.lock.entity_id
 
 
 class TestApiOnlyManualGateway:

--- a/tests/test_blueprint_behavior.py
+++ b/tests/test_blueprint_behavior.py
@@ -81,21 +81,40 @@ def patch_blueprint(blueprint_path: str, data_path: pathlib.Path) -> Iterator[No
         yield
 
 
-async def _setup_blueprint_automation(
-    hass: HomeAssistant, blueprint_path: str, inputs: dict
+async def _setup_blueprint_automations(
+    hass: HomeAssistant, *automations: tuple[str, dict]
 ) -> None:
-    """Instantiate a blueprint-based automation with the given inputs."""
-    with patch_blueprint(blueprint_path, BLUEPRINT_FOLDER / blueprint_path):
+    """
+    Instantiate several blueprint-based automations in one component setup.
+
+    ``async_setup_component`` is a no-op once the automation domain is up, so
+    every automation a test needs has to arrive in the same call. Setting a
+    second one up on its own leaves it silently nonexistent, and an assertion
+    that it never fired then passes for the wrong reason.
+    """
+    with contextlib.ExitStack() as stack:
+        for blueprint_path, _ in automations:
+            stack.enter_context(
+                patch_blueprint(blueprint_path, BLUEPRINT_FOLDER / blueprint_path)
+            )
         assert await async_setup_component(
             hass,
             "automation",
             {
-                "automation": {
-                    "use_blueprint": {"path": blueprint_path, "input": inputs}
-                }
+                "automation": [
+                    {"use_blueprint": {"path": blueprint_path, "input": inputs}}
+                    for blueprint_path, inputs in automations
+                ]
             },
         )
     await hass.async_block_till_done()
+
+
+async def _setup_blueprint_automation(
+    hass: HomeAssistant, blueprint_path: str, inputs: dict
+) -> None:
+    """Instantiate a blueprint-based automation with the given inputs."""
+    await _setup_blueprint_automations(hass, (blueprint_path, inputs))
 
 
 def _fire_pin_used(
@@ -796,11 +815,6 @@ async def test_limiter_derives_slot_and_config_entry(
     [
         ("template/lock_code_manager/calendar_condition.yaml", "_name_entity", "name"),
         (
-            "template/lock_code_manager/calendar_condition.yaml",
-            "_event_entity",
-            "credential_used",
-        ),
-        (
             "automation/lock_code_manager/calendar_pin_setter.yaml",
             "pin_entity",
             "pin",
@@ -872,28 +886,28 @@ def _find_variable(source: dict, name: str) -> str | None:
 CREDENTIAL_USED_PATH = "credential_used.yaml"
 
 
+_CREDENTIAL_USED_INPUTS = {
+    "credential_actions": [
+        {
+            "service": "test.captured",
+            "data": {
+                "name": "{{ name }}",
+                "source": "{{ source }}",
+                "target": "{{ target }}",
+                "config_entry_id": "{{ config_entry_id }}",
+                "config_entry_title": "{{ config_entry_title }}",
+                "timestamp": "{{ timestamp }}",
+            },
+        }
+    ],
+}
+
+
 async def _setup_credential_used(hass: HomeAssistant, **inputs) -> list[ServiceCall]:
     """Instantiate the credential-used blueprint and capture its actions."""
     captured = async_mock_service(hass, "test", "captured")
     await _setup_blueprint_automation(
-        hass,
-        CREDENTIAL_USED_PATH,
-        {
-            **inputs,
-            "credential_actions": [
-                {
-                    "service": "test.captured",
-                    "data": {
-                        "name": "{{ name }}",
-                        "source": "{{ source }}",
-                        "target": "{{ target }}",
-                        "config_entry_id": "{{ config_entry_id }}",
-                        "config_entry_title": "{{ config_entry_title }}",
-                        "timestamp": "{{ timestamp }}",
-                    },
-                }
-            ],
-        },
+        hass, CREDENTIAL_USED_PATH, {**inputs, **_CREDENTIAL_USED_INPUTS}
     )
     return captured
 
@@ -925,29 +939,42 @@ async def test_credential_used_exposes_the_whole_payload(
     assert data["timestamp"]
 
 
-async def test_credential_used_sees_a_use_the_event_entities_cannot(
+async def test_a_use_against_an_outside_target_reaches_both_blueprints(
     hass: HomeAssistant,
     mock_lock_config_entry,
     lock_code_manager_config_entry,
 ) -> None:
     """
-    A use against a target outside the entry reaches this blueprint alone.
+    A gate the entry knows nothing about notifies the user's blueprint too.
 
-    This is the reason the blueprint exists. ``use_credential`` records on
-    a user's event entity only when the target is a lock in the same
-    entry; with any other target there is no per-user entity to record
-    against, so Slot Usage Notifier and Slot Usage Limiter never fire.
-    The event does, so this does.
+    The per-user event entity records every use of that user's credential
+    whatever it acted on, so Slot Usage Notifier -- which triggers on that
+    entity -- fires for a target no lock in the entry could ever be. This
+    blueprint sees the same use straight off the bus, with the payload.
+
+    Both automations are instantiated together because the automation
+    domain only sets up once; separately, the second one would not exist.
     """
-    captured = await _setup_credential_used(hass)
-    notifier_captured = async_mock_service(hass, "test", "notified")
-    await _setup_blueprint_automation(
+    captured = async_mock_service(hass, "test", "captured")
+    notified = async_mock_service(hass, "test", "notified")
+    await _setup_blueprint_automations(
         hass,
-        NOTIFIER_PATH,
-        {
-            "event_entity": [SLOT_1_EVENT_ENTITY],
-            "notify_actions": [{"service": "test.notified"}],
-        },
+        (CREDENTIAL_USED_PATH, _CREDENTIAL_USED_INPUTS),
+        (
+            NOTIFIER_PATH,
+            {
+                "event_entity": [SLOT_1_EVENT_ENTITY],
+                "notify_actions": [
+                    {
+                        "service": "test.notified",
+                        "data": {
+                            "slot_name": "{{ slot_name }}",
+                            "lock_name": "{{ lock_name }}",
+                        },
+                    }
+                ],
+            },
+        ),
     )
 
     await _use_credential(hass, lock_code_manager_config_entry)
@@ -957,7 +984,12 @@ async def test_credential_used_sees_a_use_the_event_entities_cannot(
     assert captured[0].data["name"] == "test1"
     assert captured[0].data["source"] == EXTERNAL_KEYPAD
     assert captured[0].data["target"] == EXTERNAL_TARGET
-    assert notifier_captured == []
+
+    assert len(notified) == 1
+    assert notified[0].data["slot_name"] == "test1"
+    # Nothing in Home Assistant holds a state for the gate, so the target's
+    # own id is the most the notification can say about it.
+    assert notified[0].data["lock_name"] == EXTERNAL_TARGET
 
 
 @pytest.mark.parametrize(

--- a/tests/test_blueprint_behavior.py
+++ b/tests/test_blueprint_behavior.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from collections.abc import Iterator
 import contextlib
 import pathlib
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -21,6 +22,7 @@ from pytest_homeassistant_custom_component.common import (
 
 from homeassistant.components import automation
 from homeassistant.components.blueprint import models
+from homeassistant.components.template import config as template_config
 from homeassistant.const import ATTR_FRIENDLY_NAME
 from homeassistant.core import Event, HomeAssistant, ServiceCall, State, callback
 from homeassistant.helpers import entity_registry as er, template
@@ -54,12 +56,22 @@ BLUEPRINT_FOLDER = BLUEPRINTS_ROOT / "automation" / "lock_code_manager"
 NOTIFIER_PATH = "slot_usage_notifier.yaml"
 LIMITER_PATH = "slot_usage_limiter.yaml"
 
+# Template blueprints live under a different root, so this one carries the
+# folder its path is relative to.
+CALENDAR_PATH = "lock_code_manager/calendar_condition.yaml"
+
 
 @contextlib.contextmanager
-def patch_blueprint(blueprint_path: str, data_path: pathlib.Path) -> Iterator[None]:
+def patch_blueprint(
+    blueprint_path: str,
+    data_path: pathlib.Path,
+    schema: Any = automation.config.AUTOMATION_BLUEPRINT_SCHEMA,
+) -> Iterator[None]:
     """Intercept blueprint loading so HA reads our repo YAML directly.
 
     Mirrors the helper used in homeassistant.tests.components.automation.test_blueprint.
+    ``schema`` is the blueprint schema of the domain being loaded: the
+    template domain validates its blueprints against its own.
     """
     orig_load = models.DomainBlueprints._load_blueprint
 
@@ -71,7 +83,7 @@ def patch_blueprint(blueprint_path: str, data_path: pathlib.Path) -> Iterator[No
             yaml_util.load_yaml(data_path),
             expected_domain=self.domain,
             path=path,
-            schema=automation.config.AUTOMATION_BLUEPRINT_SCHEMA,
+            schema=schema,
         )
 
     with patch(
@@ -118,11 +130,20 @@ async def _setup_blueprint_automation(
 
 
 def _fire_pin_used(
-    config_entry, lock_entity_id: str, slot: int, action_text: str = "test"
+    config_entry,
+    lock_entity_id: str,
+    slot: int,
+    action_text: str = "test",
+    *,
+    to_locked: bool = False,
 ) -> None:
-    """Fire a PIN-used event from the named lock on the named slot."""
+    """Fire a PIN-used event from the named lock on the named slot.
+
+    ``to_locked`` is the direction the lock moved: False for a code that
+    unlocked the door, True for one that locked it.
+    """
     lock: BaseLock = config_entry.runtime_data.locks[lock_entity_id]
-    lock.async_fire_code_slot_event(slot, False, action_text, Event("test_source"))
+    lock.async_fire_code_slot_event(slot, to_locked, action_text, Event("test_source"))
 
 
 # A keypad and a gate Lock Code Manager manages neither of, which is the
@@ -689,6 +710,136 @@ async def test_limiter_decrements_on_pin_use(
     assert float(hass.states.get(counter).state) == 1
 
 
+async def test_limiter_does_not_spend_a_use_on_locking_by_default(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+) -> None:
+    """
+    Locking up behind yourself does not cost a use.
+
+    The entity records every use of the credential now, not just the
+    unlocks it used to filter for, so without a filter here a guest who
+    unlocks with their PIN and locks the door behind them with the same PIN
+    would spend two of their uses -- on a 1-use code, locking themselves out
+    for being polite. The blueprint's default counts ``unlock`` and
+    ``unknown`` and not ``lock``, which is the contract this pins.
+    """
+    counter = await _setup_counter(hass, initial=3)
+
+    await _setup_blueprint_automation(
+        hass,
+        LIMITER_PATH,
+        {
+            "pin_used_entity": SLOT_1_EVENT_ENTITY,
+            "enabled_switch": SLOT_1_ENABLED_ENTITY,
+            "uses_counter": counter,
+        },
+    )
+
+    _fire_pin_used(lock_code_manager_config_entry, LOCK_1_ENTITY_ID, 1, to_locked=False)
+    await hass.async_block_till_done()
+    assert float(hass.states.get(counter).state) == 2
+
+    _fire_pin_used(lock_code_manager_config_entry, LOCK_1_ENTITY_ID, 1, to_locked=True)
+    await hass.async_block_till_done()
+    assert float(hass.states.get(counter).state) == 2
+
+
+async def test_limiter_spends_a_use_on_locking_when_widened(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+) -> None:
+    """Selecting ``lock`` makes every touch of the credential cost a use."""
+    counter = await _setup_counter(hass, initial=3)
+
+    await _setup_blueprint_automation(
+        hass,
+        LIMITER_PATH,
+        {
+            "pin_used_entity": SLOT_1_EVENT_ENTITY,
+            "enabled_switch": SLOT_1_ENABLED_ENTITY,
+            "uses_counter": counter,
+            "counted_operations": ["unlock", "lock", "unknown"],
+        },
+    )
+
+    _fire_pin_used(lock_code_manager_config_entry, LOCK_1_ENTITY_ID, 1, to_locked=True)
+    await hass.async_block_till_done()
+    assert float(hass.states.get(counter).state) == 2
+
+
+async def test_limiter_spends_a_use_on_a_reported_use(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+) -> None:
+    """
+    A use reported through the action still counts by default.
+
+    ``use_credential`` reports ``unknown`` -- Lock Code Manager never sees
+    what the device did next -- so a default that counted only ``unlock``
+    would silently stop counting every external keypad use the action
+    exists to report.
+    """
+    counter = await _setup_counter(hass, initial=3)
+
+    await _setup_blueprint_automation(
+        hass,
+        LIMITER_PATH,
+        {
+            "pin_used_entity": SLOT_1_EVENT_ENTITY,
+            "enabled_switch": SLOT_1_ENABLED_ENTITY,
+            "uses_counter": counter,
+        },
+    )
+
+    await _use_credential(hass, lock_code_manager_config_entry)
+    await hass.async_block_till_done()
+    assert float(hass.states.get(counter).state) == 2
+
+
+async def test_notifier_runs_when_the_credential_locks_the_door(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+) -> None:
+    """
+    The notifier runs on locking by code and can say that is what happened.
+
+    It has no operation filter on purpose -- a notification about somebody
+    locking up is informative rather than harmful -- so the message is where
+    the distinction has to be available, which is what ``operation`` and
+    ``credential_type`` are for.
+    """
+    captured = async_mock_service(hass, "test", "captured")
+
+    await _setup_blueprint_automation(
+        hass,
+        NOTIFIER_PATH,
+        {
+            "event_entity": [SLOT_1_EVENT_ENTITY],
+            "notify_actions": [
+                {
+                    "service": "test.captured",
+                    "data": {
+                        "operation": "{{ operation }}",
+                        "credential_type": "{{ credential_type }}",
+                    },
+                }
+            ],
+        },
+    )
+
+    _fire_pin_used(lock_code_manager_config_entry, LOCK_1_ENTITY_ID, 1, to_locked=True)
+    await hass.async_block_till_done()
+
+    assert len(captured) == 1
+    assert captured[0].data["operation"] == "lock"
+    assert captured[0].data["credential_type"] == "pin"
+
+
 async def test_limiter_disables_switch_at_zero(
     hass: HomeAssistant,
     mock_lock_config_entry,
@@ -808,6 +959,78 @@ async def test_limiter_derives_slot_and_config_entry(
     # `_slot_number` ← state_attr(event_entity, 'code_slot') = 1
     assert "Mock Title" in title
     assert "Slot 1" in title
+
+
+# --------------------------------------------------------------------------- #
+# Calendar Condition
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("condition_template", "expected_state", "expect_warning"),
+    [
+        ("{{ true }}", "on", False),
+        ("{{ 'lock.front_door' in lock_entity_ids }}", "off", True),
+    ],
+    ids=["valid_template", "removed_lock_entity_ids"],
+)
+async def test_calendar_condition_fails_quietly_on_the_removed_variable(
+    hass: HomeAssistant,
+    caplog,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+    condition_template: str,
+    expected_state: str,
+    expect_warning: bool,
+) -> None:
+    """
+    A template still naming the removed ``lock_entity_ids`` reads ``off``.
+
+    This is the claim the blueprint's description and BLUEPRINTS.md make to
+    anybody upgrading, so it is pinned rather than reasoned about: Home
+    Assistant renders an undefined template variable as empty instead of
+    raising, which leaves the sensor available, reading ``off``, and the PIN
+    it gates permanently inactive. The only signal is a template variable
+    warning in the log. The valid-template case is what makes the ``off``
+    mean something -- the same calendar, the same setup, reading ``on``.
+    """
+    calendar_entity = "calendar.guest_stay"
+    hass.states.async_set(calendar_entity, "on", {"message": "Guest"})
+    caplog.clear()
+
+    with patch_blueprint(
+        CALENDAR_PATH,
+        BLUEPRINTS_ROOT / "template" / CALENDAR_PATH,
+        schema=template_config.TEMPLATE_BLUEPRINT_SCHEMA,
+    ):
+        assert await async_setup_component(
+            hass,
+            "template",
+            {
+                "template": {
+                    "name": "Guest Condition",
+                    "use_blueprint": {
+                        "path": CALENDAR_PATH,
+                        "input": {
+                            "config_entry": lock_code_manager_config_entry.entry_id,
+                            "calendar_entity": calendar_entity,
+                            "slot_number": 1,
+                            "condition_template": condition_template,
+                        },
+                    },
+                }
+            },
+        )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.guest_condition")
+    assert state is not None
+    assert state.state == expected_state
+    warned = (
+        "Template variable warning" in caplog.text
+        and "'lock_entity_ids' is undefined" in caplog.text
+    )
+    assert warned is expect_warning
 
 
 @pytest.mark.parametrize(

--- a/tests/test_blueprint_docs.py
+++ b/tests/test_blueprint_docs.py
@@ -45,6 +45,11 @@ def _documented_inputs() -> dict[str, list[str]]:
     for line in _DOC.read_text().splitlines():
         if match := _IMPORT_LINK.search(line):
             current = sections.setdefault(match[1], [])
+        # A section ends at the next heading. The doc carries reference
+        # tables of its own that belong to no blueprint, and without this
+        # they read as extra inputs of whichever one was documented last.
+        elif line.startswith("#"):
+            current = None
         elif current is not None and line.startswith("|"):
             name = line.split("|")[1].strip()
             if name != "Input" and not name.startswith("--"):

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -3,15 +3,11 @@
 import logging
 from unittest.mock import patch
 
+import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from homeassistant.components.lock import LockState
-from homeassistant.const import (
-    ATTR_ENTITY_ID,
-    ATTR_STATE,
-    STATE_UNAVAILABLE,
-    STATE_UNKNOWN,
-)
+from homeassistant.components.event import ATTR_EVENT_TYPE, ATTR_EVENT_TYPES
+from homeassistant.const import ATTR_NAME, STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import (
     Event,
     EventStateChangedData,
@@ -23,18 +19,20 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.event import async_track_state_change_event
 
 from custom_components.lock_code_manager.const import (
-    ATTR_ACTION_TEXT,
+    ATTR_CODE,
     ATTR_CODE_SLOT,
-    ATTR_CODE_SLOT_NAME,
+    ATTR_CONFIG_ENTRY_ID,
+    ATTR_CONFIG_ENTRY_TITLE,
     ATTR_CREDENTIAL_TYPE,
-    ATTR_FROM,
-    ATTR_NOTIFICATION_SOURCE,
-    ATTR_TO,
+    ATTR_SLOT_FIELD,
+    ATTR_SOURCE,
+    ATTR_TARGET,
     DOMAIN,
+    EVENT_CREDENTIAL_USED,
     EVENT_LOCK_STATE_CHANGED,
+    SERVICE_USE_CREDENTIAL,
 )
 from custom_components.lock_code_manager.domain.credentials import CredentialType
-from custom_components.lock_code_manager.event import ATTR_UNSUPPORTED_LOCKS
 from custom_components.lock_code_manager.providers import BaseLock
 
 from .common import (
@@ -48,35 +46,109 @@ from .common import (
 
 _LOGGER = logging.getLogger(__name__)
 
+# A keypad and a gate Lock Code Manager manages neither of. A use entered on
+# the one and acting on the other is a use no lock in the entry observed, and
+# neither entity is something the entry could ever have named.
+EXTERNAL_KEYPAD = "sensor.side_gate_keypad"
+EXTERNAL_TARGET = "cover.side_gate"
 
-async def test_event_entity(
+# Every attribute the lock-shaped payload used to put on the entity. None of
+# them are the entity's to publish any more; they still travel on the
+# deprecated bus event.
+RETIRED_ATTRIBUTES = (
+    "code_slot_name",
+    "action_text",
+    "notification_source",
+    "from",
+    "to",
+    "state",
+    "entity_id",
+    "device_id",
+    "extra_data",
+    "credential_type",
+    "lock_code_manager_config_entry_id",
+    "unsupported_locks",
+)
+
+
+async def _use_credential(
+    hass: HomeAssistant, config_entry, code: str, target: str
+) -> None:
+    """Report a use through the action, which is the only non-lock path in."""
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_USE_CREDENTIAL,
+        {
+            "config_entry_id": config_entry.entry_id,
+            ATTR_CODE: code,
+            ATTR_SOURCE: EXTERNAL_KEYPAD,
+            ATTR_TARGET: target,
+        },
+        blocking=True,
+    )
+
+
+async def test_the_recorded_attributes_are_the_unified_payload(
     hass: HomeAssistant,
     mock_lock_config_entry,
     lock_code_manager_config_entry,
 ):
-    """Test event entity."""
+    """
+    A recorded use publishes the unified payload and nothing else.
+
+    The attribute set is this entity's contract with every template and
+    blueprint reading it, so it is asserted whole rather than key by key --
+    one silently added or dropped is somebody's notification text breaking.
+    """
     state = hass.states.get(SLOT_2_EVENT_ENTITY)
     assert state
     assert state.state == STATE_UNKNOWN
 
     lock: BaseLock = lock_code_manager_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
-
     lock.async_fire_code_slot_event(2, False, "test", Event("zwave_js_notification"))
-
     await hass.async_block_till_done()
 
     state = hass.states.get(SLOT_2_EVENT_ENTITY)
     assert state
     assert state.state != STATE_UNKNOWN
+    assert {
+        key: value
+        for key, value in state.attributes.items()
+        if key not in (ATTR_EVENT_TYPES, "friendly_name")
+    } == {
+        ATTR_EVENT_TYPE: EVENT_CREDENTIAL_USED,
+        ATTR_NAME: "test2",
+        ATTR_CONFIG_ENTRY_ID: lock_code_manager_config_entry.entry_id,
+        ATTR_CONFIG_ENTRY_TITLE: lock_code_manager_config_entry.title,
+        # A lock that observed the use is both ends of it.
+        ATTR_SOURCE: LOCK_1_ENTITY_ID,
+        ATTR_TARGET: LOCK_1_ENTITY_ID,
+        ATTR_CODE_SLOT: 2,
+        ATTR_SLOT_FIELD: EVENT_CREDENTIAL_USED,
+    }
+    for retired in RETIRED_ATTRIBUTES:
+        assert retired not in state.attributes
 
-    assert state.attributes[ATTR_NOTIFICATION_SOURCE] == "event"
-    assert state.attributes[ATTR_ENTITY_ID] == LOCK_1_ENTITY_ID
-    assert state.attributes[ATTR_STATE] == LockState.UNLOCKED
-    assert state.attributes[ATTR_ACTION_TEXT] == "test"
-    assert state.attributes[ATTR_CODE_SLOT] == 2
-    assert state.attributes[ATTR_CODE_SLOT_NAME] == "test2"
-    assert state.attributes[ATTR_FROM] == LockState.LOCKED
-    assert state.attributes[ATTR_TO] == LockState.UNLOCKED
+
+async def test_event_types_is_one_fixed_word(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """
+    The vocabulary says what happened, never where.
+
+    Home Assistant refuses an event type an entity did not declare, so any
+    vocabulary naming the entry's locks makes a use against anything else
+    impossible to record. Naming no locks is what keeps every target
+    recordable.
+    """
+    state = hass.states.get(SLOT_1_EVENT_ENTITY)
+    assert state
+
+    assert state.attributes[ATTR_EVENT_TYPES] == [EVENT_CREDENTIAL_USED]
+    for lock_entity_id in (LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID):
+        assert lock_entity_id not in state.attributes[ATTR_EVENT_TYPES]
 
 
 async def test_a_lock_observed_use_is_recorded_once(
@@ -85,12 +157,11 @@ async def test_a_lock_observed_use_is_recorded_once(
     lock_code_manager_config_entry,
 ):
     """
-    One use the lock observed writes one state, with the full payload.
+    One use the lock observed writes one state.
 
-    Both events fire for it -- the deprecated lock-shaped one and the
-    unified one -- and this entity listens to both. Recording twice would
-    fire every automation on this entity twice and leave the state carrying
-    the unified event's five fields instead of the lock-shaped payload.
+    Two bus events fire for it -- the deprecated lock-shaped one and the
+    unified one. Recording both would fire every automation on this entity
+    twice, which is why only one of them is subscribed.
     """
     states: list[State] = []
 
@@ -107,41 +178,93 @@ async def test_a_lock_observed_use_is_recorded_once(
     unsub()
 
     assert len(states) == 1
-    assert states[0].attributes[ATTR_ACTION_TEXT] == "test"
+    assert states[0].attributes[ATTR_TARGET] == LOCK_1_ENTITY_ID
     assert states[0].attributes[ATTR_CODE_SLOT] == 2
 
 
-async def test_event_types_are_lock_entity_ids(
+async def test_a_use_against_something_that_is_not_a_lock_is_recorded(
     hass: HomeAssistant,
     mock_lock_config_entry,
     lock_code_manager_config_entry,
 ):
-    """Test that event_types are the lock entity IDs that support code slot events."""
-    state = hass.states.get(SLOT_1_EVENT_ENTITY)
-    assert state
+    """
+    A use acting on a cover records on the user's entity, target and all.
 
-    # event_types should include lock entity IDs
-    event_types = state.attributes.get("event_types", [])
-    assert LOCK_1_ENTITY_ID in event_types
-    assert LOCK_2_ENTITY_ID in event_types
+    This is the whole point of the fixed vocabulary. The target is a
+    credential's own business -- a gate, an alarm panel, a door controller
+    with no integration -- and none of them can ever be a lock this entry
+    manages, so a lock-shaped vocabulary dropped every one of them.
+    """
+    before = hass.states.get(SLOT_1_EVENT_ENTITY)
+    assert before
+    assert before.state == STATE_UNKNOWN
 
-
-async def test_event_type_is_lock_entity_id_after_event(
-    hass: HomeAssistant,
-    mock_lock_config_entry,
-    lock_code_manager_config_entry,
-):
-    """Test that event_type attribute is the lock entity ID where PIN was used."""
-    lock: BaseLock = lock_code_manager_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
-
-    lock.async_fire_code_slot_event(1, False, "test", Event("zwave_js_notification"))
+    await _use_credential(hass, lock_code_manager_config_entry, "1234", EXTERNAL_TARGET)
     await hass.async_block_till_done()
 
     state = hass.states.get(SLOT_1_EVENT_ENTITY)
     assert state
+    assert state.state != STATE_UNKNOWN
+    assert state.attributes[ATTR_EVENT_TYPE] == EVENT_CREDENTIAL_USED
+    assert state.attributes[ATTR_TARGET] == EXTERNAL_TARGET
+    assert state.attributes[ATTR_SOURCE] == EXTERNAL_KEYPAD
+    assert state.attributes[ATTR_NAME] == "test1"
 
-    # event_type should be the lock entity ID (not "pin_used")
-    assert state.attributes.get("event_type") == LOCK_1_ENTITY_ID
+
+async def test_a_use_is_recorded_for_the_user_it_belongs_to_alone(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """
+    Dropping the target check does not let another user's use through.
+
+    The unified event names the person rather than the slot they occupy, so
+    the name is the entity's only means of telling its own uses apart, and
+    it is now the only check left besides the config entry.
+    """
+    before = hass.states.get(SLOT_2_EVENT_ENTITY)
+    assert before
+
+    await _use_credential(hass, lock_code_manager_config_entry, "1234", EXTERNAL_TARGET)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(SLOT_2_EVENT_ENTITY) == before
+    assert hass.states.get(SLOT_1_EVENT_ENTITY).state != STATE_UNKNOWN
+
+
+@pytest.mark.parametrize(
+    ("to_locked", "case"),
+    [
+        pytest.param(None, "unrecognized", id="unrecognized-operation"),
+        pytest.param(True, "locked", id="locked-by-code"),
+    ],
+)
+async def test_uses_that_are_not_an_unlock_are_recorded(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+    to_locked: bool | None,
+    case: str,
+):
+    """
+    Locking by code, and an operation the provider could not classify.
+
+    Both are credential uses and neither is an unlock. The entity used to
+    take these off the deprecated event through a filter that demanded a
+    transition to ``unlocked``, so a lock-by-code and every notification a
+    provider passes through with ``to_locked=None`` -- Matter, ZHA and
+    Z-Wave JS all have one -- were recorded nowhere at all.
+    """
+    lock: BaseLock = lock_code_manager_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
+    lock.async_fire_code_slot_event(1, to_locked, case, Event("test_source"))
+    await hass.async_block_till_done()
+
+    state = hass.states.get(SLOT_1_EVENT_ENTITY)
+    assert state
+    assert state.state != STATE_UNKNOWN
+    assert state.attributes[ATTR_TARGET] == LOCK_1_ENTITY_ID
+    assert state.attributes[ATTR_NAME] == "test1"
 
 
 class MockLCMLockNoEvents(MockLCMLock):
@@ -153,24 +276,19 @@ class MockLCMLockNoEvents(MockLCMLock):
         return False
 
 
-async def test_no_unsupported_locks_when_all_support_events(
-    hass: HomeAssistant,
-    mock_lock_config_entry,
-    lock_code_manager_config_entry,
-):
-    """Test that unsupported_locks attribute is not present when all locks support events."""
-    state = hass.states.get(SLOT_1_EVENT_ENTITY)
-    assert state
-
-    # All mock locks support code slot events, so unsupported_locks should not be present
-    assert ATTR_UNSUPPORTED_LOCKS not in state.attributes
-
-
-async def test_event_entity_unavailable_when_no_supported_locks(
+async def test_available_when_no_lock_reports_code_slot_events(
     hass: HomeAssistant,
     mock_lock_config_entry,
 ):
-    """Test that event entity is unavailable when no locks support code slot events."""
+    """
+    An entry of locks that report nothing still has a usable event entity.
+
+    Availability is now the shared per-slot rule -- at least one of the
+    entry's locks is reachable -- because nothing about this entity is
+    lock-capability shaped any more. Gating on the capability is what forced
+    providers with nothing to report to claim otherwise just to keep the
+    entity alive.
+    """
     with patch(
         "custom_components.lock_code_manager.providers.INTEGRATIONS_CLASS_MAP",
         {"test": MockLCMLockNoEvents},
@@ -184,101 +302,37 @@ async def test_event_entity_unavailable_when_no_supported_locks(
 
         state = hass.states.get(SLOT_1_EVENT_ENTITY)
         assert state
-        # While unavailable, extra_state_attributes (e.g. unsupported_locks)
-        # are not exposed on the state.
-        assert state.state == STATE_UNAVAILABLE
+        assert state.state != STATE_UNAVAILABLE
+        assert state.attributes[ATTR_EVENT_TYPES] == [EVENT_CREDENTIAL_USED]
 
-        await hass.config_entries.async_unload(config_entry.entry_id)
-
-
-async def test_event_without_lock_entity_id_logs_warning(
-    hass: HomeAssistant,
-    mock_lock_config_entry,
-    lock_code_manager_config_entry,
-    caplog,
-):
-    """Test that event without lock entity ID logs a warning."""
-    ent_reg = er.async_get(hass)
-    entry = ent_reg.async_get(SLOT_1_EVENT_ENTITY)
-    assert entry
-    entity = hass.data["entity_components"]["event"].get_entity(entry.entity_id)
-    assert entity
-
-    # Bypass the event filter (which would raise KeyError on missing
-    # ATTR_ENTITY_ID before reaching the handler) so we exercise the
-    # defensive path in _handle_event itself.
-    entity._handle_event(Event("test_event", {"slot_num": 1}))
-
-    assert "Received event without lock entity ID" in caplog.text
-
-
-async def test_handle_add_locks_updates_state(
-    hass: HomeAssistant,
-    mock_lock_config_entry,
-    lock_code_manager_config_entry,
-):
-    """Test that _handle_add_locks updates unsupported_locks and writes state."""
-    ent_reg = er.async_get(hass)
-    entry = ent_reg.async_get(SLOT_1_EVENT_ENTITY)
-    assert entry
-    entity = hass.data["entity_components"]["event"].get_entity(entry.entity_id)
-    assert entity
-
-    # Get initial event_types count
-    initial_event_types = len(entity.event_types)
-
-    # Create a mock lock that supports events
-    mock_lock = lock_code_manager_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
-
-    # Call _handle_add_locks with the existing lock (simulates lock being re-added)
-    entity._handle_add_locks([mock_lock])
-    await hass.async_block_till_done()
-
-    # The state should have been written (entity still has same event_types)
-    assert len(entity.event_types) >= initial_event_types
-
-
-async def test_unsupported_locks_attribute_with_mixed_locks(
-    hass: HomeAssistant,
-    mock_lock_config_entry,
-):
-    """Test unsupported_locks attribute when some locks don't support events."""
-
-    class MockLCMLockMixed(MockLCMLock):
-        """Mock lock where support depends on entity ID."""
-
-        @property
-        def supports_code_slot_events(self) -> bool:
-            """Only lock 1 supports events."""
-            return self.lock.entity_id == LOCK_1_ENTITY_ID
-
-    with patch(
-        "custom_components.lock_code_manager.providers.INTEGRATIONS_CLASS_MAP",
-        {"test": MockLCMLockMixed},
-    ):
-        config_entry = MockConfigEntry(
-            domain=DOMAIN, data=BASE_CONFIG, unique_id="Mock Title Mixed"
-        )
-        config_entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(config_entry.entry_id)
+        lock: BaseLock = config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
+        lock.async_fire_code_slot_event(1, False, "test", Event("test_source"))
         await hass.async_block_till_done()
 
-        state = hass.states.get(SLOT_1_EVENT_ENTITY)
-        assert state
-
-        # Event entity should be available (lock 1 supports events)
-        assert state.state != STATE_UNAVAILABLE
-
-        # event_types should only include lock 1
-        event_types = state.attributes.get("event_types", [])
-        assert LOCK_1_ENTITY_ID in event_types
-        assert LOCK_2_ENTITY_ID not in event_types
-
-        # unsupported_locks should include lock 2
-        unsupported = state.attributes.get(ATTR_UNSUPPORTED_LOCKS, [])
-        assert LOCK_2_ENTITY_ID in unsupported
+        recorded = hass.states.get(SLOT_1_EVENT_ENTITY)
+        assert recorded.state != STATE_UNKNOWN
+        assert recorded.attributes[ATTR_TARGET] == LOCK_1_ENTITY_ID
 
         await hass.config_entries.async_unload(config_entry.entry_id)
+
+
+async def test_unavailable_when_every_lock_is(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """
+    The entity follows its entry's locks, the same as every other slot entity.
+
+    Blueprint authors rely on that shape: the shipped notifier explicitly
+    rejects the ``unavailable`` -> timestamp transition a recovering lock
+    produces, and would fire spuriously if this entity never went there.
+    """
+    for lock_entity_id in (LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID):
+        hass.states.async_set(lock_entity_id, STATE_UNAVAILABLE)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(SLOT_1_EVENT_ENTITY).state == STATE_UNAVAILABLE
 
 
 async def test_the_event_says_which_kind_of_credential_was_used(

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -24,6 +24,7 @@ from custom_components.lock_code_manager.const import (
     ATTR_CONFIG_ENTRY_ID,
     ATTR_CONFIG_ENTRY_TITLE,
     ATTR_CREDENTIAL_TYPE,
+    ATTR_OPERATION,
     ATTR_SLOT_FIELD,
     ATTR_SOURCE,
     ATTR_TARGET,
@@ -32,7 +33,16 @@ from custom_components.lock_code_manager.const import (
     EVENT_LOCK_STATE_CHANGED,
     SERVICE_USE_CREDENTIAL,
 )
-from custom_components.lock_code_manager.domain.credentials import CredentialType
+from custom_components.lock_code_manager.domain.credentials import (
+    MANAGED_CREDENTIAL_TYPES,
+    CredentialType,
+    CredentialTypeCapability,
+    LockCapabilities,
+)
+from custom_components.lock_code_manager.domain.events import (
+    BUS_EVENT_CREDENTIAL_USED,
+    CredentialOperation,
+)
 from custom_components.lock_code_manager.providers import BaseLock
 
 from .common import (
@@ -65,7 +75,6 @@ RETIRED_ATTRIBUTES = (
     "entity_id",
     "device_id",
     "extra_data",
-    "credential_type",
     "lock_code_manager_config_entry_id",
     "unsupported_locks",
 )
@@ -116,13 +125,16 @@ async def test_the_recorded_attributes_are_the_unified_payload(
         for key, value in state.attributes.items()
         if key not in (ATTR_EVENT_TYPES, "friendly_name")
     } == {
-        ATTR_EVENT_TYPE: EVENT_CREDENTIAL_USED,
+        # The event type is the kind of credential, not a place.
+        ATTR_EVENT_TYPE: CredentialType.PIN,
         ATTR_NAME: "test2",
         ATTR_CONFIG_ENTRY_ID: lock_code_manager_config_entry.entry_id,
         ATTR_CONFIG_ENTRY_TITLE: lock_code_manager_config_entry.title,
         # A lock that observed the use is both ends of it.
         ATTR_SOURCE: LOCK_1_ENTITY_ID,
         ATTR_TARGET: LOCK_1_ENTITY_ID,
+        ATTR_CREDENTIAL_TYPE: CredentialType.PIN,
+        ATTR_OPERATION: CredentialOperation.UNLOCK,
         ATTR_CODE_SLOT: 2,
         ATTR_SLOT_FIELD: EVENT_CREDENTIAL_USED,
     }
@@ -130,25 +142,126 @@ async def test_the_recorded_attributes_are_the_unified_payload(
         assert retired not in state.attributes
 
 
-async def test_event_types_is_one_fixed_word(
+class MockLCMLockWithCredentialTypes(MockLCMLock):
+    """A lock that answers the capability probe, advertising RFID as well."""
+
+    @property
+    def supports_native_users(self) -> bool:
+        """Take the setup path that probes capabilities."""
+        return True
+
+    async def async_get_capabilities(self) -> LockCapabilities:
+        """Advertise a reader Lock Code Manager cannot write to."""
+        return LockCapabilities(
+            supports_user_management=True,
+            max_users=10,
+            max_user_name_length=16,
+            credential_types={
+                credential_type: CredentialTypeCapability(
+                    num_slots=10, min_length=4, max_length=8, supports_learn=False
+                )
+                for credential_type in (CredentialType.PIN, CredentialType.RFID)
+            },
+        )
+
+
+async def test_event_types_names_credential_kinds_and_never_locks(
     hass: HomeAssistant,
     mock_lock_config_entry,
     lock_code_manager_config_entry,
 ):
     """
-    The vocabulary says what happened, never where.
+    The vocabulary says what kind of credential, never where it was used.
 
-    Home Assistant refuses an event type an entity did not declare, so any
+    Home Assistant refuses an event type an entity did not declare, so a
     vocabulary naming the entry's locks makes a use against anything else
-    impossible to record. Naming no locks is what keeps every target
-    recordable.
+    impossible to record -- which is what this replaced. The kind is the
+    axis that actually distinguishes one recorded use from another; where
+    it happened rides in ``target``.
+
+    These locks answer no capability probe, so this is also the floor:
+    ``MANAGED_CREDENTIAL_TYPES`` alone, which is what keeps the vocabulary
+    from being empty while a probe has not run.
     """
     state = hass.states.get(SLOT_1_EVENT_ENTITY)
     assert state
 
-    assert state.attributes[ATTR_EVENT_TYPES] == [EVENT_CREDENTIAL_USED]
+    assert state.attributes[ATTR_EVENT_TYPES] == sorted(MANAGED_CREDENTIAL_TYPES)
     for lock_entity_id in (LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID):
         assert lock_entity_id not in state.attributes[ATTR_EVENT_TYPES]
+
+
+async def test_event_types_unions_what_the_entrys_locks_advertise(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+):
+    """
+    A kind only the lock can report is still one this entity can record.
+
+    What Lock Code Manager can write and what a lock can report are
+    different sets. A lock with its own card reader reports RFID uses that
+    nothing here ever wrote, and refusing to name them would make them
+    unrecordable -- so the managed set is a floor under the union, not a
+    cap on it.
+    """
+    with patch(
+        "custom_components.lock_code_manager.providers.INTEGRATIONS_CLASS_MAP",
+        {"test": MockLCMLockWithCredentialTypes},
+    ):
+        config_entry = MockConfigEntry(
+            domain=DOMAIN, data=BASE_CONFIG, unique_id="Mock Title Credential Types"
+        )
+        config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        state = hass.states.get(SLOT_1_EVENT_ENTITY)
+        assert state
+        assert state.attributes[ATTR_EVENT_TYPES] == [
+            CredentialType.PIN,
+            CredentialType.RFID,
+        ]
+
+        await hass.config_entries.async_unload(config_entry.entry_id)
+
+
+async def test_a_use_of_an_unnamed_kind_widens_the_vocabulary(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """
+    A kind that arrives anyway is recorded, not dropped.
+
+    ``_trigger_event`` raises on an undeclared type and this runs on a bus
+    callback whose exceptions Home Assistant swallows, so a use whose kind
+    the capability probe has not admitted yet would vanish without a trace.
+    A use that happened is better evidence of what is possible here than a
+    probe that has not finished, so it widens the vocabulary instead.
+    """
+    before = hass.states.get(SLOT_1_EVENT_ENTITY)
+    assert before
+    assert CredentialType.FINGERPRINT not in before.attributes[ATTR_EVENT_TYPES]
+
+    hass.bus.async_fire(
+        BUS_EVENT_CREDENTIAL_USED,
+        event_data={
+            ATTR_NAME: "test1",
+            ATTR_CONFIG_ENTRY_ID: lock_code_manager_config_entry.entry_id,
+            ATTR_CONFIG_ENTRY_TITLE: lock_code_manager_config_entry.title,
+            ATTR_SOURCE: EXTERNAL_KEYPAD,
+            ATTR_TARGET: EXTERNAL_TARGET,
+            ATTR_CREDENTIAL_TYPE: CredentialType.FINGERPRINT,
+            ATTR_OPERATION: CredentialOperation.UNKNOWN,
+        },
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get(SLOT_1_EVENT_ENTITY)
+    assert state
+    assert state.state != STATE_UNKNOWN
+    assert state.attributes[ATTR_EVENT_TYPE] == CredentialType.FINGERPRINT
+    assert CredentialType.FINGERPRINT in state.attributes[ATTR_EVENT_TYPES]
 
 
 async def test_a_lock_observed_use_is_recorded_once(
@@ -205,7 +318,7 @@ async def test_a_use_against_something_that_is_not_a_lock_is_recorded(
     state = hass.states.get(SLOT_1_EVENT_ENTITY)
     assert state
     assert state.state != STATE_UNKNOWN
-    assert state.attributes[ATTR_EVENT_TYPE] == EVENT_CREDENTIAL_USED
+    assert state.attributes[ATTR_EVENT_TYPE] == CredentialType.PIN
     assert state.attributes[ATTR_TARGET] == EXTERNAL_TARGET
     assert state.attributes[ATTR_SOURCE] == EXTERNAL_KEYPAD
     assert state.attributes[ATTR_NAME] == "test1"
@@ -234,30 +347,36 @@ async def test_a_use_is_recorded_for_the_user_it_belongs_to_alone(
 
 
 @pytest.mark.parametrize(
-    ("to_locked", "case"),
+    ("to_locked", "operation"),
     [
-        pytest.param(None, "unrecognized", id="unrecognized-operation"),
-        pytest.param(True, "locked", id="locked-by-code"),
+        pytest.param(False, CredentialOperation.UNLOCK, id="unlocked-by-code"),
+        pytest.param(True, CredentialOperation.LOCK, id="locked-by-code"),
+        pytest.param(None, CredentialOperation.UNKNOWN, id="unclassified"),
     ],
 )
-async def test_uses_that_are_not_an_unlock_are_recorded(
+async def test_uses_that_are_not_an_unlock_are_recorded_and_say_so(
     hass: HomeAssistant,
     mock_lock_config_entry,
     lock_code_manager_config_entry,
     to_locked: bool | None,
-    case: str,
+    operation: CredentialOperation,
 ):
     """
-    Locking by code, and an operation the provider could not classify.
+    Every direction a lock can report is recorded, and named.
 
-    Both are credential uses and neither is an unlock. The entity used to
-    take these off the deprecated event through a filter that demanded a
+    All three are credential uses and only one is an unlock. The entity used
+    to take these off the deprecated event through a filter that demanded a
     transition to ``unlocked``, so a lock-by-code and every notification a
     provider passes through with ``to_locked=None`` -- Matter, ZHA and
     Z-Wave JS all have one -- were recorded nowhere at all.
+
+    Recording them all is only half the answer: a consumer that must not
+    treat locking up as an entry needs to be able to tell, which is what
+    ``operation`` is for. ``unknown`` is a real answer, not a gap -- the
+    provider saw a use it could not classify.
     """
     lock: BaseLock = lock_code_manager_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
-    lock.async_fire_code_slot_event(1, to_locked, case, Event("test_source"))
+    lock.async_fire_code_slot_event(1, to_locked, "test", Event("test_source"))
     await hass.async_block_till_done()
 
     state = hass.states.get(SLOT_1_EVENT_ENTITY)
@@ -265,6 +384,29 @@ async def test_uses_that_are_not_an_unlock_are_recorded(
     assert state.state != STATE_UNKNOWN
     assert state.attributes[ATTR_TARGET] == LOCK_1_ENTITY_ID
     assert state.attributes[ATTR_NAME] == "test1"
+    assert state.attributes[ATTR_OPERATION] == operation
+
+
+async def test_a_reported_use_never_claims_to_know_what_the_device_did(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """
+    ``use_credential`` reports ``unknown``, and must not guess.
+
+    The caller said a credential was used, not what happened next. Lock Code
+    Manager never actuates a lock, so it has no basis to claim an unlock --
+    stating one would put a fact in the payload nobody observed, and a
+    limiter counting entries would spend a use on it.
+    """
+    await _use_credential(hass, lock_code_manager_config_entry, "1234", EXTERNAL_TARGET)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(SLOT_1_EVENT_ENTITY)
+    assert state
+    assert state.attributes[ATTR_OPERATION] == CredentialOperation.UNKNOWN
+    assert state.attributes[ATTR_CREDENTIAL_TYPE] == CredentialType.PIN
 
 
 class MockLCMLockNoEvents(MockLCMLock):
@@ -303,7 +445,7 @@ async def test_available_when_no_lock_reports_code_slot_events(
         state = hass.states.get(SLOT_1_EVENT_ENTITY)
         assert state
         assert state.state != STATE_UNAVAILABLE
-        assert state.attributes[ATTR_EVENT_TYPES] == [EVENT_CREDENTIAL_USED]
+        assert state.attributes[ATTR_EVENT_TYPES] == sorted(MANAGED_CREDENTIAL_TYPES)
 
         lock: BaseLock = config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
         lock.async_fire_code_slot_event(1, False, "test", Event("test_source"))

--- a/tests/test_frontend_contract.py
+++ b/tests/test_frontend_contract.py
@@ -19,6 +19,7 @@ from custom_components.lock_code_manager.const import (
     PER_LOCK_ENTITY_SUFFIX,
 )
 from custom_components.lock_code_manager.domain.config import build_slot_unique_id
+from custom_components.lock_code_manager.domain.credentials import CredentialType
 
 _CONST_TS = pathlib.Path(__file__).resolve().parent.parent / "ts" / "const.ts"
 
@@ -244,3 +245,28 @@ def test_every_translation_matches_the_strings_it_translates() -> None:
     )
 
     assert strings == english
+
+
+def test_every_credential_kind_the_event_can_publish_is_translated() -> None:
+    """
+    The event entity's event types are credential kinds, so name them all.
+
+    Home Assistant asks nothing of an untranslated event type -- it renders
+    the raw value, so ``rfid`` appears verbatim in the UI and nothing warns.
+    The vocabulary is derived from what the entry's locks advertise, so it
+    can hold any ``CredentialType``, and the translation is the only thing
+    that turns one into a word a person recognizes.
+    """
+    strings = json.loads(
+        (
+            pathlib.Path(__file__).resolve().parent.parent
+            / "custom_components"
+            / "lock_code_manager"
+            / "strings.json"
+        ).read_text(encoding="utf-8")
+    )
+    translated = strings["entity"]["event"][EVENT_CREDENTIAL_USED]["state_attributes"][
+        "event_type"
+    ]["state"]
+
+    assert set(translated) == {member.value for member in CredentialType}

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -39,8 +39,10 @@ from custom_components.lock_code_manager.const import (
     ATTR_CODE_SLOT,
     ATTR_CONFIG_ENTRY_ID,
     ATTR_CONFIG_ENTRY_TITLE,
+    ATTR_CREDENTIAL_TYPE,
     ATTR_LENGTH,
     ATTR_LOCK_ENTITY_ID,
+    ATTR_OPERATION,
     ATTR_REASON,
     ATTR_SLOT,
     ATTR_SOURCE,
@@ -71,6 +73,8 @@ from custom_components.lock_code_manager.const import (
 from custom_components.lock_code_manager.domain import services
 from custom_components.lock_code_manager.domain.allocation import SlotAllocationError
 from custom_components.lock_code_manager.domain.config import build_slot_unique_id
+from custom_components.lock_code_manager.domain.credentials import CredentialType
+from custom_components.lock_code_manager.domain.events import CredentialOperation
 from custom_components.lock_code_manager.domain.pin_generator import is_unsafe_pin
 from custom_components.lock_code_manager.domain.queries import get_entry_config
 from custom_components.lock_code_manager.domain.services import async_set_usercode
@@ -1518,13 +1522,17 @@ async def test_use_credential_records_against_an_in_entry_lock(
             ATTR_CONFIG_ENTRY_TITLE: validate_entry.title,
             ATTR_SOURCE: VALIDATE_SOURCE_ENTITY_ID,
             ATTR_TARGET: VALIDATE_LOCK_ENTITY_ID,
+            # A PIN is what the action validates, and nothing here watched
+            # the lock move, so it never claims to know what it did.
+            ATTR_CREDENTIAL_TYPE: CredentialType.PIN,
+            ATTR_OPERATION: CredentialOperation.UNKNOWN,
         }
     ]
     assert deprecated == []
 
     state = hass.states.get(VALIDATE_EVENT_ENTITY_ID)
     assert state
-    assert state.attributes[ATTR_EVENT_TYPE] == EVENT_CREDENTIAL_USED
+    assert state.attributes[ATTR_EVENT_TYPE] == CredentialType.PIN
     assert state.attributes[ATTR_TARGET] == VALIDATE_LOCK_ENTITY_ID
     assert state.attributes[ATTR_SOURCE] == VALIDATE_SOURCE_ENTITY_ID
     assert [
@@ -1622,7 +1630,7 @@ async def test_use_credential_against_an_event_blind_lock_in_the_entry(
     ]
     recorded = hass.states.get(event_entity_id)
     assert recorded.state != STATE_UNKNOWN
-    assert recorded.attributes[ATTR_EVENT_TYPE] == EVENT_CREDENTIAL_USED
+    assert recorded.attributes[ATTR_EVENT_TYPE] == CredentialType.PIN
     assert recorded.attributes[ATTR_TARGET] == EVENT_BLIND_LOCK_ENTITY_ID
     assert [
         record for record in caplog.records if record.levelno >= logging.ERROR

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -27,6 +27,7 @@ from homeassistant.const import (
     CONF_PIN,
     MATCH_ALL,
     STATE_ON,
+    STATE_UNKNOWN,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
@@ -1523,8 +1524,9 @@ async def test_use_credential_records_against_an_in_entry_lock(
 
     state = hass.states.get(VALIDATE_EVENT_ENTITY_ID)
     assert state
-    assert state.attributes[ATTR_EVENT_TYPE] == VALIDATE_LOCK_ENTITY_ID
+    assert state.attributes[ATTR_EVENT_TYPE] == EVENT_CREDENTIAL_USED
     assert state.attributes[ATTR_TARGET] == VALIDATE_LOCK_ENTITY_ID
+    assert state.attributes[ATTR_SOURCE] == VALIDATE_SOURCE_ENTITY_ID
     assert [
         record for record in caplog.records if record.levelno >= logging.ERROR
     ] == []
@@ -1551,7 +1553,7 @@ async def test_use_credential_records_only_for_the_named_user(
     assert hass.states.get(bob_event_entity_id) == before
     alice = hass.states.get(VALIDATE_EVENT_ENTITY_ID)
     assert alice
-    assert alice.attributes[ATTR_EVENT_TYPE] == VALIDATE_LOCK_ENTITY_ID
+    assert alice.attributes[ATTR_TARGET] == VALIDATE_LOCK_ENTITY_ID
 
 
 async def test_use_credential_ignores_an_entry_that_is_not_ours(
@@ -1587,20 +1589,21 @@ async def test_use_credential_against_an_event_blind_lock_in_the_entry(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """
-    An entry lock that cannot fire code slot events is not an event type.
+    A lock that reports nothing itself still gets uses recorded against it.
 
-    Schlage and Akuvox never fire them, and zwave-js-ui does not until it
-    has learned it can, so this is an ordinary target rather than a
-    mistake. Recording against it would raise inside Home Assistant's
-    ``EventEntity`` and land as an ERROR in the log, which is exactly what
-    the absence of ERROR records here pins down.
+    Schlage and Akuvox never fire code slot events, and zwave-js-ui does not
+    until it has learned it can. Whether the lock could have told us is
+    beside the point when somebody else did: the credential is alice's, and
+    what it acted on is payload rather than vocabulary.
     """
     entry = validate_entry_with_event_blind_lock
     event_entity_id = _slot_event_entity_id(hass, entry, 1)
     unified = async_capture_events(hass, BUS_EVENT_CREDENTIAL_USED)
     before = hass.states.get(event_entity_id)
     assert before
-    assert EVENT_BLIND_LOCK_ENTITY_ID not in before.attributes["event_types"]
+    assert before.state == STATE_UNKNOWN
+    blind_lock = entry.runtime_data.locks[EVENT_BLIND_LOCK_ENTITY_ID]
+    assert blind_lock.supports_code_slot_events is False
 
     with caplog.at_level(logging.DEBUG):
         response = await _call_use_credential(
@@ -1617,7 +1620,10 @@ async def test_use_credential_against_an_event_blind_lock_in_the_entry(
     assert [event.data[ATTR_TARGET] for event in unified] == [
         EVENT_BLIND_LOCK_ENTITY_ID
     ]
-    assert hass.states.get(event_entity_id) == before
+    recorded = hass.states.get(event_entity_id)
+    assert recorded.state != STATE_UNKNOWN
+    assert recorded.attributes[ATTR_EVENT_TYPE] == EVENT_CREDENTIAL_USED
+    assert recorded.attributes[ATTR_TARGET] == EVENT_BLIND_LOCK_ENTITY_ID
     assert [
         record for record in caplog.records if record.levelno >= logging.ERROR
     ] == []
@@ -1627,18 +1633,19 @@ async def test_use_credential_with_a_target_outside_the_entry(
     hass: HomeAssistant, validate_entry, caplog: pytest.LogCaptureFixture
 ) -> None:
     """
-    A target Lock Code Manager does not manage is announced, not refused.
+    A target Lock Code Manager does not manage records like any other.
 
-    Only the unified event fires: there is no entity of ours to record
-    against, and the caller knows their setup better than we do. The
-    absence of ERROR records is the load-bearing half -- routing this into
-    the slot's event entity would trip its unknown-event-type check, and
-    Home Assistant would swallow that into a log line rather than raise.
+    A cover is not a lock, is not in the entry, and could never be named by
+    anything the entry knows -- and it is still alice's credential being
+    used, so her entity is where that belongs. Only the unified event
+    fires: the deprecated lock-shaped one would have to claim a from/to
+    transition that never happened.
     """
     unified = async_capture_events(hass, BUS_EVENT_CREDENTIAL_USED)
     deprecated = async_capture_events(hass, EVENT_LOCK_STATE_CHANGED)
     before = hass.states.get(VALIDATE_EVENT_ENTITY_ID)
     assert before
+    assert before.state == STATE_UNKNOWN
 
     with caplog.at_level(logging.DEBUG):
         response = await _call_use_credential(
@@ -1654,7 +1661,9 @@ async def test_use_credential_with_a_target_outside_the_entry(
     assert response == {ATTR_VALID: True, ATTR_USER: "alice", ATTR_REASON: None}
     assert [event.data[ATTR_TARGET] for event in unified] == ["cover.some_other_door"]
     assert deprecated == []
-    assert hass.states.get(VALIDATE_EVENT_ENTITY_ID) == before
+    recorded = hass.states.get(VALIDATE_EVENT_ENTITY_ID)
+    assert recorded.state != STATE_UNKNOWN
+    assert recorded.attributes[ATTR_TARGET] == "cover.some_other_door"
     assert [
         record for record in caplog.records if record.levelno >= logging.ERROR
     ] == []

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -15,6 +15,7 @@ from homeassistant.components.calendar import (
 )
 from homeassistant.const import (
     ATTR_ENTITY_ID,
+    ATTR_FRIENDLY_NAME,
     CONF_CONDITION,
     CONF_ENTITY_ID,
     CONF_NAME,
@@ -57,7 +58,9 @@ from custom_components.lock_code_manager.const import (
     ATTR_SCHEDULE_NEXT_EVENT,
     ATTR_SLOT,
     ATTR_SLOT_NUM,
+    ATTR_SOURCE,
     ATTR_SYNC_STATUS,
+    ATTR_TARGET,
     ATTR_USER_ENTITY_ID,
     ATTR_USERCODE,
     BACKOFF_FAILURE_THRESHOLD,
@@ -70,6 +73,7 @@ from custom_components.lock_code_manager.const import (
     CONF_SLOTS,
     CONF_USERS,
     DOMAIN,
+    SERVICE_USE_CREDENTIAL,
 )
 from custom_components.lock_code_manager.domain.config import build_slot_unique_id
 from custom_components.lock_code_manager.domain.exceptions import DuplicateCodeError
@@ -938,21 +942,23 @@ async def test_subscribe_code_slot_omits_number_of_uses(
     assert LEGACY_NUMBER_OF_USES_KEY not in data[CONF_ENTITIES]
 
 
-async def test_subscribe_code_slot_with_event_type(
+async def test_subscribe_code_slot_names_what_the_credential_was_used_on(
     hass: HomeAssistant,
     mock_lock_config_entry,
     lock_code_manager_config_entry,
     hass_ws_client: WebSocketGenerator,
 ) -> None:
     """
-    Test event_type attribute is set correctly after firing code slot event.
+    The card's "Last used on <lock>" comes from the use's ``target``.
 
-    This verifies the event entity state has the event_type attribute set to
-    the lock entity ID, which the websocket uses to look up last_used_lock_name.
+    ``event_type`` is the fixed word ``credential_used``, so resolving that
+    as an entity id yields nothing and the card silently drops to a bare
+    "Last used". Asserting the resolved friendly name rather than merely a
+    non-null timestamp is what makes that visible here.
     """
     ws_client = await hass_ws_client(hass)
 
-    # First, subscribe before any event - last_used should be None
+    # Subscribe before any use: nothing to report yet.
     await ws_client.send_json(
         {
             "id": 1,
@@ -968,34 +974,73 @@ async def test_subscribe_code_slot_with_event_type(
     event = await ws_client.receive_json()
     data = event["event"]
     assert data[ATTR_SLOT_NUM] == 2
-    # No event fired yet, so last_used should be None
     assert data.get(ATTR_LAST_USED) is None
     assert data.get(ATTR_LAST_USED_LOCK) is None
 
-    # Fire a code slot event
     lock: BaseLock = lock_code_manager_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
     lock.async_fire_code_slot_event(2, False, "test", Event("zwave_js_notification"))
     await hass.async_block_till_done()
 
-    # Check event entity state to verify event_type is set (this is what
-    # websocket code reads to determine last_used_lock_name)
     event_state = hass.states.get(SLOT_2_EVENT_ENTITY)
     assert event_state is not None
     assert event_state.state not in ("unknown", "unavailable")
-    assert event_state.attributes.get("event_type") == LOCK_1_ENTITY_ID
+    assert event_state.attributes[ATTR_TARGET] == LOCK_1_ENTITY_ID
 
-    # Verify lock state exists and has friendly_name (websocket looks this up)
     lock_state = hass.states.get(LOCK_1_ENTITY_ID)
     assert lock_state is not None
-    assert "friendly_name" in lock_state.attributes
 
-    # Should receive websocket update with last_used populated
     updated = await ws_client.receive_json()
     assert updated["type"] == "event"
     data = updated["event"]
     assert data[ATTR_SLOT_NUM] == 2
-    # last_used should have the timestamp from the event
     assert data.get(ATTR_LAST_USED) is not None
+    assert data[ATTR_LAST_USED_LOCK] == lock_state.attributes[ATTR_FRIENDLY_NAME]
+
+
+async def test_subscribe_code_slot_says_only_when_for_a_target_with_no_state(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """
+    A target Home Assistant holds no state for leaves the name unset.
+
+    Now that a use can act on anything -- a gate, a door controller with no
+    integration of its own -- the target is not guaranteed to resolve, and
+    the card has to fall back to a bare "Last used" rather than break.
+    """
+    ws_client = await hass_ws_client(hass)
+    await ws_client.send_json(
+        {
+            "id": 1,
+            "type": "lock_code_manager/subscribe_code_slot",
+            ATTR_CONFIG_ENTRY_ID: lock_code_manager_config_entry.entry_id,
+            ATTR_SLOT: 1,
+            "reveal": True,
+        }
+    )
+    assert (await ws_client.receive_json())["success"]
+    await ws_client.receive_json()
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_USE_CREDENTIAL,
+        {
+            "config_entry_id": lock_code_manager_config_entry.entry_id,
+            ATTR_CODE: "1234",
+            ATTR_SOURCE: "sensor.side_gate_keypad",
+            ATTR_TARGET: "cover.side_gate",
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get("cover.side_gate") is None
+    data = (await ws_client.receive_json())["event"]
+    assert data[ATTR_SLOT_NUM] == 1
+    assert data.get(ATTR_LAST_USED) is not None
+    assert data.get(ATTR_LAST_USED_LOCK) is None
 
 
 async def test_subscribe_lock_codes_slot_metadata(


### PR DESCRIPTION
# Breaking change

**The `credential_used` event entity's attributes changed.** `event_type` is now
the *kind of credential* presented (`pin` today), and `event_types` lists the
kinds — not locks.

| Was | Now |
|---|---|
| `event_type` = lock entity ID | `target` |
| `code_slot_name` | `name` |
| `lock_code_manager_config_entry_id` | `config_entry_id` |
| `from` / `to` | `operation` (`unlock`/`lock`/`unknown`) |
| `action_text`, `notification_source`, `state`, `entity_id`, `device_id`, `extra_data`, `lock_config_entry_id`, `unsupported_locks` | gone from the entity |

All of them still travel on the deprecated `lock_code_manager_lock_state_changed`
bus event, which keeps firing unchanged.

**Slot Usage Notifier and Slot Usage Limiter are updated in place** — re-import
them and existing automations keep working. No input was renamed or removed.

**More uses are recorded than before.** Locking by code, and operations a provider
couldn't classify, previously recorded nowhere. The limiter gains an *Operations
that spend a use* input defaulting to `unlock` + `unknown`, so a guest who unlocks
and then locks up behind them spends one use, not two.

**Calendar Condition's `lock_entity_ids` variable is removed** — it came from the
event entity's event types and nothing else exposes an entry's locks to a
template. A condition still referencing it **fails quietly**: the sensor stays
available, reads `off`, and the PIN never activates. The only signal is a
`Template variable warning` in the log. Reproduced end-to-end, not reasoned about;
nothing can make it louder. That example never worked as documented anyway — the
list was identical for every slot, so the template was constantly true or
constantly false.

## Proposed change

`event_types` was the entry's event-capable lock entity IDs, and Home Assistant
enforces `event_type ∈ event_types` — so a use whose target wasn't such a lock
**couldn't be recorded at all**: not a cover, not an alarm panel, not a Schlage or
Akuvox in the same entry.

The entity now records from the unified `lock_code_manager_credential_used` event
alone, matching on config entry and user name with **no target check**. Where a
use happened is payload, not vocabulary.

`event_types` becomes the credential kinds a use can be: what the entry's locks
advertise, unioned with `MANAGED_CREDENTIAL_TYPES` (what LCM can itself write). A
floor, not a cap — so an unprobed lock can't leave it empty, a lock can report a
kind LCM can't write, and managing more than PIN later grows it in one place.

The bus event gains two required fields: `credential_type` (the entity's event
type) and `operation`, derived from the `to_locked` flag providers already pass.
`use_credential` reports `unknown` — LCM never actuates, so it has no basis to
claim otherwise.

### Removed

`_handle_event`, the `source != target` de-duplication guard, `entity.py`'s
`_event_filter` (which could raise `ValueError: Invalid event type` for a provider
answering `supports_code_slot_events = False`), the `available` override, and
`unsupported_locks`. `VirtualLock.supports_code_slot_events` answered `True` only
to keep `event_types` non-empty — a manufactured dependency on hass-virtual — so
it now answers `False`.

### Carried along

`websocket.py`'s `_get_last_used_info` resolved `event_type` as a lock entity ID
for the card's "Last used on ‹lock›"; it reads `target` now. The payload shape is
unchanged, so no frontend edit was needed.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue: #1480
- Follow-up filed: #1488

PR 2 of 5. 2254 passing, 100% coverage, `yarn test` green, `git diff main -- ts/`
empty.
