### PR TITLE
feat: a second lock picker for locks that keep no codes of their own

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,9 +99,9 @@ entities.
   differently is treated like one that left and came back
 - One lock entity resolves to one provider across every entry, because whether a lock keeps
   codes of its own is a fact about the DEVICE. The config, options and reauth flows refuse a
-  submission whose answer contradicts another entry that manages the same member
-  (`_sibling_declarations`, error `codeless_conflict`), and ask about a member a sibling
-  declares so that agreeing is an answer this entry can give
+  submission that contradicts another entry managing the same member
+  (`_sibling_declarations`, error `codeless_conflict`), and keep a member a sibling declares
+  selectable in the codeless picker so that agreeing is a selection this entry can make
 - Two entries holding one lock therefore share a single `BaseLock`, keyed on the entity id.
   Release is by object identity, so it stays the exact inverse of the share; `BaseLock`
   defines no `__eq__`/`__hash__` so a stale instance a reload replaced can never pass for
@@ -123,35 +123,40 @@ entities.
 - Multi-step flow: select locks → configure slots → configure individual slot properties
 - Validates slots aren't already configured across other config entries
 - Supports YAML object mode for advanced slot configuration
-- The lock picker accepts ANY `lock` entity, so `_check_lock_selection` enforces at
-  submit time what the selector cannot express: an entity with no entity registry row
-  is refused outright (`base: lock_not_registered` -- the same predicate
-  `async_setup_entry` refuses on, and not grandfathered, because an entry holding one does
-  not load), and a newly selected unclaimed mqtt lock is refused with
-  `locks: unsupported_mqtt_lock` (grandfathered, because that entry does load). Both
-  accumulate, on separate error keys and separate placeholders so one submission renders
-  both. A submitted lock no provider claims (mqtt excepted -- it keeps its own refusal)
-  goes to the `codeless` menu step, which asks whether Lock Code Manager should hold that
-  lock's codes. `CodelessDeclarationFlow` is mixed into the config, reauth and options
-  flows, and either answer re-submits what was asked about: confirming saves through the
-  ordinary path, declining lands back on the form with `codeless_declined`
-- ONE member per question, and an answer applies to that member alone -- the
-  re-submission finds the next unanswered member and asks again. A single Yes/No over the
-  whole set let an answer aimed at a newly added lock strip the declaration off an
-  unrelated member. Which of two menu steps is shown depends on the population:
-  `codeless` for a lock nothing claims (declining refuses the submission),
-  `codeless_reconsider` for a member already declared -- by this entry or by another one --
-  that something now claims (declining hands the lock to that provider and saves). Every
-  declared member is asked about whatever dispatch now makes of it, so a declaration always
-  has a way back, and an answer that contradicts another entry managing the same member is
-  refused with `codeless_conflict` naming it
+- **Two lock pickers, disjoint by construction.** `locks` is filtered to
+  `CONFIG_FLOW_PLATFORMS` (every platform dispatch can answer for, plus mqtt, whose dispatch
+  is per DEVICE); `codeless_locks` offers every `lock` entity with `exclude_entities` set to
+  the ones a provider actually claims, computed from the entity registry as the form is
+  built. Both merge into `CONF_LOCKS`; membership in the second is what `declare_codeless`
+  records as `CONF_CODELESS`. All three surfaces -- config, reauth, options -- render both,
+  seeded by `_stored_selection` so each lock opens in the field that expresses what the
+  entry declares about it
+- An unrecognised-bridge mqtt lock appears in BOTH pickers, and that is expected: the
+  allowlist is per platform and the exclusion is per device. The user decides
+- `_check_lock_selection` is the backstop, not the UX -- selector filters are UI-only, and a
+  YAML import or direct submission can send anything. At most one message per key, so
+  refusals that can render together are accumulated and ones that cannot are guarded:
+  `base: lock_not_registered` (either field, not grandfathered -- an entry holding one does
+  not load); `locks: unsupported_mqtt_lock` else `locks: unclaimed_lock` (both grandfathered
+  against what the entry already holds in the ORDINARY field, so an old entry's unclaimed
+  lock does not refuse every later edit, while moving a declared member out is still
+  refused); `codeless_locks: lock_in_both_fields` else `codeless_conflict` else
+  `codeless_lock_claimed`. Placeholders are named apart (`unregistered_locks`, `locks`,
+  `codeless_locks`) so one flat mapping renders all three
+- `_declared_codeless` is what both the codeless picker and `codeless_lock_claimed`
+  treat as settled: a member this entry or a sibling already declares stays selectable
+  whatever dispatch now makes of it, because `resolve_member_provider_class` reads the
+  declaration first and an excluded member would leave that entry unable to save at all
 - Everything that reads a lock during a flow reads it through `_pending_config` -- the
-  entry's configuration as this submission would leave it, answers included -- so
-  capacity and allocation size a member against the provider it is about to become rather
-  than the one it is leaving. On write, `declare_codeless` prunes anything about members
-  the submission no longer holds -- a stored declaration AND an answer just given, since a
-  yes outlives a re-submission refused for some other reason -- so re-adding a lock is
-  asked about afresh
+  entry's configuration as this submission would leave it -- so capacity and allocation size
+  a member against the provider it is about to become rather than the one it is leaving. On
+  write, `declare_codeless` prunes anything about members the submission no longer holds, so
+  re-adding a lock finds nothing declared about it
+- `_async_discard_reclaimed_credentials` runs on every surface before the save: a member
+  that leaves the codeless field -- moved to the other picker or dropped from the entry --
+  loses its store there and then, rather than through the update listener, which an
+  unloaded, disabled or failed entry does not have. Gated on whether a sibling still
+  declares the member, because a DROPPED member is outside what any refusal looks at
 
 ### Entities
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,22 +97,24 @@ entities.
   Locks are torn down and rebuilt on a roster change AND on a declaration change: the
   declaration is what picks the provider, so a member the entry keeps but now resolves
   differently is treated like one that left and came back
-- Two entries holding one lock share a single `BaseLock`, keyed on the entity id AND the
-  provider class each entry resolves -- entries that disagree about a declaration get one
-  instance each. Release is by object identity, so each entry lets go of its own.
-  `BaseLock` defines no `__eq__`/`__hash__` for the same reason: two providers over one
-  entity are two credential stores, and equality by entity id collapsed them
-- Entity-id-addressed lookups live in `domain.locks`. `get_managed_locks_for_entity`
-  returns every provider for a lock; `get_locks_from_targets` returns all of them, so an
-  action aimed at a lock reaches both stores; `get_managed_lock` returns THE provider and
-  refuses when there are two, because its callers (set/clear usercode, the unmanaged-code
-  repair, the lock-codes subscription) name a lock and nothing else
+- One lock entity resolves to one provider across every entry, because whether a lock keeps
+  codes of its own is a fact about the DEVICE. The config, options and reauth flows refuse a
+  submission whose answer contradicts another entry that manages the same member
+  (`_sibling_declarations`, error `codeless_conflict`), and ask about a member a sibling
+  declares so that agreeing is an answer this entry can give
+- Two entries holding one lock therefore share a single `BaseLock`, keyed on the entity id.
+  Release is by object identity, so it stays the exact inverse of the share; `BaseLock`
+  defines no `__eq__`/`__hash__` so a stale instance a reload replaced can never pass for
+  the live one
+- Entity-id-addressed lookups live in `domain.locks`. `find_managed_lock` returns the
+  provider a lock has, or None; `get_managed_lock` raises for callers that name a lock and
+  nothing else (set/clear usercode, the unmanaged-code repair, the lock-codes subscription)
 - `async_remove_entry()`: entry deletion only. Clears the persistent per-lock repairs and
   retires the credentials a provider keeps off the lock (`async_remove_stored_credentials`,
   the virtual/codeless store). Unload deliberately SAVES that store instead, so deletion is
-  the only place it can be collected -- skipped only when another entry RESOLVES THE SAME
-  provider class for that lock (`_lock_store_held_by_another_entry`), since a sibling on a
-  different provider never reads the store and would block collection forever
+  the only place it can be collected -- skipped only when another entry still lists the lock
+  (`_lock_managed_by_other_entry`), which is the same question because every entry holding a
+  lock reads the same store
 - Uses dispatcher signals to notify entities of changes (e.g., `{DOMAIN}_{entry_id}_add_lock_slot`)
 - Registers Lovelace strategy resource for dashboard UI
 
@@ -138,9 +140,11 @@ entities.
   whole set let an answer aimed at a newly added lock strip the declaration off an
   unrelated member. Which of two menu steps is shown depends on the population:
   `codeless` for a lock nothing claims (declining refuses the submission),
-  `codeless_reconsider` for a member the entry already declares that something now claims
-  (declining hands the lock to that provider and saves). Every declared member is asked
-  about whatever dispatch now makes of it, so a declaration always has a way back
+  `codeless_reconsider` for a member already declared -- by this entry or by another one --
+  that something now claims (declining hands the lock to that provider and saves). Every
+  declared member is asked about whatever dispatch now makes of it, so a declaration always
+  has a way back, and an answer that contradicts another entry managing the same member is
+  refused with `codeless_conflict` naming it
 - Everything that reads a lock during a flow reads it through `_pending_config` -- the
   entry's configuration as this submission would leave it, answers included -- so
   capacity and allocation size a member against the provider it is about to become rather

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,11 +99,20 @@ entities.
   differently is treated like one that left and came back
 - Two entries holding one lock share a single `BaseLock`, keyed on the entity id AND the
   provider class each entry resolves -- entries that disagree about a declaration get one
-  instance each. Release is by object identity, so each entry lets go of its own
+  instance each. Release is by object identity, so each entry lets go of its own.
+  `BaseLock` defines no `__eq__`/`__hash__` for the same reason: two providers over one
+  entity are two credential stores, and equality by entity id collapsed them
+- Entity-id-addressed lookups live in `domain.locks`. `get_managed_locks_for_entity`
+  returns every provider for a lock; `get_locks_from_targets` returns all of them, so an
+  action aimed at a lock reaches both stores; `get_managed_lock` returns THE provider and
+  refuses when there are two, because its callers (set/clear usercode, the unmanaged-code
+  repair, the lock-codes subscription) name a lock and nothing else
 - `async_remove_entry()`: entry deletion only. Clears the persistent per-lock repairs and
   retires the credentials a provider keeps off the lock (`async_remove_stored_credentials`,
   the virtual/codeless store). Unload deliberately SAVES that store instead, so deletion is
-  the only place it can be collected -- skipped for a lock another entry still holds
+  the only place it can be collected -- skipped only when another entry RESOLVES THE SAME
+  provider class for that lock (`_lock_store_held_by_another_entry`), since a sibling on a
+  different provider never reads the store and would block collection forever
 - Uses dispatcher signals to notify entities of changes (e.g., `{DOMAIN}_{entry_id}_add_lock_slot`)
 - Registers Lovelace strategy resource for dashboard UI
 
@@ -114,23 +123,31 @@ entities.
 - Supports YAML object mode for advanced slot configuration
 - The lock picker accepts ANY `lock` entity, so `_check_lock_selection` enforces at
   submit time what the selector cannot express: an entity with no entity registry row
-  is refused outright (`lock_not_registered` -- the same predicate `async_setup_entry`
-  refuses on, and not grandfathered, because an entry holding one does not load), and
-  a newly selected unclaimed mqtt lock is refused with `unsupported_mqtt_lock`
-  (grandfathered, because that entry does load). A submitted lock no provider claims (mqtt
-  excepted -- it keeps its own refusal) goes to the `codeless` menu step, which asks
-  whether Lock Code Manager should hold that lock's codes. `CodelessDeclarationFlow` is
-  mixed into the config, reauth and options flows, and either answer re-submits what was
-  asked about: confirming saves through the ordinary path, declining lands back on the
-  form with `codeless_declined`. Asked about every unclaimed lock in a submission, not
-  only new ones, and about every member the entry already declares codeless whatever
-  dispatch now makes of it -- so a declaration always has a way back, including for a
-  member whose platform has since gained a provider (declining that one hands it to the
-  provider instead of refusing the submission). One answer per flow: a declined lock
-  keeps being refused until it is dropped from the selection or the flow is restarted.
-  On write, `declare_codeless` prunes anything about members the submission no longer
-  holds -- a stored declaration AND an answer just given, since a yes outlives a
-  re-submission refused for some other reason -- so re-adding a lock is asked about afresh
+  is refused outright (`base: lock_not_registered` -- the same predicate
+  `async_setup_entry` refuses on, and not grandfathered, because an entry holding one does
+  not load), and a newly selected unclaimed mqtt lock is refused with
+  `locks: unsupported_mqtt_lock` (grandfathered, because that entry does load). Both
+  accumulate, on separate error keys and separate placeholders so one submission renders
+  both. A submitted lock no provider claims (mqtt excepted -- it keeps its own refusal)
+  goes to the `codeless` menu step, which asks whether Lock Code Manager should hold that
+  lock's codes. `CodelessDeclarationFlow` is mixed into the config, reauth and options
+  flows, and either answer re-submits what was asked about: confirming saves through the
+  ordinary path, declining lands back on the form with `codeless_declined`
+- ONE member per question, and an answer applies to that member alone -- the
+  re-submission finds the next unanswered member and asks again. A single Yes/No over the
+  whole set let an answer aimed at a newly added lock strip the declaration off an
+  unrelated member. Which of two menu steps is shown depends on the population:
+  `codeless` for a lock nothing claims (declining refuses the submission),
+  `codeless_reconsider` for a member the entry already declares that something now claims
+  (declining hands the lock to that provider and saves). Every declared member is asked
+  about whatever dispatch now makes of it, so a declaration always has a way back
+- Everything that reads a lock during a flow reads it through `_pending_config` -- the
+  entry's configuration as this submission would leave it, answers included -- so
+  capacity and allocation size a member against the provider it is about to become rather
+  than the one it is leaving. On write, `declare_codeless` prunes anything about members
+  the submission no longer holds -- a stored declaration AND an answer just given, since a
+  yes outlives a re-submission refused for some other reason -- so re-adding a lock is
+  asked about afresh
 
 ### Entities
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,13 +102,24 @@ entities.
 - Multi-step flow: select locks → configure slots → configure individual slot properties
 - Validates slots aren't already configured across other config entries
 - Supports YAML object mode for advanced slot configuration
-- The lock picker accepts ANY `lock` entity. A submitted lock no provider claims (mqtt
+- The lock picker accepts ANY `lock` entity, so `_check_lock_selection` enforces at
+  submit time what the selector cannot express: an entity with no entity registry row
+  is refused outright (`lock_not_registered` -- the same predicate `async_setup_entry`
+  refuses on, and not grandfathered, because an entry holding one does not load), and
+  a newly selected unclaimed mqtt lock is refused with `unsupported_mqtt_lock`
+  (grandfathered, because that entry does load). A submitted lock no provider claims (mqtt
   excepted -- it keeps its own refusal) goes to the `codeless` menu step, which asks
   whether Lock Code Manager should hold that lock's codes. `CodelessDeclarationFlow` is
   mixed into the config, reauth and options flows, and either answer re-submits what was
   asked about: confirming saves through the ordinary path, declining lands back on the
   form with `codeless_declined`. Asked about every unclaimed lock in a submission, not
-  only new ones, so a declaration can be taken back
+  only new ones, and about every member the entry already declares codeless whatever
+  dispatch now makes of it -- so a declaration always has a way back, including for a
+  member whose platform has since gained a provider (declining that one hands it to the
+  provider instead of refusing the submission). One answer per flow: a declined lock
+  keeps being refused until it is dropped from the selection or the flow is restarted.
+  On write, `declare_codeless` prunes declarations about members the submission no
+  longer holds, so re-adding a lock is asked about afresh
 
 ### Entities
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,7 +93,17 @@ entities.
 **Main Module** (`__init__.py`)
 
 - Entry point manages config entry lifecycle
-- `async_update_listener()`: Core function handling dynamic entity creation/removal when config changes
+- `async_update_listener()`: Core function handling dynamic entity creation/removal when config changes.
+  Locks are torn down and rebuilt on a roster change AND on a declaration change: the
+  declaration is what picks the provider, so a member the entry keeps but now resolves
+  differently is treated like one that left and came back
+- Two entries holding one lock share a single `BaseLock`, keyed on the entity id AND the
+  provider class each entry resolves -- entries that disagree about a declaration get one
+  instance each. Release is by object identity, so each entry lets go of its own
+- `async_remove_entry()`: entry deletion only. Clears the persistent per-lock repairs and
+  retires the credentials a provider keeps off the lock (`async_remove_stored_credentials`,
+  the virtual/codeless store). Unload deliberately SAVES that store instead, so deletion is
+  the only place it can be collected -- skipped for a lock another entry still holds
 - Uses dispatcher signals to notify entities of changes (e.g., `{DOMAIN}_{entry_id}_add_lock_slot`)
 - Registers Lovelace strategy resource for dashboard UI
 
@@ -118,8 +128,9 @@ entities.
   member whose platform has since gained a provider (declining that one hands it to the
   provider instead of refusing the submission). One answer per flow: a declined lock
   keeps being refused until it is dropped from the selection or the flow is restarted.
-  On write, `declare_codeless` prunes declarations about members the submission no
-  longer holds, so re-adding a lock is asked about afresh
+  On write, `declare_codeless` prunes anything about members the submission no longer
+  holds -- a stored declaration AND an answer just given, since a yes outlives a
+  re-submission refused for some other reason -- so re-adding a lock is asked about afresh
 
 ### Entities
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,9 +65,15 @@ entities.
 - `zigbee2mqtt.py`: Zigbee2MQTT lock implementation (via MQTT)
 - `zwave_js_ui.py`: zwave-js-ui lock implementation (via MQTT, api-driven)
 - `virtual.py`: Virtual lock implementation -- a credential store rather than a device.
-  Advertises every credential type with no limits, and reports code slot events so it can be
-  the recording surface for credentials used where Lock Code Manager observes nothing
-  (`use_credential`). Also the way to try Lock Code Manager without a real lock.
+  Advertises every credential type with no limits. It observes nothing
+  (`supports_code_slot_events` is False); uses reach it through `use_credential`, which asks
+  nothing of the member it names. Also the way to try Lock Code Manager without a real lock.
+- `codeless.py`: `CodelessLock`, a `VirtualLock` pointed at a REAL lock entity that has no
+  credential storage (ESPHome and similar). Everything but `domain` is inherited. Never
+  reached by platform dispatch: it answers only for a member the entry declares codeless
+  (`EntryConfig.is_codeless`), and `domain.locks.resolve_member_provider_class` is what
+  reads that declaration -- declaration first, so a provider added later cannot silently
+  take a member's credentials off Lock Code Manager and onto a device.
 - Each provider implements: `async_get_users()`, `async_set_credential()`, `async_delete_credential()`,
   `async_is_integration_connected()`, `async_hard_refresh_codes()`
 - Providers listen for lock-specific events and translate them to LCM events via `async_fire_code_slot_event()`
@@ -96,6 +102,13 @@ entities.
 - Multi-step flow: select locks → configure slots → configure individual slot properties
 - Validates slots aren't already configured across other config entries
 - Supports YAML object mode for advanced slot configuration
+- The lock picker accepts ANY `lock` entity. A submitted lock no provider claims (mqtt
+  excepted -- it keeps its own refusal) goes to the `codeless` menu step, which asks
+  whether Lock Code Manager should hold that lock's codes. `CodelessDeclarationFlow` is
+  mixed into the config, reauth and options flows, and either answer re-submits what was
+  asked about: confirming saves through the ordinary path, declining lands back on the
+  form with `codeless_declined`. Asked about every unclaimed lock in a submission, not
+  only new ones, so a declaration can be taken back
 
 ### Entities
 
@@ -331,6 +344,7 @@ Each provider package has a `conftest.py`, a `test_provider.py`, and (except
 ```text
 tests/providers/
   akuvox/          # conftest, test_provider, test_e2e
+  codeless/        # conftest, test_provider, test_e2e
   matter/          # + helpers, fixtures/, test_sdk_exception_translation
   schlage/
   virtual/

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Supported lock integrations:
 | [Schlage WiFi][wiki-schlage] | ❌ | ❌ | ❌ | Cloud-based, PINs masked |
 | [Akuvox][wiki-akuvox]¹ | ✅ | ❌ | ❌ | Local API, polling-based |
 | [Virtual][wiki-virtual]¹ | ✅ | ❌ | ✅ | A credential store rather than a device: records uses reported by the `use_credential` action, and lets you try Lock Code Manager without a real lock |
-| Any other lock, declared codeless⁴ | ✅ | ❌ | ✅ | For a lock with no code support of its own (ESPHome and similar): Lock Code Manager holds the codes and checks uses reported with the `use_credential` action. The lock itself is never written to |
+| Any other lock, with no code storage⁴ | ✅ | ❌ | ✅ | For a lock with no code support of its own (ESPHome and similar): Lock Code Manager holds the codes and checks uses reported with the `use_credential` action. The lock itself is never written to |
 
 ¹ Custom integration required ([Local Akuvox][local-akuvox],
 [hass-virtual][hass-virtual])
@@ -73,17 +73,22 @@ MQTT api; gateway type **Named** or **ValueID** gives full functionality includi
 push updates and PIN-used events, while **Manual** runs polling-only. Configure Home
 Assistant’s **MQTT** integration on the same broker zwave-js-ui uses.
 
-⁴ **Codeless locks** — Pick any `lock` entity Home Assistant has in its entity
-registry (any lock with a unique ID) during setup. If no provider claims it,
-Lock Code Manager asks whether it should hold that lock's codes itself; say yes and it
-stores them, checks codes you report with the `use_credential` action against your users
-and their schedules, and records each use like any other. Nothing is ever written to the
-lock, so something else has to check the code — a keypad automation, an intercom, a door
-controller. This covers ESPHome and any other integration without code support, and it
-means a keypad-only setup no longer needs a separate virtual lock integration. You are
-asked again each time you edit the configuration, so the answer can be changed later —
-but only once per visit: if you answer no and change your mind, close the dialog and
-start over.
+⁴ **Codeless locks** — Setup, reauth and the options dialog all show two lock
+pickers. The first offers the locks Lock Code Manager writes PIN codes to. The
+second, **Locks with no code storage**, offers everything else: any `lock` entity
+in Home Assistant's entity registry that no Lock Code Manager provider claims.
+Pick a lock there and Lock Code Manager stores its codes itself, checks codes you
+report with the `lock_code_manager.use_credential` action against your users and
+their schedules, and records each use like any other. Nothing is ever written to
+the lock, so something else has to check the code — a keypad automation, an
+intercom, a door controller. This covers ESPHome and any other integration
+without code support, and it means a keypad-only setup no longer needs a separate
+virtual lock integration.
+
+Move a lock back to the first picker, or remove it, and Lock Code Manager stops
+holding its codes — the ones it was holding are discarded. See the
+[External Keypads](https://github.com/raman325/lock_code_manager/wiki/External-Keypads)
+wiki page.
 
 [zigbee2mqtt]: https://www.zigbee2mqtt.io/
 [wiki-akuvox]: https://github.com/raman325/lock_code_manager/wiki/Akuvox-integration
@@ -109,8 +114,8 @@ libraries. See the [wiki](https://github.com/raman325/lock_code_manager/wiki/Uns
 for details.
 
 An integration whose locks simply have no code storage — ESPHome, for one — is a different
-case, and is supported: declare the lock codeless during setup and Lock Code Manager keeps
-its credentials itself (see note ⁴ above).
+case, and is supported: pick the lock under **Locks with no code storage** during setup and
+Lock Code Manager keeps its credentials itself (see note ⁴ above).
 
 ## Condition Entity Integrations Not Supported
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Supported lock integrations:
 | [Schlage WiFi][wiki-schlage] | ❌ | ❌ | ❌ | Cloud-based, PINs masked |
 | [Akuvox][wiki-akuvox]¹ | ✅ | ❌ | ❌ | Local API, polling-based |
 | [Virtual][wiki-virtual]¹ | ✅ | ❌ | ✅ | A credential store rather than a device: records uses reported by the `use_credential` action, and lets you try Lock Code Manager without a real lock |
+| Any other lock, declared codeless⁴ | ✅ | ❌ | ✅ | For a lock with no code support of its own (ESPHome and similar): Lock Code Manager holds the codes and checks uses reported with the `use_credential` action. The lock itself is never written to |
 
 ¹ Custom integration required ([Local Akuvox][local-akuvox],
 [hass-virtual][hass-virtual])
@@ -72,6 +73,16 @@ MQTT api; gateway type **Named** or **ValueID** gives full functionality includi
 push updates and PIN-used events, while **Manual** runs polling-only. Configure Home
 Assistant’s **MQTT** integration on the same broker zwave-js-ui uses.
 
+⁴ **Codeless locks** — Pick any `lock` entity during setup. If no provider claims it,
+Lock Code Manager asks whether it should hold that lock's codes itself; say yes and it
+stores them, checks codes you report with the `use_credential` action against your users
+and their schedules, and records each use like any other. Nothing is ever written to the
+lock, so something else has to check the code — a keypad automation, an intercom, a door
+controller. This covers ESPHome and any other integration without code support, and it
+means a keypad-only setup no longer needs a separate virtual lock integration. The
+question is asked again whenever you edit the configuration, so the answer can be
+changed.
+
 [zigbee2mqtt]: https://www.zigbee2mqtt.io/
 [wiki-akuvox]: https://github.com/raman325/lock_code_manager/wiki/Akuvox-integration
 [wiki-zigbee2mqtt]: https://github.com/raman325/lock_code_manager/wiki/Zigbee2MQTT-integration
@@ -94,6 +105,10 @@ guide. Contributors welcome!
 Some lock integrations cannot currently be supported due to limitations in their underlying
 libraries. See the [wiki](https://github.com/raman325/lock_code_manager/wiki/Unsupported-Integrations)
 for details.
+
+An integration whose locks simply have no code storage — ESPHome, for one — is a different
+case, and is supported: declare the lock codeless during setup and Lock Code Manager keeps
+its credentials itself (see note ⁴ above).
 
 ## Condition Entity Integrations Not Supported
 

--- a/README.md
+++ b/README.md
@@ -73,15 +73,17 @@ MQTT api; gateway type **Named** or **ValueID** gives full functionality includi
 push updates and PIN-used events, while **Manual** runs polling-only. Configure Home
 Assistant’s **MQTT** integration on the same broker zwave-js-ui uses.
 
-⁴ **Codeless locks** — Pick any `lock` entity during setup. If no provider claims it,
+⁴ **Codeless locks** — Pick any `lock` entity Home Assistant has in its entity
+registry (any lock with a unique ID) during setup. If no provider claims it,
 Lock Code Manager asks whether it should hold that lock's codes itself; say yes and it
 stores them, checks codes you report with the `use_credential` action against your users
 and their schedules, and records each use like any other. Nothing is ever written to the
 lock, so something else has to check the code — a keypad automation, an intercom, a door
 controller. This covers ESPHome and any other integration without code support, and it
-means a keypad-only setup no longer needs a separate virtual lock integration. The
-question is asked again whenever you edit the configuration, so the answer can be
-changed.
+means a keypad-only setup no longer needs a separate virtual lock integration. You are
+asked again each time you edit the configuration, so the answer can be changed later —
+but only once per visit: if you answer no and change your mind, close the dialog and
+start over.
 
 [zigbee2mqtt]: https://www.zigbee2mqtt.io/
 [wiki-akuvox]: https://github.com/raman325/lock_code_manager/wiki/Akuvox-integration

--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -109,7 +109,11 @@ from .domain.exceptions import (
     LockOperationFailed,
     UnclaimedLockError,
 )
-from .domain.locks import async_create_lock_instance, get_locks_from_targets
+from .domain.locks import (
+    async_create_lock_instance,
+    get_locks_from_targets,
+    resolve_member_provider_class,
+)
 from .domain.models import (
     LockCodeManagerConfigEntry,
     LockCodeManagerConfigEntryRuntimeData,
@@ -857,24 +861,35 @@ def _find_shared_lock_instance(
     hass: HomeAssistant,
     config_entry: LockCodeManagerConfigEntry,
     lock_entity_id: str,
+    lock_cls: type[BaseLock],
 ) -> BaseLock | None:
     """
-    Return an existing BaseLock for ``lock_entity_id`` from another loaded entry.
+    Return another loaded entry's BaseLock for this lock, if it is the same kind.
 
     A single physical lock may be referenced by multiple Lock Code Manager
     entries. We keep one BaseLock instance and share it: when a new entry
     references a lock that another loaded entry is already managing,
     reuse that entry's instance instead of creating a duplicate.
+
+    ``lock_cls`` is what THIS entry resolves the lock to, and two entries can
+    disagree about that. A member one entry declares codeless resolves to the
+    Lock Code Manager store; the same lock in an entry that declares nothing
+    resolves to whatever platform dispatch claims it. Keying the share on the
+    entity id alone handed both entries whichever instance loaded first, so a
+    declaration decided nothing beyond load order and a device somebody said
+    must never be written to got written to. What is shared is a provider for
+    a lock, not a lock.
     """
     return next(
         (
-            entry.runtime_data.locks[lock_entity_id]
+            existing
             for entry in hass.config_entries.async_entries(
                 DOMAIN, include_disabled=False, include_ignore=False
             )
             if entry.entry_id != config_entry.entry_id
             and entry.state is ConfigEntryState.LOADED
-            and lock_entity_id in entry.runtime_data.locks
+            and (existing := entry.runtime_data.locks.get(lock_entity_id)) is not None
+            and type(existing) is lock_cls
         ),
         None,
     )
@@ -883,20 +898,33 @@ def _find_shared_lock_instance(
 def _lock_still_owned_by_another_entry(
     hass: HomeAssistant,
     config_entry: LockCodeManagerConfigEntry,
-    lock_entity_id: str,
+    lock: BaseLock,
 ) -> bool:
     """
-    Return True if another entry still holds the shared instance for this lock.
+    Return True if another entry still holds the instance being torn down.
 
-    Teardown is the exact inverse of acquisition, so it asks by calling the
-    acquiring side rather than restating its rule: any predicate that drifts
-    from ``_find_shared_lock_instance`` leaves an ownerless BaseLock whose
-    push subscription and config-entry state listener keep firing, plus a
-    second instance beside it on the next setup that doubles every code-slot
-    event. Config membership is not the question -- a loaded entry that
-    dropped this lock during setup lists it but does not own it.
+    Teardown is the exact inverse of acquisition, and acquisition is "take
+    the object that entry is holding" -- so this asks after that same object
+    rather than restating the rule that chose it. Any predicate that drifts
+    leaves an ownerless BaseLock whose push subscription and config-entry
+    state listener keep firing, plus a second instance beside it on the next
+    setup that doubles every code-slot event.
+
+    Identity, not entity id: two entries that resolve one lock to different
+    providers hold two instances, and each has to be able to release its own.
+    ``BaseLock`` equality keys on the entity id, so ``in`` and ``==`` would
+    both answer about the other entry's instance. Config membership is not
+    the question either -- a loaded entry that dropped this lock during setup
+    lists it but does not own it.
     """
-    return _find_shared_lock_instance(hass, config_entry, lock_entity_id) is not None
+    return any(
+        entry.entry_id != config_entry.entry_id
+        and entry.state is ConfigEntryState.LOADED
+        and entry.runtime_data.locks.get(lock.lock.entity_id) is lock
+        for entry in hass.config_entries.async_entries(
+            DOMAIN, include_disabled=False, include_ignore=False
+        )
+    )
 
 
 async def async_unload_lock(
@@ -914,7 +942,7 @@ async def async_unload_lock(
         lock = runtime_data.locks.pop(_lock_entity_id, None)
         if lock is None:
             continue
-        if not _lock_still_owned_by_another_entry(hass, config_entry, _lock_entity_id):
+        if not _lock_still_owned_by_another_entry(hass, config_entry, lock):
             # ``remove_permanently`` discards state that deliberately outlives
             # an unload -- the per-lock setup-failed repair, the provider's
             # stored codes. Only a lock leaving Lock Code Manager altogether
@@ -1031,20 +1059,71 @@ async def async_unload_entry(
     return unload_ok
 
 
+async def _async_discard_stored_credentials(
+    hass: HomeAssistant,
+    config_entry: LockCodeManagerConfigEntry,
+    config: EntryConfig,
+) -> None:
+    """
+    Retire the credentials a deleted entry's providers kept off the lock.
+
+    Some providers ARE the credential store: a virtual lock's codes, and
+    those of a member declared codeless, live in a Home Assistant store and
+    nowhere else. Unload writes that store back rather than removing it --
+    a reload must not be a reset -- and entry deletion unloads first, so
+    deleting an entry left its users' Personal Identification Numbers on
+    disk in cleartext with nothing left that could ever read them.
+
+    Instances are built fresh because the entry's own are gone by now, and
+    only to name the store: nothing here reaches the lock.
+
+    A lock another entry still holds keeps its store, which is the same gate
+    ``async_unload_lock`` puts on ``remove_permanently``. Conservative on
+    purpose: presence, not the provider that entry resolves, so the rare case
+    of two entries disagreeing about a lock leaves a store behind rather than
+    deleting one the other entry is still reading.
+    """
+    dev_reg = dr.async_get(hass)
+    ent_reg = er.async_get(hass)
+    for lock_entity_id in config.locks:
+        if _lock_managed_by_other_entry(hass, config_entry, lock_entity_id):
+            continue
+        lock_entry = ent_reg.async_get(lock_entity_id)
+        if lock_entry is None:
+            # The entity went before the entry did. Its store is named after
+            # the entity id, so there is nothing left here to name it with.
+            continue
+        lock_cls = resolve_member_provider_class(dev_reg, config, lock_entry)
+        if lock_cls is None:
+            # Nothing claimed it and nothing was declared about it, so no
+            # provider ever ran and no provider ever wrote a store.
+            continue
+        lock = lock_cls(
+            hass,
+            dev_reg,
+            ent_reg,
+            hass.config_entries.async_get_entry(lock_entry.config_entry_id),
+            lock_entry,
+        )
+        await lock.async_remove_stored_credentials()
+
+
 async def async_remove_entry(
     hass: HomeAssistant, config_entry: LockCodeManagerConfigEntry
 ) -> None:
     """
-    Clean up persistent repair issues when the entry is fully removed.
+    Clean up what a deleted entry leaves behind Home Assistant will not.
 
     Called by Home Assistant only on entry deletion -- not on unload,
     reload, disable, or HA restart. The repair issues created by this
     integration are flagged ``is_persistent=True`` so they survive
     restarts and reloads; clearing them belongs here, not in
-    ``async_unload_entry``, so they outlive any non-deletion unload.
+    ``async_unload_entry``, so they outlive any non-deletion unload. The
+    same is true of a provider's stored credentials, for the same reason.
     """
     entry_id = config_entry.entry_id
     config = get_entry_config(config_entry)
+    await _async_discard_stored_credentials(hass, config_entry, config)
     for slot_num in config.slot_numbers:
         async_delete_issue(hass, DOMAIN, f"slot_disabled_{entry_id}_{slot_num}")
         async_delete_issue(hass, DOMAIN, f"pin_required_{entry_id}_{slot_num}")
@@ -1458,6 +1537,48 @@ def _async_report_dropped_lock(
     )
 
 
+@callback
+def _async_locks_redeclared(
+    hass: HomeAssistant,
+    config_entry: LockCodeManagerConfigEntry,
+    new_config: EntryConfig,
+    ent_reg: er.EntityRegistry,
+) -> tuple[str, ...]:
+    """
+    Return the entry's locks whose live instance no longer matches the config.
+
+    Compared against the instance the entry is actually holding rather than
+    against a second resolution of the old config: that is the state this
+    pass exists to correct, and it costs nothing to read. It also answers
+    correctly for a lock that never got an instance -- one that failed setup
+    is absent here and stays the ``locks_to_add`` path's problem.
+
+    A lock the new config resolves to nothing is left alone. There is no
+    replacement to build, so tearing the instance down would take the
+    provider's stored codes with it (``remove_permanently``) and leave the
+    entry with a lock it cannot set up and credentials it cannot get back.
+    Setup already refuses that entry on the next load, loudly.
+
+    Resolved against the entry's own refreshed view rather than the options
+    mapping this pass is applying, because that view is what the factory
+    reads a few lines later. Two readings of "the new config" that merge the
+    entry's two sides differently would name a lock here that came back as
+    the same class it just replaced, once per update, forever.
+    """
+    dev_reg = dr.async_get(hass)
+    config = get_entry_config(config_entry)
+    locks = config_entry.runtime_data.locks
+    return tuple(
+        lock_entity_id
+        for lock_entity_id in new_config.locks
+        if (lock := locks.get(lock_entity_id)) is not None
+        and (lock_entry := ent_reg.async_get(lock_entity_id)) is not None
+        and (resolved := resolve_member_provider_class(dev_reg, config, lock_entry))
+        is not None
+        and type(lock) is not resolved
+    )
+
+
 async def _async_setup_new_locks(
     hass: HomeAssistant,
     config_entry: LockCodeManagerConfigEntry,
@@ -1479,7 +1600,21 @@ async def _async_setup_new_locks(
     )
 
     async def _setup_one_lock(lock_entity_id: str) -> BaseLock:
-        existing_lock = _find_shared_lock_instance(hass, config_entry, lock_entity_id)
+        # Built before the share is looked for, because what this entry
+        # resolves the lock to is part of what it is looking for, and the
+        # factory is the one place that resolution lives. Construction is a
+        # dataclass and a device registry lookup; everything that talks to
+        # the lock is in async_setup_internal below.
+        lock = async_create_lock_instance(
+            hass,
+            dr.async_get(hass),
+            ent_reg,
+            config_entry,
+            lock_entity_id,
+        )
+        existing_lock = _find_shared_lock_instance(
+            hass, config_entry, lock_entity_id, type(lock)
+        )
         if existing_lock is not None:
             _LOGGER.debug(
                 "%s (%s): Reusing lock instance for lock %s",
@@ -1491,13 +1626,7 @@ async def _async_setup_new_locks(
             await existing_lock.async_wait_for_setup()
             return existing_lock
 
-        lock = runtime_data.locks[lock_entity_id] = async_create_lock_instance(
-            hass,
-            dr.async_get(hass),
-            ent_reg,
-            config_entry,
-            lock_entity_id,
-        )
+        runtime_data.locks[lock_entity_id] = lock
         _LOGGER.debug(
             "%s (%s): Creating lock instance for lock %s",
             entry_id,
@@ -1663,8 +1792,17 @@ async def _async_apply_entry_update(
     diff = old_config - new_config
     slots_to_add = diff.slots_added
     slots_to_remove = diff.slots_removed
-    locks_to_add = diff.locks_added
-    locks_to_remove = diff.locks_removed
+    # A member the entry keeps but now declares differently is torn down and
+    # rebuilt like one that left and came back, because the declaration is
+    # what decides the provider (``resolve_member_provider_class``) and the
+    # provider is what the instance IS. The roster diff cannot see it -- the
+    # entity id sits on both sides -- so without this the answer reached
+    # storage and nothing acted on it until a reload: a lock taken back from
+    # Lock Code Manager went on being held by it, which is the whole of what
+    # the menu offers a way out of.
+    locks_redeclared = _async_locks_redeclared(hass, config_entry, new_config, ent_reg)
+    locks_to_add = diff.locks_added + locks_redeclared
+    locks_to_remove = diff.locks_removed + locks_redeclared
 
     callbacks = runtime_data.callbacks
 

--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -857,6 +857,42 @@ def _lock_managed_by_other_entry(
     )
 
 
+def _lock_store_held_by_another_entry(
+    hass: HomeAssistant,
+    config_entry: LockCodeManagerConfigEntry,
+    lock_entry: er.RegistryEntry,
+    lock_cls: type[BaseLock],
+) -> bool:
+    """
+    Return True if another entry resolves this lock to the same provider.
+
+    What guards discarding a provider's stored credentials. Presence is the
+    wrong question: a sibling entry that lists the lock but resolves a
+    DIFFERENT provider class never opens the store being discarded, and
+    treating it as a holder blocks collection forever -- leaving cleartext
+    Personal Identification Numbers on disk with nothing left in the
+    configuration that could ever read them back.
+
+    Same class, not the same instance: an entry that is merely between loads
+    holds no instance and would still read this store on its next load.
+
+    Takes the registry entry rather than an entity id, because the
+    declaration a sibling is resolved through is keyed by
+    ``RegistryEntry.id``. Every caller holds one already -- a provider keeps
+    its own, and the sweep looks one up before it can name a store at all --
+    so there is no case here where the row is missing.
+    """
+    dev_reg = dr.async_get(hass)
+    return any(
+        entry.entry_id != config_entry.entry_id
+        and (sibling := get_entry_config(entry)).has_lock(lock_entry.entity_id)
+        and resolve_member_provider_class(dev_reg, sibling, lock_entry) is lock_cls
+        for entry in hass.config_entries.async_entries(
+            DOMAIN, include_disabled=False, include_ignore=False
+        )
+    )
+
+
 def _find_shared_lock_instance(
     hass: HomeAssistant,
     config_entry: LockCodeManagerConfigEntry,
@@ -912,10 +948,8 @@ def _lock_still_owned_by_another_entry(
 
     Identity, not entity id: two entries that resolve one lock to different
     providers hold two instances, and each has to be able to release its own.
-    ``BaseLock`` equality keys on the entity id, so ``in`` and ``==`` would
-    both answer about the other entry's instance. Config membership is not
-    the question either -- a loaded entry that dropped this lock during setup
-    lists it but does not own it.
+    Config membership is not the question either -- a loaded entry that
+    dropped this lock during setup lists it but does not own it.
     """
     return any(
         entry.entry_id != config_entry.entry_id
@@ -946,12 +980,13 @@ async def async_unload_lock(
             # ``remove_permanently`` discards state that deliberately outlives
             # an unload -- the per-lock setup-failed repair, the provider's
             # stored codes. Only a lock leaving Lock Code Manager altogether
-            # should lose those, so an entry that still manages it downgrades
-            # this to a plain teardown even while that entry is unloaded.
+            # should lose those, so an entry that still reads THIS provider's
+            # store downgrades this to a plain teardown even while that entry
+            # is unloaded.
             await lock.async_unload(
                 remove_permanently
-                and not _lock_managed_by_other_entry(
-                    hass, config_entry, _lock_entity_id
+                and not _lock_store_held_by_another_entry(
+                    hass, config_entry, lock.lock, type(lock)
                 )
             )
             if lock.coordinator is not None:
@@ -1077,17 +1112,14 @@ async def _async_discard_stored_credentials(
     Instances are built fresh because the entry's own are gone by now, and
     only to name the store: nothing here reaches the lock.
 
-    A lock another entry still holds keeps its store, which is the same gate
-    ``async_unload_lock`` puts on ``remove_permanently``. Conservative on
-    purpose: presence, not the provider that entry resolves, so the rare case
-    of two entries disagreeing about a lock leaves a store behind rather than
-    deleting one the other entry is still reading.
+    A store another entry still reads is kept, which is the same gate
+    ``async_unload_lock`` puts on ``remove_permanently``. The question is
+    whether a sibling resolves THIS provider, not whether one lists the lock
+    -- see :func:`_lock_store_held_by_another_entry`.
     """
     dev_reg = dr.async_get(hass)
     ent_reg = er.async_get(hass)
     for lock_entity_id in config.locks:
-        if _lock_managed_by_other_entry(hass, config_entry, lock_entity_id):
-            continue
         lock_entry = ent_reg.async_get(lock_entity_id)
         if lock_entry is None:
             # The entity went before the entry did. Its store is named after
@@ -1097,6 +1129,8 @@ async def _async_discard_stored_credentials(
         if lock_cls is None:
             # Nothing claimed it and nothing was declared about it, so no
             # provider ever ran and no provider ever wrote a store.
+            continue
+        if _lock_store_held_by_another_entry(hass, config_entry, lock_entry, lock_cls):
             continue
         lock = lock_cls(
             hass,

--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -857,64 +857,24 @@ def _lock_managed_by_other_entry(
     )
 
 
-def _lock_store_held_by_another_entry(
-    hass: HomeAssistant,
-    config_entry: LockCodeManagerConfigEntry,
-    lock_entry: er.RegistryEntry,
-    lock_cls: type[BaseLock],
-) -> bool:
-    """
-    Return True if another entry resolves this lock to the same provider.
-
-    What guards discarding a provider's stored credentials. Presence is the
-    wrong question: a sibling entry that lists the lock but resolves a
-    DIFFERENT provider class never opens the store being discarded, and
-    treating it as a holder blocks collection forever -- leaving cleartext
-    Personal Identification Numbers on disk with nothing left in the
-    configuration that could ever read them back.
-
-    Same class, not the same instance: an entry that is merely between loads
-    holds no instance and would still read this store on its next load.
-
-    Takes the registry entry rather than an entity id, because the
-    declaration a sibling is resolved through is keyed by
-    ``RegistryEntry.id``. Every caller holds one already -- a provider keeps
-    its own, and the sweep looks one up before it can name a store at all --
-    so there is no case here where the row is missing.
-    """
-    dev_reg = dr.async_get(hass)
-    return any(
-        entry.entry_id != config_entry.entry_id
-        and (sibling := get_entry_config(entry)).has_lock(lock_entry.entity_id)
-        and resolve_member_provider_class(dev_reg, sibling, lock_entry) is lock_cls
-        for entry in hass.config_entries.async_entries(
-            DOMAIN, include_disabled=False, include_ignore=False
-        )
-    )
-
-
 def _find_shared_lock_instance(
     hass: HomeAssistant,
     config_entry: LockCodeManagerConfigEntry,
     lock_entity_id: str,
-    lock_cls: type[BaseLock],
 ) -> BaseLock | None:
     """
-    Return another loaded entry's BaseLock for this lock, if it is the same kind.
+    Return another loaded entry's BaseLock for this lock, if there is one.
 
     A single physical lock may be referenced by multiple Lock Code Manager
     entries. We keep one BaseLock instance and share it: when a new entry
     references a lock that another loaded entry is already managing,
     reuse that entry's instance instead of creating a duplicate.
 
-    ``lock_cls`` is what THIS entry resolves the lock to, and two entries can
-    disagree about that. A member one entry declares codeless resolves to the
-    Lock Code Manager store; the same lock in an entry that declares nothing
-    resolves to whatever platform dispatch claims it. Keying the share on the
-    entity id alone handed both entries whichever instance loaded first, so a
-    declaration decided nothing beyond load order and a device somebody said
-    must never be written to got written to. What is shared is a provider for
-    a lock, not a lock.
+    The entity id is the whole of the key, because one lock entity resolves
+    to one provider everywhere. Whether a lock keeps codes of its own is a
+    fact about the device, and the config flow refuses to let two entries
+    answer it differently, so a sibling's instance is never a different kind
+    of store from the one this entry was about to build.
     """
     return next(
         (
@@ -925,7 +885,6 @@ def _find_shared_lock_instance(
             if entry.entry_id != config_entry.entry_id
             and entry.state is ConfigEntryState.LOADED
             and (existing := entry.runtime_data.locks.get(lock_entity_id)) is not None
-            and type(existing) is lock_cls
         ),
         None,
     )
@@ -946,10 +905,15 @@ def _lock_still_owned_by_another_entry(
     state listener keep firing, plus a second instance beside it on the next
     setup that doubles every code-slot event.
 
-    Identity, not entity id: two entries that resolve one lock to different
-    providers hold two instances, and each has to be able to release its own.
-    Config membership is not the question either -- a loaded entry that
-    dropped this lock during setup lists it but does not own it.
+    Config membership is not the question: a loaded entry that dropped this
+    lock during setup lists it but does not own it, and reading the roster
+    as ownership walks away from an instance nothing will ever tear down.
+
+    Identity rather than mere presence, even though one lock entity means
+    one shared instance, so this stays the inverse of acquisition however
+    the sharing is keyed. Value equality on the entity id would be the same
+    drift by another route -- see the note on ``BaseLock`` about why it has
+    no ``__eq__``.
     """
     return any(
         entry.entry_id != config_entry.entry_id
@@ -980,13 +944,15 @@ async def async_unload_lock(
             # ``remove_permanently`` discards state that deliberately outlives
             # an unload -- the per-lock setup-failed repair, the provider's
             # stored codes. Only a lock leaving Lock Code Manager altogether
-            # should lose those, so an entry that still reads THIS provider's
-            # store downgrades this to a plain teardown even while that entry
-            # is unloaded.
+            # should lose those, so an entry that still lists the lock
+            # downgrades this to a plain teardown even while that entry is
+            # unloaded. Presence is the right question because every entry
+            # holding one lock resolves it to one provider, so an entry that
+            # lists it is an entry that reads this same store.
             await lock.async_unload(
                 remove_permanently
-                and not _lock_store_held_by_another_entry(
-                    hass, config_entry, lock.lock, type(lock)
+                and not _lock_managed_by_other_entry(
+                    hass, config_entry, _lock_entity_id
                 )
             )
             if lock.coordinator is not None:
@@ -1113,9 +1079,10 @@ async def _async_discard_stored_credentials(
     only to name the store: nothing here reaches the lock.
 
     A store another entry still reads is kept, which is the same gate
-    ``async_unload_lock`` puts on ``remove_permanently``. The question is
-    whether a sibling resolves THIS provider, not whether one lists the lock
-    -- see :func:`_lock_store_held_by_another_entry`.
+    ``async_unload_lock`` puts on ``remove_permanently``. Listing the lock
+    is the whole of that question: one lock entity resolves to one provider
+    across every entry, so an entry that still holds it is one that still
+    opens this file.
     """
     dev_reg = dr.async_get(hass)
     ent_reg = er.async_get(hass)
@@ -1130,7 +1097,7 @@ async def _async_discard_stored_credentials(
             # Nothing claimed it and nothing was declared about it, so no
             # provider ever ran and no provider ever wrote a store.
             continue
-        if _lock_store_held_by_another_entry(hass, config_entry, lock_entry, lock_cls):
+        if _lock_managed_by_other_entry(hass, config_entry, lock_entity_id):
             continue
         lock = lock_cls(
             hass,
@@ -1634,11 +1601,11 @@ async def _async_setup_new_locks(
     )
 
     async def _setup_one_lock(lock_entity_id: str) -> BaseLock:
-        # Built before the share is looked for, because what this entry
-        # resolves the lock to is part of what it is looking for, and the
-        # factory is the one place that resolution lives. Construction is a
-        # dataclass and a device registry lookup; everything that talks to
-        # the lock is in async_setup_internal below.
+        # Built before the share is looked for, so an entry that cannot
+        # resolve the lock at all fails here rather than adopting a
+        # sibling's instance for a member it was never able to name.
+        # Construction is a dataclass and a device registry lookup;
+        # everything that talks to the lock is in async_setup_internal below.
         lock = async_create_lock_instance(
             hass,
             dr.async_get(hass),
@@ -1646,9 +1613,7 @@ async def _async_setup_new_locks(
             config_entry,
             lock_entity_id,
         )
-        existing_lock = _find_shared_lock_instance(
-            hass, config_entry, lock_entity_id, type(lock)
-        )
+        existing_lock = _find_shared_lock_instance(hass, config_entry, lock_entity_id)
         if existing_lock is not None:
             _LOGGER.debug(
                 "%s (%s): Reusing lock instance for lock %s",

--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -119,17 +119,17 @@ def _check_lock_selection(
     codes -- so everything the selector cannot express is enforced here, at
     submit time, rather than by narrowing it back down.
 
-    An entity with no registry row goes first, and is refused outright. It is
-    the same predicate ``async_setup_entry`` refuses on, moved to where the
-    lock is chosen: there is no id to key a declaration or a device to, so
-    the entry cannot load with one in its roster. Accepting it made the
-    guided path fail three steps later with ``occupancy_unknown``, which
-    tells the user to go wake a lock that was never going to answer.
+    An entity with no registry row is refused outright. It is the same
+    predicate ``async_setup_entry`` refuses on, moved to where the lock is
+    chosen: there is no id to key a declaration or a device to, so the entry
+    cannot load with one in its roster. Accepting it made the guided path
+    fail three steps later with ``occupancy_unknown``, which tells the user
+    to go wake a lock that was never going to answer.
 
-    It is NOT grandfathered the way the mqtt refusal below is: an entry
-    holding one is not running at all, so there is no working configuration
-    to lock somebody out of, and the reauth that setup starts is the flow
-    that has to refuse the lock for the loop to ever end.
+    It is NOT grandfathered the way the mqtt refusal is: an entry holding one
+    is not running at all, so there is no working configuration to lock
+    somebody out of, and the reauth that setup starts is the flow that has to
+    refuse the lock for the loop to ever end.
 
     ``already_configured`` is what the entry holds now, and unclaimed mqtt
     locks in it are waved through. An entry configured before that check
@@ -139,26 +139,37 @@ def _check_lock_selection(
     changed and no reauth could complete, for a lock the form was not being
     asked to add. That lock is not silently accepted either; it is dropped at
     setup and says so in its own repair.
+
+    Both refusals are collected, so a selection that has one of each says so
+    once instead of over two round trips. They sit on different error keys --
+    the mqtt one on the field, the registry one on ``base`` alongside
+    ``slots_already_configured``, which likewise names locks -- because a
+    dict holds one message per key and a second refusal on the field would
+    replace the first. Their placeholders are named apart for the same
+    reason: one flat mapping renders both.
     """
     ent_reg = er.async_get(hass)
     dev_reg = dr.async_get(hass)
+    errors: dict[str, str] = {}
+    placeholders: dict[str, Any] = {}
     if unregistered := [
         entity_id
         for entity_id in lock_entity_ids
         if ent_reg.async_get(entity_id) is None
     ]:
-        return {CONF_LOCKS: "lock_not_registered"}, {"locks": ", ".join(unregistered)}
-    unclaimed = [
+        errors["base"] = "lock_not_registered"
+        placeholders["unregistered_locks"] = ", ".join(unregistered)
+    if unclaimed := [
         entity_id
         for entity_id in lock_entity_ids
         if entity_id not in already_configured
         and (entry := ent_reg.async_get(entity_id)) is not None
         and entry.platform == MQTT_DOMAIN
         and resolve_provider_class_for_entity(dev_reg, entry) is None
-    ]
-    if unclaimed:
-        return {CONF_LOCKS: "unsupported_mqtt_lock"}, {"locks": ", ".join(unclaimed)}
-    return {}, {}
+    ]:
+        errors[CONF_LOCKS] = "unsupported_mqtt_lock"
+        placeholders["locks"] = ", ".join(unclaimed)
+    return errors, placeholders
 
 
 def _codeless_candidates(
@@ -191,6 +202,18 @@ def _codeless_candidates(
     storage. Offering the declaration there answers a question nobody asked,
     and taking it would strand that lock's credentials in a Lock Code
     Manager store on the day its bridge became supported.
+
+    Every OTHER unclaimed platform is offered, including the ones that do
+    have code storage this integration simply has not been taught -- August,
+    Yale, Tuya. Settled deliberately, so it is not re-litigated: nothing
+    distinguishes them from an ESPHome lock here. Dispatch answers None for
+    both, and the only alternative is a hardcoded list of platforms known to
+    have keypads, which goes stale silently and in the dangerous direction --
+    a lock wrongly on it can never be declared, and its owner has no way to
+    say otherwise. The person choosing the lock is the one who knows whether
+    it has a keypad, the question says what declaring means, and since the
+    menu also offers every member already declared, a wrong answer is one
+    the same form takes back.
 
     Every selected entity is in the registry by the time this runs:
     :func:`_check_lock_selection` refuses the whole submission over one that
@@ -230,13 +253,28 @@ class CodelessDeclarationFlow(config_entries.ConfigEntryBaseFlow):
     re-submits it: the answer changes what the same validation makes of the
     same input, so confirming saves through exactly the path that would have
     run without the detour, and declining lands back on the form with the
-    refusal that names the locks -- somewhere the lock selection can be
+    refusal that names the lock -- somewhere the lock selection can be
     changed, rather than a dead end.
+
+    ONE member per question, and the answer applies to that member alone.
+    The set asked about mixes two populations -- a lock just added that
+    nothing claims, and a member the entry already declares -- and a single
+    Yes/No over both let an answer aimed at one silently rewrite the other:
+    declining a newly added lock stripped the declaration off an unrelated
+    member, and handed a device somebody had said must never be written to
+    back to its provider. The re-submission each answer triggers finds the
+    next unanswered member and asks again, so N members cost N questions and
+    every one of them names what it is about.
+
+    Which of the two populations a member is in decides which question it
+    gets, because declining means different things: for a lock nothing
+    claims it refuses the submission, and for a declared member something
+    now claims it hands the lock back to that provider and saves.
 
     Asked about every lock nothing claims, not only the ones nobody has
     answered for yet, so a declaration made earlier can be taken back. Once
-    per flow, because an answer suppresses the question for the re-submission
-    it caused.
+    per member per flow, because an answer suppresses that member's question
+    for the re-submission it caused.
 
     Based on the class the config and options flows already share, so the
     steps here are typed against the same flow surface they run on rather
@@ -254,7 +292,7 @@ class CodelessDeclarationFlow(config_entries.ConfigEntryBaseFlow):
         # it.
         self._codeless_origin: str = ""
         self._codeless_input: dict[str, Any] = {}
-        self._codeless_locks: list[er.RegistryEntry] = []
+        self._codeless_lock: er.RegistryEntry | None = None
 
     async def _async_check_codeless(
         self, origin: str, user_input: dict[str, Any], config: EntryConfig
@@ -270,16 +308,24 @@ class CodelessDeclarationFlow(config_entries.ConfigEntryBaseFlow):
         ask, unmanageable = _codeless_candidates(
             self.hass, user_input[CONF_LOCKS], config
         )
-        if unanswered := [
-            lock_entry
-            for lock_entry in ask
-            if lock_entry.id not in self._codeless_answers
-        ]:
+        if pending := next(
+            (
+                lock_entry
+                for lock_entry in ask
+                if lock_entry.id not in self._codeless_answers
+            ),
+            None,
+        ):
             self._codeless_origin = origin
             # Copied: the step this comes back to consumes what it is given.
             self._codeless_input = dict(user_input)
-            self._codeless_locks = unanswered
-            return await self.async_step_codeless(), {}, {}
+            self._codeless_lock = pending
+            step = (
+                "codeless"
+                if any(entry.id == pending.id for entry in unmanageable)
+                else "codeless_reconsider"
+            )
+            return await getattr(self, f"async_step_{step}")(), {}, {}
         if undeclared := [
             lock_entry
             for lock_entry in unmanageable
@@ -318,22 +364,62 @@ class CodelessDeclarationFlow(config_entries.ConfigEntryBaseFlow):
             roster.add(lock_entry.id)
         return declare_codeless(config.members, self._codeless_answers, roster)
 
+    def _pending_config(
+        self, config: EntryConfig, lock_entity_ids: Iterable[str]
+    ) -> EntryConfig:
+        """
+        Return the entry's configuration as this submission would leave it.
+
+        What the locks get read through. Reading the STORED declaration
+        instead made a pending answer invisible to the very validation the
+        answer triggers a re-run of: taking a declaration back checked the
+        slot numbers against the Lock Code Manager store -- no capacity, and
+        empty -- rather than against the provider the lock is about to
+        become, so a configuration far too large for the real lock saved
+        without a word.
+
+        An entity the registry does not know is skipped rather than
+        asserted, unlike :meth:`_declared_members`. This runs beside the
+        lock-selection check rather than after it, so it can see a selection
+        that is about to be refused; the write path runs only once that
+        refusal has not happened, and there an entity missing here would
+        silently drop a declaration.
+        """
+        ent_reg = er.async_get(self.hass)
+        roster = {
+            lock_entry.id
+            for entity_id in lock_entity_ids
+            if (lock_entry := ent_reg.async_get(entity_id)) is not None
+        }
+        return config.with_members(
+            declare_codeless(config.members, self._codeless_answers, roster)
+        )
+
+    def _codeless_menu(self, step_id: str) -> dict[str, Any]:
+        """Offer both answers about the one member the question is about."""
+        assert self._codeless_lock is not None
+        return self.async_show_menu(
+            step_id=step_id,
+            menu_options=["codeless_confirm", "codeless_decline"],
+            description_placeholders={"lock": self._codeless_lock.entity_id},
+        )
+
     async def async_step_codeless(
         self, user_input: dict[str, Any] | None = None
     ) -> dict[str, Any]:
-        """Explain what declaring these locks means, and offer both answers."""
-        return self.async_show_menu(
-            step_id="codeless",
-            menu_options=["codeless_confirm", "codeless_decline"],
-            description_placeholders={
-                "locks": ", ".join(entry.entity_id for entry in self._codeless_locks)
-            },
-        )
+        """Ask about a lock nothing else can manage, where "no" refuses it."""
+        return self._codeless_menu("codeless")
+
+    async def async_step_codeless_reconsider(
+        self, user_input: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        """Ask again about a declared member, where "no" hands it to a provider."""
+        return self._codeless_menu("codeless_reconsider")
 
     async def async_step_codeless_confirm(
         self, user_input: dict[str, Any] | None = None
     ) -> dict[str, Any]:
-        """Record that Lock Code Manager holds these locks' credentials."""
+        """Record that Lock Code Manager holds this lock's credentials."""
         return await self._async_answer_codeless(True)
 
     async def async_step_codeless_decline(
@@ -343,10 +429,9 @@ class CodelessDeclarationFlow(config_entries.ConfigEntryBaseFlow):
         return await self._async_answer_codeless(False)
 
     async def _async_answer_codeless(self, codeless: bool) -> dict[str, Any]:
-        """Record one answer for every lock the step named, and re-submit."""
-        self._codeless_answers.update(
-            dict.fromkeys((entry.id for entry in self._codeless_locks), codeless)
-        )
+        """Record the answer about the member the step named, and re-submit."""
+        assert self._codeless_lock is not None
+        self._codeless_answers[self._codeless_lock.id] = codeless
         # Resolved by name, the way the flow manager resolves every step.
         return await getattr(self, f"async_step_{self._codeless_origin}")(
             dict(self._codeless_input)
@@ -388,6 +473,7 @@ async def _async_validate_users_yaml(
     config_entry: ConfigEntry | None,
     raw_users: dict[Any, Any],
     locks: Iterable[str],
+    config: EntryConfig | None = None,
 ) -> tuple[dict | None, dict, dict]:
     """
     Validate a users submission for the editor and the yaml setup path.
@@ -399,7 +485,10 @@ async def _async_validate_users_yaml(
 
     ``config_entry`` is the entry the submission is for, or ``None`` from
     the flow that is still creating one; it is what the lock reads this
-    performs are made on behalf of.
+    performs are made on behalf of. ``config`` is what that entry would
+    declare about its members once this submission is saved, so a
+    declaration taken back in this same flow is read through the provider
+    the lock is about to become rather than the one it is leaving.
 
     Returns the parsed users -- or ``None`` when validation failed -- with the
     accumulated errors and description placeholders.
@@ -443,7 +532,9 @@ async def _async_validate_users_yaml(
 
     # The count is what a lock has to hold, now that nobody picks a number.
     try:
-        await async_check_slot_capacity(hass, config_entry, locks, [len(parsed_users)])
+        await async_check_slot_capacity(
+            hass, config_entry, locks, [len(parsed_users)], config
+        )
     except SlotAllocationError as err:
         return (
             None,
@@ -458,6 +549,7 @@ async def _allocate_for(
     config_entry: ConfigEntry | None,
     locks: Sequence[str],
     num_users: int,
+    config: EntryConfig | None = None,
 ) -> tuple[frozenset[int] | None, dict[str, str], dict[str, Any]]:
     """
     Find numbers for ``num_users``, or say why it could not.
@@ -468,10 +560,14 @@ async def _allocate_for(
     ``config_entry`` is the entry being allocated for, whose own numbers do
     not constrain it: kept ones are held by tenure, released ones are free
     for whoever comes next. A flow that is still creating its entry passes
-    ``None``, which by the same rule holds nothing.
+    ``None``, which by the same rule holds nothing. ``config`` is what that
+    entry would declare once the submission is saved, so the locks are read
+    as the answers in hand leave them.
     """
     try:
-        unavailable = await async_allocate_for(hass, config_entry, locks, num_users)
+        unavailable = await async_allocate_for(
+            hass, config_entry, locks, num_users, config
+        )
     except SlotAllocationError as err:
         return None, {"base": err.translation_key}, err.placeholders
     return unavailable, {}, {}
@@ -575,7 +671,13 @@ class LockCodeManagerFlowHandler(
                 unavailable,
                 errors,
                 description_placeholders,
-            ) = await _allocate_for(self.hass, None, self.data[CONF_LOCKS], num_users)
+            ) = await _allocate_for(
+                self.hass,
+                None,
+                self.data[CONF_LOCKS],
+                num_users,
+                self._pending_config(EntryConfig.empty(), self.data[CONF_LOCKS]),
+            )
             if unavailable is not None:
                 self._users_to_configure = num_users
                 self._unavailable = unavailable
@@ -698,7 +800,11 @@ class LockCodeManagerFlowHandler(
                 validation_errors,
                 validation_placeholders,
             ) = await _async_validate_users_yaml(
-                self.hass, None, user_input[CONF_USERS], self.data[CONF_LOCKS]
+                self.hass,
+                None,
+                user_input[CONF_USERS],
+                self.data[CONF_LOCKS],
+                self._pending_config(EntryConfig.empty(), self.data[CONF_LOCKS]),
             )
             errors.update(validation_errors)
             description_placeholders.update(validation_placeholders)
@@ -715,7 +821,11 @@ class LockCodeManagerFlowHandler(
                     allocation_errors,
                     allocation_placeholders,
                 ) = await _allocate_for(
-                    self.hass, None, self.data[CONF_LOCKS], len(users)
+                    self.hass,
+                    None,
+                    self.data[CONF_LOCKS],
+                    len(users),
+                    self._pending_config(EntryConfig.empty(), self.data[CONF_LOCKS]),
                 )
                 if unavailable is None:
                     return self.async_show_form(
@@ -802,7 +912,11 @@ class LockCodeManagerFlowHandler(
                 # already-valid slot set can become too large for the new lock.
                 try:
                     await async_check_slot_capacity(
-                        self.hass, config_entry, user_input[CONF_LOCKS], existing_slots
+                        self.hass,
+                        config_entry,
+                        user_input[CONF_LOCKS],
+                        existing_slots,
+                        self._pending_config(entry_config, user_input[CONF_LOCKS]),
                     )
                 except SlotAllocationError as err:
                     additional_errors = {"base": err.translation_key}
@@ -885,17 +999,20 @@ class LockCodeManagerOptionsFlow(CodelessDeclarationFlow, config_entries.Options
             user_input = {}
 
         if user_input:
+            stored = get_entry_config(self.config_entry)
             # Accumulated alongside the users validation rather than
             # short-circuiting it: both refusals render together, so one round
             # trip shows everything wrong with the submission.
             lock_errors, lock_placeholders = _check_lock_selection(
-                self.hass,
-                user_input[CONF_LOCKS],
-                get_entry_config(self.config_entry).locks,
+                self.hass, user_input[CONF_LOCKS], stored.locks
             )
             errors.update(lock_errors)
             description_placeholders.update(lock_placeholders)
 
+            # Everything that reads a lock reads it as this submission would
+            # leave it, answers included -- so taking a declaration back is
+            # validated against the provider the lock becomes.
+            pending = self._pending_config(stored, user_input[CONF_LOCKS])
             (
                 users,
                 validation_errors,
@@ -905,6 +1022,7 @@ class LockCodeManagerOptionsFlow(CodelessDeclarationFlow, config_entries.Options
                 self.config_entry,
                 user_input[CONF_USERS],
                 user_input[CONF_LOCKS],
+                pending,
             )
             errors.update(validation_errors)
             description_placeholders.update(validation_placeholders)
@@ -920,12 +1038,12 @@ class LockCodeManagerOptionsFlow(CodelessDeclarationFlow, config_entries.Options
                     self.config_entry,
                     user_input[CONF_LOCKS],
                     len(users),
+                    pending,
                 )
                 if unavailable is None:
                     errors.update(allocation_errors)
                     description_placeholders.update(allocation_placeholders)
                 else:
-                    config = get_entry_config(self.config_entry)
                     # Asked here, where the submission is otherwise ready to
                     # save, so nobody is asked to declare something about a
                     # submission that was never going to be stored.
@@ -933,7 +1051,7 @@ class LockCodeManagerOptionsFlow(CodelessDeclarationFlow, config_entries.Options
                         ask,
                         codeless_errors,
                         codeless_placeholders,
-                    ) = await self._async_check_codeless("init", user_input, config)
+                    ) = await self._async_check_codeless("init", user_input, stored)
                     if ask is not None:
                         return ask
                     errors.update(codeless_errors)
@@ -943,7 +1061,7 @@ class LockCodeManagerOptionsFlow(CodelessDeclarationFlow, config_entries.Options
                         # user who was here before keeps their number and only
                         # newcomers are issued one. Moving somebody would rewrite
                         # their credential on every lock.
-                        assignment = config.assignment.reconcile(
+                        assignment = stored.assignment.reconcile(
                             users, start=1, unavailable=unavailable
                         )
                         # Written through EntryConfig so whatever else the entry
@@ -954,11 +1072,11 @@ class LockCodeManagerOptionsFlow(CodelessDeclarationFlow, config_entries.Options
                             data=EntryConfig(
                                 locks=tuple(user_input[CONF_LOCKS]),
                                 members=self._declared_members(
-                                    config, user_input[CONF_LOCKS]
+                                    stored, user_input[CONF_LOCKS]
                                 ),
                                 users=users,
                                 assignment=assignment,
-                                extra=config.extra,
+                                extra=stored.extra,
                             ).to_dict(),
                         )
 

--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -468,15 +468,23 @@ class CodelessDeclarationFlow(config_entries.ConfigEntryBaseFlow):
         Retire the store of every member this flow just handed back.
 
         ``codeless_reconsider`` promises in so many words that answering no
-        discards the codes Lock Code Manager was holding. On the options path
-        that promise is kept by the update listener, which sees the member
-        resolve to a different class and tears the old instance down
-        permanently. A save that does not go through that listener has to
-        keep the promise itself, or the answer leaves a file of cleartext
-        Personal Identification Numbers behind for a lock whose own
+        discards the codes Lock Code Manager was holding, and every surface
+        that asks the question keeps that promise here rather than leaving it
+        to the redeclaration teardown. That teardown runs from the update
+        listener, which is registered during setup and released on unload, so
+        it is absent for exactly the entries this question tends to be
+        answered about: a failed one being repaired through reauth, an
+        unloaded or disabled one being edited through options. Left to it,
+        the answer reached storage while a file of cleartext Personal
+        Identification Numbers stayed on disk for a lock whose own
         integration now holds the codes -- readable by nothing, and swept by
         nothing, because the entry no longer declares the member it would
         have been collected under.
+
+        Asked unconditionally rather than only when that listener is known to
+        be missing. Naming a store and removing it is idempotent, and this is
+        awaited before the save that would trigger the listener, so when the
+        teardown does also run it finds the file already gone.
 
         Only members the submission KEEPS. A lock leaving the roster entirely
         is a different question with a different answer, and this is not the
@@ -1092,10 +1100,6 @@ class LockCodeManagerFlowHandler(
             errors.update(additional_errors)
             description_placeholders.update(additional_placeholders)
             if not errors:
-                # Discarded here rather than by the redeclaration teardown:
-                # this save writes the entry and reloads it, and the entry it
-                # is repairing is failed, so no instance is being held for
-                # that teardown to find and collect.
                 await self._async_discard_reclaimed_credentials(
                     entry_config, user_input[CONF_LOCKS]
                 )
@@ -1229,6 +1233,9 @@ class LockCodeManagerOptionsFlow(CodelessDeclarationFlow, config_entries.Options
                         # their credential on every lock.
                         assignment = stored.assignment.reconcile(
                             users, start=1, unavailable=unavailable
+                        )
+                        await self._async_discard_reclaimed_credentials(
+                            stored, user_input[CONF_LOCKS]
                         )
                         # Written through EntryConfig so whatever else the entry
                         # carries survives the edit. Building the dict by hand

--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -25,6 +25,7 @@ from homeassistant.util import slugify
 from .const import (
     CONDITION_ENTITY_DOMAINS,
     CONF_LOCKS,
+    CONF_MEMBERS,
     CONF_NUM_USERS,
     CONF_USERS,
     DEFAULT_NUM_USERS,
@@ -36,11 +37,11 @@ from .domain.allocation import (
     async_allocate_for,
     async_check_slot_capacity,
 )
-from .domain.config import EntryConfig
+from .domain.config import EntryConfig, declare_codeless
 from .domain.names import name_error, normalize_name, validate_user_names
 from .domain.queries import get_entry_config
 from .domain.slot_assignment import CONF_SLOT_ASSIGNMENT, SlotAssignment
-from .providers import CONFIG_FLOW_PLATFORMS, resolve_provider_class_for_entity
+from .providers import resolve_provider_class_for_entity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -90,12 +91,14 @@ USER_SCHEMA = vol.Schema(
 
 USERS_SCHEMA = vol.All(vol.Schema({cv.string: USER_SCHEMA}), enabled_requires_pin)
 
-LOCKS_FILTER_CONFIG = [
-    sel.EntityFilterSelectorConfig(integration=platform, domain=LOCK_DOMAIN)
-    for platform in CONFIG_FLOW_PLATFORMS
-]
+# Every lock entity, from any integration. Not an allowlist of the
+# platforms that resolve to a provider: a lock nothing claims may still be
+# one Lock Code Manager can manage codes for by holding them itself, and the
+# user is asked about exactly those after they submit. Filtering them out of
+# the picker instead would make the question unaskable -- a lock that cannot
+# be selected cannot be declared about.
 LOCK_ENTITY_SELECTOR = sel.EntitySelector(
-    sel.EntitySelectorConfig(filter=LOCKS_FILTER_CONFIG, multiple=True)
+    sel.EntitySelectorConfig(domain=LOCK_DOMAIN, multiple=True)
 )
 SLOTS_YAML_SELECTOR = sel.ObjectSelector(sel.ObjectSelectorConfig())
 
@@ -137,6 +140,157 @@ def _check_unclaimed_mqtt_locks(
     if unclaimed:
         return {CONF_LOCKS: "unsupported_mqtt_lock"}, {"locks": ", ".join(unclaimed)}
     return {}, {}
+
+
+def _codeless_candidates(
+    hass: HomeAssistant, lock_entity_ids: Iterable[str]
+) -> list[er.RegistryEntry]:
+    """
+    Return the selected locks that only a declaration can account for.
+
+    A lock no provider claims is not necessarily a lock this integration
+    cannot manage: if it keeps no codes of its own, Lock Code Manager can
+    hold them itself and treat the entity as the thing being locked. Which
+    of the two it is, is not derivable from anything here -- so these are
+    the locks the user is asked about.
+
+    mqtt is left out, and keeps the refusal it already has. Its dispatch is
+    per DEVICE, so an unclaimed one means "this bridge is not one of the two
+    Lock Code Manager speaks" -- a gap that may close in a later version,
+    not a statement that the lock has no code storage. Offering the
+    declaration there answers a question nobody asked, and taking it would
+    strand that lock's credentials in a Lock Code Manager store on the day
+    its bridge became supported.
+
+    An entity missing from the registry is left out too: a declaration is
+    keyed by registry id, so there is nothing to key one by, and setup
+    refuses that lock on its own.
+    """
+    ent_reg = er.async_get(hass)
+    dev_reg = dr.async_get(hass)
+    return [
+        lock_entry
+        for entity_id in lock_entity_ids
+        if (lock_entry := ent_reg.async_get(entity_id)) is not None
+        and lock_entry.platform != MQTT_DOMAIN
+        and resolve_provider_class_for_entity(dev_reg, lock_entry) is None
+    ]
+
+
+class CodelessDeclarationFlow(config_entries.ConfigEntryBaseFlow):
+    """
+    The step that asks whether Lock Code Manager should hold a lock's codes.
+
+    Mixed into every flow that picks locks, because any of them can pick one
+    no provider claims, and none of them may store a lock nobody was asked
+    about.
+
+    The question is asked after a submission has otherwise been accepted,
+    and the submission is held rather than acted on. Either answer then
+    re-submits it: the answer changes what the same validation makes of the
+    same input, so confirming saves through exactly the path that would have
+    run without the detour, and declining lands back on the form with the
+    refusal that names the locks -- somewhere the lock selection can be
+    changed, rather than a dead end.
+
+    Asked about every lock nothing claims, not only the ones nobody has
+    answered for yet, so a declaration made earlier can be taken back. Once
+    per flow, because an answer suppresses the question for the re-submission
+    it caused.
+
+    Based on the class the config and options flows already share, so the
+    steps here are typed against the same flow surface they run on rather
+    than asserting one exists.
+    """
+
+    def __init__(self) -> None:
+        """Start with nothing asked and nothing answered."""
+        super().__init__()
+        # Answers given in THIS flow, keyed by entity registry id, laid over
+        # whatever the entry already holds. They reach storage only when the
+        # flow that collected them writes its entry.
+        self._codeless_answers: dict[str, bool] = {}
+        # The step the pending answer belongs to, and what was submitted to
+        # it.
+        self._codeless_origin: str = ""
+        self._codeless_input: dict[str, Any] = {}
+        self._codeless_locks: list[er.RegistryEntry] = []
+
+    async def _async_check_codeless(
+        self, origin: str, user_input: dict[str, Any], config: EntryConfig
+    ) -> tuple[dict[str, Any] | None, dict[str, str], dict[str, Any]]:
+        """
+        Ask about, or refuse, the locks in a submission that nothing claims.
+
+        Returns the flow result to return when the question still has to be
+        asked, alongside the form error and placeholders for a submission
+        that cannot be saved as it stands. ``config`` is what the entry
+        already declares, which this flow's own answers override.
+        """
+        candidates = _codeless_candidates(self.hass, user_input[CONF_LOCKS])
+        if unanswered := [
+            lock_entry
+            for lock_entry in candidates
+            if lock_entry.id not in self._codeless_answers
+        ]:
+            self._codeless_origin = origin
+            # Copied: the step this comes back to consumes what it is given.
+            self._codeless_input = dict(user_input)
+            self._codeless_locks = unanswered
+            return await self.async_step_codeless(), {}, {}
+        if undeclared := [
+            lock_entry
+            for lock_entry in candidates
+            if not self._is_codeless(config, lock_entry)
+        ]:
+            return (
+                None,
+                {CONF_LOCKS: "codeless_declined"},
+                {"locks": ", ".join(entry.entity_id for entry in undeclared)},
+            )
+        return None, {}, {}
+
+    def _is_codeless(self, config: EntryConfig, lock_entry: er.RegistryEntry) -> bool:
+        """Return the answer that stands for a member: this flow's, else the entry's."""
+        return self._codeless_answers.get(lock_entry.id, config.is_codeless(lock_entry))
+
+    def _declared_members(self, config: EntryConfig) -> dict[str, dict[str, Any]]:
+        """Return what to store about this entry's members, answers applied."""
+        return declare_codeless(config.members, self._codeless_answers)
+
+    async def async_step_codeless(
+        self, user_input: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        """Explain what declaring these locks means, and offer both answers."""
+        return self.async_show_menu(
+            step_id="codeless",
+            menu_options=["codeless_confirm", "codeless_decline"],
+            description_placeholders={
+                "locks": ", ".join(entry.entity_id for entry in self._codeless_locks)
+            },
+        )
+
+    async def async_step_codeless_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        """Record that Lock Code Manager holds these locks' credentials."""
+        return await self._async_answer_codeless(True)
+
+    async def async_step_codeless_decline(
+        self, user_input: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        """Record that it does not, which is also how a declaration is undone."""
+        return await self._async_answer_codeless(False)
+
+    async def _async_answer_codeless(self, codeless: bool) -> dict[str, Any]:
+        """Record one answer for every lock the step named, and re-submit."""
+        self._codeless_answers.update(
+            dict.fromkeys((entry.id for entry in self._codeless_locks), codeless)
+        )
+        # Resolved by name, the way the flow manager resolves every step.
+        return await getattr(self, f"async_step_{self._codeless_origin}")(
+            dict(self._codeless_input)
+        )
 
 
 def _check_common_slots(
@@ -263,7 +417,9 @@ async def _allocate_for(
     return unavailable, {}, {}
 
 
-class LockCodeManagerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
+class LockCodeManagerFlowHandler(
+    CodelessDeclarationFlow, config_entries.ConfigFlow, domain=DOMAIN
+):
     """Config flow for Lock Code Manager."""
 
     VERSION = 4
@@ -271,6 +427,7 @@ class LockCodeManagerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     def __init__(self) -> None:
         """Initialize config flow."""
+        super().__init__()
         self.data: dict[str, Any] = {}
         self.title: str = ""
         self.ent_reg: er.EntityRegistry = None
@@ -298,6 +455,20 @@ class LockCodeManagerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             errors, description_placeholders = _check_unclaimed_mqtt_locks(
                 self.hass, user_input[CONF_LOCKS]
             )
+            if not errors:
+                # A new entry declares nothing yet, so every lock nothing
+                # claims is one this step has to ask about. Asked before the
+                # name is consumed, because a refusal re-renders this form
+                # from what was submitted.
+                (
+                    ask,
+                    errors,
+                    description_placeholders,
+                ) = await self._async_check_codeless(
+                    "user", user_input, EntryConfig.empty()
+                )
+                if ask is not None:
+                    return ask
             if not errors:
                 self.title = user_input.pop(CONF_NAME)
                 await self.async_set_unique_id(slugify(self.title))
@@ -439,6 +610,18 @@ class LockCodeManagerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             self.data[CONF_USERS], start=1, unavailable=self._unavailable
         )
         self.data[CONF_SLOT_ASSIGNMENT] = dict(assignment.slots)
+        return self._create_entry()
+
+    def _create_entry(self) -> dict[str, Any]:
+        """
+        Create the entry, carrying what this flow was told about its members.
+
+        The key is left out entirely when nothing was declared, rather than
+        written empty: an entry that was never asked anything should not
+        read as one that answered nothing.
+        """
+        if members := self._declared_members(EntryConfig.empty()):
+            self.data[CONF_MEMBERS] = members
         return self.async_create_entry(title=self.title, data=self.data)
 
     async def async_step_yaml(self, user_input: dict[str, Any] | None = None):
@@ -485,7 +668,7 @@ class LockCodeManagerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     users, start=1, unavailable=unavailable
                 )
                 self.data[CONF_SLOT_ASSIGNMENT] = dict(assignment.slots)
-                return self.async_create_entry(title=self.title, data=self.data)
+                return self._create_entry()
 
         return self.async_show_form(
             step_id="yaml",
@@ -562,6 +745,21 @@ class LockCodeManagerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 except SlotAllocationError as err:
                     additional_errors = {"base": err.translation_key}
                     additional_placeholders = err.placeholders
+            if not additional_errors:
+                # Reauth renders the same picker as the other two flows, so
+                # it is a third way to put a lock nothing claims into the
+                # entry, and needs the same question. Left out, a user
+                # repairing one broken lock could swap in a codeless one and
+                # land straight back in reauth.
+                (
+                    ask,
+                    additional_errors,
+                    additional_placeholders,
+                ) = await self._async_check_codeless(
+                    "reauth_confirm", user_input, entry_config
+                )
+                if ask is not None:
+                    return ask
             errors.update(additional_errors)
             description_placeholders.update(additional_placeholders)
             if not errors:
@@ -577,8 +775,9 @@ class LockCodeManagerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 self.hass.config_entries.async_update_entry(
                     config_entry,
                     data={
-                        **get_entry_config(config_entry).to_dict(),
+                        **entry_config.to_dict(),
                         **user_input,
+                        CONF_MEMBERS: self._declared_members(entry_config),
                     },
                     options={},
                 )
@@ -609,7 +808,7 @@ class LockCodeManagerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         return LockCodeManagerOptionsFlow()
 
 
-class LockCodeManagerOptionsFlow(config_entries.OptionsFlow):
+class LockCodeManagerOptionsFlow(CodelessDeclarationFlow, config_entries.OptionsFlow):
     """Options flow for Lock Code Manager."""
 
     async def async_step_init(
@@ -663,26 +862,39 @@ class LockCodeManagerOptionsFlow(config_entries.OptionsFlow):
                     description_placeholders.update(allocation_placeholders)
                 else:
                     config = get_entry_config(self.config_entry)
-                    # Reconciled against what the entry already holds, so a
-                    # user who was here before keeps their number and only
-                    # newcomers are issued one. Moving somebody would rewrite
-                    # their credential on every lock.
-                    assignment = config.assignment.reconcile(
-                        users, start=1, unavailable=unavailable
-                    )
-                    # Written through EntryConfig so whatever else the entry
-                    # carries survives the edit. Building the dict by hand
-                    # drops every key this form does not ask about.
-                    return self.async_create_entry(
-                        title="",
-                        data=EntryConfig(
-                            locks=tuple(user_input[CONF_LOCKS]),
-                            members=config.members,
-                            users=users,
-                            assignment=assignment,
-                            extra=config.extra,
-                        ).to_dict(),
-                    )
+                    # Asked here, where the submission is otherwise ready to
+                    # save, so nobody is asked to declare something about a
+                    # submission that was never going to be stored.
+                    (
+                        ask,
+                        codeless_errors,
+                        codeless_placeholders,
+                    ) = await self._async_check_codeless("init", user_input, config)
+                    if ask is not None:
+                        return ask
+                    errors.update(codeless_errors)
+                    description_placeholders.update(codeless_placeholders)
+                    if not errors:
+                        # Reconciled against what the entry already holds, so a
+                        # user who was here before keeps their number and only
+                        # newcomers are issued one. Moving somebody would rewrite
+                        # their credential on every lock.
+                        assignment = config.assignment.reconcile(
+                            users, start=1, unavailable=unavailable
+                        )
+                        # Written through EntryConfig so whatever else the entry
+                        # carries survives the edit. Building the dict by hand
+                        # drops every key this form does not ask about.
+                        return self.async_create_entry(
+                            title="",
+                            data=EntryConfig(
+                                locks=tuple(user_input[CONF_LOCKS]),
+                                members=self._declared_members(config),
+                                users=users,
+                                assignment=assignment,
+                                extra=config.extra,
+                            ).to_dict(),
+                        )
 
         config = get_entry_config(self.config_entry)
         # Plain dict/list, because the form selectors cannot serialize the

--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -102,6 +102,12 @@ LOCKS_FILTER_CONFIG = [
     sel.EntityFilterSelectorConfig(integration=platform, domain=LOCK_DOMAIN)
     for platform in CONFIG_FLOW_PLATFORMS
 ]
+# Hassfest refuses a literal URL inside a data_description, so the wiki link
+# the codeless picker needs is supplied as a placeholder instead.
+WIKI_EXTERNAL_KEYPADS = (
+    "https://github.com/raman325/lock_code_manager/wiki/External-Keypads"
+)
+
 LOCK_ENTITY_SELECTOR = sel.EntitySelector(
     sel.EntitySelectorConfig(filter=LOCKS_FILTER_CONFIG, multiple=True)
 )
@@ -738,7 +744,10 @@ class LockCodeManagerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 user_input,
             ),
             errors=errors,
-            description_placeholders=description_placeholders,
+            description_placeholders={
+                **description_placeholders,
+                "wiki_url": WIKI_EXTERNAL_KEYPADS,
+            },
             last_step=False,
         )
 
@@ -1071,7 +1080,10 @@ class LockCodeManagerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 }
             ),
             errors=errors,
-            description_placeholders=description_placeholders,
+            description_placeholders={
+                **description_placeholders,
+                "wiki_url": WIKI_EXTERNAL_KEYPADS,
+            },
             last_step=True,
         )
 
@@ -1199,6 +1211,9 @@ class LockCodeManagerOptionsFlow(config_entries.OptionsFlow):
                 }
             ),
             errors=errors,
-            description_placeholders=description_placeholders,
+            description_placeholders={
+                **description_placeholders,
+                "wiki_url": WIKI_EXTERNAL_KEYPADS,
+            },
             last_step=True,
         )

--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -24,6 +24,7 @@ from homeassistant.util import slugify
 
 from .const import (
     CONDITION_ENTITY_DOMAINS,
+    CONF_CODELESS_LOCKS,
     CONF_LOCKS,
     CONF_MEMBERS,
     CONF_NUM_USERS,
@@ -41,7 +42,7 @@ from .domain.config import EntryConfig, declare_codeless
 from .domain.names import name_error, normalize_name, validate_user_names
 from .domain.queries import get_entry_config
 from .domain.slot_assignment import CONF_SLOT_ASSIGNMENT, SlotAssignment
-from .providers import resolve_provider_class_for_entity
+from .providers import CONFIG_FLOW_PLATFORMS, resolve_provider_class_for_entity
 from .providers.codeless import CodelessLock
 
 _LOGGER = logging.getLogger(__name__)
@@ -92,85 +93,22 @@ USER_SCHEMA = vol.Schema(
 
 USERS_SCHEMA = vol.All(vol.Schema({cv.string: USER_SCHEMA}), enabled_requires_pin)
 
-# Every lock entity, from any integration. Not an allowlist of the
-# platforms that resolve to a provider: a lock nothing claims may still be
-# one Lock Code Manager can manage codes for by holding them itself, and the
-# user is asked about exactly those after they submit. Filtering them out of
-# the picker instead would make the question unaskable -- a lock that cannot
-# be selected cannot be declared about.
+# The locks a provider can be resolved for. Wider than what actually
+# resolves, because mqtt dispatch is per DEVICE and a selector can only
+# express an integration -- an unrecognized bridge is refused at submit
+# time. Nothing is hidden by narrowing this: the field beside it offers
+# exactly the locks no provider claims.
+LOCKS_FILTER_CONFIG = [
+    sel.EntityFilterSelectorConfig(integration=platform, domain=LOCK_DOMAIN)
+    for platform in CONFIG_FLOW_PLATFORMS
+]
 LOCK_ENTITY_SELECTOR = sel.EntitySelector(
-    sel.EntitySelectorConfig(domain=LOCK_DOMAIN, multiple=True)
+    sel.EntitySelectorConfig(filter=LOCKS_FILTER_CONFIG, multiple=True)
 )
 SLOTS_YAML_SELECTOR = sel.ObjectSelector(sel.ObjectSelectorConfig())
 
 
 POSITIVE_INT = vol.All(vol.Coerce(int), vol.Range(min=1))
-
-
-def _check_lock_selection(
-    hass: HomeAssistant,
-    lock_entity_ids: Iterable[str],
-    already_configured: Container[str] = (),
-) -> tuple[dict[str, str], dict[str, Any]]:
-    """
-    Turn a lock that cannot be set up into the form error that names it.
-
-    The picker offers every ``lock`` entity on purpose -- a lock no provider
-    claims may still be one Lock Code Manager can manage by holding its
-    codes -- so everything the selector cannot express is enforced here, at
-    submit time, rather than by narrowing it back down.
-
-    An entity with no registry row is refused outright. It is the same
-    predicate ``async_setup_entry`` refuses on, moved to where the lock is
-    chosen: there is no id to key a declaration or a device to, so the entry
-    cannot load with one in its roster. Accepting it made the guided path
-    fail three steps later with ``occupancy_unknown``, which tells the user
-    to go wake a lock that was never going to answer.
-
-    It is NOT grandfathered the way the mqtt refusal is: an entry holding one
-    is not running at all, so there is no working configuration to lock
-    somebody out of, and the reauth that setup starts is the flow that has to
-    refuse the lock for the loop to ever end.
-
-    ``already_configured`` is what the entry holds now, and unclaimed mqtt
-    locks in it are waved through. An entry configured before that check
-    existed can be carrying one, and every options and reauth submission
-    re-renders that entry's whole lock list -- so validating all of it made
-    one grandfathered lock refuse every subsequent edit: no PIN could be
-    changed and no reauth could complete, for a lock the form was not being
-    asked to add. That lock is not silently accepted either; it is dropped at
-    setup and says so in its own repair.
-
-    Both refusals are collected, so a selection that has one of each says so
-    once instead of over two round trips. They sit on different error keys --
-    the mqtt one on the field, the registry one on ``base`` alongside
-    ``slots_already_configured``, which likewise names locks -- because a
-    dict holds one message per key and a second refusal on the field would
-    replace the first. Their placeholders are named apart for the same
-    reason: one flat mapping renders both.
-    """
-    ent_reg = er.async_get(hass)
-    dev_reg = dr.async_get(hass)
-    errors: dict[str, str] = {}
-    placeholders: dict[str, Any] = {}
-    if unregistered := [
-        entity_id
-        for entity_id in lock_entity_ids
-        if ent_reg.async_get(entity_id) is None
-    ]:
-        errors["base"] = "lock_not_registered"
-        placeholders["unregistered_locks"] = ", ".join(unregistered)
-    if unclaimed := [
-        entity_id
-        for entity_id in lock_entity_ids
-        if entity_id not in already_configured
-        and (entry := ent_reg.async_get(entity_id)) is not None
-        and entry.platform == MQTT_DOMAIN
-        and resolve_provider_class_for_entity(dev_reg, entry) is None
-    ]:
-        errors[CONF_LOCKS] = "unsupported_mqtt_lock"
-        placeholders["locks"] = ", ".join(unclaimed)
-    return errors, placeholders
 
 
 class _SiblingAnswer(NamedTuple):
@@ -181,12 +119,10 @@ class _SiblingAnswer(NamedTuple):
 
 
 def _sibling_declarations(
-    hass: HomeAssistant,
-    config_entry: ConfigEntry | None,
-    lock_entries: Iterable[er.RegistryEntry],
+    hass: HomeAssistant, config_entry: ConfigEntry | None
 ) -> dict[str, _SiblingAnswer]:
     """
-    Return what another entry already says about each of these members.
+    Return what every other entry says about each member it holds.
 
     Whether a lock has credential storage is a fact about the DEVICE, not
     about a configuration: an ESPHome lock with no keypad has none no matter
@@ -194,20 +130,17 @@ def _sibling_declarations(
     therefore not a configuration but a contradiction, and one with teeth --
     the two answers resolve to two providers over one entity, so a Personal
     Identification Number lands in whichever store the caller happened to
-    reach. Every surface that records an answer consults this and refuses to
-    add a second opinion.
+    reach. Every surface that saves a lock selection consults this.
 
     Keyed by ``er.RegistryEntry.id``, the same handle the declarations
-    themselves are keyed by, so "the same lock" is an exact key match rather
-    than anything inferred from an entity id that a rename can move. The
-    value carries the entry's title alongside its answer, because a refusal
-    that does not name the other configuration leaves the user with nowhere
-    to go.
+    themselves are keyed by. The value carries the entry's title alongside
+    its answer, because a refusal that does not name the other configuration
+    leaves the user with nowhere to go.
 
     Only entries that HOLD the member answer for it. A declaration left
     behind by an entry that no longer lists the lock is not an opinion about
-    anything -- nothing resolves it -- and reading one would refuse an
-    answer no live provider contradicts.
+    anything -- nothing resolves it -- and reading one would refuse a
+    selection no live provider contradicts.
 
     ``config_entry`` is the entry being edited, left out because its own
     stored answer is the one being replaced. A flow that is still creating
@@ -222,13 +155,14 @@ def _sibling_declarations(
     with each other -- this is what stops them -- so which one is arbitrary
     only in the sense that they all say the same thing.
     """
+    ent_reg = er.async_get(hass)
     declarations: dict[str, _SiblingAnswer] = {}
     for entry in hass.config_entries.async_entries(DOMAIN):
         if config_entry is not None and entry.entry_id == config_entry.entry_id:
             continue
         sibling = get_entry_config(entry)
-        for lock_entry in lock_entries:
-            if sibling.has_lock(lock_entry.entity_id):
+        for entity_id in sibling.locks:
+            if (lock_entry := ent_reg.async_get(entity_id)) is not None:
                 declarations.setdefault(
                     lock_entry.id,
                     _SiblingAnswer(sibling.is_codeless(lock_entry), entry.title),
@@ -236,360 +170,357 @@ def _sibling_declarations(
     return declarations
 
 
-def _codeless_candidates(
-    hass: HomeAssistant,
-    lock_entries: Iterable[er.RegistryEntry],
-    config: EntryConfig,
-    siblings: Mapping[str, _SiblingAnswer],
-) -> tuple[list[er.RegistryEntry], list[er.RegistryEntry]]:
+def _declared_codeless(
+    hass: HomeAssistant, config: EntryConfig, config_entry: ConfigEntry | None
+) -> set[str]:
     """
-    Return the selected locks to ask about, and those nothing else can manage.
+    Return the members some configuration already declares codeless.
 
-    A lock no provider claims is not necessarily a lock this integration
-    cannot manage: if it keeps no codes of its own, Lock Code Manager can
-    hold them itself and treat the entity as the thing being locked. Which
-    of the two it is, is not derivable from anything here -- so these are
-    the locks the user is asked about, and, unless the answer is yes, the
-    ones the submission is refused over.
+    What both the codeless picker and its refusal treat as settled. A
+    declaration outranks platform dispatch permanently
+    (``domain.locks.resolve_member_provider_class``), so a member declared
+    before Lock Code Manager learned to claim its lock keeps resolving to
+    the Lock Code Manager store -- and hiding it from the picker, or
+    refusing it there, would leave that entry unable to save any edit at all
+    while its way out is to move the lock to the other field.
 
-    Every member ALREADY declared codeless is asked about too, whatever
-    platform dispatch now makes of it, and whether this entry or another one
-    declared it. The declaration wins over a provider, deliberately and
-    permanently (``domain.locks.resolve_member_provider_class``), so a
-    member whose platform gained a provider after it was declared would
-    otherwise keep resolving to the Lock Code Manager store with no form
-    that so much as mentions it. Reading a SIBLING'S declaration here is
-    what leaves room to agree with it: a lock something claims is otherwise
-    never asked about, so an entry adding one another entry declares could
-    only ever contradict it, and would be refused with no answer available
-    that was not.
+    A sibling's declarations count for the same reason they gate the
+    conflict refusal: an entry adding a lock another entry already declares
+    has to be able to agree with it, and a picker that excluded the lock
+    would make agreeing the one answer it could not give.
+    """
+    ent_reg = er.async_get(hass)
+    declared = {
+        lock_entry.id
+        for entity_id in config.locks
+        if (lock_entry := ent_reg.async_get(entity_id)) is not None
+        and config.is_codeless(lock_entry)
+    }
+    declared.update(
+        registry_id
+        for registry_id, answer in _sibling_declarations(hass, config_entry).items()
+        if answer.codeless
+    )
+    return declared
 
-    mqtt is never asked about on dispatch alone, and keeps the refusal it
-    already has. Its dispatch is per DEVICE, so an unclaimed one means "this
-    bridge is not one of the two Lock Code Manager speaks" -- a gap that may
-    close in a later version, not a statement that the lock has no code
-    storage. Offering the declaration there answers a question nobody asked,
-    and taking it would strand that lock's credentials in a Lock Code
-    Manager store on the day its bridge became supported.
 
-    Every OTHER unclaimed platform is offered, including the ones that do
-    have code storage this integration simply has not been taught -- August,
-    Yale, Tuya. Settled deliberately, so it is not re-litigated: nothing
-    distinguishes them from an ESPHome lock here. Dispatch answers None for
-    both, and the only alternative is a hardcoded list of platforms known to
-    have keypads, which goes stale silently and in the dangerous direction --
-    a lock wrongly on it can never be declared, and its owner has no way to
-    say otherwise. The person choosing the lock is the one who knows whether
-    it has a keypad, the question says what declaring means, and since the
-    menu also offers every member already declared, a wrong answer is one
-    the same form takes back.
+def _codeless_lock_selector(
+    hass: HomeAssistant, declared: Container[str]
+) -> sel.EntitySelector:
+    """
+    Return the picker for locks that keep no codes of their own.
+
+    Every ``lock`` entity is on offer except the ones a provider claims, so
+    the two pickers are disjoint by construction and each offers only what
+    belongs in it. The exclusions are computed from the entity registry each
+    time the form is built, which is what keeps them honest -- a lock whose
+    integration Lock Code Manager learns to claim in a later version moves
+    fields the next time somebody opens the dialog.
+
+    Home Assistant enforces this on submit as well as on render: an
+    ``EntitySelector`` validates its own ``exclude_entities``. So what
+    reaches ``_check_lock_selection`` from the UI is a selection the
+    exclusions of the LAST RENDERED form allowed, which is why that refusal
+    exists too -- dispatch can start claiming a lock between the render and
+    the submit.
+
+    Dispatch is what decides, so an mqtt lock from a bridge Lock Code
+    Manager does not recognize is offered here -- and, because the other
+    picker allowlists the mqtt PLATFORM, appears in both. That is not a
+    contradiction to resolve: the platform is supported and this particular
+    bridge is not, and the user is the one who knows whether the lock has a
+    keypad.
+
+    ``declared`` is what some configuration already declares codeless, and
+    is offered whatever dispatch now makes of it -- see
+    :func:`_declared_codeless`.
     """
     dev_reg = dr.async_get(hass)
-    ask: list[er.RegistryEntry] = []
-    unmanageable: list[er.RegistryEntry] = []
-    for lock_entry in lock_entries:
-        sibling = siblings.get(lock_entry.id)
-        if (
-            lock_entry.platform != MQTT_DOMAIN
-            and resolve_provider_class_for_entity(dev_reg, lock_entry) is None
-        ):
-            unmanageable.append(lock_entry)
-            ask.append(lock_entry)
-        elif config.is_codeless(lock_entry) or (
-            sibling is not None and sibling.codeless
-        ):
-            ask.append(lock_entry)
-    return ask, unmanageable
-
-
-class CodelessDeclarationFlow(config_entries.ConfigEntryBaseFlow):
-    """
-    The step that asks whether Lock Code Manager should hold a lock's codes.
-
-    Mixed into every flow that picks locks, because any of them can pick one
-    no provider claims, and none of them may store a lock nobody was asked
-    about.
-
-    The question is asked after a submission has otherwise been accepted,
-    and the submission is held rather than acted on. Either answer then
-    re-submits it: the answer changes what the same validation makes of the
-    same input, so confirming saves through exactly the path that would have
-    run without the detour, and declining lands back on the form with the
-    refusal that names the lock -- somewhere the lock selection can be
-    changed, rather than a dead end.
-
-    ONE member per question, and the answer applies to that member alone.
-    The set asked about mixes two populations -- a lock just added that
-    nothing claims, and a member the entry already declares -- and a single
-    Yes/No over both let an answer aimed at one silently rewrite the other:
-    declining a newly added lock stripped the declaration off an unrelated
-    member, and handed a device somebody had said must never be written to
-    back to its provider. The re-submission each answer triggers finds the
-    next unanswered member and asks again, so N members cost N questions and
-    every one of them names what it is about.
-
-    Which of the two populations a member is in decides which question it
-    gets, because declining means different things: for a lock nothing
-    claims it refuses the submission, and for a declared member something
-    now claims it hands the lock back to that provider and saves.
-
-    Asked about every lock nothing claims, not only the ones nobody has
-    answered for yet, so a declaration made earlier can be taken back. Once
-    per member per flow, because an answer suppresses that member's question
-    for the re-submission it caused.
-
-    Based on the class the config and options flows already share, so the
-    steps here are typed against the same flow surface they run on rather
-    than asserting one exists.
-    """
-
-    def __init__(self) -> None:
-        """Start with nothing asked and nothing answered."""
-        super().__init__()
-        # Answers given in THIS flow, keyed by entity registry id, laid over
-        # whatever the entry already holds. They reach storage only when the
-        # flow that collected them writes its entry.
-        self._codeless_answers: dict[str, bool] = {}
-        # The step the pending answer belongs to, and what was submitted to
-        # it.
-        self._codeless_origin: str = ""
-        self._codeless_input: dict[str, Any] = {}
-        self._codeless_lock: er.RegistryEntry | None = None
-
-    async def _async_check_codeless(
-        self,
-        origin: str,
-        user_input: dict[str, Any],
-        config: EntryConfig,
-        config_entry: ConfigEntry | None = None,
-    ) -> tuple[dict[str, Any] | None, dict[str, str], dict[str, Any]]:
-        """
-        Ask about, or refuse, the locks in a submission that nothing claims.
-
-        Returns the flow result to return when the question still has to be
-        asked, alongside the form error and placeholders for a submission
-        that cannot be saved as it stands. ``config`` is what the entry
-        already declares, which this flow's own answers override, and
-        ``config_entry`` is that entry -- left out of the sibling scan
-        because its own answer is the one being replaced.
-
-        Every selected entity is in the registry by the time this runs:
-        :func:`_check_lock_selection` refuses the whole submission over one
-        that is not, and runs first at every call site. Asserted rather than
-        skipped, the way the lock factory asserts the same thing -- a
-        declaration is keyed by registry id, so an entity that got here
-        without a row would be one this silently declined to ask about.
-        """
-        ent_reg = er.async_get(self.hass)
-        lock_entries: list[er.RegistryEntry] = []
-        for entity_id in user_input[CONF_LOCKS]:
-            lock_entry = ent_reg.async_get(entity_id)
-            assert lock_entry
-            lock_entries.append(lock_entry)
-        siblings = _sibling_declarations(self.hass, config_entry, lock_entries)
-        ask, unmanageable = _codeless_candidates(
-            self.hass, lock_entries, config, siblings
-        )
-        if pending := next(
-            (
-                lock_entry
-                for lock_entry in ask
-                if lock_entry.id not in self._codeless_answers
+    return sel.EntitySelector(
+        sel.EntitySelectorConfig(
+            domain=LOCK_DOMAIN,
+            multiple=True,
+            exclude_entities=sorted(
+                lock_entry.entity_id
+                for lock_entry in er.async_get(hass).entities.values()
+                if lock_entry.domain == LOCK_DOMAIN
+                and lock_entry.id not in declared
+                and resolve_provider_class_for_entity(dev_reg, lock_entry) is not None
             ),
-            None,
-        ):
-            self._codeless_origin = origin
-            # Copied: the step this comes back to consumes what it is given.
-            self._codeless_input = dict(user_input)
-            self._codeless_lock = pending
-            step = (
-                "codeless"
-                if any(entry.id == pending.id for entry in unmanageable)
-                else "codeless_reconsider"
-            )
-            return await getattr(self, f"async_step_{step}")(), {}, {}
-        # Checked before the refusal below, and it is the more specific of
-        # the two: a lock nothing claims that a sibling already declares IS
-        # manageable, so "there is no way to manage codes on this" would be
-        # false, and the sibling is the thing the user has to reconcile.
-        if contradicted := [
-            f"{lock_entry.entity_id} ({sibling.entry_title})"
-            for lock_entry in lock_entries
-            if (sibling := siblings.get(lock_entry.id)) is not None
-            and sibling.codeless != self._is_codeless(config, lock_entry)
-        ]:
-            return (
-                None,
-                {CONF_LOCKS: "codeless_conflict"},
-                {"locks": ", ".join(contradicted)},
-            )
-        if undeclared := [
-            lock_entry
-            for lock_entry in unmanageable
-            if not self._is_codeless(config, lock_entry)
-        ]:
-            return (
-                None,
-                {CONF_LOCKS: "codeless_declined"},
-                {"locks": ", ".join(entry.entity_id for entry in undeclared)},
-            )
-        return None, {}, {}
+        )
+    )
 
-    def _is_codeless(self, config: EntryConfig, lock_entry: er.RegistryEntry) -> bool:
-        """Return the answer that stands for a member: this flow's, else the entry's."""
-        return self._codeless_answers.get(lock_entry.id, config.is_codeless(lock_entry))
 
-    def _declared_members(
-        self, config: EntryConfig, lock_entity_ids: Iterable[str]
-    ) -> dict[str, dict[str, Any]]:
-        """
-        Return what to store about this entry's members, answers applied.
+def _selected_locks(user_input: Mapping[str, Any]) -> list[str]:
+    """Return the roster the two pickers add up to, in the order they were shown."""
+    return [*user_input[CONF_LOCKS], *user_input[CONF_CODELESS_LOCKS]]
 
-        The roster the entry is about to have is resolved here and passed
-        along, so a declaration about a member this submission drops goes
-        with it. Every entity resolves, for the same reason it does in
-        :func:`_codeless_candidates`, and is asserted rather than skipped:
-        one quietly missing from the roster would take its declaration with
-        it while its entity id stayed in ``locks``, leaving an entry that
-        cannot load and no longer remembers what it was told.
-        """
-        ent_reg = er.async_get(self.hass)
-        roster = set()
-        for entity_id in lock_entity_ids:
-            lock_entry = ent_reg.async_get(entity_id)
-            assert lock_entry
-            roster.add(lock_entry.id)
-        return declare_codeless(config.members, self._codeless_answers, roster)
 
-    async def _async_discard_reclaimed_credentials(
-        self, config: EntryConfig, lock_entity_ids: Iterable[str]
-    ) -> None:
-        """
-        Retire the store of every member this flow just handed back.
+def _registry_ids(hass: HomeAssistant, entity_ids: Iterable[str]) -> set[str]:
+    """Return the registry ids of the entities the registry knows."""
+    ent_reg = er.async_get(hass)
+    return {
+        lock_entry.id
+        for entity_id in entity_ids
+        if (lock_entry := ent_reg.async_get(entity_id)) is not None
+    }
 
-        ``codeless_reconsider`` promises in so many words that answering no
-        discards the codes Lock Code Manager was holding, and every surface
-        that asks the question keeps that promise here rather than leaving it
-        to the redeclaration teardown. That teardown runs from the update
-        listener, which is registered during setup and released on unload, so
-        it is absent for exactly the entries this question tends to be
-        answered about: a failed one being repaired through reauth, an
-        unloaded or disabled one being edited through options. Left to it,
-        the answer reached storage while a file of cleartext Personal
-        Identification Numbers stayed on disk for a lock whose own
-        integration now holds the codes -- readable by nothing, and swept by
-        nothing, because the entry no longer declares the member it would
-        have been collected under.
 
-        Asked unconditionally rather than only when that listener is known to
-        be missing. Naming a store and removing it is idempotent, and this is
-        awaited before the save that would trigger the listener, so when the
-        teardown does also run it finds the file already gone.
+def _stored_selection(hass: HomeAssistant, config: EntryConfig) -> dict[str, list[str]]:
+    """
+    Return an entry's roster split back into the two fields that express it.
 
-        Only members the submission KEEPS. A lock leaving the roster entirely
-        is a different question with a different answer, and this is not the
-        surface that answers it.
+    What every surface seeds its form from, so the picker a lock appears in
+    is the declaration the entry holds about it. A member the registry no
+    longer knows lands in the ordinary field, where ``lock_not_registered``
+    is waiting for it -- there is no id to read a declaration by, so there
+    is nothing to put it in the other one on.
+    """
+    ent_reg = er.async_get(hass)
+    selection: dict[str, list[str]] = {CONF_LOCKS: [], CONF_CODELESS_LOCKS: []}
+    for entity_id in config.locks:
+        lock_entry = ent_reg.async_get(entity_id)
+        field = (
+            CONF_CODELESS_LOCKS
+            if lock_entry is not None and config.is_codeless(lock_entry)
+            else CONF_LOCKS
+        )
+        selection[field].append(entity_id)
+    return selection
 
-        No sibling gate, unlike the sweep entry deletion performs. A
-        declaration may only be taken back when no other configuration still
-        declares the member -- ``codeless_conflict`` refuses the submission
-        otherwise, before it can be saved -- so nothing else reads this store
-        by the time an answer of no can land.
 
-        Instances are built fresh and only to name the store: nothing here
-        reaches the lock. Every entity resolves for the same reason it does
-        in :meth:`_declared_members`, and is asserted for the same reason.
-        """
-        ent_reg = er.async_get(self.hass)
-        dev_reg = dr.async_get(self.hass)
-        for entity_id in lock_entity_ids:
-            lock_entry = ent_reg.async_get(entity_id)
-            assert lock_entry
-            if not config.is_codeless(lock_entry) or self._is_codeless(
-                config, lock_entry
-            ):
-                continue
-            lock = CodelessLock(
-                self.hass,
-                dev_reg,
-                ent_reg,
-                self.hass.config_entries.async_get_entry(lock_entry.config_entry_id),
-                lock_entry,
-            )
-            await lock.async_remove_stored_credentials()
+def _check_lock_selection(
+    hass: HomeAssistant,
+    user_input: Mapping[str, Any],
+    config: EntryConfig,
+    config_entry: ConfigEntry | None = None,
+) -> tuple[dict[str, str], dict[str, Any]]:
+    """
+    Turn a lock selection that cannot be set up into the errors that name it.
 
-    def _pending_config(
-        self, config: EntryConfig, lock_entity_ids: Iterable[str]
-    ) -> EntryConfig:
-        """
-        Return the entry's configuration as this submission would leave it.
+    A backstop rather than the way the rule is taught. The two pickers are
+    disjoint by construction -- one offers the locks a provider claims, the
+    other exactly the locks nothing claims -- so a user is shown where each
+    lock belongs instead of being told afterwards. Selector filters are
+    UI-only though: a YAML import or a direct submission to the flow can
+    send anything, and every refusal below is what stands between that and
+    an entry that cannot load.
 
-        What the locks get read through. Reading the STORED declaration
-        instead made a pending answer invisible to the very validation the
-        answer triggers a re-run of: taking a declaration back checked the
-        slot numbers against the Lock Code Manager store -- no capacity, and
-        empty -- rather than against the provider the lock is about to
-        become, so a configuration far too large for the real lock saved
-        without a word.
+    Refusals that CAN render together are accumulated, and ones that cannot
+    are guarded. A dict holds one message per key, so two refusals on one
+    key means the later silently replaces the earlier and the user is
+    refused twice for a submission that was wrong in two ways from the
+    start. The three keys here -- ``base``, and one per field -- are
+    therefore filled at most once each, and their placeholders are named
+    apart so one flat mapping renders all three.
 
-        An entity the registry does not know is skipped rather than
-        asserted, unlike :meth:`_declared_members`. This runs beside the
-        lock-selection check rather than after it, so it can see a selection
-        that is about to be refused; the write path runs only once that
-        refusal has not happened, and there an entity missing here would
-        silently drop a declaration.
-        """
-        ent_reg = er.async_get(self.hass)
-        roster = {
-            lock_entry.id
-            for entity_id in lock_entity_ids
-            if (lock_entry := ent_reg.async_get(entity_id)) is not None
-        }
-        return config.with_members(
-            declare_codeless(config.members, self._codeless_answers, roster)
+    An entity with no entity registry row is refused outright, in either
+    field. It is the same predicate ``async_setup_entry`` refuses on, moved
+    to where the lock is chosen: there is no id to key a declaration or a
+    device to, so the entry cannot load with one in its roster. It is NOT
+    grandfathered the way the two unclaimed refusals are -- an entry holding
+    one is not running at all, so there is no working configuration to lock
+    somebody out of, and the reauth that setup starts is the flow that has
+    to refuse the lock for the loop to ever end.
+
+    What the entry already holds in the ordinary field IS grandfathered. An
+    entry configured before these checks existed can be carrying an
+    unclaimed lock, and every options and reauth submission re-renders that
+    entry's whole roster -- so validating all of it made one such lock
+    refuse every subsequent edit: no PIN could be changed and no reauth
+    could complete, for a lock the form was not being asked to add. That
+    lock is not silently accepted either; it is dropped at setup and says so
+    in its own repair. A member the entry declares CODELESS is deliberately
+    not grandfathered here: moving one into the ordinary field is how a
+    declaration is taken back, and taking it back for a lock nothing claims
+    leaves an entry with a member nothing can manage.
+    """
+    ent_reg = er.async_get(hass)
+    dev_reg = dr.async_get(hass)
+    errors: dict[str, str] = {}
+    placeholders: dict[str, Any] = {}
+
+    picked = list(user_input[CONF_LOCKS])
+    declared = list(user_input[CONF_CODELESS_LOCKS])
+
+    if unregistered := [
+        entity_id
+        for entity_id in (*picked, *declared)
+        if ent_reg.async_get(entity_id) is None
+    ]:
+        errors["base"] = "lock_not_registered"
+        placeholders["unregistered_locks"] = ", ".join(unregistered)
+
+    grandfathered = _stored_selection(hass, config)[CONF_LOCKS]
+    unclaimed = [
+        lock_entry
+        for entity_id in picked
+        if entity_id not in grandfathered
+        and (lock_entry := ent_reg.async_get(entity_id)) is not None
+        and resolve_provider_class_for_entity(dev_reg, lock_entry) is None
+    ]
+    # mqtt keeps its own wording: its platform IS supported and this bridge
+    # is not, which is a different thing to know than "nothing claims this".
+    # Guarded rather than accumulated because both name the same field; mqtt
+    # goes first because it is the only one of the two the picker can put
+    # there, so a user reaching this reads the message about their own lock.
+    if mqtt_unclaimed := [
+        lock_entry for lock_entry in unclaimed if lock_entry.platform == MQTT_DOMAIN
+    ]:
+        errors[CONF_LOCKS] = "unsupported_mqtt_lock"
+        placeholders["locks"] = ", ".join(
+            lock_entry.entity_id for lock_entry in mqtt_unclaimed
+        )
+    elif unclaimed:
+        errors[CONF_LOCKS] = "unclaimed_lock"
+        placeholders["locks"] = ", ".join(
+            lock_entry.entity_id for lock_entry in unclaimed
         )
 
-    def _codeless_menu(self, step_id: str) -> dict[str, Any]:
-        """Offer both answers about the one member the question is about."""
-        assert self._codeless_lock is not None
-        return self.async_show_menu(
-            step_id=step_id,
-            menu_options=["codeless_confirm", "codeless_decline"],
-            description_placeholders={"lock": self._codeless_lock.entity_id},
+    siblings = _sibling_declarations(hass, config_entry)
+    settled = _declared_codeless(hass, config, config_entry)
+    codeless_ids = _registry_ids(hass, declared)
+    # Guarded for the same reason, and ordered by how readily each is
+    # reached: a lock offered in both pickers can be selected in both, a
+    # sibling can be contradicted straight from the form, and a claimed lock
+    # gets into the codeless field only if dispatch started claiming it
+    # between the render and the submit.
+    picked_ids = set(picked)
+    if both := [entity_id for entity_id in declared if entity_id in picked_ids]:
+        errors[CONF_CODELESS_LOCKS] = "lock_in_both_fields"
+        placeholders["codeless_locks"] = ", ".join(both)
+    elif contradicted := [
+        f"{lock_entry.entity_id} ({sibling.entry_title})"
+        for entity_id in (*picked, *declared)
+        if (lock_entry := ent_reg.async_get(entity_id)) is not None
+        and (sibling := siblings.get(lock_entry.id)) is not None
+        and sibling.codeless != (lock_entry.id in codeless_ids)
+    ]:
+        errors[CONF_CODELESS_LOCKS] = "codeless_conflict"
+        placeholders["codeless_locks"] = ", ".join(contradicted)
+    elif claimed := [
+        lock_entry.entity_id
+        for entity_id in declared
+        if (lock_entry := ent_reg.async_get(entity_id)) is not None
+        and lock_entry.id not in settled
+        and resolve_provider_class_for_entity(dev_reg, lock_entry) is not None
+    ]:
+        errors[CONF_CODELESS_LOCKS] = "codeless_lock_claimed"
+        placeholders["codeless_locks"] = ", ".join(claimed)
+
+    return errors, placeholders
+
+
+def _declared_members(
+    hass: HomeAssistant, config: EntryConfig, user_input: Mapping[str, Any]
+) -> dict[str, dict[str, Any]]:
+    """
+    Return what to store about this entry's members, as the two fields say it.
+
+    The roster the entry is about to have is resolved here and passed along,
+    so a declaration about a member this submission drops goes with it.
+    Every entity resolves, because :func:`_check_lock_selection` refuses the
+    whole submission over one that does not and runs first at every call
+    site, and is asserted rather than skipped: one quietly missing from the
+    roster would take its declaration with it while its entity id stayed in
+    ``locks``, leaving an entry that cannot load and no longer remembers
+    what it was told.
+    """
+    ent_reg = er.async_get(hass)
+    roster = set()
+    for entity_id in _selected_locks(user_input):
+        lock_entry = ent_reg.async_get(entity_id)
+        assert lock_entry
+        roster.add(lock_entry.id)
+    return declare_codeless(
+        config.members, _registry_ids(hass, user_input[CONF_CODELESS_LOCKS]), roster
+    )
+
+
+async def _async_discard_reclaimed_credentials(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry | None,
+    config: EntryConfig,
+    user_input: Mapping[str, Any],
+) -> None:
+    """
+    Retire the store of every member this submission stops declaring codeless.
+
+    A member leaves the codeless field two ways -- moved to the other
+    picker, or dropped from the entry entirely -- and both mean the same
+    thing: Lock Code Manager is no longer the place that lock's credentials
+    live. Leaving the store behind leaves a file of cleartext Personal
+    Identification Numbers on disk that nothing will ever read again, and
+    nothing will ever collect either, because the entry no longer declares
+    the member it would have been collected under.
+
+    Done here rather than left to the redeclaration teardown, which runs
+    from the update listener. That listener is registered during setup and
+    released on unload, so it is absent for exactly the entries this gets
+    edited on: a failed one being repaired through reauth, an unloaded or
+    disabled one being edited through options. Asked unconditionally rather
+    than only when the listener is known to be missing -- naming a store and
+    removing it is idempotent, and this is awaited before the save that
+    would trigger the listener, so when the teardown does also run it finds
+    the file already gone.
+
+    A store another configuration still reads is kept, which is the same
+    gate entry deletion puts on its own sweep. The conflict refusal already
+    stops a lock this entry KEEPS from disagreeing with a sibling, but a
+    lock this entry DROPS is outside what any refusal looks at, and
+    discarding one a sibling still holds would delete that entry's codes.
+
+    Instances are built fresh and only to name the store: nothing here
+    reaches the lock.
+    """
+    ent_reg = er.async_get(hass)
+    dev_reg = dr.async_get(hass)
+    keeping = _registry_ids(hass, user_input[CONF_CODELESS_LOCKS])
+    siblings = _sibling_declarations(hass, config_entry)
+    for entity_id in config.locks:
+        lock_entry = ent_reg.async_get(entity_id)
+        if lock_entry is None or not config.is_codeless(lock_entry):
+            continue
+        if lock_entry.id in keeping:
+            continue
+        if (sibling := siblings.get(lock_entry.id)) is not None and sibling.codeless:
+            continue
+        lock = CodelessLock(
+            hass,
+            dev_reg,
+            ent_reg,
+            hass.config_entries.async_get_entry(lock_entry.config_entry_id),
+            lock_entry,
         )
+        await lock.async_remove_stored_credentials()
 
-    async def async_step_codeless(
-        self, user_input: dict[str, Any] | None = None
-    ) -> dict[str, Any]:
-        """Ask about a lock nothing else can manage, where "no" refuses it."""
-        return self._codeless_menu("codeless")
 
-    async def async_step_codeless_reconsider(
-        self, user_input: dict[str, Any] | None = None
-    ) -> dict[str, Any]:
-        """Ask again about a declared member, where "no" hands it to a provider."""
-        return self._codeless_menu("codeless_reconsider")
+def _pending_config(
+    hass: HomeAssistant, config: EntryConfig, user_input: Mapping[str, Any]
+) -> EntryConfig:
+    """
+    Return the entry's configuration as this submission would leave it.
 
-    async def async_step_codeless_confirm(
-        self, user_input: dict[str, Any] | None = None
-    ) -> dict[str, Any]:
-        """Record that Lock Code Manager holds this lock's credentials."""
-        return await self._async_answer_codeless(True)
+    What the locks get read through. Reading the STORED declaration instead
+    made a pending change invisible to the very validation the change
+    triggers: moving a member out of the codeless field checked the slot
+    numbers against the Lock Code Manager store -- no capacity, and empty --
+    rather than against the provider the lock is about to become, so a
+    configuration far too large for the real lock saved without a word.
 
-    async def async_step_codeless_decline(
-        self, user_input: dict[str, Any] | None = None
-    ) -> dict[str, Any]:
-        """Record that it does not, which is also how a declaration is undone."""
-        return await self._async_answer_codeless(False)
-
-    async def _async_answer_codeless(self, codeless: bool) -> dict[str, Any]:
-        """Record the answer about the member the step named, and re-submit."""
-        assert self._codeless_lock is not None
-        self._codeless_answers[self._codeless_lock.id] = codeless
-        # Resolved by name, the way the flow manager resolves every step.
-        return await getattr(self, f"async_step_{self._codeless_origin}")(
-            dict(self._codeless_input)
+    An entity the registry does not know is skipped rather than asserted,
+    unlike :func:`_declared_members`. This runs beside the lock-selection
+    check rather than after it, so it can see a selection that is about to
+    be refused; the write path runs only once that refusal has not happened,
+    and there an entity missing here would silently drop a declaration.
+    """
+    return config.with_members(
+        declare_codeless(
+            config.members,
+            _registry_ids(hass, user_input[CONF_CODELESS_LOCKS]),
+            _registry_ids(hass, _selected_locks(user_input)),
         )
+    )
 
 
 def _check_common_slots(
@@ -734,9 +665,7 @@ async def _allocate_for(
     return unavailable, {}, {}
 
 
-class LockCodeManagerFlowHandler(
-    CodelessDeclarationFlow, config_entries.ConfigFlow, domain=DOMAIN
-):
+class LockCodeManagerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Config flow for Lock Code Manager."""
 
     VERSION = 4
@@ -753,6 +682,14 @@ class LockCodeManagerFlowHandler(
         # The numbers allocation must avoid, settled when the user said how
         # many users they wanted.
         self._unavailable: frozenset[int] = frozenset()
+        # The two pickers as they were submitted, kept because the steps
+        # after this one still have to know which field each lock came from:
+        # the entry stores one merged roster, and which picker a lock was in
+        # is the whole of what it declares about that lock.
+        self._selection: dict[str, list[str]] = {
+            CONF_LOCKS: [],
+            CONF_CODELESS_LOCKS: [],
+        }
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -770,27 +707,17 @@ class LockCodeManagerFlowHandler(
             # refusal re-renders this form from what was submitted, and the
             # name has to still be in there when it does.
             errors, description_placeholders = _check_lock_selection(
-                self.hass, user_input[CONF_LOCKS]
+                self.hass, user_input, EntryConfig.empty()
             )
-            if not errors:
-                # A new entry declares nothing yet, so every lock nothing
-                # claims is one this step has to ask about. Asked before the
-                # name is consumed, because a refusal re-renders this form
-                # from what was submitted.
-                (
-                    ask,
-                    errors,
-                    description_placeholders,
-                ) = await self._async_check_codeless(
-                    "user", user_input, EntryConfig.empty()
-                )
-                if ask is not None:
-                    return ask
             if not errors:
                 self.title = user_input.pop(CONF_NAME)
                 await self.async_set_unique_id(slugify(self.title))
                 self._abort_if_unique_id_configured()
-                self.data = user_input
+                self._selection = {
+                    CONF_LOCKS: list(user_input[CONF_LOCKS]),
+                    CONF_CODELESS_LOCKS: list(user_input[CONF_CODELESS_LOCKS]),
+                }
+                self.data = {CONF_LOCKS: _selected_locks(user_input)}
                 return await self.async_step_choose_path()
 
         return self.async_show_form(
@@ -799,7 +726,13 @@ class LockCodeManagerFlowHandler(
                 vol.Schema(
                     {
                         vol.Required(CONF_NAME): cv.string,
-                        vol.Required(CONF_LOCKS): LOCK_ENTITY_SELECTOR,
+                        vol.Required(CONF_LOCKS, default=list): LOCK_ENTITY_SELECTOR,
+                        vol.Required(
+                            CONF_CODELESS_LOCKS, default=list
+                        ): _codeless_lock_selector(
+                            self.hass,
+                            _declared_codeless(self.hass, EntryConfig.empty(), None),
+                        ),
                     }
                 ),
                 user_input,
@@ -837,7 +770,7 @@ class LockCodeManagerFlowHandler(
                 None,
                 self.data[CONF_LOCKS],
                 num_users,
-                self._pending_config(EntryConfig.empty(), self.data[CONF_LOCKS]),
+                _pending_config(self.hass, EntryConfig.empty(), self._selection),
             )
             if unavailable is not None:
                 self._users_to_configure = num_users
@@ -943,8 +876,8 @@ class LockCodeManagerFlowHandler(
         written empty: an entry that was never asked anything should not
         read as one that answered nothing.
         """
-        if members := self._declared_members(
-            EntryConfig.empty(), self.data[CONF_LOCKS]
+        if members := _declared_members(
+            self.hass, EntryConfig.empty(), self._selection
         ):
             self.data[CONF_MEMBERS] = members
         return self.async_create_entry(title=self.title, data=self.data)
@@ -965,7 +898,7 @@ class LockCodeManagerFlowHandler(
                 None,
                 user_input[CONF_USERS],
                 self.data[CONF_LOCKS],
-                self._pending_config(EntryConfig.empty(), self.data[CONF_LOCKS]),
+                _pending_config(self.hass, EntryConfig.empty(), self._selection),
             )
             errors.update(validation_errors)
             description_placeholders.update(validation_placeholders)
@@ -986,7 +919,7 @@ class LockCodeManagerFlowHandler(
                     None,
                     self.data[CONF_LOCKS],
                     len(users),
-                    self._pending_config(EntryConfig.empty(), self.data[CONF_LOCKS]),
+                    _pending_config(self.hass, EntryConfig.empty(), self._selection),
                 )
                 if unavailable is None:
                     return self.async_show_form(
@@ -1050,58 +983,50 @@ class LockCodeManagerFlowHandler(
             "lock": self.context["lock_entity_id"],
         }
 
+        entry_config = get_entry_config(config_entry)
         if user_input is None:
             # Either the frontend re-invoking the step to render the form, or
-            # the initial call carrying the entry's data. Seed the lock
-            # selector from the entry's current config either way.
-            user_input = {CONF_LOCKS: list(get_entry_config(config_entry).locks)}
+            # the initial call carrying the entry's data. Seed both pickers
+            # from the entry's current config either way, so each lock comes
+            # back in the field that expresses what the entry declares about
+            # it.
+            user_input = _stored_selection(self.hass, entry_config)
         else:
-            entry_config = get_entry_config(config_entry)
             existing_slots = entry_config.slot_numbers
+            selected = _selected_locks(user_input)
             additional_errors, additional_placeholders = _check_lock_selection(
-                self.hass, user_input[CONF_LOCKS], entry_config.locks
+                self.hass, user_input, entry_config, config_entry
             )
             if not additional_errors:
                 additional_errors, additional_placeholders = _check_common_slots(
                     self.hass,
-                    user_input[CONF_LOCKS],
+                    selected,
                     existing_slots,
                     config_entry,
                 )
             if not additional_errors:
                 # Reauth is where a lock gets swapped, so it is also where an
-                # already-valid slot set can become too large for the new lock.
+                # already-valid slot set can become too large for the new
+                # lock -- including a member moved out of the codeless field,
+                # which is sized against the provider it is about to become
+                # rather than the empty Lock Code Manager store it is
+                # leaving.
                 try:
                     await async_check_slot_capacity(
                         self.hass,
                         config_entry,
-                        user_input[CONF_LOCKS],
+                        selected,
                         existing_slots,
-                        self._pending_config(entry_config, user_input[CONF_LOCKS]),
+                        _pending_config(self.hass, entry_config, user_input),
                     )
                 except SlotAllocationError as err:
                     additional_errors = {"base": err.translation_key}
                     additional_placeholders = err.placeholders
-            if not additional_errors:
-                # Reauth renders the same picker as the other two flows, so
-                # it is a third way to put a lock nothing claims into the
-                # entry, and needs the same question. Left out, a user
-                # repairing one broken lock could swap in a codeless one and
-                # land straight back in reauth.
-                (
-                    ask,
-                    additional_errors,
-                    additional_placeholders,
-                ) = await self._async_check_codeless(
-                    "reauth_confirm", user_input, entry_config, config_entry
-                )
-                if ask is not None:
-                    return ask
             errors.update(additional_errors)
             description_placeholders.update(additional_placeholders)
             if not errors:
-                await self._async_discard_reclaimed_credentials(
-                    entry_config, user_input[CONF_LOCKS]
+                await _async_discard_reclaimed_credentials(
+                    self.hass, config_entry, entry_config, user_input
                 )
                 # Consume any options-flow save that sat unprocessed while
                 # the entry was failed (no update listener registered in
@@ -1116,9 +1041,9 @@ class LockCodeManagerFlowHandler(
                     config_entry,
                     data={
                         **entry_config.to_dict(),
-                        **user_input,
-                        CONF_MEMBERS: self._declared_members(
-                            entry_config, user_input[CONF_LOCKS]
+                        CONF_LOCKS: selected,
+                        CONF_MEMBERS: _declared_members(
+                            self.hass, entry_config, user_input
                         ),
                     },
                     options={},
@@ -1135,7 +1060,14 @@ class LockCodeManagerFlowHandler(
                 {
                     vol.Required(
                         CONF_LOCKS, default=user_input[CONF_LOCKS]
-                    ): LOCK_ENTITY_SELECTOR
+                    ): LOCK_ENTITY_SELECTOR,
+                    vol.Required(
+                        CONF_CODELESS_LOCKS,
+                        default=user_input[CONF_CODELESS_LOCKS],
+                    ): _codeless_lock_selector(
+                        self.hass,
+                        _declared_codeless(self.hass, entry_config, config_entry),
+                    ),
                 }
             ),
             errors=errors,
@@ -1150,7 +1082,7 @@ class LockCodeManagerFlowHandler(
         return LockCodeManagerOptionsFlow()
 
 
-class LockCodeManagerOptionsFlow(CodelessDeclarationFlow, config_entries.OptionsFlow):
+class LockCodeManagerOptionsFlow(config_entries.OptionsFlow):
     """Options flow for Lock Code Manager."""
 
     async def async_step_init(
@@ -1162,25 +1094,25 @@ class LockCodeManagerOptionsFlow(CodelessDeclarationFlow, config_entries.Options
         if not user_input:
             user_input = {}
 
+        stored = get_entry_config(self.config_entry)
         if user_input:
-            stored = get_entry_config(self.config_entry)
+            selected = _selected_locks(user_input)
             # Accumulated alongside the users validation rather than
-            # short-circuiting it, which the two lock-picking steps do. The
-            # rule is the same in all three: accumulate what can render
-            # together, guard what cannot. These two can, because they are
-            # keyed to different fields; the allocation refusals below share
-            # ``base`` with this one and the codeless question is a menu
-            # rather than an error, so both are guarded instead.
+            # short-circuiting it. The rule is the same everywhere here:
+            # accumulate what can render together, guard what cannot. These
+            # two can, because they are keyed to different fields; the
+            # allocation refusals below share ``base`` with the registry
+            # refusal, so they are guarded instead.
             lock_errors, lock_placeholders = _check_lock_selection(
-                self.hass, user_input[CONF_LOCKS], stored.locks
+                self.hass, user_input, stored, self.config_entry
             )
             errors.update(lock_errors)
             description_placeholders.update(lock_placeholders)
 
             # Everything that reads a lock reads it as this submission would
-            # leave it, answers included -- so taking a declaration back is
-            # validated against the provider the lock becomes.
-            pending = self._pending_config(stored, user_input[CONF_LOCKS])
+            # leave it, declarations included -- so a member moved out of the
+            # codeless field is validated against the provider it becomes.
+            pending = _pending_config(self.hass, stored, user_input)
             (
                 users,
                 validation_errors,
@@ -1189,7 +1121,7 @@ class LockCodeManagerOptionsFlow(CodelessDeclarationFlow, config_entries.Options
                 self.hass,
                 self.config_entry,
                 user_input[CONF_USERS],
-                user_input[CONF_LOCKS],
+                selected,
                 pending,
             )
             errors.update(validation_errors)
@@ -1204,7 +1136,7 @@ class LockCodeManagerOptionsFlow(CodelessDeclarationFlow, config_entries.Options
                 ) = await _allocate_for(
                     self.hass,
                     self.config_entry,
-                    user_input[CONF_LOCKS],
+                    selected,
                     len(users),
                     pending,
                 )
@@ -1212,53 +1144,35 @@ class LockCodeManagerOptionsFlow(CodelessDeclarationFlow, config_entries.Options
                     errors.update(allocation_errors)
                     description_placeholders.update(allocation_placeholders)
                 else:
-                    # Asked here, where the submission is otherwise ready to
-                    # save, so nobody is asked to declare something about a
-                    # submission that was never going to be stored.
-                    (
-                        ask,
-                        codeless_errors,
-                        codeless_placeholders,
-                    ) = await self._async_check_codeless(
-                        "init", user_input, stored, self.config_entry
+                    # Reconciled against what the entry already holds, so a
+                    # user who was here before keeps their number and only
+                    # newcomers are issued one. Moving somebody would rewrite
+                    # their credential on every lock.
+                    assignment = stored.assignment.reconcile(
+                        users, start=1, unavailable=unavailable
                     )
-                    if ask is not None:
-                        return ask
-                    errors.update(codeless_errors)
-                    description_placeholders.update(codeless_placeholders)
-                    if not errors:
-                        # Reconciled against what the entry already holds, so a
-                        # user who was here before keeps their number and only
-                        # newcomers are issued one. Moving somebody would rewrite
-                        # their credential on every lock.
-                        assignment = stored.assignment.reconcile(
-                            users, start=1, unavailable=unavailable
-                        )
-                        await self._async_discard_reclaimed_credentials(
-                            stored, user_input[CONF_LOCKS]
-                        )
-                        # Written through EntryConfig so whatever else the entry
-                        # carries survives the edit. Building the dict by hand
-                        # drops every key this form does not ask about.
-                        return self.async_create_entry(
-                            title="",
-                            data=EntryConfig(
-                                locks=tuple(user_input[CONF_LOCKS]),
-                                members=self._declared_members(
-                                    stored, user_input[CONF_LOCKS]
-                                ),
-                                users=users,
-                                assignment=assignment,
-                                extra=stored.extra,
-                            ).to_dict(),
-                        )
+                    await _async_discard_reclaimed_credentials(
+                        self.hass, self.config_entry, stored, user_input
+                    )
+                    # Written through EntryConfig so whatever else the entry
+                    # carries survives the edit. Building the dict by hand
+                    # drops every key this form does not ask about.
+                    return self.async_create_entry(
+                        title="",
+                        data=EntryConfig(
+                            locks=tuple(selected),
+                            members=_declared_members(self.hass, stored, user_input),
+                            users=users,
+                            assignment=assignment,
+                            extra=stored.extra,
+                        ).to_dict(),
+                    )
 
-        config = get_entry_config(self.config_entry)
         # Plain dict/list, because the form selectors cannot serialize the
         # deeply read-only mappings EntryConfig uses internally.
         defaults = {
-            CONF_LOCKS: list(config.locks),
-            CONF_USERS: {name: dict(user) for name, user in config.users.items()},
+            **_stored_selection(self.hass, stored),
+            CONF_USERS: {name: dict(user) for name, user in stored.users.items()},
         }
 
         return self.async_show_form(
@@ -1269,6 +1183,15 @@ class LockCodeManagerOptionsFlow(CodelessDeclarationFlow, config_entries.Options
                         CONF_LOCKS,
                         default=user_input.get(CONF_LOCKS, defaults[CONF_LOCKS]),
                     ): LOCK_ENTITY_SELECTOR,
+                    vol.Required(
+                        CONF_CODELESS_LOCKS,
+                        default=user_input.get(
+                            CONF_CODELESS_LOCKS, defaults[CONF_CODELESS_LOCKS]
+                        ),
+                    ): _codeless_lock_selector(
+                        self.hass,
+                        _declared_codeless(self.hass, stored, self.config_entry),
+                    ),
                     vol.Required(
                         CONF_USERS,
                         default=user_input.get(CONF_USERS, defaults[CONF_USERS]),

--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -42,6 +42,7 @@ from .domain.names import name_error, normalize_name, validate_user_names
 from .domain.queries import get_entry_config
 from .domain.slot_assignment import CONF_SLOT_ASSIGNMENT, SlotAssignment
 from .providers import resolve_provider_class_for_entity
+from .providers.codeless import CodelessLock
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -460,6 +461,55 @@ class CodelessDeclarationFlow(config_entries.ConfigEntryBaseFlow):
             roster.add(lock_entry.id)
         return declare_codeless(config.members, self._codeless_answers, roster)
 
+    async def _async_discard_reclaimed_credentials(
+        self, config: EntryConfig, lock_entity_ids: Iterable[str]
+    ) -> None:
+        """
+        Retire the store of every member this flow just handed back.
+
+        ``codeless_reconsider`` promises in so many words that answering no
+        discards the codes Lock Code Manager was holding. On the options path
+        that promise is kept by the update listener, which sees the member
+        resolve to a different class and tears the old instance down
+        permanently. A save that does not go through that listener has to
+        keep the promise itself, or the answer leaves a file of cleartext
+        Personal Identification Numbers behind for a lock whose own
+        integration now holds the codes -- readable by nothing, and swept by
+        nothing, because the entry no longer declares the member it would
+        have been collected under.
+
+        Only members the submission KEEPS. A lock leaving the roster entirely
+        is a different question with a different answer, and this is not the
+        surface that answers it.
+
+        No sibling gate, unlike the sweep entry deletion performs. A
+        declaration may only be taken back when no other configuration still
+        declares the member -- ``codeless_conflict`` refuses the submission
+        otherwise, before it can be saved -- so nothing else reads this store
+        by the time an answer of no can land.
+
+        Instances are built fresh and only to name the store: nothing here
+        reaches the lock. Every entity resolves for the same reason it does
+        in :meth:`_declared_members`, and is asserted for the same reason.
+        """
+        ent_reg = er.async_get(self.hass)
+        dev_reg = dr.async_get(self.hass)
+        for entity_id in lock_entity_ids:
+            lock_entry = ent_reg.async_get(entity_id)
+            assert lock_entry
+            if not config.is_codeless(lock_entry) or self._is_codeless(
+                config, lock_entry
+            ):
+                continue
+            lock = CodelessLock(
+                self.hass,
+                dev_reg,
+                ent_reg,
+                self.hass.config_entries.async_get_entry(lock_entry.config_entry_id),
+                lock_entry,
+            )
+            await lock.async_remove_stored_credentials()
+
     def _pending_config(
         self, config: EntryConfig, lock_entity_ids: Iterable[str]
     ) -> EntryConfig:
@@ -588,21 +638,28 @@ async def _async_validate_users_yaml(
 
     Returns the parsed users -- or ``None`` when validation failed -- with the
     accumulated errors and description placeholders.
+
+    Every refusal is keyed to the users field rather than to ``base``, so it
+    renders beside the block it is about and, more to the point, alongside
+    whatever the lock list was refused for. A dict holds one message per key:
+    sharing ``base`` with ``_check_lock_selection`` meant the later of the two
+    silently replaced the earlier, and the user was refused twice for a
+    submission that was wrong in two ways from the start.
     """
     # A block still keyed by slot number coerces cleanly into users named
     # "1", "2", which is a silently wrong reading of what was pasted.
     if raw_users and all(isinstance(key, int) for key in raw_users):
-        return None, {"base": "users_keyed_by_slot"}, {}
+        return None, {CONF_USERS: "users_keyed_by_slot"}, {}
 
     try:
         parsed_users = USERS_SCHEMA(raw_users)
     except vol.Invalid as err:
         _LOGGER.error("Invalid users: %s", err)
-        return None, {"base": "invalid_config"}, {}
+        return None, {CONF_USERS: "invalid_config"}, {}
 
     if problem := validate_user_names(parsed_users):
         name, error = problem
-        return None, {"base": error}, {"name": name}
+        return None, {CONF_USERS: error}, {"name": name}
 
     # The same refusal the guided path gives. Both write the one field, so a
     # condition entity this integration cannot read must fail on both routes
@@ -615,7 +672,7 @@ async def _async_validate_users_yaml(
         if entity_entry and entity_entry.platform in EXCLUDED_CONDITION_PLATFORMS:
             return (
                 None,
-                {"base": "excluded_platform"},
+                {CONF_USERS: "excluded_platform"},
                 {
                     "name": name,
                     "integration": entity_entry.platform,
@@ -634,7 +691,7 @@ async def _async_validate_users_yaml(
     except SlotAllocationError as err:
         return (
             None,
-            {"base": "too_many_users"},
+            {CONF_USERS: "too_many_users"},
             {**err.placeholders, "num_users": str(len(parsed_users))},
         )
     return parsed_users, {}, {}
@@ -1035,6 +1092,13 @@ class LockCodeManagerFlowHandler(
             errors.update(additional_errors)
             description_placeholders.update(additional_placeholders)
             if not errors:
+                # Discarded here rather than by the redeclaration teardown:
+                # this save writes the entry and reloads it, and the entry it
+                # is repairing is failed, so no instance is being held for
+                # that teardown to find and collect.
+                await self._async_discard_reclaimed_credentials(
+                    entry_config, user_input[CONF_LOCKS]
+                )
                 # Consume any options-flow save that sat unprocessed while
                 # the entry was failed (no update listener registered in
                 # that state) and clear it: the data→options migration
@@ -1097,8 +1161,12 @@ class LockCodeManagerOptionsFlow(CodelessDeclarationFlow, config_entries.Options
         if user_input:
             stored = get_entry_config(self.config_entry)
             # Accumulated alongside the users validation rather than
-            # short-circuiting it: both refusals render together, so one round
-            # trip shows everything wrong with the submission.
+            # short-circuiting it, which the two lock-picking steps do. The
+            # rule is the same in all three: accumulate what can render
+            # together, guard what cannot. These two can, because they are
+            # keyed to different fields; the allocation refusals below share
+            # ``base`` with this one and the codeless question is a menu
+            # rather than an error, so both are guarded instead.
             lock_errors, lock_placeholders = _check_lock_selection(
                 self.hass, user_input[CONF_LOCKS], stored.locks
             )

--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -106,21 +106,34 @@ SLOTS_YAML_SELECTOR = sel.ObjectSelector(sel.ObjectSelectorConfig())
 POSITIVE_INT = vol.All(vol.Coerce(int), vol.Range(min=1))
 
 
-def _check_unclaimed_mqtt_locks(
+def _check_lock_selection(
     hass: HomeAssistant,
     lock_entity_ids: Iterable[str],
     already_configured: Container[str] = (),
 ) -> tuple[dict[str, str], dict[str, Any]]:
     """
-    Turn any newly selected unclaimed mqtt lock into the form error that names it.
+    Turn a lock that cannot be set up into the form error that names it.
 
-    The entity selector filter can only express integration+domain, so
-    per-device dispatch has to be enforced here at submit time -- otherwise
-    an unclaimed mqtt lock is accepted and only refused at setup.
+    The picker offers every ``lock`` entity on purpose -- a lock no provider
+    claims may still be one Lock Code Manager can manage by holding its
+    codes -- so everything the selector cannot express is enforced here, at
+    submit time, rather than by narrowing it back down.
 
-    ``already_configured`` is what the entry holds now, and locks in it are
-    waved through. An entry configured before this check existed can be
-    carrying an unclaimed lock, and every options and reauth submission
+    An entity with no registry row goes first, and is refused outright. It is
+    the same predicate ``async_setup_entry`` refuses on, moved to where the
+    lock is chosen: there is no id to key a declaration or a device to, so
+    the entry cannot load with one in its roster. Accepting it made the
+    guided path fail three steps later with ``occupancy_unknown``, which
+    tells the user to go wake a lock that was never going to answer.
+
+    It is NOT grandfathered the way the mqtt refusal below is: an entry
+    holding one is not running at all, so there is no working configuration
+    to lock somebody out of, and the reauth that setup starts is the flow
+    that has to refuse the lock for the loop to ever end.
+
+    ``already_configured`` is what the entry holds now, and unclaimed mqtt
+    locks in it are waved through. An entry configured before that check
+    existed can be carrying one, and every options and reauth submission
     re-renders that entry's whole lock list -- so validating all of it made
     one grandfathered lock refuse every subsequent edit: no PIN could be
     changed and no reauth could complete, for a lock the form was not being
@@ -129,6 +142,12 @@ def _check_unclaimed_mqtt_locks(
     """
     ent_reg = er.async_get(hass)
     dev_reg = dr.async_get(hass)
+    if unregistered := [
+        entity_id
+        for entity_id in lock_entity_ids
+        if ent_reg.async_get(entity_id) is None
+    ]:
+        return {CONF_LOCKS: "lock_not_registered"}, {"locks": ", ".join(unregistered)}
     unclaimed = [
         entity_id
         for entity_id in lock_entity_ids
@@ -143,38 +162,59 @@ def _check_unclaimed_mqtt_locks(
 
 
 def _codeless_candidates(
-    hass: HomeAssistant, lock_entity_ids: Iterable[str]
-) -> list[er.RegistryEntry]:
+    hass: HomeAssistant, lock_entity_ids: Iterable[str], config: EntryConfig
+) -> tuple[list[er.RegistryEntry], list[er.RegistryEntry]]:
     """
-    Return the selected locks that only a declaration can account for.
+    Return the selected locks to ask about, and those nothing else can manage.
 
     A lock no provider claims is not necessarily a lock this integration
     cannot manage: if it keeps no codes of its own, Lock Code Manager can
     hold them itself and treat the entity as the thing being locked. Which
     of the two it is, is not derivable from anything here -- so these are
-    the locks the user is asked about.
+    the locks the user is asked about, and, unless the answer is yes, the
+    ones the submission is refused over.
 
-    mqtt is left out, and keeps the refusal it already has. Its dispatch is
-    per DEVICE, so an unclaimed one means "this bridge is not one of the two
-    Lock Code Manager speaks" -- a gap that may close in a later version,
-    not a statement that the lock has no code storage. Offering the
-    declaration there answers a question nobody asked, and taking it would
-    strand that lock's credentials in a Lock Code Manager store on the day
-    its bridge became supported.
+    Every member the entry ALREADY declares codeless is asked about too,
+    whatever platform dispatch now makes of it. The declaration wins over a
+    provider, deliberately and permanently
+    (``domain.locks.resolve_member_provider_class``), so a member whose
+    platform gained a provider after it was declared would otherwise keep
+    resolving to the Lock Code Manager store with no form that so much as
+    mentions it. It is asked about but never refused over: something does
+    claim it now, so declining hands it to that provider rather than
+    leaving a lock nothing can manage.
 
-    An entity missing from the registry is left out too: a declaration is
-    keyed by registry id, so there is nothing to key one by, and setup
-    refuses that lock on its own.
+    mqtt is never asked about on dispatch alone, and keeps the refusal it
+    already has. Its dispatch is per DEVICE, so an unclaimed one means "this
+    bridge is not one of the two Lock Code Manager speaks" -- a gap that may
+    close in a later version, not a statement that the lock has no code
+    storage. Offering the declaration there answers a question nobody asked,
+    and taking it would strand that lock's credentials in a Lock Code
+    Manager store on the day its bridge became supported.
+
+    Every selected entity is in the registry by the time this runs:
+    :func:`_check_lock_selection` refuses the whole submission over one that
+    is not, and runs first at every call site. Asserted rather than skipped,
+    the way the lock factory asserts the same thing -- a declaration is keyed
+    by registry id, so an entity that got here without a row would be one
+    this function silently declined to ask about.
     """
     ent_reg = er.async_get(hass)
     dev_reg = dr.async_get(hass)
-    return [
-        lock_entry
-        for entity_id in lock_entity_ids
-        if (lock_entry := ent_reg.async_get(entity_id)) is not None
-        and lock_entry.platform != MQTT_DOMAIN
-        and resolve_provider_class_for_entity(dev_reg, lock_entry) is None
-    ]
+    ask: list[er.RegistryEntry] = []
+    unmanageable: list[er.RegistryEntry] = []
+    for entity_id in lock_entity_ids:
+        lock_entry = ent_reg.async_get(entity_id)
+        assert lock_entry
+        if (
+            lock_entry.platform != MQTT_DOMAIN
+            and resolve_provider_class_for_entity(dev_reg, lock_entry) is None
+        ):
+            unmanageable.append(lock_entry)
+            ask.append(lock_entry)
+        elif config.is_codeless(lock_entry):
+            ask.append(lock_entry)
+    return ask, unmanageable
 
 
 class CodelessDeclarationFlow(config_entries.ConfigEntryBaseFlow):
@@ -227,10 +267,12 @@ class CodelessDeclarationFlow(config_entries.ConfigEntryBaseFlow):
         that cannot be saved as it stands. ``config`` is what the entry
         already declares, which this flow's own answers override.
         """
-        candidates = _codeless_candidates(self.hass, user_input[CONF_LOCKS])
+        ask, unmanageable = _codeless_candidates(
+            self.hass, user_input[CONF_LOCKS], config
+        )
         if unanswered := [
             lock_entry
-            for lock_entry in candidates
+            for lock_entry in ask
             if lock_entry.id not in self._codeless_answers
         ]:
             self._codeless_origin = origin
@@ -240,7 +282,7 @@ class CodelessDeclarationFlow(config_entries.ConfigEntryBaseFlow):
             return await self.async_step_codeless(), {}, {}
         if undeclared := [
             lock_entry
-            for lock_entry in candidates
+            for lock_entry in unmanageable
             if not self._is_codeless(config, lock_entry)
         ]:
             return (
@@ -254,9 +296,27 @@ class CodelessDeclarationFlow(config_entries.ConfigEntryBaseFlow):
         """Return the answer that stands for a member: this flow's, else the entry's."""
         return self._codeless_answers.get(lock_entry.id, config.is_codeless(lock_entry))
 
-    def _declared_members(self, config: EntryConfig) -> dict[str, dict[str, Any]]:
-        """Return what to store about this entry's members, answers applied."""
-        return declare_codeless(config.members, self._codeless_answers)
+    def _declared_members(
+        self, config: EntryConfig, lock_entity_ids: Iterable[str]
+    ) -> dict[str, dict[str, Any]]:
+        """
+        Return what to store about this entry's members, answers applied.
+
+        The roster the entry is about to have is resolved here and passed
+        along, so a declaration about a member this submission drops goes
+        with it. Every entity resolves, for the same reason it does in
+        :func:`_codeless_candidates`, and is asserted rather than skipped:
+        one quietly missing from the roster would take its declaration with
+        it while its entity id stayed in ``locks``, leaving an entry that
+        cannot load and no longer remembers what it was told.
+        """
+        ent_reg = er.async_get(self.hass)
+        roster = set()
+        for entity_id in lock_entity_ids:
+            lock_entry = ent_reg.async_get(entity_id)
+            assert lock_entry
+            roster.add(lock_entry.id)
+        return declare_codeless(config.members, self._codeless_answers, roster)
 
     async def async_step_codeless(
         self, user_input: dict[str, Any] | None = None
@@ -452,7 +512,7 @@ class LockCodeManagerFlowHandler(
             # Checked before the step consumes anything from user_input: a
             # refusal re-renders this form from what was submitted, and the
             # name has to still be in there when it does.
-            errors, description_placeholders = _check_unclaimed_mqtt_locks(
+            errors, description_placeholders = _check_lock_selection(
                 self.hass, user_input[CONF_LOCKS]
             )
             if not errors:
@@ -620,7 +680,9 @@ class LockCodeManagerFlowHandler(
         written empty: an entry that was never asked anything should not
         read as one that answered nothing.
         """
-        if members := self._declared_members(EntryConfig.empty()):
+        if members := self._declared_members(
+            EntryConfig.empty(), self.data[CONF_LOCKS]
+        ):
             self.data[CONF_MEMBERS] = members
         return self.async_create_entry(title=self.title, data=self.data)
 
@@ -725,7 +787,7 @@ class LockCodeManagerFlowHandler(
         else:
             entry_config = get_entry_config(config_entry)
             existing_slots = entry_config.slot_numbers
-            additional_errors, additional_placeholders = _check_unclaimed_mqtt_locks(
+            additional_errors, additional_placeholders = _check_lock_selection(
                 self.hass, user_input[CONF_LOCKS], entry_config.locks
             )
             if not additional_errors:
@@ -777,7 +839,9 @@ class LockCodeManagerFlowHandler(
                     data={
                         **entry_config.to_dict(),
                         **user_input,
-                        CONF_MEMBERS: self._declared_members(entry_config),
+                        CONF_MEMBERS: self._declared_members(
+                            entry_config, user_input[CONF_LOCKS]
+                        ),
                     },
                     options={},
                 )
@@ -824,7 +888,7 @@ class LockCodeManagerOptionsFlow(CodelessDeclarationFlow, config_entries.Options
             # Accumulated alongside the users validation rather than
             # short-circuiting it: both refusals render together, so one round
             # trip shows everything wrong with the submission.
-            lock_errors, lock_placeholders = _check_unclaimed_mqtt_locks(
+            lock_errors, lock_placeholders = _check_lock_selection(
                 self.hass,
                 user_input[CONF_LOCKS],
                 get_entry_config(self.config_entry).locks,
@@ -889,7 +953,9 @@ class LockCodeManagerOptionsFlow(CodelessDeclarationFlow, config_entries.Options
                             title="",
                             data=EntryConfig(
                                 locks=tuple(user_input[CONF_LOCKS]),
-                                members=self._declared_members(config),
+                                members=self._declared_members(
+                                    config, user_input[CONF_LOCKS]
+                                ),
                                 users=users,
                                 assignment=assignment,
                                 extra=config.extra,

--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Container, Iterable, Mapping, Sequence
 import logging
-from typing import Any
+from typing import Any, NamedTuple
 
 import voluptuous as vol
 
@@ -172,8 +172,74 @@ def _check_lock_selection(
     return errors, placeholders
 
 
+class _SiblingAnswer(NamedTuple):
+    """What another entry that manages a member already says about it."""
+
+    codeless: bool
+    entry_title: str
+
+
+def _sibling_declarations(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry | None,
+    lock_entries: Iterable[er.RegistryEntry],
+) -> dict[str, _SiblingAnswer]:
+    """
+    Return what another entry already says about each of these members.
+
+    Whether a lock has credential storage is a fact about the DEVICE, not
+    about a configuration: an ESPHome lock with no keypad has none no matter
+    how many entries manage it. Two entries answering differently is
+    therefore not a configuration but a contradiction, and one with teeth --
+    the two answers resolve to two providers over one entity, so a Personal
+    Identification Number lands in whichever store the caller happened to
+    reach. Every surface that records an answer consults this and refuses to
+    add a second opinion.
+
+    Keyed by ``er.RegistryEntry.id``, the same handle the declarations
+    themselves are keyed by, so "the same lock" is an exact key match rather
+    than anything inferred from an entity id that a rename can move. The
+    value carries the entry's title alongside its answer, because a refusal
+    that does not name the other configuration leaves the user with nowhere
+    to go.
+
+    Only entries that HOLD the member answer for it. A declaration left
+    behind by an entry that no longer lists the lock is not an opinion about
+    anything -- nothing resolves it -- and reading one would refuse an
+    answer no live provider contradicts.
+
+    ``config_entry`` is the entry being edited, left out because its own
+    stored answer is the one being replaced. A flow that is still creating
+    its entry passes ``None`` and excludes nothing.
+
+    Every entry is consulted, disabled ones included. A disabled entry holds
+    its configuration and resolves it again the moment it is re-enabled, so
+    an answer that contradicts it is a contradiction deferred rather than
+    avoided.
+
+    The first holder found answers for a member. Siblings cannot disagree
+    with each other -- this is what stops them -- so which one is arbitrary
+    only in the sense that they all say the same thing.
+    """
+    declarations: dict[str, _SiblingAnswer] = {}
+    for entry in hass.config_entries.async_entries(DOMAIN):
+        if config_entry is not None and entry.entry_id == config_entry.entry_id:
+            continue
+        sibling = get_entry_config(entry)
+        for lock_entry in lock_entries:
+            if sibling.has_lock(lock_entry.entity_id):
+                declarations.setdefault(
+                    lock_entry.id,
+                    _SiblingAnswer(sibling.is_codeless(lock_entry), entry.title),
+                )
+    return declarations
+
+
 def _codeless_candidates(
-    hass: HomeAssistant, lock_entity_ids: Iterable[str], config: EntryConfig
+    hass: HomeAssistant,
+    lock_entries: Iterable[er.RegistryEntry],
+    config: EntryConfig,
+    siblings: Mapping[str, _SiblingAnswer],
 ) -> tuple[list[er.RegistryEntry], list[er.RegistryEntry]]:
     """
     Return the selected locks to ask about, and those nothing else can manage.
@@ -185,15 +251,17 @@ def _codeless_candidates(
     the locks the user is asked about, and, unless the answer is yes, the
     ones the submission is refused over.
 
-    Every member the entry ALREADY declares codeless is asked about too,
-    whatever platform dispatch now makes of it. The declaration wins over a
-    provider, deliberately and permanently
-    (``domain.locks.resolve_member_provider_class``), so a member whose
-    platform gained a provider after it was declared would otherwise keep
-    resolving to the Lock Code Manager store with no form that so much as
-    mentions it. It is asked about but never refused over: something does
-    claim it now, so declining hands it to that provider rather than
-    leaving a lock nothing can manage.
+    Every member ALREADY declared codeless is asked about too, whatever
+    platform dispatch now makes of it, and whether this entry or another one
+    declared it. The declaration wins over a provider, deliberately and
+    permanently (``domain.locks.resolve_member_provider_class``), so a
+    member whose platform gained a provider after it was declared would
+    otherwise keep resolving to the Lock Code Manager store with no form
+    that so much as mentions it. Reading a SIBLING'S declaration here is
+    what leaves room to agree with it: a lock something claims is otherwise
+    never asked about, so an entry adding one another entry declares could
+    only ever contradict it, and would be refused with no answer available
+    that was not.
 
     mqtt is never asked about on dispatch alone, and keeps the refusal it
     already has. Its dispatch is per DEVICE, so an unclaimed one means "this
@@ -214,28 +282,21 @@ def _codeless_candidates(
     it has a keypad, the question says what declaring means, and since the
     menu also offers every member already declared, a wrong answer is one
     the same form takes back.
-
-    Every selected entity is in the registry by the time this runs:
-    :func:`_check_lock_selection` refuses the whole submission over one that
-    is not, and runs first at every call site. Asserted rather than skipped,
-    the way the lock factory asserts the same thing -- a declaration is keyed
-    by registry id, so an entity that got here without a row would be one
-    this function silently declined to ask about.
     """
-    ent_reg = er.async_get(hass)
     dev_reg = dr.async_get(hass)
     ask: list[er.RegistryEntry] = []
     unmanageable: list[er.RegistryEntry] = []
-    for entity_id in lock_entity_ids:
-        lock_entry = ent_reg.async_get(entity_id)
-        assert lock_entry
+    for lock_entry in lock_entries:
+        sibling = siblings.get(lock_entry.id)
         if (
             lock_entry.platform != MQTT_DOMAIN
             and resolve_provider_class_for_entity(dev_reg, lock_entry) is None
         ):
             unmanageable.append(lock_entry)
             ask.append(lock_entry)
-        elif config.is_codeless(lock_entry):
+        elif config.is_codeless(lock_entry) or (
+            sibling is not None and sibling.codeless
+        ):
             ask.append(lock_entry)
     return ask, unmanageable
 
@@ -295,7 +356,11 @@ class CodelessDeclarationFlow(config_entries.ConfigEntryBaseFlow):
         self._codeless_lock: er.RegistryEntry | None = None
 
     async def _async_check_codeless(
-        self, origin: str, user_input: dict[str, Any], config: EntryConfig
+        self,
+        origin: str,
+        user_input: dict[str, Any],
+        config: EntryConfig,
+        config_entry: ConfigEntry | None = None,
     ) -> tuple[dict[str, Any] | None, dict[str, str], dict[str, Any]]:
         """
         Ask about, or refuse, the locks in a submission that nothing claims.
@@ -303,10 +368,26 @@ class CodelessDeclarationFlow(config_entries.ConfigEntryBaseFlow):
         Returns the flow result to return when the question still has to be
         asked, alongside the form error and placeholders for a submission
         that cannot be saved as it stands. ``config`` is what the entry
-        already declares, which this flow's own answers override.
+        already declares, which this flow's own answers override, and
+        ``config_entry`` is that entry -- left out of the sibling scan
+        because its own answer is the one being replaced.
+
+        Every selected entity is in the registry by the time this runs:
+        :func:`_check_lock_selection` refuses the whole submission over one
+        that is not, and runs first at every call site. Asserted rather than
+        skipped, the way the lock factory asserts the same thing -- a
+        declaration is keyed by registry id, so an entity that got here
+        without a row would be one this silently declined to ask about.
         """
+        ent_reg = er.async_get(self.hass)
+        lock_entries: list[er.RegistryEntry] = []
+        for entity_id in user_input[CONF_LOCKS]:
+            lock_entry = ent_reg.async_get(entity_id)
+            assert lock_entry
+            lock_entries.append(lock_entry)
+        siblings = _sibling_declarations(self.hass, config_entry, lock_entries)
         ask, unmanageable = _codeless_candidates(
-            self.hass, user_input[CONF_LOCKS], config
+            self.hass, lock_entries, config, siblings
         )
         if pending := next(
             (
@@ -326,6 +407,21 @@ class CodelessDeclarationFlow(config_entries.ConfigEntryBaseFlow):
                 else "codeless_reconsider"
             )
             return await getattr(self, f"async_step_{step}")(), {}, {}
+        # Checked before the refusal below, and it is the more specific of
+        # the two: a lock nothing claims that a sibling already declares IS
+        # manageable, so "there is no way to manage codes on this" would be
+        # false, and the sibling is the thing the user has to reconcile.
+        if contradicted := [
+            f"{lock_entry.entity_id} ({sibling.entry_title})"
+            for lock_entry in lock_entries
+            if (sibling := siblings.get(lock_entry.id)) is not None
+            and sibling.codeless != self._is_codeless(config, lock_entry)
+        ]:
+            return (
+                None,
+                {CONF_LOCKS: "codeless_conflict"},
+                {"locks": ", ".join(contradicted)},
+            )
         if undeclared := [
             lock_entry
             for lock_entry in unmanageable
@@ -932,7 +1028,7 @@ class LockCodeManagerFlowHandler(
                     additional_errors,
                     additional_placeholders,
                 ) = await self._async_check_codeless(
-                    "reauth_confirm", user_input, entry_config
+                    "reauth_confirm", user_input, entry_config, config_entry
                 )
                 if ask is not None:
                     return ask
@@ -1051,7 +1147,9 @@ class LockCodeManagerOptionsFlow(CodelessDeclarationFlow, config_entries.Options
                         ask,
                         codeless_errors,
                         codeless_placeholders,
-                    ) = await self._async_check_codeless("init", user_input, stored)
+                    ) = await self._async_check_codeless(
+                        "init", user_input, stored, self.config_entry
+                    )
                     if ask is not None:
                         return ask
                     errors.update(codeless_errors)

--- a/custom_components/lock_code_manager/const.py
+++ b/custom_components/lock_code_manager/const.py
@@ -155,6 +155,10 @@ CONF_MEMBERS = "members"
 # no credential storage of its own, so Lock Code Manager holds them instead.
 # See EntryConfig.is_codeless().
 CONF_CODELESS = "codeless"
+# The config-flow field that collects those members. A form key, never
+# stored: both lock pickers merge into CONF_LOCKS, and which picker a lock
+# came from is what CONF_CODELESS records.
+CONF_CODELESS_LOCKS = "codeless_locks"
 CONF_SLOTS = "slots"
 CONF_USERS = "users"
 CONF_NUM_USERS = "num_users"

--- a/custom_components/lock_code_manager/const.py
+++ b/custom_components/lock_code_manager/const.py
@@ -151,6 +151,10 @@ CONF_LOCKS = "locks"
 # Per-member declarations, keyed by entity registry entry id, alongside the
 # CONF_LOCKS roster. See EntryConfig.member().
 CONF_MEMBERS = "members"
+# A member declaration field: the user told Lock Code Manager this member has
+# no credential storage of its own, so Lock Code Manager holds them instead.
+# See EntryConfig.is_codeless().
+CONF_CODELESS = "codeless"
 CONF_SLOTS = "slots"
 CONF_USERS = "users"
 CONF_NUM_USERS = "num_users"

--- a/custom_components/lock_code_manager/domain/allocation.py
+++ b/custom_components/lock_code_manager/domain/allocation.py
@@ -71,6 +71,7 @@ def build_lock_instance(
     ent_reg: er.EntityRegistry,
     config_entry: ConfigEntry | None,
     lock_entity_id: str,
+    config: EntryConfig | None = None,
 ) -> Any:
     """
     Build a temporary lock provider instance for ``lock_entity_id``.
@@ -86,6 +87,10 @@ def build_lock_instance(
     whether an unbuildable one is still one credentials get written to --
     is a question about that entry's configuration, not about the lock
     alone, so the entry has to be reachable from here.
+
+    ``config`` overrides what that entry currently declares, and is how a
+    config flow reads a lock through an answer it has collected but not yet
+    written. Omitted, the entry's own stored configuration stands.
     """
     # Locks are shared between entries, so a skipped read names the entry
     # that asked as well as the lock it gave up on.
@@ -102,7 +107,8 @@ def build_lock_instance(
     # A member it is about to declare codeless is also one this integration
     # holds no credentials for yet, and a codeless member advertises no
     # capacity, so the numbering is unconstrained either way.
-    config = get_entry_config(config_entry) if config_entry else EntryConfig.empty()
+    if config is None:
+        config = get_entry_config(config_entry) if config_entry else EntryConfig.empty()
     lock_cls = resolve_member_provider_class(dev_reg, config, lock_entry)
     if lock_cls is None:
         # Covers an unsupported platform, and an mqtt lock whose bridge no
@@ -133,6 +139,7 @@ async def async_check_slot_capacity(
     config_entry: ConfigEntry | None,
     locks: Iterable[str],
     slots_list: Iterable[int | str],
+    config: EntryConfig | None = None,
 ) -> None:
     """
     Reject slot numbers no lock in the set could ever hold.
@@ -148,7 +155,8 @@ async def async_check_slot_capacity(
     make the config flow unusable. The same check runs at write time, where
     it can suspend the affected slot precisely.
 
-    ``config_entry`` is the entry the locks are being read for, on the terms
+    ``config_entry`` and ``config`` are the entry the locks are being read
+    for and what it declares about them, on the terms
     ``build_lock_instance`` describes.
     """
     dev_reg = dr.async_get(hass)
@@ -158,7 +166,7 @@ async def async_check_slot_capacity(
         try:
             async with borrowed_lock_instance(
                 build_lock_instance(
-                    hass, dev_reg, ent_reg, config_entry, lock_entity_id
+                    hass, dev_reg, ent_reg, config_entry, lock_entity_id, config
                 )
             ) as lock_instance:
                 if not lock_instance.credential_index_follows_slot:
@@ -199,6 +207,7 @@ async def async_read_occupancy(
     config_entry: ConfigEntry | None,
     locks: Sequence[str],
     indices: Collection[int],
+    config: EntryConfig | None = None,
 ) -> Occupancy:
     """
     Ask every lock in ``locks`` which of ``indices`` it holds.
@@ -221,7 +230,7 @@ async def async_read_occupancy(
     for lock_entity_id in locks:
         try:
             lock_instance = build_lock_instance(
-                hass, dev_reg, ent_reg, config_entry, lock_entity_id
+                hass, dev_reg, ent_reg, config_entry, lock_entity_id, config
             )
         except LockQuerySkipped as skipped:
             lock_occupancies.append(
@@ -335,7 +344,10 @@ def _too_far(
 
 
 async def async_max_slot(
-    hass: HomeAssistant, config_entry: ConfigEntry | None, locks: Sequence[str]
+    hass: HomeAssistant,
+    config_entry: ConfigEntry | None,
+    locks: Sequence[str],
+    config: EntryConfig | None = None,
 ) -> tuple[int, str | None]:
     """
     Return how far a search for free numbers may go across these locks.
@@ -350,7 +362,8 @@ async def async_max_slot(
     integration's own -- which a message must not describe as a capacity
     some lock reported.
 
-    ``config_entry`` is the entry the locks are being read for, on the terms
+    ``config_entry`` and ``config`` are the entry the locks are being read
+    for and what it declares about them, on the terms
     ``build_lock_instance`` describes.
     """
     dev_reg = dr.async_get(hass)
@@ -360,7 +373,7 @@ async def async_max_slot(
         try:
             async with borrowed_lock_instance(
                 build_lock_instance(
-                    hass, dev_reg, ent_reg, config_entry, lock_entity_id
+                    hass, dev_reg, ent_reg, config_entry, lock_entity_id, config
                 )
             ) as lock_instance:
                 if not lock_instance.credential_index_follows_slot:
@@ -390,6 +403,7 @@ async def async_allocate_for(
     config_entry: ConfigEntry | None,
     locks: Sequence[str],
     num_users: int,
+    config: EntryConfig | None = None,
 ) -> frozenset[int]:
     """
     Find numbers for ``num_users``, reading only as far as it has to.
@@ -409,17 +423,18 @@ async def async_allocate_for(
     wide enough to hold everyone. The users are numbered from it later,
     once they have names.
 
-    ``config_entry`` is the entry the numbers are being allocated for, on the
-    terms ``build_lock_instance`` describes.
+    ``config_entry`` and ``config`` are the entry the numbers are being
+    allocated for and what it declares about its locks, on the terms
+    ``build_lock_instance`` describes.
     """
     try:
-        await async_check_slot_capacity(hass, config_entry, locks, [num_users])
+        await async_check_slot_capacity(hass, config_entry, locks, [num_users], config)
     except SlotAllocationError as err:
         raise SlotAllocationError(
             "too_many_users", {**err.placeholders, "num_users": str(num_users)}
         ) from err
 
-    max_slot, limiting_lock = await async_max_slot(hass, config_entry, locks)
+    max_slot, limiting_lock = await async_max_slot(hass, config_entry, locks, config)
     if num_users > max_slot:
         # Before the first read, not just before each widening: a count
         # past the range walks off the end of the lock on the way in, and
@@ -434,7 +449,7 @@ async def async_allocate_for(
         # each pass would cost a nearly-full lock several times its own
         # capacity to place a couple of users.
         occupancy = await async_read_occupancy(
-            hass, config_entry, locks, range(read_up_to + 1, window + 1)
+            hass, config_entry, locks, range(read_up_to + 1, window + 1), config
         )
         if not occupancy.is_known:
             # Unreadable is not free: issuing a number could overwrite a
@@ -452,7 +467,7 @@ async def async_allocate_for(
         # Every number in the way pushes the last user one further out.
         wider = num_users + taken_in_window
         try:
-            await async_check_slot_capacity(hass, config_entry, locks, [wider])
+            await async_check_slot_capacity(hass, config_entry, locks, [wider], config)
         except SlotAllocationError as err:
             # Distinct from the count being too large: the count fits,
             # and the numbers needed to reach around what is already

--- a/custom_components/lock_code_manager/domain/allocation.py
+++ b/custom_components/lock_code_manager/domain/allocation.py
@@ -19,12 +19,12 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from ..const import MAX_SEARCHED_SLOT
-from ..providers import resolve_provider_class_for_entity
+from .config import EntryConfig
 from .credentials import CredentialType
 from .exceptions import LockCodeManagerError
-from .locks import borrowed_lock_instance
+from .locks import borrowed_lock_instance, resolve_member_provider_class
 from .occupancy import LockOccupancy, Occupancy
-from .queries import get_managed_slots
+from .queries import get_entry_config, get_managed_slots
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -75,8 +75,9 @@ def build_lock_instance(
     """
     Build a temporary lock provider instance for ``lock_entity_id``.
 
-    Performs setup-time checks (entity in registry, a provider claims it,
-    parent config entry exists) and instantiates the provider class.
+    Performs setup-time checks (entity in registry, a provider claims it or
+    the entry declares it codeless, parent config entry exists) and
+    instantiates the provider class.
     Raises ``LockQuerySkipped`` if any setup-time check fails.
 
     ``config_entry`` is the Lock Code Manager entry the lock is being read
@@ -97,11 +98,17 @@ def build_lock_instance(
             lock_entity_id,
         )
         raise LockQuerySkipped(lock_entity_id, managed=True)
-    lock_cls = resolve_provider_class_for_entity(dev_reg, lock_entry)
+    # An entry still being created has nothing to read a declaration from.
+    # A member it is about to declare codeless is also one this integration
+    # holds no credentials for yet, and a codeless member advertises no
+    # capacity, so the numbering is unconstrained either way.
+    config = get_entry_config(config_entry) if config_entry else EntryConfig.empty()
+    lock_cls = resolve_member_provider_class(dev_reg, config, lock_entry)
     if lock_cls is None:
-        # Covers both an unsupported platform and an mqtt lock whose bridge
-        # no provider speaks: either way nothing is ever written there, so
-        # the lock constrains no numbering.
+        # Covers an unsupported platform, and an mqtt lock whose bridge no
+        # provider speaks, and a lock nothing claims that nobody declared
+        # about: either way nothing is ever written there, so the lock
+        # constrains no numbering.
         _LOGGER.debug(
             "%s: no provider claims lock %s (platform %s); skipping usercode check",
             asked_by,

--- a/custom_components/lock_code_manager/domain/config.py
+++ b/custom_components/lock_code_manager/domain/config.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Container, Mapping
+from collections.abc import Collection, Container, Mapping
 from dataclasses import dataclass, field
 import logging
 from types import MappingProxyType
@@ -110,48 +110,44 @@ def _member_declarations(raw: Any) -> Mapping[str, Mapping[str, Any]]:
 
 def declare_codeless(
     members: Mapping[str, Mapping[str, Any]],
-    answers: Mapping[str, bool],
-    roster: Container[str],
+    codeless: Container[str],
+    roster: Collection[str],
 ) -> dict[str, dict[str, Any]]:
     """
-    Return the declarations with an answer recorded about each named member.
+    Return the declarations for a roster, codeless recorded for those named.
 
-    Keyed by ``er.RegistryEntry.id``, like the declarations themselves, and
-    merged into each member's own rather than replacing it: recording this
-    one field must not erase another field the same member carries.
+    ``roster`` is every member the entry will hold after this write, and
+    ``codeless`` is the subset whose credentials Lock Code Manager keeps
+    itself. Both are ``er.RegistryEntry.id``, like the declarations
+    themselves, so "the same lock" is an exact key match rather than
+    anything inferred from an entity id a rename can move.
 
-    A False answer removes the field, and a declaration left holding nothing
-    goes with it. "Nothing declared" is already what every reader treats as
-    the default, so a stored ``codeless: false`` would mean exactly what an
-    absent key means while looking different in storage -- and every member
-    anybody ever declined about would leave a husk behind.
+    Merged into each member's own declaration rather than replacing it:
+    recording this one field must not erase another field the same member
+    carries.
 
-    ``roster`` is the registry ids the entry will hold after this write, and
-    anything else is dropped -- a declaration already stored AND an answer
-    just given. Nothing reads a declaration for a member the entry does not
-    have, so keeping one would grow the entry without bound -- and it is not
-    merely untidy: re-adding the same lock later would find an answer nobody
-    was asked for again, and resolve a lock with real code storage to the
-    Lock Code Manager store without a word.
+    A member outside ``codeless`` loses the field, and a declaration left
+    holding nothing goes with it. "Nothing declared" is already what every
+    reader treats as the default, so a stored ``codeless: false`` would mean
+    exactly what an absent key means while looking different in storage --
+    and every lock anybody ever moved out of the codeless field would leave
+    a husk behind.
 
-    The answers need the same filter as the stored declarations because a
-    flow can outlive its own question. An answer is cached for the life of
-    the flow, so a yes whose re-submission is refused for some unrelated
-    reason -- a sibling lock too asleep to report its occupancy -- is still
-    held when the user reacts by dropping the lock they just answered about.
-    Written back, that answer is a declaration about a member the entry no
-    longer has, which is the husk this pruning exists to prevent.
+    Anything outside ``roster`` is dropped, stored declarations included.
+    Nothing reads a declaration for a member the entry does not have, so
+    keeping one would grow the entry without bound -- and it is not merely
+    untidy: re-adding the same lock later would find a declaration nobody
+    made this time, and resolve a lock with real code storage to the Lock
+    Code Manager store without a word.
     """
     declared = {
         registry_id: dict(fields)
         for registry_id, fields in members.items()
         if registry_id in roster
     }
-    for registry_id, codeless in answers.items():
-        if registry_id not in roster:
-            continue
+    for registry_id in roster:
         member = declared.setdefault(registry_id, {})
-        if codeless:
+        if registry_id in codeless:
             member[CONF_CODELESS] = True
         else:
             member.pop(CONF_CODELESS, None)

--- a/custom_components/lock_code_manager/domain/config.py
+++ b/custom_components/lock_code_manager/domain/config.py
@@ -12,7 +12,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME, CONF_PIN
 from homeassistant.helpers import entity_registry as er
 
-from ..const import CONF_LOCKS, CONF_MEMBERS, CONF_SLOTS, CONF_USERS
+from ..const import CONF_CODELESS, CONF_LOCKS, CONF_MEMBERS, CONF_SLOTS, CONF_USERS
 from .names import normalize_name
 from .slot_assignment import (
     CONF_SLOT_ASSIGNMENT,
@@ -106,6 +106,32 @@ def _member_declarations(raw: Any) -> Mapping[str, Mapping[str, Any]]:
             continue
         declarations[registry_id] = MappingProxyType(dict(declared))
     return MappingProxyType(declarations)
+
+
+def declare_codeless(
+    members: Mapping[str, Mapping[str, Any]], answers: Mapping[str, bool]
+) -> dict[str, dict[str, Any]]:
+    """
+    Return the declarations with an answer recorded about each named member.
+
+    Keyed by ``er.RegistryEntry.id``, like the declarations themselves, and
+    merged into each member's own rather than replacing it: recording this
+    one field must not erase another field the same member carries.
+
+    A False answer removes the field, and a declaration left holding nothing
+    goes with it. "Nothing declared" is already what every reader treats as
+    the default, so a stored ``codeless: false`` would mean exactly what an
+    absent key means while looking different in storage -- and every member
+    anybody ever declined about would leave a husk behind.
+    """
+    declared = {registry_id: dict(fields) for registry_id, fields in members.items()}
+    for registry_id, codeless in answers.items():
+        member = declared.setdefault(registry_id, {})
+        if codeless:
+            member[CONF_CODELESS] = True
+        else:
+            member.pop(CONF_CODELESS, None)
+    return {registry_id: fields for registry_id, fields in declared.items() if fields}
 
 
 @dataclass(frozen=True, slots=True)
@@ -321,6 +347,24 @@ class EntryConfig:
         and nothing declared about it.
         """
         return self.members.get(lock_entry.id, _EMPTY_MEMBER)
+
+    def is_codeless(self, lock_entry: er.RegistryEntry) -> bool:
+        """
+        Return whether this entry holds this member's credentials itself.
+
+        The field dispatch keys on. A member declared this way has no
+        credential storage of its own -- an ESPHome lock, or any other lock
+        entity that is real and actuatable but keeps no codes -- so nothing
+        is ever written to the device and Lock Code Manager keeps the
+        credentials in a store of its own.
+
+        Never inferred. The config and options flows ask about exactly the
+        members no provider claims, and only an answer puts this here: a
+        lock somebody meant to reach through a provider Lock Code Manager
+        has not been taught yet must keep failing loudly rather than
+        quietly becoming a lock nothing is written to.
+        """
+        return bool(self.member(lock_entry).get(CONF_CODELESS))
 
     def name_for(self, slot_num: int | str) -> str | None:
         """Return the user occupying a slot, or None if it is unoccupied."""

--- a/custom_components/lock_code_manager/domain/config.py
+++ b/custom_components/lock_code_manager/domain/config.py
@@ -127,11 +127,20 @@ def declare_codeless(
     anybody ever declined about would leave a husk behind.
 
     ``roster`` is the registry ids the entry will hold after this write, and
-    a declaration about anything else is dropped. Nothing reads a declaration
-    for a member the entry does not have, so keeping one would grow the entry
-    without bound -- and it is not merely untidy: re-adding the same lock
-    later would find an answer nobody was asked for again, and resolve a lock
-    with real code storage to the Lock Code Manager store without a word.
+    anything else is dropped -- a declaration already stored AND an answer
+    just given. Nothing reads a declaration for a member the entry does not
+    have, so keeping one would grow the entry without bound -- and it is not
+    merely untidy: re-adding the same lock later would find an answer nobody
+    was asked for again, and resolve a lock with real code storage to the
+    Lock Code Manager store without a word.
+
+    The answers need the same filter as the stored declarations because a
+    flow can outlive its own question. An answer is cached for the life of
+    the flow, so a yes whose re-submission is refused for some unrelated
+    reason -- a sibling lock too asleep to report its occupancy -- is still
+    held when the user reacts by dropping the lock they just answered about.
+    Written back, that answer is a declaration about a member the entry no
+    longer has, which is the husk this pruning exists to prevent.
     """
     declared = {
         registry_id: dict(fields)
@@ -139,6 +148,8 @@ def declare_codeless(
         if registry_id in roster
     }
     for registry_id, codeless in answers.items():
+        if registry_id not in roster:
+            continue
         member = declared.setdefault(registry_id, {})
         if codeless:
             member[CONF_CODELESS] = True

--- a/custom_components/lock_code_manager/domain/config.py
+++ b/custom_components/lock_code_manager/domain/config.py
@@ -423,6 +423,27 @@ class EntryConfig:
             return NotImplemented
         return EntryConfigDiff(old=self, new=other)
 
+    def with_members(self, members: Mapping[str, Mapping[str, Any]]) -> EntryConfig:
+        """
+        Return a copy declaring these members instead of the stored ones.
+
+        For reading a submission's locks through the answers it carries
+        before any of it is written: what a member resolves to decides which
+        credential store gets read, so validation that consults the stored
+        declaration is answering about the wrong lock.
+
+        Normalized on the way in, like every other construction path, so a
+        plain dict handed in here cannot make an instance that is only
+        shallowly read-only.
+        """
+        return EntryConfig(
+            locks=self.locks,
+            members=_member_declarations(members),
+            users=self.users,
+            assignment=self.assignment,
+            extra=self.extra,
+        )
+
     def with_user_renamed(self, old: str, new: str) -> EntryConfig:
         """
         Return a copy with a user re-keyed, keeping their slot.

--- a/custom_components/lock_code_manager/domain/config.py
+++ b/custom_components/lock_code_manager/domain/config.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Container, Mapping
 from dataclasses import dataclass, field
 import logging
 from types import MappingProxyType
@@ -109,7 +109,9 @@ def _member_declarations(raw: Any) -> Mapping[str, Mapping[str, Any]]:
 
 
 def declare_codeless(
-    members: Mapping[str, Mapping[str, Any]], answers: Mapping[str, bool]
+    members: Mapping[str, Mapping[str, Any]],
+    answers: Mapping[str, bool],
+    roster: Container[str],
 ) -> dict[str, dict[str, Any]]:
     """
     Return the declarations with an answer recorded about each named member.
@@ -123,8 +125,19 @@ def declare_codeless(
     the default, so a stored ``codeless: false`` would mean exactly what an
     absent key means while looking different in storage -- and every member
     anybody ever declined about would leave a husk behind.
+
+    ``roster`` is the registry ids the entry will hold after this write, and
+    a declaration about anything else is dropped. Nothing reads a declaration
+    for a member the entry does not have, so keeping one would grow the entry
+    without bound -- and it is not merely untidy: re-adding the same lock
+    later would find an answer nobody was asked for again, and resolve a lock
+    with real code storage to the Lock Code Manager store without a word.
     """
-    declared = {registry_id: dict(fields) for registry_id, fields in members.items()}
+    declared = {
+        registry_id: dict(fields)
+        for registry_id, fields in members.items()
+        if registry_id in roster
+    }
     for registry_id, codeless in answers.items():
         member = declared.setdefault(registry_id, {})
         if codeless:
@@ -340,11 +353,12 @@ class EntryConfig:
         every field a caller reads takes its own default. Membership itself is
         the ``locks`` roster; this records only what somebody said about a
         member, which is why an entity absent from the roster still answers
-        rather than raising. A declaration outlives both a rename and the
-        member's removal from the roster -- re-adding the same entity finds it
-        again -- but not the entity's removal from the entity registry, since
-        anything recreated afterwards is a new registry entry with a new id
-        and nothing declared about it.
+        rather than raising -- storage hand-edited, or written before
+        :func:`declare_codeless` pruned, can carry one. A declaration
+        outlives a rename, because the id does. It does not outlive the
+        member leaving the roster, or the entity leaving the registry: the
+        next write drops it either way, and re-adding the same lock is asked
+        about afresh.
         """
         return self.members.get(lock_entry.id, _EMPTY_MEMBER)
 

--- a/custom_components/lock_code_manager/domain/locks.py
+++ b/custom_components/lock_code_manager/domain/locks.py
@@ -48,7 +48,9 @@ def resolve_member_provider_class(
     credentials out of this integration's store and onto a device the user
     never agreed to write to, silently, on a version upgrade. Keeping the
     declaration means the only thing that changes an answer is somebody
-    answering again.
+    answering again -- which is why the flows ask about every declared
+    member, not only the ones nothing claims: a rule with no exit would
+    strand the member here forever.
 
     This is what every factory has to call, and why neither factory may go
     through platform dispatch alone: a declared member that resolved to

--- a/custom_components/lock_code_manager/domain/locks.py
+++ b/custom_components/lock_code_manager/domain/locks.py
@@ -118,47 +118,82 @@ async def borrowed_lock_instance(lock: BaseLock) -> AsyncIterator[BaseLock]:
         lock.unsubscribe_push_updates()
 
 
-def get_managed_locks(hass: HomeAssistant) -> dict[str, BaseLock]:
+def get_managed_locks_for_entity(
+    hass: HomeAssistant, lock_entity_id: str
+) -> list[BaseLock]:
     """
-    Return the union of locks across all loaded Lock Code Manager entries.
+    Return every provider the loaded entries hold for one lock entity.
 
-    When two entries share the same physical lock they hold the same
-    ``BaseLock`` instance, so a flat ``entity_id -> BaseLock`` mapping is
-    well-defined.
+    One entity does not mean one credential store, which is why this
+    answers with a list. Two entries can resolve the same lock differently
+    -- a member one entry declares codeless resolves to the Lock Code
+    Manager store, while the same lock in an entry that declares nothing
+    resolves to whatever platform dispatch claims -- and those two providers
+    have no more to do with each other than two separate locks would. A
+    caller that can act on only one of them has to say which, or refuse.
+
+    Two entries sharing one instance is the common case, and it is listed
+    once however many entries hold it.
     """
-    return {
-        entity_id: lock
-        for entry in iter_loaded_lcm_entries(hass)
-        for entity_id, lock in entry.runtime_data.locks.items()
-    }
+    instances: list[BaseLock] = []
+    for entry in iter_loaded_lcm_entries(hass):
+        lock = entry.runtime_data.locks.get(lock_entity_id)
+        if lock is not None and lock not in instances:
+            instances.append(lock)
+    return instances
 
 
 def get_managed_lock(hass: HomeAssistant, lock_entity_id: str) -> BaseLock:
-    """Get a managed lock by entity ID, raising if not found."""
-    lock = next(
-        (
-            entry.runtime_data.locks[lock_entity_id]
-            for entry in iter_loaded_lcm_entries(hass)
-            if lock_entity_id in entry.runtime_data.locks
-        ),
-        None,
-    )
-    if not lock:
+    """
+    Return the one provider that holds a lock's credentials, or refuse.
+
+    For the callers that name a lock by entity id and nothing else: the
+    set and clear usercode actions, the unmanaged-code repair, and the
+    websocket subscription that shows what a lock holds. Every one of them
+    reads or writes a single credential store, and none of them carries a
+    config entry that could say which.
+
+    So more than one is refused rather than picked. Choosing arbitrarily is
+    not a harmless tie-break here: writing to the device when the caller
+    meant the Lock Code Manager store, or the reverse, puts the Personal
+    Identification Number somewhere nobody will look for it, and the
+    displayed codes then belong to a different store than the one an edit
+    lands in. The refusal names both providers, which is also the shortest
+    route to the configuration that has to be reconciled.
+    """
+    locks = get_managed_locks_for_entity(hass, lock_entity_id)
+    if not locks:
         raise ServiceValidationError(
             f"Lock {lock_entity_id} is not managed by Lock Code Manager"
         )
-    return lock
+    if len(locks) > 1:
+        raise ServiceValidationError(
+            f"Lock {lock_entity_id} is managed by more than one Lock Code Manager "
+            "configuration, and they do not agree on where its credentials live "
+            f"({', '.join(sorted(lock.domain for lock in locks))}). Make them agree "
+            "before managing this lock's codes directly."
+        )
+    return locks[0]
 
 
 def get_locks_from_targets(
     hass: HomeAssistant, target_data: dict[str, Any]
-) -> set[BaseLock]:
-    """Get lock(s) from target IDs."""
+) -> list[BaseLock]:
+    """
+    Get lock(s) from target IDs.
+
+    Every provider for every targeted lock, not one per entity: a lock two
+    entries resolve differently has two credential stores, and an action
+    aimed at "this lock" means both of them.
+    """
     area_ids: list[str] = cv.ensure_list(target_data.get(ATTR_AREA_ID, []))
     device_ids: list[str] = cv.ensure_list(target_data.get(ATTR_DEVICE_ID, []))
     entity_ids: list[str] = cv.ensure_list(target_data.get(ATTR_ENTITY_ID, []))
-    managed_locks = get_managed_locks(hass)
-    lcm_lock_entity_ids = managed_locks.keys()
+    lcm_lock_entity_ids = {
+        entity_id
+        for entry in iter_loaded_lcm_entries(hass)
+        for entity_id in entry.runtime_data.locks
+    }
     lock_entity_ids: set[str] = set()
     ent_reg = er.async_get(hass)
     lock_entity_ids.update(
@@ -199,8 +234,8 @@ def get_locks_from_targets(
             ", ".join(unmanaged_entities),
         )
 
-    return {
+    return [
         lock
-        for ent_id in (lock_entity_ids & lcm_lock_entity_ids)
-        if (lock := managed_locks.get(ent_id))
-    }
+        for ent_id in sorted(lock_entity_ids & lcm_lock_entity_ids)
+        for lock in get_managed_locks_for_entity(hass, ent_id)
+    ]

--- a/custom_components/lock_code_manager/domain/locks.py
+++ b/custom_components/lock_code_manager/domain/locks.py
@@ -19,10 +19,45 @@ from homeassistant.helpers import (
 )
 
 from ..providers import BaseLock, resolve_provider_class_for_entity
+from ..providers.codeless import CodelessLock
+from .config import EntryConfig
 from .exceptions import UnclaimedLockError
-from .queries import iter_loaded_lcm_entries
+from .queries import get_entry_config, iter_loaded_lcm_entries
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def resolve_member_provider_class(
+    dev_reg: dr.DeviceRegistry,
+    config: EntryConfig,
+    lock_entry: er.RegistryEntry,
+) -> type[BaseLock] | None:
+    """
+    Resolve the provider for one of an entry's members, declaration first.
+
+    Platform dispatch (``providers.resolve_provider_class_for_entity``)
+    answers for a lock whose integration Lock Code Manager speaks. It cannot
+    answer for a lock that keeps no codes at all, because that is not a
+    property of the integration -- ESPHome will happily expose a lock with a
+    keypad and a lock without one -- which is why the user is asked and the
+    answer is stored per member.
+
+    The declaration is read FIRST, and the ordering is the point. Should
+    Lock Code Manager ever gain a provider for a platform somebody already
+    declared codeless, letting that provider win would move a member's
+    credentials out of this integration's store and onto a device the user
+    never agreed to write to, silently, on a version upgrade. Keeping the
+    declaration means the only thing that changes an answer is somebody
+    answering again.
+
+    This is what every factory has to call, and why neither factory may go
+    through platform dispatch alone: a declared member that resolved to
+    nothing would be refused at setup and would issue slot numbers against
+    a lock nothing ever read.
+    """
+    if config.is_codeless(lock_entry):
+        return CodelessLock
+    return resolve_provider_class_for_entity(dev_reg, lock_entry)
 
 
 @callback
@@ -37,7 +72,9 @@ def async_create_lock_instance(
     lock_entry = ent_reg.async_get(lock_entity_id)
     assert lock_entry
     lock_config_entry = hass.config_entries.async_get_entry(lock_entry.config_entry_id)
-    lock_cls = resolve_provider_class_for_entity(dev_reg, lock_entry)
+    lock_cls = resolve_member_provider_class(
+        dev_reg, get_entry_config(config_entry), lock_entry
+    )
     if lock_cls is None:
         # Selection-time validation and this guard share one rule: never
         # guess a provider for an unclaimed lock.

--- a/custom_components/lock_code_manager/domain/locks.py
+++ b/custom_components/lock_code_manager/domain/locks.py
@@ -118,74 +118,48 @@ async def borrowed_lock_instance(lock: BaseLock) -> AsyncIterator[BaseLock]:
         lock.unsubscribe_push_updates()
 
 
-def get_managed_locks_for_entity(
-    hass: HomeAssistant, lock_entity_id: str
-) -> list[BaseLock]:
+def find_managed_lock(hass: HomeAssistant, lock_entity_id: str) -> BaseLock | None:
     """
-    Return every provider the loaded entries hold for one lock entity.
+    Return the provider the loaded entries hold for one lock entity, if any.
 
-    One entity does not mean one credential store, which is why this
-    answers with a list. Two entries can resolve the same lock differently
-    -- a member one entry declares codeless resolves to the Lock Code
-    Manager store, while the same lock in an entry that declares nothing
-    resolves to whatever platform dispatch claims -- and those two providers
-    have no more to do with each other than two separate locks would. A
-    caller that can act on only one of them has to say which, or refuse.
-
-    Two entries sharing one instance is the common case, and it is listed
-    once however many entries hold it.
+    One entity, one provider: whether a lock keeps codes of its own is a
+    fact about the device rather than about a configuration, so every entry
+    that manages a lock resolves it the same way and shares the one
+    instance. The first loaded entry holding it therefore answers for all of
+    them.
     """
-    instances: list[BaseLock] = []
-    for entry in iter_loaded_lcm_entries(hass):
-        lock = entry.runtime_data.locks.get(lock_entity_id)
-        if lock is not None and lock not in instances:
-            instances.append(lock)
-    return instances
+    return next(
+        (
+            lock
+            for entry in iter_loaded_lcm_entries(hass)
+            if (lock := entry.runtime_data.locks.get(lock_entity_id)) is not None
+        ),
+        None,
+    )
 
 
 def get_managed_lock(hass: HomeAssistant, lock_entity_id: str) -> BaseLock:
     """
-    Return the one provider that holds a lock's credentials, or refuse.
+    Return the provider that holds a lock's credentials, or refuse.
 
     For the callers that name a lock by entity id and nothing else: the
     set and clear usercode actions, the unmanaged-code repair, and the
     websocket subscription that shows what a lock holds. Every one of them
     reads or writes a single credential store, and none of them carries a
-    config entry that could say which.
-
-    So more than one is refused rather than picked. Choosing arbitrarily is
-    not a harmless tie-break here: writing to the device when the caller
-    meant the Lock Code Manager store, or the reverse, puts the Personal
-    Identification Number somewhere nobody will look for it, and the
-    displayed codes then belong to a different store than the one an edit
-    lands in. The refusal names both providers, which is also the shortest
-    route to the configuration that has to be reconciled.
+    config entry that could say which -- which is answerable because there
+    is only ever one.
     """
-    locks = get_managed_locks_for_entity(hass, lock_entity_id)
-    if not locks:
+    if (lock := find_managed_lock(hass, lock_entity_id)) is None:
         raise ServiceValidationError(
             f"Lock {lock_entity_id} is not managed by Lock Code Manager"
         )
-    if len(locks) > 1:
-        raise ServiceValidationError(
-            f"Lock {lock_entity_id} is managed by more than one Lock Code Manager "
-            "configuration, and they do not agree on where its credentials live "
-            f"({', '.join(sorted(lock.domain for lock in locks))}). Make them agree "
-            "before managing this lock's codes directly."
-        )
-    return locks[0]
+    return lock
 
 
 def get_locks_from_targets(
     hass: HomeAssistant, target_data: dict[str, Any]
 ) -> list[BaseLock]:
-    """
-    Get lock(s) from target IDs.
-
-    Every provider for every targeted lock, not one per entity: a lock two
-    entries resolve differently has two credential stores, and an action
-    aimed at "this lock" means both of them.
-    """
+    """Get lock(s) from target IDs."""
     area_ids: list[str] = cv.ensure_list(target_data.get(ATTR_AREA_ID, []))
     device_ids: list[str] = cv.ensure_list(target_data.get(ATTR_DEVICE_ID, []))
     entity_ids: list[str] = cv.ensure_list(target_data.get(ATTR_ENTITY_ID, []))
@@ -237,5 +211,5 @@ def get_locks_from_targets(
     return [
         lock
         for ent_id in sorted(lock_entity_ids & lcm_lock_entity_ids)
-        for lock in get_managed_locks_for_entity(hass, ent_id)
+        if (lock := find_managed_lock(hass, ent_id)) is not None
     ]

--- a/custom_components/lock_code_manager/providers/__init__.py
+++ b/custom_components/lock_code_manager/providers/__init__.py
@@ -15,6 +15,11 @@ from .zigbee2mqtt import Z2M_IDENTIFIER_PREFIX, Zigbee2MQTTLock
 from .zwave_js import ZWaveJSLock
 from .zwave_js_ui import ZWaveJSUILock, parse_zwave_js_ui_identifier
 
+# Platform dispatch, and the whole of it. ``CodelessLock`` is deliberately
+# absent -- and not imported here either: it answers for the members an entry
+# declares it holds the credentials for, which is a fact about that entry's
+# configuration rather than about a platform, so the factory that reads the
+# declaration imports it. See ``domain.locks.resolve_member_provider_class``.
 INTEGRATIONS_CLASS_MAP: dict[str, type[BaseLock]] = {
     "local_akuvox": AkuvoxLock,
     "matter": MatterLock,
@@ -23,9 +28,6 @@ INTEGRATIONS_CLASS_MAP: dict[str, type[BaseLock]] = {
     "zha": ZHALock,
     "zwave_js": ZWaveJSLock,
 }
-
-# Selector allowlist; wider than what resolves, because mqtt is per-device.
-CONFIG_FLOW_PLATFORMS: tuple[str, ...] = (*INTEGRATIONS_CLASS_MAP, MQTT_DOMAIN)
 
 
 def resolve_provider_class(

--- a/custom_components/lock_code_manager/providers/__init__.py
+++ b/custom_components/lock_code_manager/providers/__init__.py
@@ -29,6 +29,12 @@ INTEGRATIONS_CLASS_MAP: dict[str, type[BaseLock]] = {
     "zwave_js": ZWaveJSLock,
 }
 
+# The lock picker's allowlist, wider than what resolves: mqtt dispatch is per
+# DEVICE, so the platform is offered and the bridge is checked at submit time.
+# A lock this leaves out is not unreachable -- the codeless picker beside it
+# offers exactly the locks nothing here claims.
+CONFIG_FLOW_PLATFORMS: tuple[str, ...] = (*INTEGRATIONS_CLASS_MAP, MQTT_DOMAIN)
+
 
 def resolve_provider_class(
     platform: str, device_entry: dr.DeviceEntry | None

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -391,17 +391,12 @@ class BaseLock:
         """Return a string representation."""
         return f"{self.__class__.__name__}(domain={self.domain}, lock={self.lock.entity_id})"
 
-    @final
-    def __hash__(self) -> int:
-        """Hash by lock entity ID (one BaseLock instance per physical lock)."""
-        return hash(self.lock.entity_id)
-
-    @final
-    def __eq__(self, other: Any) -> bool:
-        """Two BaseLock instances are equal when they wrap the same lock entity."""
-        if not isinstance(other, BaseLock):
-            return False
-        return self.lock.entity_id == other.lock.entity_id
+    # No __eq__ or __hash__: a provider is only ever equal to itself. Keying
+    # either on the lock entity id would say two instances over the same
+    # entity are the same lock, and two entries can resolve one entity to
+    # different providers -- two credential stores with nothing in common. A
+    # collection of providers would silently keep one of them, and whichever
+    # it kept would decide where a Personal Identification Number goes.
 
     @final
     def _raise_not_implemented(self, method_name: str, guidance: str = "") -> NoReturn:

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -980,6 +980,19 @@ class BaseLock:
         """Wait until async_setup has completed."""
         await self._setup_complete.wait()
 
+    async def async_remove_stored_credentials(self) -> None:
+        """
+        Discard whatever this provider persists outside the config entry.
+
+        Default is a no-op: a provider whose credentials live on the lock has
+        nothing of its own to retire, and must not reach for the device here
+        -- this runs for an entry that has already been deleted, and codes on
+        a lock outlive the entry that wrote them by design.
+
+        Overridden by the providers that ARE the store. Their copy is the
+        only copy, so nothing else would ever collect it.
+        """
+
     async def async_unload(self, remove_permanently: bool) -> None:
         """Tear down config-entry-state listener, reconnect task, and push subscription."""
         if remove_permanently:

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -391,12 +391,12 @@ class BaseLock:
         """Return a string representation."""
         return f"{self.__class__.__name__}(domain={self.domain}, lock={self.lock.entity_id})"
 
-    # No __eq__ or __hash__: a provider is only ever equal to itself. Keying
-    # either on the lock entity id would say two instances over the same
-    # entity are the same lock, and two entries can resolve one entity to
-    # different providers -- two credential stores with nothing in common. A
-    # collection of providers would silently keep one of them, and whichever
-    # it kept would decide where a Personal Identification Number goes.
+    # No __eq__ or __hash__: a provider is only ever equal to itself. One
+    # lock entity means one live instance, shared by every entry that holds
+    # it, and teardown asks whether a sibling still holds THIS object.
+    # Keying equality on the entity id would answer yes for a stale instance
+    # a reload replaced, so the entry would walk away from the live one --
+    # leaving its push subscription firing with nothing owning it.
 
     @final
     def _raise_not_implemented(self, method_name: str, guidance: str = "") -> NoReturn:

--- a/custom_components/lock_code_manager/providers/codeless.py
+++ b/custom_components/lock_code_manager/providers/codeless.py
@@ -1,0 +1,59 @@
+"""Module for locks that keep no codes of their own."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .virtual import VirtualLock
+
+
+@dataclass(repr=False, eq=False)
+class CodelessLock(VirtualLock):
+    """
+    A real lock entity that has no credential storage, so this holds it.
+
+    The lock is genuinely there -- an ESPHome lock, or any other integration
+    with no code support -- and it is what gets locked and unlocked. What it
+    has no notion of is a credential: nothing can be written to it and
+    nothing can be read back. So Lock Code Manager keeps the credentials
+    itself, in the same per-entity store a virtual lock uses, and a code
+    entered at the device reaches this integration through the
+    ``use_credential`` action rather than from the lock.
+
+    Everything that makes that work is already ``VirtualLock``: the store,
+    capabilities that advertise no limits of any kind, an integration that
+    is always connected, and set/delete/get addressed by slot. The
+    difference is what it is pointed at -- a real entity from any
+    integration, rather than an entity the virtual integration made -- and
+    that a user had to say so. Nothing here is inferred from a platform;
+    see ``EntryConfig.is_codeless``.
+
+    ``supports_code_slot_events`` stays False, inherited: a lock nothing can
+    read codes from cannot report which one was used either. Uses are
+    recorded from ``use_credential``, which needs no capability from the
+    member it names.
+    """
+
+    @property
+    def domain(self) -> str:
+        """
+        Return the name this provider answers to, not the member's platform.
+
+        A fixed string rather than ``self.lock.platform``, for two reasons.
+        It is what diagnostics reports per lock, and "codeless" is the fact
+        somebody debugging needs -- that Lock Code Manager is holding these
+        credentials, rather than the ESPHome (or whatever) integration the
+        entity happens to come from, which the entity id already says.
+
+        And the store key derives from it (``VirtualLock.async_setup``), so
+        it decides where a member's credentials live. A member's own
+        platform in that key would put two declared members of different
+        integrations in differently named stores for no reason anybody can
+        act on, and would move a store if a member were ever re-created
+        elsewhere under the same entity id. Distinct from ``VirtualLock``'s
+        "virtual" for the opposite reason: these two classes hold different
+        things -- a virtual lock's codes belong to that integration, these
+        belong to a declaration -- so neither may ever read the other's
+        store for the same entity id.
+        """
+        return "codeless"

--- a/custom_components/lock_code_manager/providers/virtual.py
+++ b/custom_components/lock_code_manager/providers/virtual.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Collection
 from dataclasses import dataclass, field
+from functools import cached_property
 import logging
 from typing import Literal, TypedDict
 
@@ -39,8 +40,21 @@ class CodeSlotData(TypedDict):
 class VirtualLock(BaseLock):
     """Class to represent Virtual lock."""
 
-    _store: Store[dict[str, CodeSlotData]] = field(init=False, repr=False)
     _data: dict[str, CodeSlotData] = field(default_factory=dict, init=False, repr=False)
+
+    @cached_property
+    def _store(self) -> Store[dict[str, CodeSlotData]]:
+        """
+        Return the store this lock's credentials live in.
+
+        Derived from the provider domain and the lock's entity id, and from
+        nothing that setup produces, so an instance built purely to retire
+        the store names the same file one that has been running does. That
+        is the only way to reach it once the entry it belonged to is gone:
+        entry deletion unloads first, and unload deliberately keeps the
+        store.
+        """
+        return Store(self.hass, 1, f"{self.domain}_{DOMAIN}_{self.lock.entity_id}")
 
     @property
     def domain(self) -> str:
@@ -93,9 +107,6 @@ class VirtualLock(BaseLock):
 
     async def async_setup(self, config_entry: ConfigEntry) -> None:
         """Set up lock by provider."""
-        self._store = Store(
-            self.hass, 1, f"{self.domain}_{DOMAIN}_{self.lock.entity_id}"
-        )
         await self.async_hard_refresh_codes()
 
     async def async_unload(self, remove_permanently: bool) -> None:
@@ -107,9 +118,13 @@ class VirtualLock(BaseLock):
         # the entry crashes on its missing runtime data.
         await super().async_unload(remove_permanently)
         if remove_permanently:
-            await self._store.async_remove()
+            await self.async_remove_stored_credentials()
         else:
             await self._store.async_save(self._data)
+
+    async def async_remove_stored_credentials(self) -> None:
+        """Discard the store, because it is the credential rather than a cache."""
+        await self._store.async_remove()
 
     async def async_hard_refresh_codes(self) -> dict[int, SlotCredential]:
         """Reload from store and return all codes."""

--- a/custom_components/lock_code_manager/strings.json
+++ b/custom_components/lock_code_manager/strings.json
@@ -20,6 +20,7 @@
       "lock_not_registered": "Home Assistant has no entity registry entry for {unregistered_locks}, so Lock Code Manager has nothing stable to attach their configuration to and cannot be set up with them. A lock set up in YAML without a unique ID is the usual cause: give it one, or select a different lock.",
       "unsupported_mqtt_lock": "These MQTT locks are not from a supported bridge (Zigbee2MQTT or Z-Wave JS UI): {locks}",
       "users_keyed_by_slot": "This looks like the old slot-numbered format. Users are now listed by name, and Lock Code Manager picks the slot numbers itself:\n\nusers:\n  Raman:\n    pin: \"1234\"\n    enabled: true",
+      "codeless_conflict": "Another Lock Code Manager configuration already manages {locks}, and does not agree about where the codes for it live. A lock either has code storage of its own or it does not, and every configuration that manages it has to say the same thing. Answer the same way here, or remove the lock from one of the two configurations.",
       "codeless_declined": "Lock Code Manager has no way to manage codes on {locks}. Remove them from the list to continue. Your \"no\" stands for the rest of this attempt -- to let Lock Code Manager hold their codes after all, close this dialog and start again."
     },
     "step": {
@@ -162,6 +163,7 @@
       "missing_pin_if_enabled": "PIN must be set if slot is enabled.",
       "lock_not_registered": "Home Assistant has no entity registry entry for {unregistered_locks}, so Lock Code Manager has nothing stable to attach their configuration to and cannot be set up with them. A lock set up in YAML without a unique ID is the usual cause: give it one, or select a different lock.",
       "unsupported_mqtt_lock": "These MQTT locks are not from a supported bridge (Zigbee2MQTT or Z-Wave JS UI): {locks}",
+      "codeless_conflict": "Another Lock Code Manager configuration already manages {locks}, and does not agree about where the codes for it live. A lock either has code storage of its own or it does not, and every configuration that manages it has to say the same thing. Answer the same way here, or remove the lock from one of the two configurations.",
       "codeless_declined": "Lock Code Manager has no way to manage codes on {locks}. Remove them from the list to continue. Your \"no\" stands for the rest of this attempt -- to let Lock Code Manager hold their codes after all, close this dialog and start again."
     },
     "step": {

--- a/custom_components/lock_code_manager/strings.json
+++ b/custom_components/lock_code_manager/strings.json
@@ -17,7 +17,7 @@
       "slot_out_of_range": "Lock {lock} reports only {num_slots} PIN code slots, and this configuration already uses numbers beyond that: {out_of_range_slots}. Lock Code Manager assigns those numbers itself, so the way to free them is to remove some users, or to manage the rest from a separate configuration.",
       "slots_already_configured": "The following slots for lock {lock} are already managed by another config entry ({entry_title}) and can't be added to this configuration without being removed from the other one: {common_slots}",
       "too_many_users": "Lock {lock} has {num_slots} PIN code slots, so {num_users} users will not fit. Set up fewer users here, or manage the rest from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity.",
-      "lock_not_registered": "Home Assistant has no entity registry entry for {locks}, so Lock Code Manager has nothing stable to attach their configuration to and cannot be set up with them. A lock set up in YAML without a unique ID is the usual cause: give it one, or select a different lock.",
+      "lock_not_registered": "Home Assistant has no entity registry entry for {unregistered_locks}, so Lock Code Manager has nothing stable to attach their configuration to and cannot be set up with them. A lock set up in YAML without a unique ID is the usual cause: give it one, or select a different lock.",
       "unsupported_mqtt_lock": "These MQTT locks are not from a supported bridge (Zigbee2MQTT or Z-Wave JS UI): {locks}",
       "users_keyed_by_slot": "This looks like the old slot-numbered format. Users are now listed by name, and Lock Code Manager picks the slot numbers itself:\n\nusers:\n  Raman:\n    pin: \"1234\"\n    enabled: true",
       "codeless_declined": "Lock Code Manager has no way to manage codes on {locks}. Remove them from the list to continue. Your \"no\" stands for the rest of this attempt -- to let Lock Code Manager hold their codes after all, close this dialog and start again."
@@ -72,10 +72,18 @@
       },
       "codeless": {
         "title": "Locks with no code storage",
-        "description": "Lock Code Manager can't read or write codes on {locks}.\n\nIt can still manage codes for these locks: it stores them itself, and checks codes you report with the `use_credential` action against your users and their schedules, recording each use like any other. The locks themselves are never written to, so a code set up here does not open them on its own -- something else has to check it, such as a keypad automation calling `use_credential`.\n\nChoose \"No\" to return to the lock list and select different locks. Your answer stands for the rest of this attempt -- to change it, close this dialog and start again.",
+        "description": "Lock Code Manager can't read or write codes on {lock}.\n\nIt can still manage codes for this lock: it stores them itself, and checks codes you report with the `use_credential` action against your users and their schedules, recording each use like any other. The lock itself is never written to, so a code set up here does not open it on its own -- something else has to check it, such as a keypad automation calling `use_credential`.\n\nAnswer only for this lock; anything else you selected is asked about separately. Choose \"No\" to return to the lock list and select different locks. Your answer stands for the rest of this attempt -- to change it, close this dialog and start again.",
         "menu_options": {
-          "codeless_confirm": "Yes, Lock Code Manager holds the codes for these locks",
-          "codeless_decline": "No, don't manage codes for these locks"
+          "codeless_confirm": "Yes, Lock Code Manager holds the codes for this lock",
+          "codeless_decline": "No, don't manage codes for this lock"
+        }
+      },
+      "codeless_reconsider": {
+        "title": "Lock Code Manager still holds this lock's codes",
+        "description": "Lock Code Manager currently holds the codes for {lock} itself, because you said it has no code storage of its own. Something now claims that lock, so the answer is worth confirming.\n\nChoose \"Yes\" and nothing changes: the codes stay in Lock Code Manager, the lock is never written to, and a code reaches it only through the `use_credential` action. Choose \"No\" and the lock's own integration takes over, so the codes get written to the device from then on -- the codes Lock Code Manager was holding for it are discarded.\n\nAnswer only for this lock; anything else you selected is asked about separately. Your answer stands for the rest of this attempt -- to change it, close this dialog and start again.",
+        "menu_options": {
+          "codeless_confirm": "Yes, Lock Code Manager keeps holding the codes",
+          "codeless_decline": "No, hand this lock back to its own integration"
         }
       }
     }
@@ -152,7 +160,7 @@
       "search_limit_reached": "Placing {num_users} users would need slot numbers past {max_slot}, which is as far as Lock Code Manager looks. No lock here reported how many PIN code slots it has, so this limit is Lock Code Manager's own rather than the lock's. Set up fewer users, or re-interview the lock so it reports its capacity.",
       "name_not_unique": "That name is already used by another user in this configuration. Names must be unique.",
       "missing_pin_if_enabled": "PIN must be set if slot is enabled.",
-      "lock_not_registered": "Home Assistant has no entity registry entry for {locks}, so Lock Code Manager has nothing stable to attach their configuration to and cannot be set up with them. A lock set up in YAML without a unique ID is the usual cause: give it one, or select a different lock.",
+      "lock_not_registered": "Home Assistant has no entity registry entry for {unregistered_locks}, so Lock Code Manager has nothing stable to attach their configuration to and cannot be set up with them. A lock set up in YAML without a unique ID is the usual cause: give it one, or select a different lock.",
       "unsupported_mqtt_lock": "These MQTT locks are not from a supported bridge (Zigbee2MQTT or Z-Wave JS UI): {locks}",
       "codeless_declined": "Lock Code Manager has no way to manage codes on {locks}. Remove them from the list to continue. Your \"no\" stands for the rest of this attempt -- to let Lock Code Manager hold their codes after all, close this dialog and start again."
     },
@@ -167,10 +175,18 @@
       },
       "codeless": {
         "title": "Locks with no code storage",
-        "description": "Lock Code Manager can't read or write codes on {locks}.\n\nIt can still manage codes for these locks: it stores them itself, and checks codes you report with the `use_credential` action against your users and their schedules, recording each use like any other. The locks themselves are never written to, so a code set up here does not open them on its own -- something else has to check it, such as a keypad automation calling `use_credential`.\n\nChoose \"No\" to return to the lock list and select different locks. Your answer stands for the rest of this attempt -- to change it, close this dialog and start again.",
+        "description": "Lock Code Manager can't read or write codes on {lock}.\n\nIt can still manage codes for this lock: it stores them itself, and checks codes you report with the `use_credential` action against your users and their schedules, recording each use like any other. The lock itself is never written to, so a code set up here does not open it on its own -- something else has to check it, such as a keypad automation calling `use_credential`.\n\nAnswer only for this lock; anything else you selected is asked about separately. Choose \"No\" to return to the lock list and select different locks. Your answer stands for the rest of this attempt -- to change it, close this dialog and start again.",
         "menu_options": {
-          "codeless_confirm": "Yes, Lock Code Manager holds the codes for these locks",
-          "codeless_decline": "No, don't manage codes for these locks"
+          "codeless_confirm": "Yes, Lock Code Manager holds the codes for this lock",
+          "codeless_decline": "No, don't manage codes for this lock"
+        }
+      },
+      "codeless_reconsider": {
+        "title": "Lock Code Manager still holds this lock's codes",
+        "description": "Lock Code Manager currently holds the codes for {lock} itself, because you said it has no code storage of its own. Something now claims that lock, so the answer is worth confirming.\n\nChoose \"Yes\" and nothing changes: the codes stay in Lock Code Manager, the lock is never written to, and a code reaches it only through the `use_credential` action. Choose \"No\" and the lock's own integration takes over, so the codes get written to the device from then on -- the codes Lock Code Manager was holding for it are discarded.\n\nAnswer only for this lock; anything else you selected is asked about separately. Your answer stands for the rest of this attempt -- to change it, close this dialog and start again.",
+        "menu_options": {
+          "codeless_confirm": "Yes, Lock Code Manager keeps holding the codes",
+          "codeless_decline": "No, hand this lock back to its own integration"
         }
       }
     }

--- a/custom_components/lock_code_manager/strings.json
+++ b/custom_components/lock_code_manager/strings.json
@@ -18,7 +18,8 @@
       "slots_already_configured": "The following slots for lock {lock} are already managed by another config entry ({entry_title}) and can't be added to this configuration without being removed from the other one: {common_slots}",
       "too_many_users": "Lock {lock} has {num_slots} PIN code slots, so {num_users} users will not fit. Set up fewer users here, or manage the rest from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity.",
       "unsupported_mqtt_lock": "These MQTT locks are not from a supported bridge (Zigbee2MQTT or Z-Wave JS UI): {locks}",
-      "users_keyed_by_slot": "This looks like the old slot-numbered format. Users are now listed by name, and Lock Code Manager picks the slot numbers itself:\n\nusers:\n  Raman:\n    pin: \"1234\"\n    enabled: true"
+      "users_keyed_by_slot": "This looks like the old slot-numbered format. Users are now listed by name, and Lock Code Manager picks the slot numbers itself:\n\nusers:\n  Raman:\n    pin: \"1234\"\n    enabled: true",
+      "codeless_declined": "Lock Code Manager has no way to manage codes on {locks}. Remove them from the list, or go back and let Lock Code Manager hold their codes."
     },
     "step": {
       "choose_path": {
@@ -67,6 +68,14 @@
         },
         "description": "The lock `{lock}`, in the configuration for `{name}`, is no longer configured in Home Assistant and must be removed from your configuration. Choose new locks that this configuration is for. If you no longer need this configuration, delete the configuration entry.",
         "title": "Update locks for {name}"
+      },
+      "codeless": {
+        "title": "Locks with no code storage",
+        "description": "Lock Code Manager can't read or write codes on {locks}.\n\nIt can still manage codes for these locks: it stores them itself, and checks codes you report with the `use_credential` action against your users and their schedules, recording each use like any other. The locks themselves are never written to, so a code set up here does not open them on its own -- something else has to check it, such as a keypad automation calling `use_credential`.\n\nChoose \"No\" to go back and change which locks you selected.",
+        "menu_options": {
+          "codeless_confirm": "Yes, Lock Code Manager holds the codes for these locks",
+          "codeless_decline": "No, don't manage codes for these locks"
+        }
       }
     }
   },
@@ -142,7 +151,8 @@
       "search_limit_reached": "Placing {num_users} users would need slot numbers past {max_slot}, which is as far as Lock Code Manager looks. No lock here reported how many PIN code slots it has, so this limit is Lock Code Manager's own rather than the lock's. Set up fewer users, or re-interview the lock so it reports its capacity.",
       "name_not_unique": "That name is already used by another user in this configuration. Names must be unique.",
       "missing_pin_if_enabled": "PIN must be set if slot is enabled.",
-      "unsupported_mqtt_lock": "These MQTT locks are not from a supported bridge (Zigbee2MQTT or Z-Wave JS UI): {locks}"
+      "unsupported_mqtt_lock": "These MQTT locks are not from a supported bridge (Zigbee2MQTT or Z-Wave JS UI): {locks}",
+      "codeless_declined": "Lock Code Manager has no way to manage codes on {locks}. Remove them from the list, or go back and let Lock Code Manager hold their codes."
     },
     "step": {
       "init": {
@@ -152,6 +162,14 @@
         },
         "description": "Update the locks that are associated with this config entry and/or the users.",
         "title": "Lock Code Manager"
+      },
+      "codeless": {
+        "title": "Locks with no code storage",
+        "description": "Lock Code Manager can't read or write codes on {locks}.\n\nIt can still manage codes for these locks: it stores them itself, and checks codes you report with the `use_credential` action against your users and their schedules, recording each use like any other. The locks themselves are never written to, so a code set up here does not open them on its own -- something else has to check it, such as a keypad automation calling `use_credential`.\n\nChoose \"No\" to go back and change which locks you selected.",
+        "menu_options": {
+          "codeless_confirm": "Yes, Lock Code Manager holds the codes for these locks",
+          "codeless_decline": "No, don't manage codes for these locks"
+        }
       }
     }
   },

--- a/custom_components/lock_code_manager/strings.json
+++ b/custom_components/lock_code_manager/strings.json
@@ -18,10 +18,12 @@
       "slots_already_configured": "The following slots for lock {lock} are already managed by another config entry ({entry_title}) and can't be added to this configuration without being removed from the other one: {common_slots}",
       "too_many_users": "Lock {lock} has {num_slots} PIN code slots, so {num_users} users will not fit. Set up fewer users here, or manage the rest from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity.",
       "lock_not_registered": "Home Assistant has no entity registry entry for {unregistered_locks}, so Lock Code Manager has nothing stable to attach their configuration to and cannot be set up with them. A lock set up in YAML without a unique ID is the usual cause: give it one, or select a different lock.",
-      "unsupported_mqtt_lock": "These MQTT locks are not from a supported bridge (Zigbee2MQTT or Z-Wave JS UI): {locks}",
+      "unsupported_mqtt_lock": "These MQTT locks are not from a supported bridge (Zigbee2MQTT or Z-Wave JS UI): {locks}. If one of them keeps no PIN codes of its own, select it under “Locks with no code storage” instead.",
       "users_keyed_by_slot": "This looks like the old slot-numbered format. Users are now listed by name, and Lock Code Manager picks the slot numbers itself:\n\nusers:\n  Raman:\n    pin: \"1234\"\n    enabled: true",
-      "codeless_conflict": "Another Lock Code Manager configuration already manages {locks}, and does not agree about where the codes for it live. A lock either has code storage of its own or it does not, and every configuration that manages it has to say the same thing. Answer the same way here, or remove the lock from one of the two configurations.",
-      "codeless_declined": "Lock Code Manager has no way to manage codes on {locks}. Remove them from the list to continue. Your \"no\" stands for the rest of this attempt -- to let Lock Code Manager hold their codes after all, close this dialog and start again."
+      "codeless_conflict": "Another Lock Code Manager configuration does not agree about where the codes for {codeless_locks} live. A lock either has code storage of its own or it does not, and every configuration that manages it has to say the same thing. Select the lock in the same field the other configuration uses, or remove it from one of the two configurations.",
+      "unclaimed_lock": "No Lock Code Manager provider claims {locks}. If a lock keeps no PIN codes of its own, select it under “Locks with no code storage” instead and Lock Code Manager will hold its codes for you.",
+      "lock_in_both_fields": "{codeless_locks} are selected in both lock fields. A lock belongs in one or the other: “Locks” if its own integration stores the codes, “Locks with no code storage” if Lock Code Manager holds them instead.",
+      "codeless_lock_claimed": "Lock Code Manager can already read and write the codes on {codeless_locks} through their own integration, so it must not hold codes for them as well — codes it held would never reach the lock. Select them under “Locks” instead."
     },
     "step": {
       "choose_path": {
@@ -52,10 +54,15 @@
       "user": {
         "data": {
           "locks": "Locks",
-          "name": "Name"
+          "name": "Name",
+          "codeless_locks": "Locks with no code storage"
         },
         "description": "Give this configuration a unique name (e.g. `House Locks`) and select the locks you would like to manage with it.",
-        "title": "Lock Code Manager"
+        "title": "Lock Code Manager",
+        "data_description": {
+          "locks": "Locks whose own integration stores the PIN codes, which Lock Code Manager writes to and reads back.",
+          "codeless_locks": "Locks that keep no PIN codes of their own — an ESPHome lock, or any door you unlock with a keypad Home Assistant reads for you. Lock Code Manager stores the codes for these itself and never writes anything to the lock: a code is checked only when something calls the `lock_code_manager.use_credential` action with the code that was entered, which is then matched against your users and their schedules and recorded like any other use. See https://github.com/raman325/lock_code_manager/wiki/External-Keypads"
+        }
       },
       "yaml": {
         "data": {
@@ -66,25 +73,14 @@
       },
       "reauth_confirm": {
         "data": {
-          "locks": "Locks"
+          "locks": "Locks",
+          "codeless_locks": "Locks with no code storage"
         },
         "description": "The lock `{lock}`, in the configuration for `{name}`, is no longer configured in Home Assistant and must be removed from your configuration. Choose new locks that this configuration is for. If you no longer need this configuration, delete the configuration entry.",
-        "title": "Update locks for {name}"
-      },
-      "codeless": {
-        "title": "Locks with no code storage",
-        "description": "Lock Code Manager can't read or write codes on {lock}.\n\nIt can still manage codes for this lock: it stores them itself, and checks codes you report with the `use_credential` action against your users and their schedules, recording each use like any other. The lock itself is never written to, so a code set up here does not open it on its own -- something else has to check it, such as a keypad automation calling `use_credential`.\n\nAnswer only for this lock; anything else you selected is asked about separately. Choose \"No\" to return to the lock list and select different locks. Your answer stands for the rest of this attempt -- to change it, close this dialog and start again.",
-        "menu_options": {
-          "codeless_confirm": "Yes, Lock Code Manager holds the codes for this lock",
-          "codeless_decline": "No, don't manage codes for this lock"
-        }
-      },
-      "codeless_reconsider": {
-        "title": "Lock Code Manager still holds this lock's codes",
-        "description": "Lock Code Manager currently holds the codes for {lock} itself, because you said it has no code storage of its own. Something now claims that lock, so the answer is worth confirming.\n\nChoose \"Yes\" and nothing changes: the codes stay in Lock Code Manager, the lock is never written to, and a code reaches it only through the `use_credential` action. Choose \"No\" and the lock's own integration takes over, so the codes get written to the device from then on -- the codes Lock Code Manager was holding for it are discarded.\n\nAnswer only for this lock; anything else you selected is asked about separately. Your answer stands for the rest of this attempt -- to change it, close this dialog and start again.",
-        "menu_options": {
-          "codeless_confirm": "Yes, Lock Code Manager keeps holding the codes",
-          "codeless_decline": "No, hand this lock back to its own integration"
+        "title": "Update locks for {name}",
+        "data_description": {
+          "locks": "Locks whose own integration stores the PIN codes, which Lock Code Manager writes to and reads back.",
+          "codeless_locks": "Locks that keep no PIN codes of their own — an ESPHome lock, or any door you unlock with a keypad Home Assistant reads for you. Lock Code Manager stores the codes for these itself and never writes anything to the lock: a code is checked only when something calls the `lock_code_manager.use_credential` action with the code that was entered, which is then matched against your users and their schedules and recorded like any other use. See https://github.com/raman325/lock_code_manager/wiki/External-Keypads"
         }
       }
     }
@@ -162,33 +158,24 @@
       "name_not_unique": "That name is already used by another user in this configuration. Names must be unique.",
       "missing_pin_if_enabled": "PIN must be set if slot is enabled.",
       "lock_not_registered": "Home Assistant has no entity registry entry for {unregistered_locks}, so Lock Code Manager has nothing stable to attach their configuration to and cannot be set up with them. A lock set up in YAML without a unique ID is the usual cause: give it one, or select a different lock.",
-      "unsupported_mqtt_lock": "These MQTT locks are not from a supported bridge (Zigbee2MQTT or Z-Wave JS UI): {locks}",
-      "codeless_conflict": "Another Lock Code Manager configuration already manages {locks}, and does not agree about where the codes for it live. A lock either has code storage of its own or it does not, and every configuration that manages it has to say the same thing. Answer the same way here, or remove the lock from one of the two configurations.",
-      "codeless_declined": "Lock Code Manager has no way to manage codes on {locks}. Remove them from the list to continue. Your \"no\" stands for the rest of this attempt -- to let Lock Code Manager hold their codes after all, close this dialog and start again."
+      "unsupported_mqtt_lock": "These MQTT locks are not from a supported bridge (Zigbee2MQTT or Z-Wave JS UI): {locks}. If one of them keeps no PIN codes of its own, select it under “Locks with no code storage” instead.",
+      "codeless_conflict": "Another Lock Code Manager configuration does not agree about where the codes for {codeless_locks} live. A lock either has code storage of its own or it does not, and every configuration that manages it has to say the same thing. Select the lock in the same field the other configuration uses, or remove it from one of the two configurations.",
+      "unclaimed_lock": "No Lock Code Manager provider claims {locks}. If a lock keeps no PIN codes of its own, select it under “Locks with no code storage” instead and Lock Code Manager will hold its codes for you.",
+      "lock_in_both_fields": "{codeless_locks} are selected in both lock fields. A lock belongs in one or the other: “Locks” if its own integration stores the codes, “Locks with no code storage” if Lock Code Manager holds them instead.",
+      "codeless_lock_claimed": "Lock Code Manager can already read and write the codes on {codeless_locks} through their own integration, so it must not hold codes for them as well — codes it held would never reach the lock. Select them under “Locks” instead."
     },
     "step": {
       "init": {
         "data": {
           "locks": "Locks",
-          "users": "Users YAML"
+          "users": "Users YAML",
+          "codeless_locks": "Locks with no code storage"
         },
         "description": "Update the locks that are associated with this config entry and/or the users.",
-        "title": "Lock Code Manager"
-      },
-      "codeless": {
-        "title": "Locks with no code storage",
-        "description": "Lock Code Manager can't read or write codes on {lock}.\n\nIt can still manage codes for this lock: it stores them itself, and checks codes you report with the `use_credential` action against your users and their schedules, recording each use like any other. The lock itself is never written to, so a code set up here does not open it on its own -- something else has to check it, such as a keypad automation calling `use_credential`.\n\nAnswer only for this lock; anything else you selected is asked about separately. Choose \"No\" to return to the lock list and select different locks. Your answer stands for the rest of this attempt -- to change it, close this dialog and start again.",
-        "menu_options": {
-          "codeless_confirm": "Yes, Lock Code Manager holds the codes for this lock",
-          "codeless_decline": "No, don't manage codes for this lock"
-        }
-      },
-      "codeless_reconsider": {
-        "title": "Lock Code Manager still holds this lock's codes",
-        "description": "Lock Code Manager currently holds the codes for {lock} itself, because you said it has no code storage of its own. Something now claims that lock, so the answer is worth confirming.\n\nChoose \"Yes\" and nothing changes: the codes stay in Lock Code Manager, the lock is never written to, and a code reaches it only through the `use_credential` action. Choose \"No\" and the lock's own integration takes over, so the codes get written to the device from then on -- the codes Lock Code Manager was holding for it are discarded.\n\nAnswer only for this lock; anything else you selected is asked about separately. Your answer stands for the rest of this attempt -- to change it, close this dialog and start again.",
-        "menu_options": {
-          "codeless_confirm": "Yes, Lock Code Manager keeps holding the codes",
-          "codeless_decline": "No, hand this lock back to its own integration"
+        "title": "Lock Code Manager",
+        "data_description": {
+          "locks": "Locks whose own integration stores the PIN codes, which Lock Code Manager writes to and reads back.",
+          "codeless_locks": "Locks that keep no PIN codes of their own — an ESPHome lock, or any door you unlock with a keypad Home Assistant reads for you. Lock Code Manager stores the codes for these itself and never writes anything to the lock: a code is checked only when something calls the `lock_code_manager.use_credential` action with the code that was entered, which is then matched against your users and their schedules and recorded like any other use. See https://github.com/raman325/lock_code_manager/wiki/External-Keypads"
         }
       }
     }

--- a/custom_components/lock_code_manager/strings.json
+++ b/custom_components/lock_code_manager/strings.json
@@ -17,9 +17,10 @@
       "slot_out_of_range": "Lock {lock} reports only {num_slots} PIN code slots, and this configuration already uses numbers beyond that: {out_of_range_slots}. Lock Code Manager assigns those numbers itself, so the way to free them is to remove some users, or to manage the rest from a separate configuration.",
       "slots_already_configured": "The following slots for lock {lock} are already managed by another config entry ({entry_title}) and can't be added to this configuration without being removed from the other one: {common_slots}",
       "too_many_users": "Lock {lock} has {num_slots} PIN code slots, so {num_users} users will not fit. Set up fewer users here, or manage the rest from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity.",
+      "lock_not_registered": "Home Assistant has no entity registry entry for {locks}, so Lock Code Manager has nothing stable to attach their configuration to and cannot be set up with them. A lock set up in YAML without a unique ID is the usual cause: give it one, or select a different lock.",
       "unsupported_mqtt_lock": "These MQTT locks are not from a supported bridge (Zigbee2MQTT or Z-Wave JS UI): {locks}",
       "users_keyed_by_slot": "This looks like the old slot-numbered format. Users are now listed by name, and Lock Code Manager picks the slot numbers itself:\n\nusers:\n  Raman:\n    pin: \"1234\"\n    enabled: true",
-      "codeless_declined": "Lock Code Manager has no way to manage codes on {locks}. Remove them from the list, or go back and let Lock Code Manager hold their codes."
+      "codeless_declined": "Lock Code Manager has no way to manage codes on {locks}. Remove them from the list to continue. Your \"no\" stands for the rest of this attempt -- to let Lock Code Manager hold their codes after all, close this dialog and start again."
     },
     "step": {
       "choose_path": {
@@ -71,7 +72,7 @@
       },
       "codeless": {
         "title": "Locks with no code storage",
-        "description": "Lock Code Manager can't read or write codes on {locks}.\n\nIt can still manage codes for these locks: it stores them itself, and checks codes you report with the `use_credential` action against your users and their schedules, recording each use like any other. The locks themselves are never written to, so a code set up here does not open them on its own -- something else has to check it, such as a keypad automation calling `use_credential`.\n\nChoose \"No\" to go back and change which locks you selected.",
+        "description": "Lock Code Manager can't read or write codes on {locks}.\n\nIt can still manage codes for these locks: it stores them itself, and checks codes you report with the `use_credential` action against your users and their schedules, recording each use like any other. The locks themselves are never written to, so a code set up here does not open them on its own -- something else has to check it, such as a keypad automation calling `use_credential`.\n\nChoose \"No\" to return to the lock list and select different locks. Your answer stands for the rest of this attempt -- to change it, close this dialog and start again.",
         "menu_options": {
           "codeless_confirm": "Yes, Lock Code Manager holds the codes for these locks",
           "codeless_decline": "No, don't manage codes for these locks"
@@ -151,8 +152,9 @@
       "search_limit_reached": "Placing {num_users} users would need slot numbers past {max_slot}, which is as far as Lock Code Manager looks. No lock here reported how many PIN code slots it has, so this limit is Lock Code Manager's own rather than the lock's. Set up fewer users, or re-interview the lock so it reports its capacity.",
       "name_not_unique": "That name is already used by another user in this configuration. Names must be unique.",
       "missing_pin_if_enabled": "PIN must be set if slot is enabled.",
+      "lock_not_registered": "Home Assistant has no entity registry entry for {locks}, so Lock Code Manager has nothing stable to attach their configuration to and cannot be set up with them. A lock set up in YAML without a unique ID is the usual cause: give it one, or select a different lock.",
       "unsupported_mqtt_lock": "These MQTT locks are not from a supported bridge (Zigbee2MQTT or Z-Wave JS UI): {locks}",
-      "codeless_declined": "Lock Code Manager has no way to manage codes on {locks}. Remove them from the list, or go back and let Lock Code Manager hold their codes."
+      "codeless_declined": "Lock Code Manager has no way to manage codes on {locks}. Remove them from the list to continue. Your \"no\" stands for the rest of this attempt -- to let Lock Code Manager hold their codes after all, close this dialog and start again."
     },
     "step": {
       "init": {
@@ -165,7 +167,7 @@
       },
       "codeless": {
         "title": "Locks with no code storage",
-        "description": "Lock Code Manager can't read or write codes on {locks}.\n\nIt can still manage codes for these locks: it stores them itself, and checks codes you report with the `use_credential` action against your users and their schedules, recording each use like any other. The locks themselves are never written to, so a code set up here does not open them on its own -- something else has to check it, such as a keypad automation calling `use_credential`.\n\nChoose \"No\" to go back and change which locks you selected.",
+        "description": "Lock Code Manager can't read or write codes on {locks}.\n\nIt can still manage codes for these locks: it stores them itself, and checks codes you report with the `use_credential` action against your users and their schedules, recording each use like any other. The locks themselves are never written to, so a code set up here does not open them on its own -- something else has to check it, such as a keypad automation calling `use_credential`.\n\nChoose \"No\" to return to the lock list and select different locks. Your answer stands for the rest of this attempt -- to change it, close this dialog and start again.",
         "menu_options": {
           "codeless_confirm": "Yes, Lock Code Manager holds the codes for these locks",
           "codeless_decline": "No, don't manage codes for these locks"

--- a/custom_components/lock_code_manager/strings.json
+++ b/custom_components/lock_code_manager/strings.json
@@ -61,7 +61,7 @@
         "title": "Lock Code Manager",
         "data_description": {
           "locks": "Locks whose own integration stores the PIN codes, which Lock Code Manager writes to and reads back.",
-          "codeless_locks": "Locks that keep no PIN codes of their own — an ESPHome lock, or any door you unlock with a keypad Home Assistant reads for you. Lock Code Manager stores the codes for these itself and never writes anything to the lock: a code is checked only when something calls the `lock_code_manager.use_credential` action with the code that was entered, which is then matched against your users and their schedules and recorded like any other use. See https://github.com/raman325/lock_code_manager/wiki/External-Keypads"
+          "codeless_locks": "Locks that keep no PIN codes of their own — an ESPHome lock, or any door you unlock with a keypad Home Assistant reads for you. Lock Code Manager stores the codes for these itself and never writes anything to the lock: a code is checked only when something calls the `lock_code_manager.use_credential` action with the code that was entered, which is then matched against your users and their schedules and recorded like any other use. See {wiki_url}"
         }
       },
       "yaml": {
@@ -80,7 +80,7 @@
         "title": "Update locks for {name}",
         "data_description": {
           "locks": "Locks whose own integration stores the PIN codes, which Lock Code Manager writes to and reads back.",
-          "codeless_locks": "Locks that keep no PIN codes of their own — an ESPHome lock, or any door you unlock with a keypad Home Assistant reads for you. Lock Code Manager stores the codes for these itself and never writes anything to the lock: a code is checked only when something calls the `lock_code_manager.use_credential` action with the code that was entered, which is then matched against your users and their schedules and recorded like any other use. See https://github.com/raman325/lock_code_manager/wiki/External-Keypads"
+          "codeless_locks": "Locks that keep no PIN codes of their own — an ESPHome lock, or any door you unlock with a keypad Home Assistant reads for you. Lock Code Manager stores the codes for these itself and never writes anything to the lock: a code is checked only when something calls the `lock_code_manager.use_credential` action with the code that was entered, which is then matched against your users and their schedules and recorded like any other use. See {wiki_url}"
         }
       }
     }
@@ -175,7 +175,7 @@
         "title": "Lock Code Manager",
         "data_description": {
           "locks": "Locks whose own integration stores the PIN codes, which Lock Code Manager writes to and reads back.",
-          "codeless_locks": "Locks that keep no PIN codes of their own — an ESPHome lock, or any door you unlock with a keypad Home Assistant reads for you. Lock Code Manager stores the codes for these itself and never writes anything to the lock: a code is checked only when something calls the `lock_code_manager.use_credential` action with the code that was entered, which is then matched against your users and their schedules and recorded like any other use. See https://github.com/raman325/lock_code_manager/wiki/External-Keypads"
+          "codeless_locks": "Locks that keep no PIN codes of their own — an ESPHome lock, or any door you unlock with a keypad Home Assistant reads for you. Lock Code Manager stores the codes for these itself and never writes anything to the lock: a code is checked only when something calls the `lock_code_manager.use_credential` action with the code that was entered, which is then matched against your users and their schedules and recorded like any other use. See {wiki_url}"
         }
       }
     }

--- a/custom_components/lock_code_manager/translations/en.json
+++ b/custom_components/lock_code_manager/translations/en.json
@@ -20,6 +20,7 @@
       "lock_not_registered": "Home Assistant has no entity registry entry for {unregistered_locks}, so Lock Code Manager has nothing stable to attach their configuration to and cannot be set up with them. A lock set up in YAML without a unique ID is the usual cause: give it one, or select a different lock.",
       "unsupported_mqtt_lock": "These MQTT locks are not from a supported bridge (Zigbee2MQTT or Z-Wave JS UI): {locks}",
       "users_keyed_by_slot": "This looks like the old slot-numbered format. Users are now listed by name, and Lock Code Manager picks the slot numbers itself:\n\nusers:\n  Raman:\n    pin: \"1234\"\n    enabled: true",
+      "codeless_conflict": "Another Lock Code Manager configuration already manages {locks}, and does not agree about where the codes for it live. A lock either has code storage of its own or it does not, and every configuration that manages it has to say the same thing. Answer the same way here, or remove the lock from one of the two configurations.",
       "codeless_declined": "Lock Code Manager has no way to manage codes on {locks}. Remove them from the list to continue. Your \"no\" stands for the rest of this attempt -- to let Lock Code Manager hold their codes after all, close this dialog and start again."
     },
     "step": {
@@ -162,6 +163,7 @@
       "missing_pin_if_enabled": "PIN must be set if slot is enabled.",
       "lock_not_registered": "Home Assistant has no entity registry entry for {unregistered_locks}, so Lock Code Manager has nothing stable to attach their configuration to and cannot be set up with them. A lock set up in YAML without a unique ID is the usual cause: give it one, or select a different lock.",
       "unsupported_mqtt_lock": "These MQTT locks are not from a supported bridge (Zigbee2MQTT or Z-Wave JS UI): {locks}",
+      "codeless_conflict": "Another Lock Code Manager configuration already manages {locks}, and does not agree about where the codes for it live. A lock either has code storage of its own or it does not, and every configuration that manages it has to say the same thing. Answer the same way here, or remove the lock from one of the two configurations.",
       "codeless_declined": "Lock Code Manager has no way to manage codes on {locks}. Remove them from the list to continue. Your \"no\" stands for the rest of this attempt -- to let Lock Code Manager hold their codes after all, close this dialog and start again."
     },
     "step": {

--- a/custom_components/lock_code_manager/translations/en.json
+++ b/custom_components/lock_code_manager/translations/en.json
@@ -17,7 +17,7 @@
       "slot_out_of_range": "Lock {lock} reports only {num_slots} PIN code slots, and this configuration already uses numbers beyond that: {out_of_range_slots}. Lock Code Manager assigns those numbers itself, so the way to free them is to remove some users, or to manage the rest from a separate configuration.",
       "slots_already_configured": "The following slots for lock {lock} are already managed by another config entry ({entry_title}) and can't be added to this configuration without being removed from the other one: {common_slots}",
       "too_many_users": "Lock {lock} has {num_slots} PIN code slots, so {num_users} users will not fit. Set up fewer users here, or manage the rest from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity.",
-      "lock_not_registered": "Home Assistant has no entity registry entry for {locks}, so Lock Code Manager has nothing stable to attach their configuration to and cannot be set up with them. A lock set up in YAML without a unique ID is the usual cause: give it one, or select a different lock.",
+      "lock_not_registered": "Home Assistant has no entity registry entry for {unregistered_locks}, so Lock Code Manager has nothing stable to attach their configuration to and cannot be set up with them. A lock set up in YAML without a unique ID is the usual cause: give it one, or select a different lock.",
       "unsupported_mqtt_lock": "These MQTT locks are not from a supported bridge (Zigbee2MQTT or Z-Wave JS UI): {locks}",
       "users_keyed_by_slot": "This looks like the old slot-numbered format. Users are now listed by name, and Lock Code Manager picks the slot numbers itself:\n\nusers:\n  Raman:\n    pin: \"1234\"\n    enabled: true",
       "codeless_declined": "Lock Code Manager has no way to manage codes on {locks}. Remove them from the list to continue. Your \"no\" stands for the rest of this attempt -- to let Lock Code Manager hold their codes after all, close this dialog and start again."
@@ -72,10 +72,18 @@
       },
       "codeless": {
         "title": "Locks with no code storage",
-        "description": "Lock Code Manager can't read or write codes on {locks}.\n\nIt can still manage codes for these locks: it stores them itself, and checks codes you report with the `use_credential` action against your users and their schedules, recording each use like any other. The locks themselves are never written to, so a code set up here does not open them on its own -- something else has to check it, such as a keypad automation calling `use_credential`.\n\nChoose \"No\" to return to the lock list and select different locks. Your answer stands for the rest of this attempt -- to change it, close this dialog and start again.",
+        "description": "Lock Code Manager can't read or write codes on {lock}.\n\nIt can still manage codes for this lock: it stores them itself, and checks codes you report with the `use_credential` action against your users and their schedules, recording each use like any other. The lock itself is never written to, so a code set up here does not open it on its own -- something else has to check it, such as a keypad automation calling `use_credential`.\n\nAnswer only for this lock; anything else you selected is asked about separately. Choose \"No\" to return to the lock list and select different locks. Your answer stands for the rest of this attempt -- to change it, close this dialog and start again.",
         "menu_options": {
-          "codeless_confirm": "Yes, Lock Code Manager holds the codes for these locks",
-          "codeless_decline": "No, don't manage codes for these locks"
+          "codeless_confirm": "Yes, Lock Code Manager holds the codes for this lock",
+          "codeless_decline": "No, don't manage codes for this lock"
+        }
+      },
+      "codeless_reconsider": {
+        "title": "Lock Code Manager still holds this lock's codes",
+        "description": "Lock Code Manager currently holds the codes for {lock} itself, because you said it has no code storage of its own. Something now claims that lock, so the answer is worth confirming.\n\nChoose \"Yes\" and nothing changes: the codes stay in Lock Code Manager, the lock is never written to, and a code reaches it only through the `use_credential` action. Choose \"No\" and the lock's own integration takes over, so the codes get written to the device from then on -- the codes Lock Code Manager was holding for it are discarded.\n\nAnswer only for this lock; anything else you selected is asked about separately. Your answer stands for the rest of this attempt -- to change it, close this dialog and start again.",
+        "menu_options": {
+          "codeless_confirm": "Yes, Lock Code Manager keeps holding the codes",
+          "codeless_decline": "No, hand this lock back to its own integration"
         }
       }
     }
@@ -152,7 +160,7 @@
       "search_limit_reached": "Placing {num_users} users would need slot numbers past {max_slot}, which is as far as Lock Code Manager looks. No lock here reported how many PIN code slots it has, so this limit is Lock Code Manager's own rather than the lock's. Set up fewer users, or re-interview the lock so it reports its capacity.",
       "name_not_unique": "That name is already used by another user in this configuration. Names must be unique.",
       "missing_pin_if_enabled": "PIN must be set if slot is enabled.",
-      "lock_not_registered": "Home Assistant has no entity registry entry for {locks}, so Lock Code Manager has nothing stable to attach their configuration to and cannot be set up with them. A lock set up in YAML without a unique ID is the usual cause: give it one, or select a different lock.",
+      "lock_not_registered": "Home Assistant has no entity registry entry for {unregistered_locks}, so Lock Code Manager has nothing stable to attach their configuration to and cannot be set up with them. A lock set up in YAML without a unique ID is the usual cause: give it one, or select a different lock.",
       "unsupported_mqtt_lock": "These MQTT locks are not from a supported bridge (Zigbee2MQTT or Z-Wave JS UI): {locks}",
       "codeless_declined": "Lock Code Manager has no way to manage codes on {locks}. Remove them from the list to continue. Your \"no\" stands for the rest of this attempt -- to let Lock Code Manager hold their codes after all, close this dialog and start again."
     },
@@ -167,10 +175,18 @@
       },
       "codeless": {
         "title": "Locks with no code storage",
-        "description": "Lock Code Manager can't read or write codes on {locks}.\n\nIt can still manage codes for these locks: it stores them itself, and checks codes you report with the `use_credential` action against your users and their schedules, recording each use like any other. The locks themselves are never written to, so a code set up here does not open them on its own -- something else has to check it, such as a keypad automation calling `use_credential`.\n\nChoose \"No\" to return to the lock list and select different locks. Your answer stands for the rest of this attempt -- to change it, close this dialog and start again.",
+        "description": "Lock Code Manager can't read or write codes on {lock}.\n\nIt can still manage codes for this lock: it stores them itself, and checks codes you report with the `use_credential` action against your users and their schedules, recording each use like any other. The lock itself is never written to, so a code set up here does not open it on its own -- something else has to check it, such as a keypad automation calling `use_credential`.\n\nAnswer only for this lock; anything else you selected is asked about separately. Choose \"No\" to return to the lock list and select different locks. Your answer stands for the rest of this attempt -- to change it, close this dialog and start again.",
         "menu_options": {
-          "codeless_confirm": "Yes, Lock Code Manager holds the codes for these locks",
-          "codeless_decline": "No, don't manage codes for these locks"
+          "codeless_confirm": "Yes, Lock Code Manager holds the codes for this lock",
+          "codeless_decline": "No, don't manage codes for this lock"
+        }
+      },
+      "codeless_reconsider": {
+        "title": "Lock Code Manager still holds this lock's codes",
+        "description": "Lock Code Manager currently holds the codes for {lock} itself, because you said it has no code storage of its own. Something now claims that lock, so the answer is worth confirming.\n\nChoose \"Yes\" and nothing changes: the codes stay in Lock Code Manager, the lock is never written to, and a code reaches it only through the `use_credential` action. Choose \"No\" and the lock's own integration takes over, so the codes get written to the device from then on -- the codes Lock Code Manager was holding for it are discarded.\n\nAnswer only for this lock; anything else you selected is asked about separately. Your answer stands for the rest of this attempt -- to change it, close this dialog and start again.",
+        "menu_options": {
+          "codeless_confirm": "Yes, Lock Code Manager keeps holding the codes",
+          "codeless_decline": "No, hand this lock back to its own integration"
         }
       }
     }

--- a/custom_components/lock_code_manager/translations/en.json
+++ b/custom_components/lock_code_manager/translations/en.json
@@ -18,7 +18,8 @@
       "slots_already_configured": "The following slots for lock {lock} are already managed by another config entry ({entry_title}) and can't be added to this configuration without being removed from the other one: {common_slots}",
       "too_many_users": "Lock {lock} has {num_slots} PIN code slots, so {num_users} users will not fit. Set up fewer users here, or manage the rest from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity.",
       "unsupported_mqtt_lock": "These MQTT locks are not from a supported bridge (Zigbee2MQTT or Z-Wave JS UI): {locks}",
-      "users_keyed_by_slot": "This looks like the old slot-numbered format. Users are now listed by name, and Lock Code Manager picks the slot numbers itself:\n\nusers:\n  Raman:\n    pin: \"1234\"\n    enabled: true"
+      "users_keyed_by_slot": "This looks like the old slot-numbered format. Users are now listed by name, and Lock Code Manager picks the slot numbers itself:\n\nusers:\n  Raman:\n    pin: \"1234\"\n    enabled: true",
+      "codeless_declined": "Lock Code Manager has no way to manage codes on {locks}. Remove them from the list, or go back and let Lock Code Manager hold their codes."
     },
     "step": {
       "choose_path": {
@@ -67,6 +68,14 @@
         },
         "description": "The lock `{lock}`, in the configuration for `{name}`, is no longer configured in Home Assistant and must be removed from your configuration. Choose new locks that this configuration is for. If you no longer need this configuration, delete the configuration entry.",
         "title": "Update locks for {name}"
+      },
+      "codeless": {
+        "title": "Locks with no code storage",
+        "description": "Lock Code Manager can't read or write codes on {locks}.\n\nIt can still manage codes for these locks: it stores them itself, and checks codes you report with the `use_credential` action against your users and their schedules, recording each use like any other. The locks themselves are never written to, so a code set up here does not open them on its own -- something else has to check it, such as a keypad automation calling `use_credential`.\n\nChoose \"No\" to go back and change which locks you selected.",
+        "menu_options": {
+          "codeless_confirm": "Yes, Lock Code Manager holds the codes for these locks",
+          "codeless_decline": "No, don't manage codes for these locks"
+        }
       }
     }
   },
@@ -142,7 +151,8 @@
       "search_limit_reached": "Placing {num_users} users would need slot numbers past {max_slot}, which is as far as Lock Code Manager looks. No lock here reported how many PIN code slots it has, so this limit is Lock Code Manager's own rather than the lock's. Set up fewer users, or re-interview the lock so it reports its capacity.",
       "name_not_unique": "That name is already used by another user in this configuration. Names must be unique.",
       "missing_pin_if_enabled": "PIN must be set if slot is enabled.",
-      "unsupported_mqtt_lock": "These MQTT locks are not from a supported bridge (Zigbee2MQTT or Z-Wave JS UI): {locks}"
+      "unsupported_mqtt_lock": "These MQTT locks are not from a supported bridge (Zigbee2MQTT or Z-Wave JS UI): {locks}",
+      "codeless_declined": "Lock Code Manager has no way to manage codes on {locks}. Remove them from the list, or go back and let Lock Code Manager hold their codes."
     },
     "step": {
       "init": {
@@ -152,6 +162,14 @@
         },
         "description": "Update the locks that are associated with this config entry and/or the users.",
         "title": "Lock Code Manager"
+      },
+      "codeless": {
+        "title": "Locks with no code storage",
+        "description": "Lock Code Manager can't read or write codes on {locks}.\n\nIt can still manage codes for these locks: it stores them itself, and checks codes you report with the `use_credential` action against your users and their schedules, recording each use like any other. The locks themselves are never written to, so a code set up here does not open them on its own -- something else has to check it, such as a keypad automation calling `use_credential`.\n\nChoose \"No\" to go back and change which locks you selected.",
+        "menu_options": {
+          "codeless_confirm": "Yes, Lock Code Manager holds the codes for these locks",
+          "codeless_decline": "No, don't manage codes for these locks"
+        }
       }
     }
   },

--- a/custom_components/lock_code_manager/translations/en.json
+++ b/custom_components/lock_code_manager/translations/en.json
@@ -18,10 +18,12 @@
       "slots_already_configured": "The following slots for lock {lock} are already managed by another config entry ({entry_title}) and can't be added to this configuration without being removed from the other one: {common_slots}",
       "too_many_users": "Lock {lock} has {num_slots} PIN code slots, so {num_users} users will not fit. Set up fewer users here, or manage the rest from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity.",
       "lock_not_registered": "Home Assistant has no entity registry entry for {unregistered_locks}, so Lock Code Manager has nothing stable to attach their configuration to and cannot be set up with them. A lock set up in YAML without a unique ID is the usual cause: give it one, or select a different lock.",
-      "unsupported_mqtt_lock": "These MQTT locks are not from a supported bridge (Zigbee2MQTT or Z-Wave JS UI): {locks}",
+      "unsupported_mqtt_lock": "These MQTT locks are not from a supported bridge (Zigbee2MQTT or Z-Wave JS UI): {locks}. If one of them keeps no PIN codes of its own, select it under “Locks with no code storage” instead.",
       "users_keyed_by_slot": "This looks like the old slot-numbered format. Users are now listed by name, and Lock Code Manager picks the slot numbers itself:\n\nusers:\n  Raman:\n    pin: \"1234\"\n    enabled: true",
-      "codeless_conflict": "Another Lock Code Manager configuration already manages {locks}, and does not agree about where the codes for it live. A lock either has code storage of its own or it does not, and every configuration that manages it has to say the same thing. Answer the same way here, or remove the lock from one of the two configurations.",
-      "codeless_declined": "Lock Code Manager has no way to manage codes on {locks}. Remove them from the list to continue. Your \"no\" stands for the rest of this attempt -- to let Lock Code Manager hold their codes after all, close this dialog and start again."
+      "codeless_conflict": "Another Lock Code Manager configuration does not agree about where the codes for {codeless_locks} live. A lock either has code storage of its own or it does not, and every configuration that manages it has to say the same thing. Select the lock in the same field the other configuration uses, or remove it from one of the two configurations.",
+      "unclaimed_lock": "No Lock Code Manager provider claims {locks}. If a lock keeps no PIN codes of its own, select it under “Locks with no code storage” instead and Lock Code Manager will hold its codes for you.",
+      "lock_in_both_fields": "{codeless_locks} are selected in both lock fields. A lock belongs in one or the other: “Locks” if its own integration stores the codes, “Locks with no code storage” if Lock Code Manager holds them instead.",
+      "codeless_lock_claimed": "Lock Code Manager can already read and write the codes on {codeless_locks} through their own integration, so it must not hold codes for them as well — codes it held would never reach the lock. Select them under “Locks” instead."
     },
     "step": {
       "choose_path": {
@@ -52,10 +54,15 @@
       "user": {
         "data": {
           "locks": "Locks",
-          "name": "Name"
+          "name": "Name",
+          "codeless_locks": "Locks with no code storage"
         },
         "description": "Give this configuration a unique name (e.g. `House Locks`) and select the locks you would like to manage with it.",
-        "title": "Lock Code Manager"
+        "title": "Lock Code Manager",
+        "data_description": {
+          "locks": "Locks whose own integration stores the PIN codes, which Lock Code Manager writes to and reads back.",
+          "codeless_locks": "Locks that keep no PIN codes of their own — an ESPHome lock, or any door you unlock with a keypad Home Assistant reads for you. Lock Code Manager stores the codes for these itself and never writes anything to the lock: a code is checked only when something calls the `lock_code_manager.use_credential` action with the code that was entered, which is then matched against your users and their schedules and recorded like any other use. See https://github.com/raman325/lock_code_manager/wiki/External-Keypads"
+        }
       },
       "yaml": {
         "data": {
@@ -66,25 +73,14 @@
       },
       "reauth_confirm": {
         "data": {
-          "locks": "Locks"
+          "locks": "Locks",
+          "codeless_locks": "Locks with no code storage"
         },
         "description": "The lock `{lock}`, in the configuration for `{name}`, is no longer configured in Home Assistant and must be removed from your configuration. Choose new locks that this configuration is for. If you no longer need this configuration, delete the configuration entry.",
-        "title": "Update locks for {name}"
-      },
-      "codeless": {
-        "title": "Locks with no code storage",
-        "description": "Lock Code Manager can't read or write codes on {lock}.\n\nIt can still manage codes for this lock: it stores them itself, and checks codes you report with the `use_credential` action against your users and their schedules, recording each use like any other. The lock itself is never written to, so a code set up here does not open it on its own -- something else has to check it, such as a keypad automation calling `use_credential`.\n\nAnswer only for this lock; anything else you selected is asked about separately. Choose \"No\" to return to the lock list and select different locks. Your answer stands for the rest of this attempt -- to change it, close this dialog and start again.",
-        "menu_options": {
-          "codeless_confirm": "Yes, Lock Code Manager holds the codes for this lock",
-          "codeless_decline": "No, don't manage codes for this lock"
-        }
-      },
-      "codeless_reconsider": {
-        "title": "Lock Code Manager still holds this lock's codes",
-        "description": "Lock Code Manager currently holds the codes for {lock} itself, because you said it has no code storage of its own. Something now claims that lock, so the answer is worth confirming.\n\nChoose \"Yes\" and nothing changes: the codes stay in Lock Code Manager, the lock is never written to, and a code reaches it only through the `use_credential` action. Choose \"No\" and the lock's own integration takes over, so the codes get written to the device from then on -- the codes Lock Code Manager was holding for it are discarded.\n\nAnswer only for this lock; anything else you selected is asked about separately. Your answer stands for the rest of this attempt -- to change it, close this dialog and start again.",
-        "menu_options": {
-          "codeless_confirm": "Yes, Lock Code Manager keeps holding the codes",
-          "codeless_decline": "No, hand this lock back to its own integration"
+        "title": "Update locks for {name}",
+        "data_description": {
+          "locks": "Locks whose own integration stores the PIN codes, which Lock Code Manager writes to and reads back.",
+          "codeless_locks": "Locks that keep no PIN codes of their own — an ESPHome lock, or any door you unlock with a keypad Home Assistant reads for you. Lock Code Manager stores the codes for these itself and never writes anything to the lock: a code is checked only when something calls the `lock_code_manager.use_credential` action with the code that was entered, which is then matched against your users and their schedules and recorded like any other use. See https://github.com/raman325/lock_code_manager/wiki/External-Keypads"
         }
       }
     }
@@ -162,33 +158,24 @@
       "name_not_unique": "That name is already used by another user in this configuration. Names must be unique.",
       "missing_pin_if_enabled": "PIN must be set if slot is enabled.",
       "lock_not_registered": "Home Assistant has no entity registry entry for {unregistered_locks}, so Lock Code Manager has nothing stable to attach their configuration to and cannot be set up with them. A lock set up in YAML without a unique ID is the usual cause: give it one, or select a different lock.",
-      "unsupported_mqtt_lock": "These MQTT locks are not from a supported bridge (Zigbee2MQTT or Z-Wave JS UI): {locks}",
-      "codeless_conflict": "Another Lock Code Manager configuration already manages {locks}, and does not agree about where the codes for it live. A lock either has code storage of its own or it does not, and every configuration that manages it has to say the same thing. Answer the same way here, or remove the lock from one of the two configurations.",
-      "codeless_declined": "Lock Code Manager has no way to manage codes on {locks}. Remove them from the list to continue. Your \"no\" stands for the rest of this attempt -- to let Lock Code Manager hold their codes after all, close this dialog and start again."
+      "unsupported_mqtt_lock": "These MQTT locks are not from a supported bridge (Zigbee2MQTT or Z-Wave JS UI): {locks}. If one of them keeps no PIN codes of its own, select it under “Locks with no code storage” instead.",
+      "codeless_conflict": "Another Lock Code Manager configuration does not agree about where the codes for {codeless_locks} live. A lock either has code storage of its own or it does not, and every configuration that manages it has to say the same thing. Select the lock in the same field the other configuration uses, or remove it from one of the two configurations.",
+      "unclaimed_lock": "No Lock Code Manager provider claims {locks}. If a lock keeps no PIN codes of its own, select it under “Locks with no code storage” instead and Lock Code Manager will hold its codes for you.",
+      "lock_in_both_fields": "{codeless_locks} are selected in both lock fields. A lock belongs in one or the other: “Locks” if its own integration stores the codes, “Locks with no code storage” if Lock Code Manager holds them instead.",
+      "codeless_lock_claimed": "Lock Code Manager can already read and write the codes on {codeless_locks} through their own integration, so it must not hold codes for them as well — codes it held would never reach the lock. Select them under “Locks” instead."
     },
     "step": {
       "init": {
         "data": {
           "locks": "Locks",
-          "users": "Users YAML"
+          "users": "Users YAML",
+          "codeless_locks": "Locks with no code storage"
         },
         "description": "Update the locks that are associated with this config entry and/or the users.",
-        "title": "Lock Code Manager"
-      },
-      "codeless": {
-        "title": "Locks with no code storage",
-        "description": "Lock Code Manager can't read or write codes on {lock}.\n\nIt can still manage codes for this lock: it stores them itself, and checks codes you report with the `use_credential` action against your users and their schedules, recording each use like any other. The lock itself is never written to, so a code set up here does not open it on its own -- something else has to check it, such as a keypad automation calling `use_credential`.\n\nAnswer only for this lock; anything else you selected is asked about separately. Choose \"No\" to return to the lock list and select different locks. Your answer stands for the rest of this attempt -- to change it, close this dialog and start again.",
-        "menu_options": {
-          "codeless_confirm": "Yes, Lock Code Manager holds the codes for this lock",
-          "codeless_decline": "No, don't manage codes for this lock"
-        }
-      },
-      "codeless_reconsider": {
-        "title": "Lock Code Manager still holds this lock's codes",
-        "description": "Lock Code Manager currently holds the codes for {lock} itself, because you said it has no code storage of its own. Something now claims that lock, so the answer is worth confirming.\n\nChoose \"Yes\" and nothing changes: the codes stay in Lock Code Manager, the lock is never written to, and a code reaches it only through the `use_credential` action. Choose \"No\" and the lock's own integration takes over, so the codes get written to the device from then on -- the codes Lock Code Manager was holding for it are discarded.\n\nAnswer only for this lock; anything else you selected is asked about separately. Your answer stands for the rest of this attempt -- to change it, close this dialog and start again.",
-        "menu_options": {
-          "codeless_confirm": "Yes, Lock Code Manager keeps holding the codes",
-          "codeless_decline": "No, hand this lock back to its own integration"
+        "title": "Lock Code Manager",
+        "data_description": {
+          "locks": "Locks whose own integration stores the PIN codes, which Lock Code Manager writes to and reads back.",
+          "codeless_locks": "Locks that keep no PIN codes of their own — an ESPHome lock, or any door you unlock with a keypad Home Assistant reads for you. Lock Code Manager stores the codes for these itself and never writes anything to the lock: a code is checked only when something calls the `lock_code_manager.use_credential` action with the code that was entered, which is then matched against your users and their schedules and recorded like any other use. See https://github.com/raman325/lock_code_manager/wiki/External-Keypads"
         }
       }
     }

--- a/custom_components/lock_code_manager/translations/en.json
+++ b/custom_components/lock_code_manager/translations/en.json
@@ -17,9 +17,10 @@
       "slot_out_of_range": "Lock {lock} reports only {num_slots} PIN code slots, and this configuration already uses numbers beyond that: {out_of_range_slots}. Lock Code Manager assigns those numbers itself, so the way to free them is to remove some users, or to manage the rest from a separate configuration.",
       "slots_already_configured": "The following slots for lock {lock} are already managed by another config entry ({entry_title}) and can't be added to this configuration without being removed from the other one: {common_slots}",
       "too_many_users": "Lock {lock} has {num_slots} PIN code slots, so {num_users} users will not fit. Set up fewer users here, or manage the rest from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity.",
+      "lock_not_registered": "Home Assistant has no entity registry entry for {locks}, so Lock Code Manager has nothing stable to attach their configuration to and cannot be set up with them. A lock set up in YAML without a unique ID is the usual cause: give it one, or select a different lock.",
       "unsupported_mqtt_lock": "These MQTT locks are not from a supported bridge (Zigbee2MQTT or Z-Wave JS UI): {locks}",
       "users_keyed_by_slot": "This looks like the old slot-numbered format. Users are now listed by name, and Lock Code Manager picks the slot numbers itself:\n\nusers:\n  Raman:\n    pin: \"1234\"\n    enabled: true",
-      "codeless_declined": "Lock Code Manager has no way to manage codes on {locks}. Remove them from the list, or go back and let Lock Code Manager hold their codes."
+      "codeless_declined": "Lock Code Manager has no way to manage codes on {locks}. Remove them from the list to continue. Your \"no\" stands for the rest of this attempt -- to let Lock Code Manager hold their codes after all, close this dialog and start again."
     },
     "step": {
       "choose_path": {
@@ -71,7 +72,7 @@
       },
       "codeless": {
         "title": "Locks with no code storage",
-        "description": "Lock Code Manager can't read or write codes on {locks}.\n\nIt can still manage codes for these locks: it stores them itself, and checks codes you report with the `use_credential` action against your users and their schedules, recording each use like any other. The locks themselves are never written to, so a code set up here does not open them on its own -- something else has to check it, such as a keypad automation calling `use_credential`.\n\nChoose \"No\" to go back and change which locks you selected.",
+        "description": "Lock Code Manager can't read or write codes on {locks}.\n\nIt can still manage codes for these locks: it stores them itself, and checks codes you report with the `use_credential` action against your users and their schedules, recording each use like any other. The locks themselves are never written to, so a code set up here does not open them on its own -- something else has to check it, such as a keypad automation calling `use_credential`.\n\nChoose \"No\" to return to the lock list and select different locks. Your answer stands for the rest of this attempt -- to change it, close this dialog and start again.",
         "menu_options": {
           "codeless_confirm": "Yes, Lock Code Manager holds the codes for these locks",
           "codeless_decline": "No, don't manage codes for these locks"
@@ -151,8 +152,9 @@
       "search_limit_reached": "Placing {num_users} users would need slot numbers past {max_slot}, which is as far as Lock Code Manager looks. No lock here reported how many PIN code slots it has, so this limit is Lock Code Manager's own rather than the lock's. Set up fewer users, or re-interview the lock so it reports its capacity.",
       "name_not_unique": "That name is already used by another user in this configuration. Names must be unique.",
       "missing_pin_if_enabled": "PIN must be set if slot is enabled.",
+      "lock_not_registered": "Home Assistant has no entity registry entry for {locks}, so Lock Code Manager has nothing stable to attach their configuration to and cannot be set up with them. A lock set up in YAML without a unique ID is the usual cause: give it one, or select a different lock.",
       "unsupported_mqtt_lock": "These MQTT locks are not from a supported bridge (Zigbee2MQTT or Z-Wave JS UI): {locks}",
-      "codeless_declined": "Lock Code Manager has no way to manage codes on {locks}. Remove them from the list, or go back and let Lock Code Manager hold their codes."
+      "codeless_declined": "Lock Code Manager has no way to manage codes on {locks}. Remove them from the list to continue. Your \"no\" stands for the rest of this attempt -- to let Lock Code Manager hold their codes after all, close this dialog and start again."
     },
     "step": {
       "init": {
@@ -165,7 +167,7 @@
       },
       "codeless": {
         "title": "Locks with no code storage",
-        "description": "Lock Code Manager can't read or write codes on {locks}.\n\nIt can still manage codes for these locks: it stores them itself, and checks codes you report with the `use_credential` action against your users and their schedules, recording each use like any other. The locks themselves are never written to, so a code set up here does not open them on its own -- something else has to check it, such as a keypad automation calling `use_credential`.\n\nChoose \"No\" to go back and change which locks you selected.",
+        "description": "Lock Code Manager can't read or write codes on {locks}.\n\nIt can still manage codes for these locks: it stores them itself, and checks codes you report with the `use_credential` action against your users and their schedules, recording each use like any other. The locks themselves are never written to, so a code set up here does not open them on its own -- something else has to check it, such as a keypad automation calling `use_credential`.\n\nChoose \"No\" to return to the lock list and select different locks. Your answer stands for the rest of this attempt -- to change it, close this dialog and start again.",
         "menu_options": {
           "codeless_confirm": "Yes, Lock Code Manager holds the codes for these locks",
           "codeless_decline": "No, don't manage codes for these locks"

--- a/custom_components/lock_code_manager/translations/en.json
+++ b/custom_components/lock_code_manager/translations/en.json
@@ -61,7 +61,7 @@
         "title": "Lock Code Manager",
         "data_description": {
           "locks": "Locks whose own integration stores the PIN codes, which Lock Code Manager writes to and reads back.",
-          "codeless_locks": "Locks that keep no PIN codes of their own — an ESPHome lock, or any door you unlock with a keypad Home Assistant reads for you. Lock Code Manager stores the codes for these itself and never writes anything to the lock: a code is checked only when something calls the `lock_code_manager.use_credential` action with the code that was entered, which is then matched against your users and their schedules and recorded like any other use. See https://github.com/raman325/lock_code_manager/wiki/External-Keypads"
+          "codeless_locks": "Locks that keep no PIN codes of their own — an ESPHome lock, or any door you unlock with a keypad Home Assistant reads for you. Lock Code Manager stores the codes for these itself and never writes anything to the lock: a code is checked only when something calls the `lock_code_manager.use_credential` action with the code that was entered, which is then matched against your users and their schedules and recorded like any other use. See {wiki_url}"
         }
       },
       "yaml": {
@@ -80,7 +80,7 @@
         "title": "Update locks for {name}",
         "data_description": {
           "locks": "Locks whose own integration stores the PIN codes, which Lock Code Manager writes to and reads back.",
-          "codeless_locks": "Locks that keep no PIN codes of their own — an ESPHome lock, or any door you unlock with a keypad Home Assistant reads for you. Lock Code Manager stores the codes for these itself and never writes anything to the lock: a code is checked only when something calls the `lock_code_manager.use_credential` action with the code that was entered, which is then matched against your users and their schedules and recorded like any other use. See https://github.com/raman325/lock_code_manager/wiki/External-Keypads"
+          "codeless_locks": "Locks that keep no PIN codes of their own — an ESPHome lock, or any door you unlock with a keypad Home Assistant reads for you. Lock Code Manager stores the codes for these itself and never writes anything to the lock: a code is checked only when something calls the `lock_code_manager.use_credential` action with the code that was entered, which is then matched against your users and their schedules and recorded like any other use. See {wiki_url}"
         }
       }
     }
@@ -175,7 +175,7 @@
         "title": "Lock Code Manager",
         "data_description": {
           "locks": "Locks whose own integration stores the PIN codes, which Lock Code Manager writes to and reads back.",
-          "codeless_locks": "Locks that keep no PIN codes of their own — an ESPHome lock, or any door you unlock with a keypad Home Assistant reads for you. Lock Code Manager stores the codes for these itself and never writes anything to the lock: a code is checked only when something calls the `lock_code_manager.use_credential` action with the code that was entered, which is then matched against your users and their schedules and recorded like any other use. See https://github.com/raman325/lock_code_manager/wiki/External-Keypads"
+          "codeless_locks": "Locks that keep no PIN codes of their own — an ESPHome lock, or any door you unlock with a keypad Home Assistant reads for you. Lock Code Manager stores the codes for these itself and never writes anything to the lock: a code is checked only when something calls the `lock_code_manager.use_credential` action with the code that was entered, which is then matched against your users and their schedules and recorded like any other use. See {wiki_url}"
         }
       }
     }

--- a/custom_components/lock_code_manager/websocket.py
+++ b/custom_components/lock_code_manager/websocket.py
@@ -100,7 +100,7 @@ from .const import (
 )
 from .domain.config import parse_slot_unique_id
 from .domain.credentials import pin_address
-from .domain.locks import get_managed_locks
+from .domain.locks import get_managed_locks_for_entity
 from .domain.models import SlotCode, SlotCredential
 from .domain.queries import (
     find_config_entry_by_title,
@@ -723,14 +723,29 @@ async def subscribe_lock_codes(
     """
     lock_entity_id = msg[ATTR_LOCK_ENTITY_ID]
     reveal = msg["reveal"]
-    lock = get_managed_locks(hass).get(lock_entity_id)
-    if not lock:
+    locks = get_managed_locks_for_entity(hass, lock_entity_id)
+    if not locks:
         connection.send_error(
             msg["id"],
             websocket_api.const.ERR_NOT_FOUND,
             f"Lock {lock_entity_id} is not managed by Lock Code Manager",
         )
         return
+    if len(locks) > 1:
+        # Two entries resolving this lock to different providers hold two
+        # credential stores. Showing one of them would put codes on screen
+        # that a subsequent edit does not touch, so this says so instead of
+        # picking. The message is the one the actions give, so the card and
+        # the actions agree about what is wrong.
+        connection.send_error(
+            msg["id"],
+            websocket_api.const.ERR_NOT_SUPPORTED,
+            f"Lock {lock_entity_id} is managed by more than one Lock Code "
+            "Manager configuration, and they do not agree on where its "
+            f"credentials live ({', '.join(sorted(lock.domain for lock in locks))})",
+        )
+        return
+    lock = locks[0]
 
     coordinator = lock.coordinator
 

--- a/custom_components/lock_code_manager/websocket.py
+++ b/custom_components/lock_code_manager/websocket.py
@@ -100,7 +100,7 @@ from .const import (
 )
 from .domain.config import parse_slot_unique_id
 from .domain.credentials import pin_address
-from .domain.locks import get_managed_locks_for_entity
+from .domain.locks import find_managed_lock
 from .domain.models import SlotCode, SlotCredential
 from .domain.queries import (
     find_config_entry_by_title,
@@ -723,29 +723,14 @@ async def subscribe_lock_codes(
     """
     lock_entity_id = msg[ATTR_LOCK_ENTITY_ID]
     reveal = msg["reveal"]
-    locks = get_managed_locks_for_entity(hass, lock_entity_id)
-    if not locks:
+    lock = find_managed_lock(hass, lock_entity_id)
+    if lock is None:
         connection.send_error(
             msg["id"],
             websocket_api.const.ERR_NOT_FOUND,
             f"Lock {lock_entity_id} is not managed by Lock Code Manager",
         )
         return
-    if len(locks) > 1:
-        # Two entries resolving this lock to different providers hold two
-        # credential stores. Showing one of them would put codes on screen
-        # that a subsequent edit does not touch, so this says so instead of
-        # picking. The message is the one the actions give, so the card and
-        # the actions agree about what is wrong.
-        connection.send_error(
-            msg["id"],
-            websocket_api.const.ERR_NOT_SUPPORTED,
-            f"Lock {lock_entity_id} is managed by more than one Lock Code "
-            "Manager configuration, and they do not agree on where its "
-            f"credentials live ({', '.join(sorted(lock.domain for lock in locks))})",
-        )
-        return
-    lock = locks[0]
 
     coordinator = lock.coordinator
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -73,9 +73,11 @@ def reading_for():
     """
     read_for: list[ConfigEntry | None] = []
 
-    def _spy(hass, dev_reg, ent_reg, config_entry, lock_entity_id):
+    def _spy(hass, dev_reg, ent_reg, config_entry, lock_entity_id, config=None):
         read_for.append(config_entry)
-        return build_lock_instance(hass, dev_reg, ent_reg, config_entry, lock_entity_id)
+        return build_lock_instance(
+            hass, dev_reg, ent_reg, config_entry, lock_entity_id, config
+        )
 
     with patch(
         "custom_components.lock_code_manager.domain.allocation.build_lock_instance",

--- a/tests/common.py
+++ b/tests/common.py
@@ -11,11 +11,14 @@ import json
 from typing import Literal
 from unittest.mock import patch
 
-from pytest_homeassistant_custom_component.common import async_fire_mqtt_message
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+    async_fire_mqtt_message,
+)
 
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
 from homeassistant.components.calendar import CalendarEntity, CalendarEvent
-from homeassistant.components.lock import LockEntity
+from homeassistant.components.lock import LockEntity, LockState
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ENABLED, CONF_ENTITY_ID, CONF_NAME, CONF_PIN
@@ -118,6 +121,28 @@ async def async_discover_unclaimed_mqtt_lock(
     assert entity_id is not None, "discovery did not create the lock entity"
     lock_entry = ent_reg.async_get(entity_id)
     assert lock_entry is not None
+    return lock_entry
+
+
+def register_codeless_lock(
+    hass: HomeAssistant, unique_id: str = "keypad_door"
+) -> er.RegistryEntry:
+    """
+    Register a real lock entity from an integration no provider claims.
+
+    ESPHome is the shape this feature exists for: a lock that genuinely
+    locks and unlocks and has no notion of a code, so nothing in
+    ``INTEGRATIONS_CLASS_MAP`` can ever claim it and only a declaration can
+    say what to do with it. Nothing about the integration is mocked -- what
+    dispatch reads is the registry row, and what everything else reads is
+    the state.
+    """
+    provider_entry = MockConfigEntry(domain="esphome", title="ESPHome")
+    provider_entry.add_to_hass(hass)
+    lock_entry = er.async_get(hass).async_get_or_create(
+        "lock", "esphome", unique_id, config_entry=provider_entry
+    )
+    hass.states.async_set(lock_entry.entity_id, LockState.LOCKED)
     return lock_entry
 
 

--- a/tests/providers/codeless/__init__.py
+++ b/tests/providers/codeless/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the codeless provider."""

--- a/tests/providers/codeless/conftest.py
+++ b/tests/providers/codeless/conftest.py
@@ -1,0 +1,75 @@
+"""Codeless provider test fixtures."""
+
+from __future__ import annotations
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from homeassistant.const import CONF_ENABLED, CONF_PIN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from custom_components.lock_code_manager.const import (
+    CONF_CODELESS,
+    CONF_LOCKS,
+    CONF_MEMBERS,
+    CONF_USERS,
+    DOMAIN,
+)
+from custom_components.lock_code_manager.domain.slot_assignment import (
+    CONF_SLOT_ASSIGNMENT,
+)
+from custom_components.lock_code_manager.providers.codeless import CodelessLock
+
+from ...common import register_codeless_lock
+
+USER_NAME = "Raman"
+USER_PIN = "1234"
+
+
+@pytest.fixture
+def codeless_lock_entity(hass: HomeAssistant) -> er.RegistryEntry:
+    """Register the real lock entity that no provider claims."""
+    return register_codeless_lock(hass)
+
+
+@pytest.fixture
+async def lcm_config_entry(
+    hass: HomeAssistant, codeless_lock_entity: er.RegistryEntry
+) -> MockConfigEntry:
+    """
+    Set up an entry whose one member is declared codeless.
+
+    Through the real setup path, so what picks the provider is the
+    declaration in the entry -- keyed by registry id, exactly as the config
+    flow writes it -- rather than anything the test hands the factory.
+    """
+    lcm_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_LOCKS: [codeless_lock_entity.entity_id],
+            CONF_MEMBERS: {codeless_lock_entity.id: {CONF_CODELESS: True}},
+            CONF_USERS: {USER_NAME: {CONF_PIN: USER_PIN, CONF_ENABLED: True}},
+            CONF_SLOT_ASSIGNMENT: {USER_NAME.casefold(): 1},
+        },
+        unique_id="test_codeless_e2e",
+    )
+    lcm_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(lcm_entry.entry_id)
+    await hass.async_block_till_done()
+
+    yield lcm_entry
+
+    await hass.config_entries.async_unload(lcm_entry.entry_id)
+
+
+@pytest.fixture
+def codeless_lock(
+    hass: HomeAssistant,
+    lcm_config_entry: MockConfigEntry,
+    codeless_lock_entity: er.RegistryEntry,
+) -> CodelessLock:
+    """Return the provider the loaded entry built for its declared member."""
+    lock = lcm_config_entry.runtime_data.locks.get(codeless_lock_entity.entity_id)
+    assert isinstance(lock, CodelessLock)
+    return lock

--- a/tests/providers/codeless/test_e2e.py
+++ b/tests/providers/codeless/test_e2e.py
@@ -606,6 +606,69 @@ async def test_handing_the_lock_back_discards_the_codes_it_was_holding(
     await hass.config_entries.async_unload(entry.entry_id)
 
 
+async def test_an_options_decline_discards_them_with_the_entry_unloaded(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+    mock_lock_config_entry,
+) -> None:
+    """
+    The listener that kept that promise is not there while the entry is not.
+
+    ``async_update_listener`` is registered during setup and released on
+    unload, so an options save against an entry that is not loaded reaches
+    storage with nothing to act on it: no ``locks_redeclared``, no permanent
+    removal, and a file of cleartext Personal Identification Numbers left on
+    disk for a member the entry has just stopped declaring -- unreadable by
+    anything, and swept by nothing, because entry deletion collects only
+    what the entry still declares.
+
+    The options form is reachable in that state, and the entry that comes
+    back later is a working one, so nothing on screen ever says the answer
+    was only half taken.
+    """
+    claimed = er.async_get(hass).async_get(LOCK_1_ENTITY_ID)
+    entry = await _entry_for(
+        hass,
+        unique_id="handing_back_unloaded",
+        slot_num=1,
+        pin="9999",
+        holding=[LOCK_1_ENTITY_ID],
+        declaring=[claimed],
+    )
+    await _settle_sync(hass)
+    # Unload is both what puts the credential on disk and what takes the
+    # listener away, which is the whole of the state under test.
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+    store_key = f"codeless_{DOMAIN}_{LOCK_1_ENTITY_ID}"
+    assert hass_storage[store_key]["data"]["1"]["code"] == "9999"
+
+    started = await hass.config_entries.options.async_init(entry.entry_id)
+    flow_id = started["flow_id"]
+    users = {f"{USER_NAME} 1": {CONF_PIN: "9999", CONF_ENABLED: True}}
+    result = await hass.config_entries.options.async_configure(
+        flow_id, user_input={CONF_LOCKS: [LOCK_1_ENTITY_ID], CONF_USERS: users}
+    )
+    assert result["step_id"] == "codeless_reconsider"
+
+    result = await hass.config_entries.options.async_configure(
+        flow_id, {"next_step_id": "codeless_decline"}
+    )
+    assert result["type"] == "create_entry"
+    await hass.async_block_till_done()
+
+    assert store_key not in hass_storage
+
+    # Loaded again, so the member is the provider's now and the store stays
+    # gone: nothing rebuilt it out of what the unloaded instance still held.
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    assert not isinstance(entry.runtime_data.locks[LOCK_1_ENTITY_ID], CodelessLock)
+    assert store_key not in hass_storage
+
+    await hass.config_entries.async_unload(entry.entry_id)
+
+
 async def test_a_reauth_decline_discards_them_the_same_way(
     hass: HomeAssistant,
     hass_storage: dict[str, Any],

--- a/tests/providers/codeless/test_e2e.py
+++ b/tests/providers/codeless/test_e2e.py
@@ -5,14 +5,19 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import Any
 
-import pytest
 from pytest_homeassistant_custom_component.common import (
     MockConfigEntry,
     async_fire_time_changed,
 )
 
 from homeassistant.components.event import ATTR_EVENT_TYPE, ATTR_EVENT_TYPES
-from homeassistant.const import CONF_ENABLED, CONF_PIN, STATE_UNAVAILABLE
+from homeassistant.config_entries import SOURCE_USER
+from homeassistant.const import (
+    CONF_ENABLED,
+    CONF_NAME,
+    CONF_PIN,
+    STATE_UNAVAILABLE,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt as dt_util
@@ -23,6 +28,7 @@ from custom_components.lock_code_manager.const import (
     CONF_CODELESS,
     CONF_LOCKS,
     CONF_MEMBERS,
+    CONF_NUM_USERS,
     CONF_USERS,
     DOMAIN,
     EVENT_CREDENTIAL_USED,
@@ -276,92 +282,28 @@ async def test_taking_the_declaration_back_hands_the_lock_to_its_provider(
     await hass.config_entries.async_unload(entry.entry_id)
 
 
-@pytest.mark.parametrize("declare_first", [True, False])
-async def test_the_entry_that_declared_the_lock_does_not_share_a_provider(
-    hass: HomeAssistant, mock_lock_config_entry, declare_first: bool
-) -> None:
-    """
-    Two entries that disagree about a lock get the provider each asked for.
-
-    A shared instance was keyed on the lock alone, so an entry that declared
-    a member codeless and one that did not were handed whichever instance
-    loaded first, and the declaration decided nothing beyond load order.
-    Loaded the wrong way round it wrote a user's Personal Identification
-    Number to a device somebody had said must never be written to.
-
-    Both orders are run because load order is exactly what the sharing was
-    sensitive to.
-    """
-    claimed = er.async_get(hass).async_get(LOCK_1_ENTITY_ID)
-
-    async def _declaring() -> MockConfigEntry:
-        return await _entry_for(
-            hass,
-            unique_id="declaring_entry",
-            slot_num=1,
-            pin="9999",
-            holding=[LOCK_1_ENTITY_ID],
-            declaring=[claimed],
-        )
-
-    async def _plain() -> MockConfigEntry:
-        return await _entry_for(
-            hass,
-            unique_id="plain_entry",
-            slot_num=2,
-            pin="8888",
-            holding=[LOCK_1_ENTITY_ID],
-        )
-
-    first, second = (_declaring, _plain) if declare_first else (_plain, _declaring)
-    await first()
-    await second()
-    await _settle_sync(hass)
-
-    declaring = hass.config_entries.async_entry_for_domain_unique_id(
-        DOMAIN, "declaring_entry"
-    )
-    plain = hass.config_entries.async_entry_for_domain_unique_id(DOMAIN, "plain_entry")
-    declared_lock = declaring.runtime_data.locks[LOCK_1_ENTITY_ID]
-    provider_lock = plain.runtime_data.locks[LOCK_1_ENTITY_ID]
-
-    assert isinstance(declared_lock, CodelessLock)
-    assert isinstance(provider_lock, MockLCMLock)
-    # The entry that declared the lock kept its credential off the device;
-    # the entry that did not put its own on it.
-    assert (await declared_lock.async_get_usercodes())[1].readable_pin == "9999"
-    assert provider_lock.codes[2] == "8888"
-    assert provider_lock.codes[1] != "9999"
-
-    for entry in (declaring, plain):
-        await hass.config_entries.async_unload(entry.entry_id)
-
-
-async def test_a_declaring_entry_releases_the_instance_it_holds(
+async def test_a_second_entry_cannot_end_up_on_a_different_provider(
     hass: HomeAssistant, mock_lock_config_entry
 ) -> None:
     """
-    Unloading one of two entries tears down the instance THAT entry holds.
+    A lock one entry declares is declared by the next one, through the flow.
 
-    Release inverts the share, so it asks after the object being given up
-    rather than after the entity id. Two entries that resolve one lock to
-    different providers hold two instances, and an entry that read a
-    sibling's entry in the roster as ownership walked away from its own --
-    leaving it running, and skipping the unload that writes the Lock Code
-    Manager store back. For a codeless member that store IS the credential,
-    so every code the entry held would be gone on the next load.
+    Whether a lock keeps codes of its own is a fact about the DEVICE, so two
+    entries answering differently is a contradiction rather than a
+    configuration -- and one with teeth: two providers over one entity are
+    two credential stores, and a Personal Identification Number lands in
+    whichever the caller happened to reach. The second entry is driven
+    through the real config flow here, because the flow is what makes the
+    contradiction unrepresentable, and the assertion is on the provider the
+    entry ends up RUNNING rather than on what it stored.
+
+    Written against a lock a provider does claim, which is the only shape
+    that can go wrong silently: an unclaimed one is asked about anyway.
     """
     claimed = er.async_get(hass).async_get(LOCK_1_ENTITY_ID)
-    await _entry_for(
+    first = await _entry_for(
         hass,
-        unique_id="plain_entry",
-        slot_num=2,
-        pin="8888",
-        holding=[LOCK_1_ENTITY_ID],
-    )
-    declaring = await _entry_for(
-        hass,
-        unique_id="declaring_entry",
+        unique_id="first_entry",
         slot_num=1,
         pin="9999",
         holding=[LOCK_1_ENTITY_ID],
@@ -369,16 +311,93 @@ async def test_a_declaring_entry_releases_the_instance_it_holds(
     )
     await _settle_sync(hass)
 
-    assert await hass.config_entries.async_reload(declaring.entry_id)
+    started = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    flow_id = started["flow_id"]
+    result = await hass.config_entries.flow.async_configure(
+        flow_id, {CONF_NAME: "second", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
+    )
+
+    # Asked, rather than quietly handed to the provider that claims the
+    # lock: agreeing has to be an answer the second entry can give.
+    assert result["step_id"] == "codeless_reconsider"
+    assert result["description_placeholders"] == {"lock": LOCK_1_ENTITY_ID}
+
+    await hass.config_entries.flow.async_configure(
+        flow_id, {"next_step_id": "codeless_confirm"}
+    )
+    await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
+    await hass.config_entries.flow.async_configure(flow_id, {CONF_NUM_USERS: 1})
+    result = await hass.config_entries.flow.async_configure(
+        flow_id, {CONF_NAME: "Bea", CONF_ENABLED: True, CONF_PIN: "8888"}
+    )
+    assert result["type"] == "create_entry"
     await hass.async_block_till_done()
 
-    reloaded = declaring.runtime_data.locks[LOCK_1_ENTITY_ID]
-    assert isinstance(reloaded, CodelessLock)
-    # Read before any tick, so this is what unload wrote rather than what a
-    # sync would put back.
-    assert (await reloaded.async_get_usercodes())[1].readable_pin == "9999"
+    second = hass.config_entries.async_entry_for_domain_unique_id(DOMAIN, "second")
+    # One entity, one provider: the second entry did not merely record the
+    # same answer, it is driving the very instance the first one holds, so
+    # there is no second store for a code to go missing in.
+    assert (
+        second.runtime_data.locks[LOCK_1_ENTITY_ID]
+        is first.runtime_data.locks[LOCK_1_ENTITY_ID]
+    )
+    assert isinstance(second.runtime_data.locks[LOCK_1_ENTITY_ID], CodelessLock)
 
-    for entry in hass.config_entries.async_entries(DOMAIN):
+    for entry in (first, second):
+        await hass.config_entries.async_unload(entry.entry_id)
+
+
+async def test_a_lock_leaving_one_entry_leaves_the_sibling_untouched(
+    hass: HomeAssistant, codeless_lock_entity: er.RegistryEntry
+) -> None:
+    """
+    Dropping a shared member from one entry neither kills nor empties it.
+
+    Both entries declare the lock, so both drive one instance and one store.
+    The entry giving it up tears down only what nothing else holds -- release
+    is the inverse of the share, asked about the object rather than about the
+    roster -- and it discards the store only when nothing else reads it. Get
+    either wrong and the sibling is left with a dead provider, or with every
+    code it held gone: for a codeless member that store IS the credential,
+    and there is nowhere else those codes exist.
+    """
+    keeping = await _entry_for(
+        hass,
+        unique_id="keeping_entry",
+        slot_num=2,
+        pin="2222",
+        holding=[codeless_lock_entity.entity_id],
+        declaring=[codeless_lock_entity],
+    )
+    giving_up = await _entry_for(
+        hass,
+        unique_id="giving_up_entry",
+        slot_num=1,
+        pin="1111",
+        holding=[codeless_lock_entity.entity_id],
+        declaring=[codeless_lock_entity],
+    )
+    await _settle_sync(hass)
+    shared = keeping.runtime_data.locks[codeless_lock_entity.entity_id]
+    assert giving_up.runtime_data.locks[codeless_lock_entity.entity_id] is shared
+
+    hass.config_entries.async_update_entry(
+        giving_up, options={**giving_up.data, CONF_LOCKS: [], CONF_MEMBERS: {}}
+    )
+    await hass.async_block_till_done()
+
+    assert keeping.runtime_data.locks[codeless_lock_entity.entity_id] is shared
+    # A reload is what would expose a discarded store: the codes come back
+    # from disk or they do not come back at all. Read before any tick, so
+    # this is what survived rather than what a sync put back.
+    assert await hass.config_entries.async_reload(keeping.entry_id)
+    await hass.async_block_till_done()
+    reloaded = keeping.runtime_data.locks[codeless_lock_entity.entity_id]
+    assert (await reloaded.async_get_usercodes())[2].readable_pin == "2222"
+
+    for entry in (keeping, giving_up):
         await hass.config_entries.async_unload(entry.entry_id)
 
 
@@ -531,51 +550,56 @@ async def test_deleting_one_entry_leaves_a_sibling_entrys_credentials_alone(
     await hass.config_entries.async_unload(keeping.entry_id)
 
 
-async def test_a_sibling_on_a_different_provider_does_not_keep_the_store(
+async def test_handing_the_lock_back_discards_the_codes_it_was_holding(
     hass: HomeAssistant,
     hass_storage: dict[str, Any],
     mock_lock_config_entry,
 ) -> None:
     """
-    Only an entry that would READ this store keeps it from being collected.
+    The ``codeless_reconsider`` question promises this in so many words.
 
-    Two entries can disagree about one lock: one declares it codeless and
-    keeps its codes in Lock Code Manager, the other declares nothing and
-    writes them to the device. Gating collection on presence -- any entry
-    still listing the lock -- meant the sibling blocked it forever, even
-    though it never opens this file. The cleartext Personal Identification
-    Numbers the sweep exists to remove survived the deletion, with nothing
-    left that could ever read them back.
+    "The codes Lock Code Manager was holding for it are discarded" is true
+    only through the redeclaration teardown: the roster carries the same
+    entity id on both sides of the edit, so the codes go only because
+    ``locks_redeclared`` feeds ``locks_to_remove`` and that removal is a
+    permanent one. Drop either coupling and the promise silently becomes a
+    lie -- a file of cleartext Personal Identification Numbers left on disk
+    for a lock nothing reads it for any more.
+
+    Driven through the options flow rather than a config write, because the
+    sentence is about what answering "no" does.
     """
     claimed = er.async_get(hass).async_get(LOCK_1_ENTITY_ID)
-    declaring = await _entry_for(
+    entry = await _entry_for(
         hass,
-        unique_id="declaring_entry",
+        unique_id="handing_back",
         slot_num=1,
-        pin=USER_PIN,
+        pin="9999",
         holding=[LOCK_1_ENTITY_ID],
         declaring=[claimed],
     )
-    sibling = await _entry_for(
-        hass,
-        unique_id="sibling_entry",
-        slot_num=2,
-        pin="2222",
-        holding=[LOCK_1_ENTITY_ID],
-    )
-    assert isinstance(sibling.runtime_data.locks[LOCK_1_ENTITY_ID], MockLCMLock)
     await _settle_sync(hass)
-
     # A reload is the cheapest way to reach the save unload performs, which
     # is what puts the credential on disk in the first place.
-    assert await hass.config_entries.async_reload(declaring.entry_id)
+    assert await hass.config_entries.async_reload(entry.entry_id)
     await hass.async_block_till_done()
     store_key = f"codeless_{DOMAIN}_{LOCK_1_ENTITY_ID}"
-    assert hass_storage[store_key]["data"]["1"]["code"] == USER_PIN
+    assert hass_storage[store_key]["data"]["1"]["code"] == "9999"
 
-    await hass.config_entries.async_remove(declaring.entry_id)
+    started = await hass.config_entries.options.async_init(entry.entry_id)
+    flow_id = started["flow_id"]
+    users = {f"{USER_NAME} 1": {CONF_PIN: "9999", CONF_ENABLED: True}}
+    result = await hass.config_entries.options.async_configure(
+        flow_id, user_input={CONF_LOCKS: [LOCK_1_ENTITY_ID], CONF_USERS: users}
+    )
+    assert result["step_id"] == "codeless_reconsider"
+
+    result = await hass.config_entries.options.async_configure(
+        flow_id, {"next_step_id": "codeless_decline"}
+    )
+    assert result["type"] == "create_entry"
     await hass.async_block_till_done()
 
     assert store_key not in hass_storage
 
-    await hass.config_entries.async_unload(sibling.entry_id)
+    await hass.config_entries.async_unload(entry.entry_id)

--- a/tests/providers/codeless/test_e2e.py
+++ b/tests/providers/codeless/test_e2e.py
@@ -1,0 +1,178 @@
+"""Full lifecycle tests for a lock the entry declares codeless."""
+
+from __future__ import annotations
+
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+    async_fire_time_changed,
+)
+
+from homeassistant.components.event import ATTR_EVENT_TYPE, ATTR_EVENT_TYPES
+from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.util import dt as dt_util
+
+from custom_components.lock_code_manager.const import (
+    ATTR_SOURCE,
+    ATTR_TARGET,
+    DOMAIN,
+    EVENT_CREDENTIAL_USED,
+    SERVICE_USE_CREDENTIAL,
+)
+from custom_components.lock_code_manager.domain.credentials import (
+    MANAGED_CREDENTIAL_TYPES,
+    CredentialType,
+)
+from custom_components.lock_code_manager.domain.sync import TICK_INTERVAL
+from custom_components.lock_code_manager.providers.codeless import CodelessLock
+
+from ...common import slot_entity_id
+from .conftest import USER_NAME, USER_PIN
+
+# The keypad the code was typed on: an entity Lock Code Manager knows
+# nothing about, which is how a use reaches a lock it cannot watch.
+KEYPAD_ENTITY_ID = "sensor.front_door_keypad"
+
+
+async def _settle_sync(hass: HomeAssistant) -> None:
+    """Run the two ticks a slot takes to load and then write."""
+    for tick in range(2):
+        async_fire_time_changed(hass, dt_util.utcnow() + TICK_INTERVAL * (tick + 1) * 2)
+        await hass.async_block_till_done()
+
+
+async def test_the_declaration_is_what_sets_the_lock_up(
+    hass: HomeAssistant,
+    lcm_config_entry: MockConfigEntry,
+    codeless_lock_entity: er.RegistryEntry,
+) -> None:
+    """
+    An entry loads a lock nothing claims, because it declared it.
+
+    The same entry without the declaration cannot be set up at all -- that
+    refusal is what this feature is an exception to -- so setup completing
+    is the whole assertion.
+    """
+    lock = lcm_config_entry.runtime_data.locks[codeless_lock_entity.entity_id]
+
+    assert isinstance(lock, CodelessLock)
+    assert lock.lock.entity_id == codeless_lock_entity.entity_id
+
+
+async def test_the_credential_is_held_by_lock_code_manager(
+    hass: HomeAssistant,
+    lcm_config_entry: MockConfigEntry,
+    codeless_lock: CodelessLock,
+) -> None:
+    """
+    A user's PIN is synced into Lock Code Manager's own store.
+
+    The store is the assertion because it is the only place the credential
+    can be: there is nothing on the device to write to, and a sync that
+    silently did nothing would leave the slot looking configured while no
+    code anywhere would validate.
+    """
+    await _settle_sync(hass)
+
+    assert codeless_lock._data["1"]["code"] == USER_PIN
+    assert codeless_lock._data["1"]["name"] == USER_NAME
+
+
+async def test_a_use_reported_for_the_lock_reaches_the_users_event_entity(
+    hass: HomeAssistant,
+    lcm_config_entry: MockConfigEntry,
+    codeless_lock_entity: er.RegistryEntry,
+) -> None:
+    """
+    A lock Lock Code Manager cannot talk to still shows up in the history.
+
+    Nothing observes this lock, so a use arrives through ``use_credential``:
+    the caller says what was typed and where, the entry checks it against
+    its users, and the use is recorded against the user who owns the code
+    like any other. That recording is the visible half of what declaring a
+    lock codeless buys.
+    """
+    await _settle_sync(hass)
+    event_entity_id = slot_entity_id(
+        hass, "event", lcm_config_entry, 1, EVENT_CREDENTIAL_USED
+    )
+    before = hass.states.get(event_entity_id)
+    assert before
+    assert before.state != STATE_UNAVAILABLE
+    assert before.attributes[ATTR_EVENT_TYPES] == sorted(MANAGED_CREDENTIAL_TYPES)
+
+    response = await hass.services.async_call(
+        DOMAIN,
+        SERVICE_USE_CREDENTIAL,
+        {
+            "code": USER_PIN,
+            ATTR_SOURCE: KEYPAD_ENTITY_ID,
+            ATTR_TARGET: codeless_lock_entity.entity_id,
+            "config_entry_id": lcm_config_entry.entry_id,
+        },
+        blocking=True,
+        return_response=True,
+    )
+    await hass.async_block_till_done()
+
+    assert response["valid"] is True
+    assert response["user"] == USER_NAME
+
+    recorded = hass.states.get(event_entity_id)
+    assert recorded.state != before.state
+    assert recorded.attributes[ATTR_EVENT_TYPE] == CredentialType.PIN
+    assert recorded.attributes[ATTR_TARGET] == codeless_lock_entity.entity_id
+
+
+async def test_an_unknown_code_is_rejected_for_the_lock(
+    hass: HomeAssistant,
+    lcm_config_entry: MockConfigEntry,
+    codeless_lock_entity: er.RegistryEntry,
+) -> None:
+    """
+    Holding the credentials means answering for them, including no.
+
+    A codeless lock never rejects anything itself, so this answer is the
+    only thing standing between a wrong code and whatever the caller does
+    with a valid one.
+    """
+    await _settle_sync(hass)
+
+    response = await hass.services.async_call(
+        DOMAIN,
+        SERVICE_USE_CREDENTIAL,
+        {
+            "code": "9999",
+            ATTR_SOURCE: KEYPAD_ENTITY_ID,
+            ATTR_TARGET: codeless_lock_entity.entity_id,
+            "config_entry_id": lcm_config_entry.entry_id,
+        },
+        blocking=True,
+        return_response=True,
+    )
+
+    assert response["valid"] is False
+    assert response["user"] is None
+
+
+async def test_the_credentials_survive_a_reload(
+    hass: HomeAssistant,
+    lcm_config_entry: MockConfigEntry,
+    codeless_lock_entity: er.RegistryEntry,
+) -> None:
+    """
+    Lock Code Manager is the only copy, so a reload must not be a reset.
+
+    Every other provider can re-read its lock; this one has nowhere to
+    re-read from, which makes the store the credential rather than a cache
+    of it.
+    """
+    await _settle_sync(hass)
+
+    assert await hass.config_entries.async_reload(lcm_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    lock = lcm_config_entry.runtime_data.locks[codeless_lock_entity.entity_id]
+    assert isinstance(lock, CodelessLock)
+    assert (await lock.async_get_usercodes())[1].readable_pin == USER_PIN

--- a/tests/providers/codeless/test_e2e.py
+++ b/tests/providers/codeless/test_e2e.py
@@ -11,7 +11,7 @@ from pytest_homeassistant_custom_component.common import (
 )
 
 from homeassistant.components.event import ATTR_EVENT_TYPE, ATTR_EVENT_TYPES
-from homeassistant.config_entries import SOURCE_USER
+from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_USER
 from homeassistant.const import (
     CONF_ENABLED,
     CONF_NAME,
@@ -46,6 +46,7 @@ from custom_components.lock_code_manager.providers.codeless import CodelessLock
 
 from ...common import (
     LOCK_1_ENTITY_ID,
+    LOCK_2_ENTITY_ID,
     MockLCMLock,
     register_codeless_lock,
     slot_entity_id,
@@ -601,5 +602,119 @@ async def test_handing_the_lock_back_discards_the_codes_it_was_holding(
     await hass.async_block_till_done()
 
     assert store_key not in hass_storage
+
+    await hass.config_entries.async_unload(entry.entry_id)
+
+
+async def test_a_reauth_decline_discards_them_the_same_way(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+    mock_lock_config_entry,
+) -> None:
+    """
+    Reauth shows the same sentence, so it has to mean the same thing there.
+
+    Reauth is the one save that does not go through the update listener: it
+    writes the entry and reloads, and the entry it is repairing is failed, so
+    nothing was holding the lock for ``locks_redeclared`` to find and
+    ``remove_permanently`` to collect. The promise on screen was therefore
+    true on one path and false on the other, and the false one left a file of
+    cleartext Personal Identification Numbers on disk for a lock that had
+    just been handed back to its own integration -- unreadable by anything,
+    and collected by nothing, because the entry that would have swept it on
+    deletion no longer declares the member.
+
+    A second lock whose registry row is gone is what puts the entry in
+    reauth, which is the only way to reach that step.
+    """
+    claimed = er.async_get(hass).async_get(LOCK_1_ENTITY_ID)
+    entry = await _entry_for(
+        hass,
+        unique_id="reauth_handing_back",
+        slot_num=1,
+        pin="9999",
+        holding=[LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID],
+        declaring=[claimed],
+    )
+    await _settle_sync(hass)
+    # Unload is what puts the credential on disk; the entry then fails to
+    # come back because one of its locks no longer exists.
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+    er.async_get(hass).async_remove(LOCK_2_ENTITY_ID)
+    assert not await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    store_key = f"codeless_{DOMAIN}_{LOCK_1_ENTITY_ID}"
+    assert hass_storage[store_key]["data"]["1"]["code"] == "9999"
+
+    [flow] = entry.async_get_active_flows(hass, {SOURCE_REAUTH})
+    result = await hass.config_entries.flow.async_configure(
+        flow["flow_id"], {CONF_LOCKS: [LOCK_1_ENTITY_ID]}
+    )
+    assert result["step_id"] == "codeless_reconsider"
+
+    result = await hass.config_entries.flow.async_configure(
+        flow["flow_id"], {"next_step_id": "codeless_decline"}
+    )
+    assert result["type"] == "abort"
+    await hass.async_block_till_done()
+
+    assert store_key not in hass_storage
+
+    await hass.config_entries.async_unload(entry.entry_id)
+
+
+async def test_a_reauth_confirmation_leaves_the_codes_exactly_where_they_are(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+    mock_lock_config_entry,
+) -> None:
+    """
+    The other answer to the same question must not cost a single code.
+
+    Discarding on decline and discarding on confirm are one line apart, and
+    the wrong one of the two is silent: the user is asked whether Lock Code
+    Manager should keep holding the codes, says yes, and every one of them is
+    deleted on the way to saving that yes. There is nowhere else a codeless
+    member's codes exist, so it is unrecoverable, and the entry that comes
+    back looks configured -- the slots are all there, holding nothing.
+    """
+    claimed = er.async_get(hass).async_get(LOCK_1_ENTITY_ID)
+    entry = await _entry_for(
+        hass,
+        unique_id="reauth_keeping_them",
+        slot_num=1,
+        pin="9999",
+        holding=[LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID],
+        declaring=[claimed],
+    )
+    await _settle_sync(hass)
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+    er.async_get(hass).async_remove(LOCK_2_ENTITY_ID)
+    assert not await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    store_key = f"codeless_{DOMAIN}_{LOCK_1_ENTITY_ID}"
+    [flow] = entry.async_get_active_flows(hass, {SOURCE_REAUTH})
+    result = await hass.config_entries.flow.async_configure(
+        flow["flow_id"], {CONF_LOCKS: [LOCK_1_ENTITY_ID]}
+    )
+    assert result["step_id"] == "codeless_reconsider"
+
+    result = await hass.config_entries.flow.async_configure(
+        flow["flow_id"], {"next_step_id": "codeless_confirm"}
+    )
+    assert result["type"] == "abort"
+    await hass.async_block_till_done()
+
+    # Read back through the provider the repaired entry loaded, so this is
+    # the code a use would be checked against rather than a file nothing
+    # opened.
+    held = entry.runtime_data.locks[LOCK_1_ENTITY_ID]
+    assert isinstance(held, CodelessLock)
+    assert (await held.async_get_usercodes())[1].readable_pin == "9999"
+    assert hass_storage[store_key]["data"]["1"]["code"] == "9999"
 
     await hass.config_entries.async_unload(entry.entry_id)

--- a/tests/providers/codeless/test_e2e.py
+++ b/tests/providers/codeless/test_e2e.py
@@ -529,3 +529,53 @@ async def test_deleting_one_entry_leaves_a_sibling_entrys_credentials_alone(
     assert hass_storage[store_key]["data"]["1"]["code"] == "1111"
 
     await hass.config_entries.async_unload(keeping.entry_id)
+
+
+async def test_a_sibling_on_a_different_provider_does_not_keep_the_store(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+    mock_lock_config_entry,
+) -> None:
+    """
+    Only an entry that would READ this store keeps it from being collected.
+
+    Two entries can disagree about one lock: one declares it codeless and
+    keeps its codes in Lock Code Manager, the other declares nothing and
+    writes them to the device. Gating collection on presence -- any entry
+    still listing the lock -- meant the sibling blocked it forever, even
+    though it never opens this file. The cleartext Personal Identification
+    Numbers the sweep exists to remove survived the deletion, with nothing
+    left that could ever read them back.
+    """
+    claimed = er.async_get(hass).async_get(LOCK_1_ENTITY_ID)
+    declaring = await _entry_for(
+        hass,
+        unique_id="declaring_entry",
+        slot_num=1,
+        pin=USER_PIN,
+        holding=[LOCK_1_ENTITY_ID],
+        declaring=[claimed],
+    )
+    sibling = await _entry_for(
+        hass,
+        unique_id="sibling_entry",
+        slot_num=2,
+        pin="2222",
+        holding=[LOCK_1_ENTITY_ID],
+    )
+    assert isinstance(sibling.runtime_data.locks[LOCK_1_ENTITY_ID], MockLCMLock)
+    await _settle_sync(hass)
+
+    # A reload is the cheapest way to reach the save unload performs, which
+    # is what puts the credential on disk in the first place.
+    assert await hass.config_entries.async_reload(declaring.entry_id)
+    await hass.async_block_till_done()
+    store_key = f"codeless_{DOMAIN}_{LOCK_1_ENTITY_ID}"
+    assert hass_storage[store_key]["data"]["1"]["code"] == USER_PIN
+
+    await hass.config_entries.async_remove(declaring.entry_id)
+    await hass.async_block_till_done()
+
+    assert store_key not in hass_storage
+
+    await hass.config_entries.async_unload(sibling.entry_id)

--- a/tests/providers/codeless/test_e2e.py
+++ b/tests/providers/codeless/test_e2e.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+from typing import Any
+
+import pytest
 from pytest_homeassistant_custom_component.common import (
     MockConfigEntry,
     async_fire_time_changed,
 )
 
 from homeassistant.components.event import ATTR_EVENT_TYPE, ATTR_EVENT_TYPES
-from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.const import CONF_ENABLED, CONF_PIN, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt as dt_util
@@ -16,6 +20,10 @@ from homeassistant.util import dt as dt_util
 from custom_components.lock_code_manager.const import (
     ATTR_SOURCE,
     ATTR_TARGET,
+    CONF_CODELESS,
+    CONF_LOCKS,
+    CONF_MEMBERS,
+    CONF_USERS,
     DOMAIN,
     EVENT_CREDENTIAL_USED,
     SERVICE_USE_CREDENTIAL,
@@ -24,10 +32,18 @@ from custom_components.lock_code_manager.domain.credentials import (
     MANAGED_CREDENTIAL_TYPES,
     CredentialType,
 )
+from custom_components.lock_code_manager.domain.slot_assignment import (
+    CONF_SLOT_ASSIGNMENT,
+)
 from custom_components.lock_code_manager.domain.sync import TICK_INTERVAL
 from custom_components.lock_code_manager.providers.codeless import CodelessLock
 
-from ...common import slot_entity_id
+from ...common import (
+    LOCK_1_ENTITY_ID,
+    MockLCMLock,
+    register_codeless_lock,
+    slot_entity_id,
+)
 from .conftest import USER_NAME, USER_PIN
 
 # The keypad the code was typed on: an entity Lock Code Manager knows
@@ -176,3 +192,340 @@ async def test_the_credentials_survive_a_reload(
     lock = lcm_config_entry.runtime_data.locks[codeless_lock_entity.entity_id]
     assert isinstance(lock, CodelessLock)
     assert (await lock.async_get_usercodes())[1].readable_pin == USER_PIN
+
+
+async def _entry_for(
+    hass: HomeAssistant,
+    *,
+    unique_id: str,
+    slot_num: int,
+    pin: str,
+    holding: Sequence[str],
+    declaring: Sequence[er.RegistryEntry] = (),
+) -> MockConfigEntry:
+    """
+    Set up an entry holding one user, declaring the members it is told to.
+
+    Added and set up in one step because Home Assistant loads every entry of
+    a domain when the domain itself loads: entries staged in advance are
+    already running by the time the first ``async_setup`` returns, and a test
+    about load order has to choose it.
+    """
+    name = f"{USER_NAME} {slot_num}"
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_LOCKS: list(holding),
+            CONF_MEMBERS: {
+                lock_entry.id: {CONF_CODELESS: True} for lock_entry in declaring
+            },
+            CONF_USERS: {name: {CONF_PIN: pin, CONF_ENABLED: True}},
+            CONF_SLOT_ASSIGNMENT: {name.casefold(): slot_num},
+        },
+        unique_id=unique_id,
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    return entry
+
+
+async def test_taking_the_declaration_back_hands_the_lock_to_its_provider(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """
+    Answering no moves the lock onto its provider without waiting for a reload.
+
+    The declaration is what picks the provider, so changing it changes what
+    the member IS -- but the roster the update listener diffs carries the
+    same entity id on both sides, so nothing rebuilt the instance. The answer
+    reached storage and the lock went on being held by Lock Code Manager,
+    which is the whole of what the menu offers a way out of.
+
+    Written against a lock a provider does claim, because that is the only
+    shape this exit exists for: a declared member whose platform gained a
+    provider, being handed to it.
+    """
+    claimed = er.async_get(hass).async_get(LOCK_1_ENTITY_ID)
+    entry = await _entry_for(
+        hass,
+        unique_id="declaration_taken_back",
+        slot_num=1,
+        pin="9999",
+        holding=[LOCK_1_ENTITY_ID],
+        declaring=[claimed],
+    )
+    await _settle_sync(hass)
+
+    held = entry.runtime_data.locks[LOCK_1_ENTITY_ID]
+    assert isinstance(held, CodelessLock)
+    assert (await held.async_get_usercodes())[1].readable_pin == "9999"
+
+    hass.config_entries.async_update_entry(
+        entry, options={**entry.data, CONF_MEMBERS: {}}
+    )
+    await hass.async_block_till_done()
+    await _settle_sync(hass)
+
+    handed_to = entry.runtime_data.locks[LOCK_1_ENTITY_ID]
+    assert isinstance(handed_to, MockLCMLock)
+    # The visible half: the credential is on the lock now, which is what
+    # handing the member to its provider means.
+    assert handed_to.codes[1] == "9999"
+
+    await hass.config_entries.async_unload(entry.entry_id)
+
+
+@pytest.mark.parametrize("declare_first", [True, False])
+async def test_the_entry_that_declared_the_lock_does_not_share_a_provider(
+    hass: HomeAssistant, mock_lock_config_entry, declare_first: bool
+) -> None:
+    """
+    Two entries that disagree about a lock get the provider each asked for.
+
+    A shared instance was keyed on the lock alone, so an entry that declared
+    a member codeless and one that did not were handed whichever instance
+    loaded first, and the declaration decided nothing beyond load order.
+    Loaded the wrong way round it wrote a user's Personal Identification
+    Number to a device somebody had said must never be written to.
+
+    Both orders are run because load order is exactly what the sharing was
+    sensitive to.
+    """
+    claimed = er.async_get(hass).async_get(LOCK_1_ENTITY_ID)
+
+    async def _declaring() -> MockConfigEntry:
+        return await _entry_for(
+            hass,
+            unique_id="declaring_entry",
+            slot_num=1,
+            pin="9999",
+            holding=[LOCK_1_ENTITY_ID],
+            declaring=[claimed],
+        )
+
+    async def _plain() -> MockConfigEntry:
+        return await _entry_for(
+            hass,
+            unique_id="plain_entry",
+            slot_num=2,
+            pin="8888",
+            holding=[LOCK_1_ENTITY_ID],
+        )
+
+    first, second = (_declaring, _plain) if declare_first else (_plain, _declaring)
+    await first()
+    await second()
+    await _settle_sync(hass)
+
+    declaring = hass.config_entries.async_entry_for_domain_unique_id(
+        DOMAIN, "declaring_entry"
+    )
+    plain = hass.config_entries.async_entry_for_domain_unique_id(DOMAIN, "plain_entry")
+    declared_lock = declaring.runtime_data.locks[LOCK_1_ENTITY_ID]
+    provider_lock = plain.runtime_data.locks[LOCK_1_ENTITY_ID]
+
+    assert isinstance(declared_lock, CodelessLock)
+    assert isinstance(provider_lock, MockLCMLock)
+    # The entry that declared the lock kept its credential off the device;
+    # the entry that did not put its own on it.
+    assert (await declared_lock.async_get_usercodes())[1].readable_pin == "9999"
+    assert provider_lock.codes[2] == "8888"
+    assert provider_lock.codes[1] != "9999"
+
+    for entry in (declaring, plain):
+        await hass.config_entries.async_unload(entry.entry_id)
+
+
+async def test_a_declaring_entry_releases_the_instance_it_holds(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """
+    Unloading one of two entries tears down the instance THAT entry holds.
+
+    Release inverts the share, so it asks after the object being given up
+    rather than after the entity id. Two entries that resolve one lock to
+    different providers hold two instances, and an entry that read a
+    sibling's entry in the roster as ownership walked away from its own --
+    leaving it running, and skipping the unload that writes the Lock Code
+    Manager store back. For a codeless member that store IS the credential,
+    so every code the entry held would be gone on the next load.
+    """
+    claimed = er.async_get(hass).async_get(LOCK_1_ENTITY_ID)
+    await _entry_for(
+        hass,
+        unique_id="plain_entry",
+        slot_num=2,
+        pin="8888",
+        holding=[LOCK_1_ENTITY_ID],
+    )
+    declaring = await _entry_for(
+        hass,
+        unique_id="declaring_entry",
+        slot_num=1,
+        pin="9999",
+        holding=[LOCK_1_ENTITY_ID],
+        declaring=[claimed],
+    )
+    await _settle_sync(hass)
+
+    assert await hass.config_entries.async_reload(declaring.entry_id)
+    await hass.async_block_till_done()
+
+    reloaded = declaring.runtime_data.locks[LOCK_1_ENTITY_ID]
+    assert isinstance(reloaded, CodelessLock)
+    # Read before any tick, so this is what unload wrote rather than what a
+    # sync would put back.
+    assert (await reloaded.async_get_usercodes())[1].readable_pin == "9999"
+
+    for entry in hass.config_entries.async_entries(DOMAIN):
+        await hass.config_entries.async_unload(entry.entry_id)
+
+
+async def test_deleting_the_entry_takes_the_stored_credentials_with_it(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+    codeless_lock_entity: er.RegistryEntry,
+) -> None:
+    """
+    A deleted entry does not leave its users' codes on disk.
+
+    Lock Code Manager is the store for a codeless member, so unload writes it
+    back rather than removing it -- a reload must not be a reset. Entry
+    deletion unloads first, so it took that same branch and SAVED, leaving
+    every Personal Identification Number the entry held in ``.storage`` in
+    cleartext, with nothing left in Home Assistant that could ever read it.
+    """
+    entry = await _entry_for(
+        hass,
+        unique_id="deleted_entry",
+        slot_num=1,
+        pin=USER_PIN,
+        holding=[codeless_lock_entity.entity_id],
+        declaring=[codeless_lock_entity],
+    )
+    await _settle_sync(hass)
+
+    # A reload is the cheapest way to reach the save unload performs, which
+    # is what puts the credential on disk in the first place.
+    assert await hass.config_entries.async_reload(entry.entry_id)
+    await hass.async_block_till_done()
+    store_key = f"codeless_{DOMAIN}_{codeless_lock_entity.entity_id}"
+    assert hass_storage[store_key]["data"]["1"]["code"] == USER_PIN
+
+    await hass.config_entries.async_remove(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert store_key not in hass_storage
+
+
+async def test_a_member_whose_entity_is_gone_does_not_strand_the_others(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+    codeless_lock_entity: er.RegistryEntry,
+) -> None:
+    """
+    A registry row can go before the entry does, and the sweep carries on.
+
+    The store is named after the entity id, so a member whose row is gone
+    cannot be named and its credentials are unreachable. That is a leak this
+    cannot close -- but stopping there would leak every OTHER member's codes
+    too, which is the difference between one orphaned file and the whole
+    entry's. It is listed first, which is where that difference shows.
+    """
+    second = register_codeless_lock(hass, "second_door")
+    entry = await _entry_for(
+        hass,
+        unique_id="entity_removed",
+        slot_num=1,
+        pin=USER_PIN,
+        holding=[second.entity_id, codeless_lock_entity.entity_id],
+        declaring=[second, codeless_lock_entity],
+    )
+    await _settle_sync(hass)
+    assert await hass.config_entries.async_reload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    kept = f"codeless_{DOMAIN}_{codeless_lock_entity.entity_id}"
+    assert hass_storage[kept]["data"]["1"]["code"] == USER_PIN
+
+    er.async_get(hass).async_remove(second.entity_id)
+    await hass.config_entries.async_remove(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert kept not in hass_storage
+
+
+async def test_a_member_no_provider_claims_does_not_strand_the_others(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+    codeless_lock_entity: er.RegistryEntry,
+) -> None:
+    """
+    A member nothing resolves never wrote a store, and is stepped over.
+
+    An entry can hold one: setup drops it with a repair rather than refusing
+    the whole entry, so the entry runs for as long as the user leaves it
+    there. Deleting it must still collect the credentials the members that
+    DID load were holding, so it is listed first.
+    """
+    unclaimed = register_codeless_lock(hass, "undeclared_door")
+    entry = await _entry_for(
+        hass,
+        unique_id="unclaimed_member",
+        slot_num=1,
+        pin=USER_PIN,
+        holding=[unclaimed.entity_id, codeless_lock_entity.entity_id],
+        declaring=[codeless_lock_entity],
+    )
+    assert unclaimed.entity_id not in entry.runtime_data.locks
+    await _settle_sync(hass)
+    assert await hass.config_entries.async_reload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    kept = f"codeless_{DOMAIN}_{codeless_lock_entity.entity_id}"
+    assert hass_storage[kept]["data"]["1"]["code"] == USER_PIN
+
+    await hass.config_entries.async_remove(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert kept not in hass_storage
+
+
+async def test_deleting_one_entry_leaves_a_sibling_entrys_credentials_alone(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+    codeless_lock_entity: er.RegistryEntry,
+) -> None:
+    """
+    A store two entries share is collected by the last one out, not the first.
+
+    The store is named after the lock, not the entry, so a member both
+    entries declare has one file behind it. Deleting either without asking
+    would take the other's users' codes with it, and for a codeless member
+    there is nowhere else those codes exist.
+    """
+    shared = {
+        "holding": [codeless_lock_entity.entity_id],
+        "declaring": [codeless_lock_entity],
+    }
+    keeping = await _entry_for(
+        hass, unique_id="keeping_entry", slot_num=1, pin="1111", **shared
+    )
+    await _settle_sync(hass)
+    # Nothing reaches disk while the instance is still held, and the entry
+    # that shares it is not the one that writes.
+    await hass.config_entries.async_unload(keeping.entry_id)
+    assert await hass.config_entries.async_setup(keeping.entry_id)
+    await hass.async_block_till_done()
+
+    going = await _entry_for(
+        hass, unique_id="going_entry", slot_num=2, pin="2222", **shared
+    )
+    await hass.config_entries.async_remove(going.entry_id)
+    await hass.async_block_till_done()
+
+    store_key = f"codeless_{DOMAIN}_{codeless_lock_entity.entity_id}"
+    assert hass_storage[store_key]["data"]["1"]["code"] == "1111"
+
+    await hass.config_entries.async_unload(keeping.entry_id)

--- a/tests/providers/codeless/test_e2e.py
+++ b/tests/providers/codeless/test_e2e.py
@@ -26,6 +26,7 @@ from custom_components.lock_code_manager.const import (
     ATTR_SOURCE,
     ATTR_TARGET,
     CONF_CODELESS,
+    CONF_CODELESS_LOCKS,
     CONF_LOCKS,
     CONF_MEMBERS,
     CONF_NUM_USERS,
@@ -245,9 +246,9 @@ async def test_taking_the_declaration_back_hands_the_lock_to_its_provider(
 
     The declaration is what picks the provider, so changing it changes what
     the member IS -- but the roster the update listener diffs carries the
-    same entity id on both sides, so nothing rebuilt the instance. The answer
+    same entity id on both sides, so nothing rebuilt the instance. The move
     reached storage and the lock went on being held by Lock Code Manager,
-    which is the whole of what the menu offers a way out of.
+    which is the whole of what the second picker offers a way out of.
 
     Written against a lock a provider does claim, because that is the only
     shape this exit exists for: a declared member whose platform gained a
@@ -317,17 +318,19 @@ async def test_a_second_entry_cannot_end_up_on_a_different_provider(
     )
     flow_id = started["flow_id"]
     result = await hass.config_entries.flow.async_configure(
-        flow_id, {CONF_NAME: "second", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
+        flow_id,
+        {
+            CONF_NAME: "second",
+            CONF_LOCKS: [],
+            CONF_CODELESS_LOCKS: [LOCK_1_ENTITY_ID],
+        },
     )
 
-    # Asked, rather than quietly handed to the provider that claims the
-    # lock: agreeing has to be an answer the second entry can give.
-    assert result["step_id"] == "codeless_reconsider"
-    assert result["description_placeholders"] == {"lock": LOCK_1_ENTITY_ID}
+    # Accepted, rather than refused for declaring a lock something claims:
+    # agreeing with the sibling has to be a selection the second entry can
+    # make.
+    assert result["step_id"] == "choose_path"
 
-    await hass.config_entries.flow.async_configure(
-        flow_id, {"next_step_id": "codeless_confirm"}
-    )
     await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
     await hass.config_entries.flow.async_configure(flow_id, {CONF_NUM_USERS: 1})
     result = await hass.config_entries.flow.async_configure(
@@ -557,18 +560,17 @@ async def test_handing_the_lock_back_discards_the_codes_it_was_holding(
     mock_lock_config_entry,
 ) -> None:
     """
-    The ``codeless_reconsider`` question promises this in so many words.
+    Moving a member out of the codeless field discards what it was holding.
 
-    "The codes Lock Code Manager was holding for it are discarded" is true
-    only through the redeclaration teardown: the roster carries the same
-    entity id on both sides of the edit, so the codes go only because
-    ``locks_redeclared`` feeds ``locks_to_remove`` and that removal is a
-    permanent one. Drop either coupling and the promise silently becomes a
-    lie -- a file of cleartext Personal Identification Numbers left on disk
+    On a loaded entry the redeclaration teardown also does this: the roster
+    carries the same entity id on both sides of the edit, so the codes go
+    because ``locks_redeclared`` feeds ``locks_to_remove`` and that removal
+    is a permanent one. Drop either coupling -- or the flow's own discard --
+    and a file of cleartext Personal Identification Numbers is left on disk
     for a lock nothing reads it for any more.
 
     Driven through the options flow rather than a config write, because the
-    sentence is about what answering "no" does.
+    promise is about what moving the lock does.
     """
     claimed = er.async_get(hass).async_get(LOCK_1_ENTITY_ID)
     entry = await _entry_for(
@@ -591,12 +593,12 @@ async def test_handing_the_lock_back_discards_the_codes_it_was_holding(
     flow_id = started["flow_id"]
     users = {f"{USER_NAME} 1": {CONF_PIN: "9999", CONF_ENABLED: True}}
     result = await hass.config_entries.options.async_configure(
-        flow_id, user_input={CONF_LOCKS: [LOCK_1_ENTITY_ID], CONF_USERS: users}
-    )
-    assert result["step_id"] == "codeless_reconsider"
-
-    result = await hass.config_entries.options.async_configure(
-        flow_id, {"next_step_id": "codeless_decline"}
+        flow_id,
+        user_input={
+            CONF_LOCKS: [LOCK_1_ENTITY_ID],
+            CONF_CODELESS_LOCKS: [],
+            CONF_USERS: users,
+        },
     )
     assert result["type"] == "create_entry"
     await hass.async_block_till_done()
@@ -606,13 +608,13 @@ async def test_handing_the_lock_back_discards_the_codes_it_was_holding(
     await hass.config_entries.async_unload(entry.entry_id)
 
 
-async def test_an_options_decline_discards_them_with_the_entry_unloaded(
+async def test_an_options_move_discards_them_with_the_entry_unloaded(
     hass: HomeAssistant,
     hass_storage: dict[str, Any],
     mock_lock_config_entry,
 ) -> None:
     """
-    The listener that kept that promise is not there while the entry is not.
+    The listener that keeps that promise is not there while the entry is not.
 
     ``async_update_listener`` is registered during setup and released on
     unload, so an options save against an entry that is not loaded reaches
@@ -620,11 +622,12 @@ async def test_an_options_decline_discards_them_with_the_entry_unloaded(
     removal, and a file of cleartext Personal Identification Numbers left on
     disk for a member the entry has just stopped declaring -- unreadable by
     anything, and swept by nothing, because entry deletion collects only
-    what the entry still declares.
+    what the entry still declares. The flow does the discard itself for
+    exactly this reason.
 
     The options form is reachable in that state, and the entry that comes
-    back later is a working one, so nothing on screen ever says the answer
-    was only half taken.
+    back later is a working one, so nothing on screen ever says the move was
+    only half made.
     """
     claimed = er.async_get(hass).async_get(LOCK_1_ENTITY_ID)
     entry = await _entry_for(
@@ -647,12 +650,12 @@ async def test_an_options_decline_discards_them_with_the_entry_unloaded(
     flow_id = started["flow_id"]
     users = {f"{USER_NAME} 1": {CONF_PIN: "9999", CONF_ENABLED: True}}
     result = await hass.config_entries.options.async_configure(
-        flow_id, user_input={CONF_LOCKS: [LOCK_1_ENTITY_ID], CONF_USERS: users}
-    )
-    assert result["step_id"] == "codeless_reconsider"
-
-    result = await hass.config_entries.options.async_configure(
-        flow_id, {"next_step_id": "codeless_decline"}
+        flow_id,
+        user_input={
+            CONF_LOCKS: [LOCK_1_ENTITY_ID],
+            CONF_CODELESS_LOCKS: [],
+            CONF_USERS: users,
+        },
     )
     assert result["type"] == "create_entry"
     await hass.async_block_till_done()
@@ -669,22 +672,23 @@ async def test_an_options_decline_discards_them_with_the_entry_unloaded(
     await hass.config_entries.async_unload(entry.entry_id)
 
 
-async def test_a_reauth_decline_discards_them_the_same_way(
+async def test_a_reauth_move_discards_them_the_same_way(
     hass: HomeAssistant,
     hass_storage: dict[str, Any],
     mock_lock_config_entry,
 ) -> None:
     """
-    Reauth shows the same sentence, so it has to mean the same thing there.
+    Reauth shows the same two pickers, so a move made there has to mean the
+    same thing.
 
     Reauth is the one save that does not go through the update listener: it
     writes the entry and reloads, and the entry it is repairing is failed, so
     nothing was holding the lock for ``locks_redeclared`` to find and
-    ``remove_permanently`` to collect. The promise on screen was therefore
-    true on one path and false on the other, and the false one left a file of
-    cleartext Personal Identification Numbers on disk for a lock that had
-    just been handed back to its own integration -- unreadable by anything,
-    and collected by nothing, because the entry that would have swept it on
+    ``remove_permanently`` to collect. The promise was therefore true on one
+    path and false on the other, and the false one left a file of cleartext
+    Personal Identification Numbers on disk for a lock that had just been
+    handed back to its own integration -- unreadable by anything, and
+    collected by nothing, because the entry that would have swept it on
     deletion no longer declares the member.
 
     A second lock whose registry row is gone is what puts the entry in
@@ -713,12 +717,8 @@ async def test_a_reauth_decline_discards_them_the_same_way(
 
     [flow] = entry.async_get_active_flows(hass, {SOURCE_REAUTH})
     result = await hass.config_entries.flow.async_configure(
-        flow["flow_id"], {CONF_LOCKS: [LOCK_1_ENTITY_ID]}
-    )
-    assert result["step_id"] == "codeless_reconsider"
-
-    result = await hass.config_entries.flow.async_configure(
-        flow["flow_id"], {"next_step_id": "codeless_decline"}
+        flow["flow_id"],
+        {CONF_LOCKS: [LOCK_1_ENTITY_ID], CONF_CODELESS_LOCKS: []},
     )
     assert result["type"] == "abort"
     await hass.async_block_till_done()
@@ -734,14 +734,14 @@ async def test_a_reauth_confirmation_leaves_the_codes_exactly_where_they_are(
     mock_lock_config_entry,
 ) -> None:
     """
-    The other answer to the same question must not cost a single code.
+    Leaving the member where it is must not cost a single code.
 
-    Discarding on decline and discarding on confirm are one line apart, and
-    the wrong one of the two is silent: the user is asked whether Lock Code
-    Manager should keep holding the codes, says yes, and every one of them is
-    deleted on the way to saving that yes. There is nowhere else a codeless
-    member's codes exist, so it is unrecoverable, and the entry that comes
-    back looks configured -- the slots are all there, holding nothing.
+    Discarding what the submission drops and discarding what it keeps are one
+    predicate apart, and the wrong one of the two is silent: the user
+    resubmits the form unchanged and every code is deleted on the way to
+    saving it. There is nowhere else a codeless member's codes exist, so it
+    is unrecoverable, and the entry that comes back looks configured -- the
+    slots are all there, holding nothing.
     """
     claimed = er.async_get(hass).async_get(LOCK_1_ENTITY_ID)
     entry = await _entry_for(
@@ -762,12 +762,8 @@ async def test_a_reauth_confirmation_leaves_the_codes_exactly_where_they_are(
     store_key = f"codeless_{DOMAIN}_{LOCK_1_ENTITY_ID}"
     [flow] = entry.async_get_active_flows(hass, {SOURCE_REAUTH})
     result = await hass.config_entries.flow.async_configure(
-        flow["flow_id"], {CONF_LOCKS: [LOCK_1_ENTITY_ID]}
-    )
-    assert result["step_id"] == "codeless_reconsider"
-
-    result = await hass.config_entries.flow.async_configure(
-        flow["flow_id"], {"next_step_id": "codeless_confirm"}
+        flow["flow_id"],
+        {CONF_LOCKS: [], CONF_CODELESS_LOCKS: [LOCK_1_ENTITY_ID]},
     )
     assert result["type"] == "abort"
     await hass.async_block_till_done()
@@ -781,3 +777,111 @@ async def test_a_reauth_confirmation_leaves_the_codes_exactly_where_they_are(
     assert hass_storage[store_key]["data"]["1"]["code"] == "9999"
 
     await hass.config_entries.async_unload(entry.entry_id)
+
+
+async def test_dropping_a_declared_lock_discards_the_codes_it_was_holding(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+    mock_lock_config_entry,
+    codeless_lock_entity: er.RegistryEntry,
+) -> None:
+    """
+    A lock that leaves the entry altogether is a declaration taken back too.
+
+    Moving a member to the other picker and dropping it from both mean the
+    same thing: Lock Code Manager is no longer where that lock's codes live.
+    The teardown that would collect the store runs from the update listener,
+    which an unloaded entry does not have -- so the file of cleartext
+    Personal Identification Numbers stayed on disk, unreadable by anything
+    and swept by nothing, since entry deletion collects only what the entry
+    still declares.
+    """
+    entry = await _entry_for(
+        hass,
+        unique_id="dropping_declared",
+        slot_num=1,
+        pin="1111",
+        holding=[codeless_lock_entity.entity_id, LOCK_1_ENTITY_ID],
+        declaring=[codeless_lock_entity],
+    )
+    await _settle_sync(hass)
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    store_key = f"codeless_{DOMAIN}_{codeless_lock_entity.entity_id}"
+    assert hass_storage[store_key]["data"]["1"]["code"] == "1111"
+
+    started = await hass.config_entries.options.async_init(entry.entry_id)
+    users = {f"{USER_NAME} 1": {CONF_PIN: "1111", CONF_ENABLED: True}}
+    result = await hass.config_entries.options.async_configure(
+        started["flow_id"],
+        user_input={
+            CONF_LOCKS: [LOCK_1_ENTITY_ID],
+            CONF_CODELESS_LOCKS: [],
+            CONF_USERS: users,
+        },
+    )
+    assert result["type"] == "create_entry"
+    await hass.async_block_till_done()
+
+    assert store_key not in hass_storage
+
+
+async def test_dropping_a_lock_a_sibling_still_declares_leaves_its_codes(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+    mock_lock_config_entry,
+    codeless_lock_entity: er.RegistryEntry,
+) -> None:
+    """
+    The discard asks whether anybody else still reads the store first.
+
+    A member this entry KEEPS cannot disagree with a sibling -- the conflict
+    refusal stops the submission -- but a member it DROPS is outside what any
+    refusal looks at. Discarding unconditionally would delete the other
+    configuration's users' codes, and for a codeless member there is nowhere
+    else those codes exist.
+    """
+    shared = {
+        "holding": [codeless_lock_entity.entity_id, LOCK_1_ENTITY_ID],
+        "declaring": [codeless_lock_entity],
+    }
+    keeping = await _entry_for(
+        hass, unique_id="sibling_keeping", slot_num=1, pin="1111", **shared
+    )
+    await _settle_sync(hass)
+    # A reload is the cheapest way to reach the save unload performs, which
+    # is what puts the sibling's credential on disk in the first place.
+    assert await hass.config_entries.async_reload(keeping.entry_id)
+    await hass.async_block_till_done()
+    going = await _entry_for(
+        hass, unique_id="sibling_going", slot_num=2, pin="2222", **shared
+    )
+    await _settle_sync(hass)
+    # Unloading the entry about to be edited takes away its listener, which
+    # is the state the flow's own discard is for. It writes nothing, because
+    # the instance belongs to the sibling that is still holding it.
+    await hass.config_entries.async_unload(going.entry_id)
+    await hass.async_block_till_done()
+
+    store_key = f"codeless_{DOMAIN}_{codeless_lock_entity.entity_id}"
+    assert hass_storage[store_key]["data"]["1"]["code"] == "1111"
+
+    started = await hass.config_entries.options.async_init(going.entry_id)
+    users = {f"{USER_NAME} 2": {CONF_PIN: "2222", CONF_ENABLED: True}}
+    result = await hass.config_entries.options.async_configure(
+        started["flow_id"],
+        user_input={
+            CONF_LOCKS: [LOCK_1_ENTITY_ID],
+            CONF_CODELESS_LOCKS: [],
+            CONF_USERS: users,
+        },
+    )
+    assert result["type"] == "create_entry"
+    await hass.async_block_till_done()
+
+    # The file the sibling reads its codes back from survives, which is the
+    # whole of what "there is nowhere else those codes exist" means.
+    assert hass_storage[store_key]["data"]["1"]["code"] == "1111"
+
+    await hass.config_entries.async_unload(keeping.entry_id)

--- a/tests/providers/codeless/test_provider.py
+++ b/tests/providers/codeless/test_provider.py
@@ -1,0 +1,74 @@
+"""Unit tests for the codeless provider itself."""
+
+from __future__ import annotations
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+from custom_components.lock_code_manager.domain.credentials import CredentialType
+from custom_components.lock_code_manager.providers.codeless import CodelessLock
+from custom_components.lock_code_manager.providers.virtual import VirtualLock
+
+
+def _build(cls, hass: HomeAssistant, lock_entry: er.RegistryEntry):
+    """Build a provider of ``cls`` over a lock entity, without setting it up."""
+    return cls(hass, dr.async_get(hass), er.async_get(hass), None, lock_entry)
+
+
+async def test_the_store_is_keyed_by_the_declaration_not_the_integration(
+    hass: HomeAssistant, codeless_lock_entity: er.RegistryEntry
+) -> None:
+    """
+    Where a member's credentials live follows the declaration, and only it.
+
+    ``domain`` is what diagnostics reports per lock and what the store key
+    is built from, so it decides both what somebody debugging is told and
+    which file the credentials are in. The member's own platform would name
+    the integration that has nothing to do with these credentials; the
+    virtual provider's would put two classes holding different things --
+    an integration's codes, and a declaration's -- on one file for the same
+    entity.
+    """
+    codeless = _build(CodelessLock, hass, codeless_lock_entity)
+    virtual = _build(VirtualLock, hass, codeless_lock_entity)
+    await codeless.async_setup(None)
+    await virtual.async_setup(None)
+
+    assert codeless.domain == "codeless" != codeless_lock_entity.platform
+    assert codeless.domain in codeless._store.key
+    assert codeless_lock_entity.entity_id in codeless._store.key
+    assert codeless._store.key != virtual._store.key
+
+
+async def test_it_reports_observing_nothing(
+    hass: HomeAssistant, codeless_lock_entity: er.RegistryEntry
+) -> None:
+    """
+    A lock no code can be read from cannot report which one was used, either.
+
+    Uses reach this integration through the ``use_credential`` action, which
+    asks nothing of the member it names -- so the honest answer here is the
+    one inherited, and a provider claiming otherwise would be advertising an
+    observation nobody makes.
+    """
+    codeless = _build(CodelessLock, hass, codeless_lock_entity)
+
+    assert codeless.supports_code_slot_events is False
+
+
+async def test_it_advertises_no_limits_and_is_always_connected(
+    hass: HomeAssistant, codeless_lock_entity: er.RegistryEntry
+) -> None:
+    """
+    Nothing is asked of the device, so nothing about the device bounds a code.
+
+    A capacity or a length this reported would be invented: the credentials
+    live in a Lock Code Manager store, which has neither.
+    """
+    codeless = _build(CodelessLock, hass, codeless_lock_entity)
+
+    capabilities = await codeless.async_get_capabilities()
+
+    assert await codeless.async_is_integration_connected() is True
+    assert capabilities.bounded_slot_count(CredentialType.PIN) is None
+    assert not capabilities.supports_user_management

--- a/tests/providers/test_base.py
+++ b/tests/providers/test_base.py
@@ -842,10 +842,12 @@ async def test_two_providers_over_one_entity_are_not_one_lock(hass: HomeAssistan
     A provider is equal only to itself, and a set of them keeps both.
 
     Equality used to key on the lock entity id, which said two instances
-    wrapping one entity were the same logical lock. Two entries can resolve
-    one entity to different providers, and those hold different credential
-    stores -- so a collection of providers silently kept one of them, and
-    whichever it kept decided where a Personal Identification Number went.
+    wrapping one entity were the same logical lock. One entity does mean one
+    live instance, but not one instance ever: a reload builds a replacement,
+    and teardown asks whether a sibling still holds THIS object. Answering
+    that by entity id says yes for the stale instance the reload replaced,
+    so the entry walks away from the live one and leaves its push
+    subscription firing with nothing owning it.
     """
     entity_reg = er.async_get(hass)
     config_entry = MockConfigEntry(domain=DOMAIN)

--- a/tests/providers/test_base.py
+++ b/tests/providers/test_base.py
@@ -837,8 +837,16 @@ async def test_clear_usercode_refreshes_coordinator_on_change(
         assert refresh_count[0] == 1  # Still 1, no new refresh
 
 
-async def test_lock_equality_with_non_baselock(hass: HomeAssistant):
-    """Test that __eq__ returns False when comparing with non-BaseLock object."""
+async def test_two_providers_over_one_entity_are_not_one_lock(hass: HomeAssistant):
+    """
+    A provider is equal only to itself, and a set of them keeps both.
+
+    Equality used to key on the lock entity id, which said two instances
+    wrapping one entity were the same logical lock. Two entries can resolve
+    one entity to different providers, and those hold different credential
+    stores -- so a collection of providers silently kept one of them, and
+    whichever it kept decided where a Personal Identification Number went.
+    """
     entity_reg = er.async_get(hass)
     config_entry = MockConfigEntry(domain=DOMAIN)
     config_entry.add_to_hass(hass)
@@ -850,45 +858,13 @@ async def test_lock_equality_with_non_baselock(hass: HomeAssistant):
         config_entry=config_entry,
     )
 
-    lock = BaseLock(
-        hass,
-        dr.async_get(hass),
-        entity_reg,
-        config_entry,
-        lock_entity,
-    )
-
-    # Comparing to non-BaseLock objects should return False
-    assert lock != "not a lock"
-    assert lock != 123
-    assert (lock == None) is False  # noqa: E711 - Intentionally testing __eq__ with None
-    assert lock != {"entity_id": lock_entity.entity_id}
-
-
-async def test_lock_equality_with_same_entity_id(hass: HomeAssistant):
-    """Two BaseLock instances wrapping the same lock entity are equal.
-
-    __hash__ is defined by entity ID alone, so __eq__ must agree: any two
-    BaseLock objects (even different provider classes or instances) that
-    wrap the same lock.entity_id are the same logical lock.
-    """
-    entity_reg = er.async_get(hass)
-    config_entry = MockConfigEntry(domain=DOMAIN)
-    config_entry.add_to_hass(hass)
-
-    lock_entity = entity_reg.async_get_or_create(
-        "lock",
-        "test",
-        "test_lock_eq_same",
-        config_entry=config_entry,
-    )
-
     lock_a = BaseLock(hass, dr.async_get(hass), entity_reg, config_entry, lock_entity)
     lock_b = BaseLock(hass, dr.async_get(hass), entity_reg, config_entry, lock_entity)
 
-    assert lock_a is not lock_b
-    assert lock_a == lock_b
-    assert lock_a == lock_a  # noqa: PLR0124 - Intentionally testing reflexive __eq__
+    assert lock_a != lock_b
+    assert lock_a == lock_a  # noqa: PLR0124 - a provider is still itself
+    assert len({lock_a, lock_b}) == 2
+    assert lock_a != "not a lock"
 
 
 async def test_fire_code_slot_event_fires_both_events(

--- a/tests/providers/test_dispatch.py
+++ b/tests/providers/test_dispatch.py
@@ -9,26 +9,33 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
-from custom_components.lock_code_manager.const import DOMAIN
+from custom_components.lock_code_manager.const import (
+    CONF_CODELESS,
+    CONF_LOCKS,
+    CONF_MEMBERS,
+    DOMAIN,
+)
 from custom_components.lock_code_manager.domain.allocation import (
     LockQuerySkipped,
     build_lock_instance,
 )
 from custom_components.lock_code_manager.domain.locks import async_create_lock_instance
 from custom_components.lock_code_manager.providers import (
-    CONFIG_FLOW_PLATFORMS,
-    INTEGRATIONS_CLASS_MAP,
     Zigbee2MQTTLock,
     ZWaveJSLock,
     ZWaveJSUILock,
     resolve_provider_class,
 )
+from custom_components.lock_code_manager.providers.codeless import CodelessLock
 from custom_components.lock_code_manager.providers.zwave_js_ui import (
     parse_zwave_js_ui_identifier,
 )
 
-from ..common import async_discover_unclaimed_mqtt_lock
-from ..conftest import TEST_DOMAIN
+from ..common import (
+    LOCK_1_ENTITY_ID,
+    async_discover_unclaimed_mqtt_lock,
+    register_codeless_lock,
+)
 
 
 def test_single_provider_platform_ignores_device():
@@ -184,16 +191,6 @@ async def test_mqtt_dispatch_skips_malformed_identifier(hass: HomeAssistant) -> 
     assert resolve_provider_class("mqtt", malformed_only) is None
 
 
-def test_config_flow_platforms():
-    """CONFIG_FLOW_PLATFORMS covers every shipped map key plus mqtt exactly once."""
-    # The harness injects a mock provider into the map at runtime, while
-    # CONFIG_FLOW_PLATFORMS is a tuple built from it at import. Only the
-    # shipped platforms have to be selectable.
-    assert set(INTEGRATIONS_CLASS_MAP) - {TEST_DOMAIN} <= set(CONFIG_FLOW_PLATFORMS)
-    assert "mqtt" in CONFIG_FLOW_PLATFORMS
-    assert len(CONFIG_FLOW_PLATFORMS) == len(set(CONFIG_FLOW_PLATFORMS))
-
-
 async def test_factory_rejects_unclaimed_mqtt_lock(
     hass: HomeAssistant, mqtt_mock, mqtt_teardown
 ) -> None:
@@ -226,3 +223,112 @@ async def test_allocation_skips_unclaimed_mqtt_lock(
         )
 
     assert raised.value.managed is False
+
+
+def _entry_declaring(
+    hass: HomeAssistant, lock_entry: er.RegistryEntry, **declared: bool
+) -> MockConfigEntry:
+    """Return an entry that manages a lock and declares what it was told."""
+    lcm_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=f"declaring-{lock_entry.entity_id}",
+        data={
+            CONF_LOCKS: [lock_entry.entity_id],
+            CONF_MEMBERS: {lock_entry.id: declared},
+        },
+    )
+    lcm_entry.add_to_hass(hass)
+    return lcm_entry
+
+
+async def test_a_declared_member_resolves_to_the_codeless_provider(
+    hass: HomeAssistant,
+) -> None:
+    """A lock nothing claims is buildable once its entry declares it."""
+    lock_entry = register_codeless_lock(hass)
+    lcm_entry = _entry_declaring(hass, lock_entry, **{CONF_CODELESS: True})
+
+    lock = async_create_lock_instance(
+        hass, dr.async_get(hass), er.async_get(hass), lcm_entry, lock_entry.entity_id
+    )
+
+    assert isinstance(lock, CodelessLock)
+    assert lock.lock.entity_id == lock_entry.entity_id
+
+
+async def test_allocation_reads_a_declared_member(hass: HomeAssistant) -> None:
+    """
+    Allocation builds the same provider the entry's own setup will.
+
+    Skipping it instead would issue slot numbers against a member Lock Code
+    Manager is about to start writing credentials to.
+    """
+    lock_entry = register_codeless_lock(hass)
+    lcm_entry = _entry_declaring(hass, lock_entry, **{CONF_CODELESS: True})
+
+    lock = build_lock_instance(
+        hass, dr.async_get(hass), er.async_get(hass), lcm_entry, lock_entry.entity_id
+    )
+
+    assert isinstance(lock, CodelessLock)
+
+
+async def test_an_undeclared_lock_nothing_claims_is_still_refused(
+    hass: HomeAssistant,
+) -> None:
+    """
+    Never guessing is the rule the declaration is an exception to.
+
+    Only somebody answering makes a lock codeless; a lock somebody meant to
+    reach through a provider Lock Code Manager has not been taught yet has
+    to keep failing loudly.
+    """
+    lock_entry = register_codeless_lock(hass)
+    lcm_entry = _entry_declaring(hass, lock_entry)
+
+    with pytest.raises(
+        HomeAssistantError, match="No Lock Code Manager provider claims"
+    ):
+        async_create_lock_instance(
+            hass,
+            dr.async_get(hass),
+            er.async_get(hass),
+            lcm_entry,
+            lock_entry.entity_id,
+        )
+
+    with pytest.raises(LockQuerySkipped) as raised:
+        build_lock_instance(
+            hass,
+            dr.async_get(hass),
+            er.async_get(hass),
+            lcm_entry,
+            lock_entry.entity_id,
+        )
+
+    assert raised.value.managed is False
+
+
+async def test_a_declaration_outranks_platform_dispatch(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """
+    The declaration is read first, and the order is the point.
+
+    Should Lock Code Manager ever gain a provider for a platform somebody
+    already declared codeless, letting that provider win would move a
+    member's credentials out of this integration's store and onto a device
+    the user never agreed to write to, silently, on a version upgrade.
+    """
+    lock_entry = er.async_get(hass).async_get(LOCK_1_ENTITY_ID)
+    assert lock_entry is not None
+    # Claimed by platform dispatch on its own.
+    assert resolve_provider_class(lock_entry.platform, None) is not None
+
+    lcm_entry = _entry_declaring(hass, lock_entry, **{CONF_CODELESS: True})
+
+    lock = async_create_lock_instance(
+        hass, dr.async_get(hass), er.async_get(hass), lcm_entry, LOCK_1_ENTITY_ID
+    )
+
+    assert isinstance(lock, CodelessLock)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -889,11 +889,12 @@ def test_nothing_declared_is_the_default() -> None:
 
 def test_a_member_absent_from_the_roster_still_answers() -> None:
     """
-    Declarations outlive membership.
+    Reading a declaration does not consult the roster.
 
-    Removing a lock from the entry does not erase what was declared about it,
-    so re-adding it restores the declaration instead of silently reverting to
-    defaults.
+    ``declare_codeless`` prunes on write, so this state comes from storage
+    written by hand or by a version that did not prune. Reading it has to
+    answer rather than raise: the alternative is an entry that cannot load
+    over a member it no longer has.
     """
     config = EntryConfig.from_mapping(
         {CONF_LOCKS: [], CONF_MEMBERS: {_MEMBER_A: _DECLARED}}
@@ -1144,7 +1145,7 @@ def test_declaring_codeless_survives_a_write() -> None:
     disagreeing is invisible until a member silently resolves to the wrong
     provider.
     """
-    stored = declare_codeless({}, {_MEMBER_A: True})
+    stored = declare_codeless({}, {_MEMBER_A: True}, {_MEMBER_A})
 
     config = EntryConfig.from_mapping(
         EntryConfig.from_mapping({CONF_MEMBERS: stored}).to_dict()
@@ -1164,6 +1165,7 @@ def test_declaring_codeless_leaves_every_other_field_alone() -> None:
     declared = declare_codeless(
         {_MEMBER_A: {"something_else": "kept"}, _MEMBER_B: {"untouched": True}},
         {_MEMBER_A: True},
+        {_MEMBER_A, _MEMBER_B},
     )
 
     assert declared == {
@@ -1186,6 +1188,7 @@ def test_declining_takes_the_declaration_back() -> None:
             _MEMBER_B: {CONF_CODELESS: True, "something_else": "kept"},
         },
         {_MEMBER_A: False, _MEMBER_B: False},
+        {_MEMBER_A, _MEMBER_B},
     )
 
     assert declared == {_MEMBER_B: {"something_else": "kept"}}
@@ -1196,4 +1199,32 @@ def test_declining_takes_the_declaration_back() -> None:
 
 def test_declining_a_member_nobody_declared_about_stores_nothing() -> None:
     """An answer of no, for a member with nothing recorded, is not a record."""
-    assert declare_codeless({}, {_MEMBER_A: False}) == {}
+    assert declare_codeless({}, {_MEMBER_A: False}, {_MEMBER_A}) == {}
+
+
+def test_a_declaration_about_a_member_that_left_the_roster_is_dropped() -> None:
+    """
+    Writing prunes what the entry no longer holds.
+
+    Nothing reads a declaration for a member outside the roster, so keeping
+    one is invisible until the same lock is added back -- and then it decides
+    that lock's provider, with nobody having been asked twice.
+    """
+    declared = declare_codeless(
+        {_MEMBER_A: {CONF_CODELESS: True}, _MEMBER_B: {CONF_CODELESS: True}},
+        {},
+        {_MEMBER_B},
+    )
+
+    assert declared == {_MEMBER_B: {CONF_CODELESS: True}}
+
+
+def test_pruning_takes_every_field_a_dropped_member_carried() -> None:
+    """
+    The whole declaration goes, not just the codeless field.
+
+    A declaration is not a fixed record, so a member that left the roster
+    carrying a field this version does not model would otherwise be exactly
+    the husk that grows the entry without bound.
+    """
+    assert declare_codeless({_MEMBER_A: {"something_else": "kept"}}, {}, set()) == {}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,6 +11,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from homeassistant.helpers import entity_registry as er
 
 from custom_components.lock_code_manager.const import (
+    CONF_CODELESS,
     CONF_LOCKS,
     CONF_MEMBERS,
     CONF_SLOTS,
@@ -22,6 +23,7 @@ from custom_components.lock_code_manager.domain.config import (
     EntryConfigDiff,
     build_slot_device_identifier,
     build_slot_unique_id,
+    declare_codeless,
     parse_slot_device_identifier,
     parse_slot_unique_id,
 )
@@ -1104,3 +1106,94 @@ def test_from_entry_falls_back_to_data_for_member_declarations() -> None:
     )
 
     assert EntryConfig.from_entry(entry).member(_member_entry(_MEMBER_A)) == _DECLARED
+
+
+# --- Codeless declarations (issue #1484) ---
+
+
+def test_a_member_is_codeless_only_when_it_says_so() -> None:
+    """
+    Nothing infers the field, so anything short of it reads as False.
+
+    The answer decides which provider a member gets, and getting it wrong in
+    this direction hands a lock with real credential storage to a provider
+    that writes to a file instead.
+    """
+    config = EntryConfig.from_mapping(
+        {
+            CONF_MEMBERS: {
+                _MEMBER_A: {CONF_CODELESS: True},
+                _MEMBER_B: {"something_else": True},
+                _MEMBER_C: {},
+            }
+        }
+    )
+
+    assert config.is_codeless(_member_entry(_MEMBER_A))
+    assert not config.is_codeless(_member_entry(_MEMBER_B))
+    assert not config.is_codeless(_member_entry(_MEMBER_C))
+    # A member nothing was ever said about.
+    assert not config.is_codeless(_member_entry("0dddddddddddddddddddddddddddddddd"))
+
+
+def test_declaring_codeless_survives_a_write() -> None:
+    """
+    What the flow records is what dispatch reads back.
+
+    ``declare_codeless`` writes storage and ``is_codeless`` reads it; the two
+    disagreeing is invisible until a member silently resolves to the wrong
+    provider.
+    """
+    stored = declare_codeless({}, {_MEMBER_A: True})
+
+    config = EntryConfig.from_mapping(
+        EntryConfig.from_mapping({CONF_MEMBERS: stored}).to_dict()
+    )
+
+    assert config.is_codeless(_member_entry(_MEMBER_A))
+
+
+def test_declaring_codeless_leaves_every_other_field_alone() -> None:
+    """
+    One field is recorded, not the whole declaration.
+
+    A member's declaration is not a fixed record, so writing this field by
+    replacing the mapping would silently drop whatever else the member
+    carries -- including fields a later version adds.
+    """
+    declared = declare_codeless(
+        {_MEMBER_A: {"something_else": "kept"}, _MEMBER_B: {"untouched": True}},
+        {_MEMBER_A: True},
+    )
+
+    assert declared == {
+        _MEMBER_A: {"something_else": "kept", CONF_CODELESS: True},
+        _MEMBER_B: {"untouched": True},
+    }
+
+
+def test_declining_takes_the_declaration_back() -> None:
+    """
+    Declining has to erase, because it is how a declaration is undone.
+
+    A member left holding nothing else goes with it: an empty declaration
+    and no declaration mean the same thing to every reader, so storing one
+    would leave a husk behind for every member anybody ever declined about.
+    """
+    declared = declare_codeless(
+        {
+            _MEMBER_A: {CONF_CODELESS: True},
+            _MEMBER_B: {CONF_CODELESS: True, "something_else": "kept"},
+        },
+        {_MEMBER_A: False, _MEMBER_B: False},
+    )
+
+    assert declared == {_MEMBER_B: {"something_else": "kept"}}
+    assert not EntryConfig.from_mapping({CONF_MEMBERS: declared}).is_codeless(
+        _member_entry(_MEMBER_A)
+    )
+
+
+def test_declining_a_member_nobody_declared_about_stores_nothing() -> None:
+    """An answer of no, for a member with nothing recorded, is not a record."""
+    assert declare_codeless({}, {_MEMBER_A: False}) == {}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1145,7 +1145,7 @@ def test_declaring_codeless_survives_a_write() -> None:
     disagreeing is invisible until a member silently resolves to the wrong
     provider.
     """
-    stored = declare_codeless({}, {_MEMBER_A: True}, {_MEMBER_A})
+    stored = declare_codeless({}, {_MEMBER_A}, {_MEMBER_A})
 
     config = EntryConfig.from_mapping(
         EntryConfig.from_mapping({CONF_MEMBERS: stored}).to_dict()
@@ -1164,7 +1164,7 @@ def test_declaring_codeless_leaves_every_other_field_alone() -> None:
     """
     declared = declare_codeless(
         {_MEMBER_A: {"something_else": "kept"}, _MEMBER_B: {"untouched": True}},
-        {_MEMBER_A: True},
+        {_MEMBER_A},
         {_MEMBER_A, _MEMBER_B},
     )
 
@@ -1174,20 +1174,20 @@ def test_declaring_codeless_leaves_every_other_field_alone() -> None:
     }
 
 
-def test_declining_takes_the_declaration_back() -> None:
+def test_a_member_outside_the_codeless_set_loses_the_field() -> None:
     """
-    Declining has to erase, because it is how a declaration is undone.
+    Leaving the codeless field erases, because it is how a declaration is undone.
 
     A member left holding nothing else goes with it: an empty declaration
     and no declaration mean the same thing to every reader, so storing one
-    would leave a husk behind for every member anybody ever declined about.
+    would leave a husk behind for every member anybody ever moved out.
     """
     declared = declare_codeless(
         {
             _MEMBER_A: {CONF_CODELESS: True},
             _MEMBER_B: {CONF_CODELESS: True, "something_else": "kept"},
         },
-        {_MEMBER_A: False, _MEMBER_B: False},
+        set(),
         {_MEMBER_A, _MEMBER_B},
     )
 
@@ -1197,22 +1197,25 @@ def test_declining_takes_the_declaration_back() -> None:
     )
 
 
-def test_declining_a_member_nobody_declared_about_stores_nothing() -> None:
-    """An answer of no, for a member with nothing recorded, is not a record."""
-    assert declare_codeless({}, {_MEMBER_A: False}, {_MEMBER_A}) == {}
+def test_a_member_nobody_ever_declared_about_stores_nothing() -> None:
+    """A member in the roster and outside the codeless set is not a record."""
+    assert declare_codeless({}, set(), {_MEMBER_A}) == {}
 
 
-def test_a_declaration_about_a_member_that_left_the_roster_is_dropped() -> None:
+def test_the_roster_outranks_the_codeless_set() -> None:
     """
-    Writing prunes what the entry no longer holds.
+    Writing prunes what the entry no longer holds, whatever else it was told.
 
     Nothing reads a declaration for a member outside the roster, so keeping
     one is invisible until the same lock is added back -- and then it decides
-    that lock's provider, with nobody having been asked twice.
+    that lock's provider, with nobody having selected it. The codeless set is
+    filtered by the same rule as the stored declarations, because a lock can
+    be dropped from the roster while still sitting in the field that named
+    it.
     """
     declared = declare_codeless(
         {_MEMBER_A: {CONF_CODELESS: True}, _MEMBER_B: {CONF_CODELESS: True}},
-        {},
+        {_MEMBER_A, _MEMBER_B},
         {_MEMBER_B},
     )
 
@@ -1227,4 +1230,4 @@ def test_pruning_takes_every_field_a_dropped_member_carried() -> None:
     carrying a field this version does not model would otherwise be exactly
     the husk that grows the entry without bound.
     """
-    assert declare_codeless({_MEMBER_A: {"something_else": "kept"}}, {}, set()) == {}
+    assert declare_codeless({_MEMBER_A: {"something_else": "kept"}}, set(), set()) == {}

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -30,6 +30,7 @@ from custom_components.lock_code_manager.domain.allocation import (
     LockQuerySkipped,
     build_lock_instance,
 )
+from custom_components.lock_code_manager.domain.config import EntryConfig
 from custom_components.lock_code_manager.domain.credentials import (
     CredentialType,
     CredentialTypeCapability,
@@ -38,6 +39,9 @@ from custom_components.lock_code_manager.domain.credentials import (
 from custom_components.lock_code_manager.domain.exceptions import (
     LockCodeManagerError,
     LockDisconnected,
+)
+from custom_components.lock_code_manager.domain.locks import (
+    resolve_member_provider_class,
 )
 from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.domain.queries import get_entry_config
@@ -2917,7 +2921,85 @@ async def test_a_declared_member_a_provider_now_claims_is_still_asked_about(
     # that provider rather than leaving a lock nothing can manage.
     assert result["type"] == "create_entry"
     assert result["data"][CONF_LOCKS] == [LOCK_1_ENTITY_ID]
+    # Read the way dispatch reads it, not as a dict. What declining buys is
+    # the provider that claims the lock now taking it back; an assertion on
+    # the stored shape passes just as well while the member goes on
+    # resolving to the Lock Code Manager store.
+    assert (
+        resolve_member_provider_class(
+            dr.async_get(hass), EntryConfig.from_mapping(result["data"]), claimed
+        )
+        is MockLCMLock
+    )
+
+
+async def test_an_answer_about_a_lock_the_same_visit_drops_is_not_stored(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """
+    A yes is not written back about a lock the submission no longer holds.
+
+    The answer outlives the question it answered: it is cached for the life
+    of the flow, so a re-submission refused for some unrelated reason -- a
+    sibling lock too asleep to report its occupancy -- comes back with the
+    yes still held. Dropping the lock is the obvious reaction to that
+    refusal, and storing the answer anyway leaves a declaration about a
+    member the entry does not have, waiting to decide the provider for
+    whatever is added under that registry id next.
+    """
+    codeless = register_codeless_lock(hass)
+    entry = MockConfigEntry(domain=DOMAIN, data=BASE_CONFIG, unique_id="Mock Title")
+    entry.add_to_hass(hass)
+    users = {"test1": {CONF_PIN: "1234", CONF_ENABLED: True}}
+
+    started = await hass.config_entries.options.async_init(entry.entry_id)
+    flow_id = started["flow_id"]
+
+    with _holding():
+        result = await hass.config_entries.options.async_configure(
+            flow_id,
+            user_input={
+                CONF_LOCKS: [LOCK_1_ENTITY_ID, codeless.entity_id],
+                CONF_USERS: users,
+            },
+        )
+    await _menu_about(result, codeless)
+
+    async def _unreadable(self, slots=None):
+        raise LockCodeManagerError("lock is asleep")
+
+    # Yes -- and the re-submission it causes fails over the sibling lock.
+    with patch.object(MockLCMLock, "async_get_usercodes", _unreadable):
+        result = await hass.config_entries.options.async_configure(
+            flow_id, {"next_step_id": "codeless_confirm"}
+        )
+
+    assert result["errors"] == {"base": "occupancy_unknown"}
+
+    # So the lock that was answered about is dropped instead.
+    with _holding():
+        result = await hass.config_entries.options.async_configure(
+            flow_id, user_input={CONF_LOCKS: [LOCK_1_ENTITY_ID], CONF_USERS: users}
+        )
+
+    assert result["type"] == "create_entry"
     assert result["data"][CONF_MEMBERS] == {}
+
+    # And the lock re-added later is a lock nobody has answered for, rather
+    # than one that resolves to the Lock Code Manager store unasked.
+    hass.config_entries.async_update_entry(entry, data=result["data"], options={})
+    started = await hass.config_entries.options.async_init(entry.entry_id)
+
+    with _holding():
+        result = await hass.config_entries.options.async_configure(
+            started["flow_id"],
+            user_input={
+                CONF_LOCKS: [LOCK_1_ENTITY_ID, codeless.entity_id],
+                CONF_USERS: users,
+            },
+        )
+
+    await _menu_about(result, codeless)
 
 
 async def test_dropping_a_lock_drops_what_was_declared_about_it(

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -354,7 +354,7 @@ async def test_config_flow_yaml_error(hass: HomeAssistant, mock_lock_config_entr
 
     assert result["type"] == "form"
     assert result["step_id"] == "yaml"
-    assert result["errors"] == {"base": "invalid_config"}
+    assert result["errors"] == {CONF_USERS: "invalid_config"}
 
 
 async def test_config_flow_ui_stores_a_padded_pin_stripped(
@@ -439,7 +439,7 @@ async def test_config_flow_yaml_rejects_a_whitespace_only_pin(
 
     assert result["type"] == "form"
     assert result["step_id"] == "yaml"
-    assert result["errors"] == {"base": "invalid_config"}
+    assert result["errors"] == {CONF_USERS: "invalid_config"}
 
 
 async def test_options_flow(hass: HomeAssistant, mock_lock_config_entry):
@@ -473,7 +473,7 @@ async def test_options_flow(hass: HomeAssistant, mock_lock_config_entry):
 
     assert result["type"] == "form"
     assert result["step_id"] == "init"
-    assert result["errors"] == {"base": "invalid_config"}
+    assert result["errors"] == {CONF_USERS: "invalid_config"}
 
     # Give the enabled user a PIN and it saves.
     new_config[CONF_USERS]["User 3"][CONF_PIN] = "1234"
@@ -827,7 +827,7 @@ async def test_options_flow_invalid_yaml_shows_error(
     )
 
     assert result["type"] == "form"
-    assert result["errors"] == {"base": "invalid_config"}
+    assert result["errors"] == {CONF_USERS: "invalid_config"}
 
 
 # Slot capacity validation (issue #1398)
@@ -883,7 +883,7 @@ async def test_config_flow_yaml_rejects_slot_beyond_lock_capacity(
         )
 
     assert result["type"] == "form"
-    assert result["errors"] == {"base": "too_many_users"}
+    assert result["errors"] == {CONF_USERS: "too_many_users"}
     assert result["description_placeholders"]["num_users"] == "31"
     assert result["description_placeholders"]["num_slots"] == "30"
 
@@ -1334,7 +1334,7 @@ async def test_config_flow_yaml_enforces_name_rules(
         )
 
     assert result["type"] == "form"
-    assert result["errors"] == {"base": expected_error}
+    assert result["errors"] == {CONF_USERS: expected_error}
 
 
 async def test_a_slot_keyed_block_is_rejected_not_reinterpreted(
@@ -1356,7 +1356,7 @@ async def test_a_slot_keyed_block_is_rejected_not_reinterpreted(
     assert result["type"] == "form"
     # Named for what it is, rather than the generic parse failure: those
     # digits would otherwise coerce into users literally called "1".
-    assert result["errors"] == {"base": "users_keyed_by_slot"}
+    assert result["errors"] == {CONF_USERS: "users_keyed_by_slot"}
 
 
 async def test_every_name_error_supplies_what_its_message_asks_for(
@@ -1691,7 +1691,7 @@ async def test_a_blank_yaml_name_names_the_slot_it_came_from(
             {CONF_USERS: {"   ": {CONF_ENABLED: True, CONF_PIN: "1234"}}},
         )
 
-    assert result["errors"] == {"base": "name_required"}
+    assert result["errors"] == {CONF_USERS: "name_required"}
     assert result["description_placeholders"]["name"] == "   "
     message = strings["config"]["error"]["name_required"]
     assert not {
@@ -2241,7 +2241,7 @@ async def test_the_editor_refuses_a_condition_entity_the_guided_path_would(
         )
 
     assert result["type"] == "form"
-    assert result["errors"] == {"base": "excluded_platform"}
+    assert result["errors"] == {CONF_USERS: "excluded_platform"}
     assert result["description_placeholders"]["name"] == "Raman"
 
 
@@ -2552,9 +2552,54 @@ async def test_options_flow_renders_lock_and_users_errors_together(
     assert result["step_id"] == "init"
     assert result["errors"] == {
         CONF_LOCKS: "unsupported_mqtt_lock",
-        "base": "invalid_config",
+        CONF_USERS: "invalid_config",
     }
     assert result["description_placeholders"]["locks"] == unclaimed.entity_id
+
+
+async def test_the_registry_refusal_renders_beside_a_users_one_too(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """
+    The other lock refusal accumulates too, which took a third key to arrange.
+
+    Collecting both was never enough on its own. This refusal and every users
+    one were keyed to ``base``, and a dict holds one message per key, so the
+    users message overwrote it and the lock refusal reached the user only
+    after they had fixed the users block and submitted again -- the exact
+    second round trip collecting them was for. The pair above never showed it
+    because those two were already keyed apart.
+    """
+    hass.states.async_set("lock.yaml_only", LockState.LOCKED)
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="test",
+        data={
+            CONF_LOCKS: [LOCK_1_ENTITY_ID],
+            CONF_USERS: {"User 1": {CONF_ENABLED: True, CONF_PIN: "1234"}},
+            CONF_SLOT_ASSIGNMENT: {"user 1": 1},
+        },
+    )
+    entry.add_to_hass(hass)
+
+    started = await hass.config_entries.options.async_init(entry.entry_id)
+    with _holding():
+        result = await hass.config_entries.options.async_configure(
+            started["flow_id"],
+            user_input={
+                CONF_LOCKS: [LOCK_1_ENTITY_ID, "lock.yaml_only"],
+                CONF_USERS: {"   ": {CONF_ENABLED: True, CONF_PIN: "1234"}},
+            },
+        )
+
+    assert result["type"] == "form"
+    assert result["errors"] == {
+        "base": "lock_not_registered",
+        CONF_USERS: "name_required",
+    }
+    # Named apart, so one flat mapping renders both messages.
+    assert result["description_placeholders"]["unregistered_locks"] == "lock.yaml_only"
+    assert result["description_placeholders"]["name"] == "   "
 
 
 async def test_reauth_rejects_unclaimed_mqtt_lock(
@@ -3269,7 +3314,7 @@ async def test_taking_a_declaration_back_is_sized_against_the_real_lock(
         )
 
     assert result["type"] == "form"
-    assert result["errors"] == {"base": "too_many_users"}
+    assert result["errors"] == {CONF_USERS: "too_many_users"}
     assert result["description_placeholders"]["num_slots"] == "2"
     # Nothing was written, so the member is still what it was.
     assert get_entry_config(entry).is_codeless(claimed)

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, PropertyMock, patch
 
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
+import voluptuous as vol
 
 from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN, LockState
 from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_USER
@@ -18,6 +19,7 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 from custom_components.lock_code_manager.config_flow import _check_common_slots
 from custom_components.lock_code_manager.const import (
     CONF_CODELESS,
+    CONF_CODELESS_LOCKS,
     CONF_LOCKS,
     CONF_MEMBERS,
     CONF_NUM_USERS,
@@ -48,6 +50,7 @@ from custom_components.lock_code_manager.domain.queries import get_entry_config
 from custom_components.lock_code_manager.domain.slot_assignment import (
     CONF_SLOT_ASSIGNMENT,
 )
+from custom_components.lock_code_manager.providers import CONFIG_FLOW_PLATFORMS
 from custom_components.lock_code_manager.providers.codeless import CodelessLock
 
 from .common import (
@@ -2311,6 +2314,7 @@ async def test_user_step_rejects_a_lock_the_entity_registry_does_not_know(
     assert _suggested_values(result) == {
         CONF_NAME: "test",
         CONF_LOCKS: [LOCK_1_ENTITY_ID, "lock.yaml_only"],
+        CONF_CODELESS_LOCKS: [],
     }
 
 
@@ -2383,6 +2387,7 @@ async def test_user_step_rejects_unclaimed_mqtt_lock(
     assert _suggested_values(result) == {
         CONF_NAME: "test",
         CONF_LOCKS: [LOCK_1_ENTITY_ID, unclaimed.entity_id],
+        CONF_CODELESS_LOCKS: [],
     }
 
     result = await hass.config_entries.flow.async_configure(
@@ -2701,246 +2706,97 @@ async def test_options_flow_preserves_member_declarations(
 # --- Locks nothing claims, that the user declares codeless (issue #1484) ---
 
 
-async def _menu_about(result, lock_entry, step_id: str = "codeless") -> None:
-    """Assert a flow result is the codeless question, naming this one lock."""
-    assert result["type"] == "menu"
-    assert result["step_id"] == step_id
-    assert result["description_placeholders"] == {"lock": lock_entry.entity_id}
+def _field_config(result, field: str) -> dict:
+    """Return the selector configuration a rendered form carries for a field."""
+    [marker] = [key for key in result["data_schema"].schema if str(key) == field]
+    return result["data_schema"].schema[marker].config
 
 
-async def test_the_lock_picker_offers_every_lock(
+async def _codeless_field(hass: HomeAssistant) -> dict:
+    """Return the codeless picker's configuration as the setup form builds it."""
+    flow_id = await _init_flow_to_user_step(hass)
+    result = await hass.config_entries.flow.async_configure(flow_id)
+    return _field_config(result, CONF_CODELESS_LOCKS)
+
+
+async def test_the_lock_picker_offers_only_platforms_that_resolve(
     hass: HomeAssistant, mock_lock_config_entry
 ) -> None:
     """
-    The picker is not an allowlist of the platforms that resolve to a provider.
+    The ordinary picker is an allowlist of the platforms dispatch can answer for.
 
-    A lock nothing claims may still be one Lock Code Manager can manage by
-    holding its codes, and the question that settles it is asked after the
-    submission -- which a picker that hides the lock makes unaskable.
+    It is what keeps the two fields apart: a lock offered here is one Lock
+    Code Manager writes codes to, and the field beside it offers exactly the
+    rest. Widening this to every lock puts locks in both fields and leaves
+    the user to guess which one is meant.
     """
     flow_id = await _init_flow_to_user_step(hass)
     result = await hass.config_entries.flow.async_configure(flow_id)
 
-    [locks_field] = [
-        key for key in result["data_schema"].schema if str(key) == CONF_LOCKS
-    ]
-    config = result["data_schema"].schema[locks_field].config
+    config = _field_config(result, CONF_LOCKS)
+
+    assert config["multiple"] is True
+    assert {entry["integration"] for entry in config["filter"]} == set(
+        CONFIG_FLOW_PLATFORMS
+    )
+    assert all(entry["domain"] == [LOCK_DOMAIN] for entry in config["filter"])
+
+
+async def test_the_codeless_picker_hides_every_lock_a_provider_claims(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """
+    The second picker offers the locks nothing claims, and only those.
+
+    This is where the rule is taught: a user sees each lock in exactly one
+    field instead of being told after the fact which one it belonged in. A
+    lock Lock Code Manager can write codes to has no business being one Lock
+    Code Manager holds the codes for, and the exclusion is what says so.
+    """
+    codeless = register_codeless_lock(hass)
+
+    config = await _codeless_field(hass)
 
     assert config["domain"] == [LOCK_DOMAIN]
-    assert "filter" not in config
+    assert config["multiple"] is True
+    assert LOCK_1_ENTITY_ID in config["exclude_entities"]
+    assert LOCK_2_ENTITY_ID in config["exclude_entities"]
+    assert codeless.entity_id not in config["exclude_entities"]
 
 
-async def test_the_user_step_asks_about_a_lock_nothing_claims(
-    hass: HomeAssistant, mock_lock_config_entry
-) -> None:
-    """Confirming records the declaration on the entry it creates."""
-    codeless = register_codeless_lock(hass)
-    flow_id = await _init_flow_to_user_step(hass)
-
-    result = await hass.config_entries.flow.async_configure(
-        flow_id, {CONF_NAME: "test", CONF_LOCKS: [codeless.entity_id]}
-    )
-    await _menu_about(result, codeless)
-
-    result = await hass.config_entries.flow.async_configure(
-        flow_id, {"next_step_id": "codeless_confirm"}
-    )
-
-    # The answer re-submits what it was asked about, so the flow carries on
-    # from where it would have been.
-    assert result["type"] == "menu"
-    assert result["step_id"] == "choose_path"
-
-    await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
-    await hass.config_entries.flow.async_configure(flow_id, {CONF_NUM_USERS: 1})
-    result = await hass.config_entries.flow.async_configure(
-        flow_id, {CONF_NAME: "User 1", CONF_ENABLED: True, CONF_PIN: "1234"}
-    )
-
-    assert result["type"] == "create_entry"
-    assert result["data"][CONF_MEMBERS] == {codeless.id: {CONF_CODELESS: True}}
-
-
-async def test_a_lock_a_provider_claims_is_never_asked_about(
-    hass: HomeAssistant, mock_lock_config_entry
-) -> None:
-    """The question is only for the locks whose answer is not already known."""
-    flow_id = await _init_flow_to_user_step(hass)
-
-    result = await hass.config_entries.flow.async_configure(
-        flow_id, {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
-    )
-
-    assert result["step_id"] == "choose_path"
-
-
-async def test_an_unclaimed_mqtt_lock_is_refused_rather_than_asked_about(
+async def test_an_unrecognised_mqtt_bridge_is_offered_in_both_pickers(
     hass: HomeAssistant, mock_lock_config_entry, mqtt_mock, mqtt_teardown
 ) -> None:
     """
-    mqtt keeps its own refusal.
+    mqtt gets no special case, and the overlap it creates is expected.
 
-    Its dispatch is per device, so an unclaimed one means "this bridge is
-    not one Lock Code Manager speaks" -- a gap that may close later, not a
-    lock with no code storage. Offering the declaration there would strand
-    that lock's credentials in a Lock Code Manager store on the day its
-    bridge became supported.
+    The ordinary picker allowlists the mqtt PLATFORM because dispatch there
+    is per device and a selector cannot express a device; the codeless
+    picker excludes what a provider actually claims, which an unrecognised
+    bridge is not. So the lock shows up in both, and the user -- who is the
+    one who knows whether the door has a keypad -- decides. Refusing it in
+    the ordinary field is the backstop for the wrong choice.
     """
     unclaimed = await async_discover_unclaimed_mqtt_lock(hass)
-    flow_id = await _init_flow_to_user_step(hass)
 
-    result = await hass.config_entries.flow.async_configure(
-        flow_id, {CONF_NAME: "test", CONF_LOCKS: [unclaimed.entity_id]}
-    )
+    config = await _codeless_field(hass)
 
-    assert result["type"] == "form"
-    assert result["errors"] == {CONF_LOCKS: "unsupported_mqtt_lock"}
+    assert unclaimed.entity_id not in config["exclude_entities"]
 
 
-async def test_declining_lands_back_on_the_form_that_asked(
+async def test_a_member_already_declared_is_still_offered_where_it_lives(
     hass: HomeAssistant, mock_lock_config_entry
 ) -> None:
     """
-    Declining is not a dead end: the way out is to choose different locks.
+    A declaration outranks dispatch, so the picker holding it has to keep it.
 
-    The refusal names them and the form comes back holding what was
-    submitted, so the selection can be changed rather than retyped.
-    """
-    codeless = register_codeless_lock(hass)
-    flow_id = await _init_flow_to_user_step(hass)
-
-    await hass.config_entries.flow.async_configure(
-        flow_id,
-        {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID, codeless.entity_id]},
-    )
-    result = await hass.config_entries.flow.async_configure(
-        flow_id, {"next_step_id": "codeless_decline"}
-    )
-
-    assert result["type"] == "form"
-    assert result["step_id"] == "user"
-    assert result["errors"] == {CONF_LOCKS: "codeless_declined"}
-    assert result["description_placeholders"] == {"locks": codeless.entity_id}
-    assert _suggested_values(result) == {
-        CONF_NAME: "test",
-        CONF_LOCKS: [LOCK_1_ENTITY_ID, codeless.entity_id],
-    }
-
-    # Submitting the same locks again asks nothing new -- the answer stands
-    # for this flow -- and refuses again. Dropping the lock is what clears it.
-    result = await hass.config_entries.flow.async_configure(
-        flow_id,
-        {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID, codeless.entity_id]},
-    )
-
-    assert result["errors"] == {CONF_LOCKS: "codeless_declined"}
-
-    result = await hass.config_entries.flow.async_configure(
-        flow_id, {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
-    )
-
-    assert result["type"] == "menu"
-    assert result["step_id"] == "choose_path"
-
-
-async def test_the_options_flow_asks_about_a_lock_added_later(
-    hass: HomeAssistant, mock_lock_config_entry
-) -> None:
-    """A lock that arrives after setup gets the same question setup would ask."""
-    codeless = register_codeless_lock(hass)
-    entry = MockConfigEntry(domain=DOMAIN, data=BASE_CONFIG, unique_id="Mock Title")
-    entry.add_to_hass(hass)
-    users = {"test1": {CONF_PIN: "1234", CONF_ENABLED: True}}
-    locks = [LOCK_1_ENTITY_ID, codeless.entity_id]
-
-    started = await hass.config_entries.options.async_init(entry.entry_id)
-    flow_id = started["flow_id"]
-
-    with _holding():
-        result = await hass.config_entries.options.async_configure(
-            flow_id, user_input={CONF_LOCKS: locks, CONF_USERS: users}
-        )
-    await _menu_about(result, codeless)
-
-    with _holding():
-        result = await hass.config_entries.options.async_configure(
-            flow_id, {"next_step_id": "codeless_confirm"}
-        )
-
-    assert result["type"] == "create_entry"
-    assert result["data"][CONF_LOCKS] == locks
-    assert result["data"][CONF_MEMBERS] == {codeless.id: {CONF_CODELESS: True}}
-
-
-async def test_the_options_flow_lets_a_declaration_be_taken_back(
-    hass: HomeAssistant, mock_lock_config_entry
-) -> None:
-    """
-    An entry that already declares a lock is asked again, and can answer no.
-
-    Asking only about locks nobody has answered for would leave a
-    declaration with no way back: there is no second provider to hand the
-    lock to, so taking it back means dropping the lock, and the user has to
-    be able to reach that decision from the form.
-    """
-    codeless = register_codeless_lock(hass)
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        title="test",
-        data={
-            **BASE_CONFIG,
-            CONF_LOCKS: [LOCK_1_ENTITY_ID, codeless.entity_id],
-            CONF_MEMBERS: {codeless.id: {CONF_CODELESS: True}},
-        },
-    )
-    entry.add_to_hass(hass)
-    users = {"test1": {CONF_PIN: "1234", CONF_ENABLED: True}}
-
-    started = await hass.config_entries.options.async_init(entry.entry_id)
-    flow_id = started["flow_id"]
-
-    with _holding():
-        result = await hass.config_entries.options.async_configure(
-            flow_id,
-            user_input={
-                CONF_LOCKS: [LOCK_1_ENTITY_ID, codeless.entity_id],
-                CONF_USERS: users,
-            },
-        )
-    await _menu_about(result, codeless)
-
-    with _holding():
-        result = await hass.config_entries.options.async_configure(
-            flow_id, {"next_step_id": "codeless_decline"}
-        )
-
-    assert result["type"] == "form"
-    assert result["step_id"] == "init"
-    assert result["errors"] == {CONF_LOCKS: "codeless_declined"}
-
-    with _holding():
-        result = await hass.config_entries.options.async_configure(
-            flow_id, user_input={CONF_LOCKS: [LOCK_1_ENTITY_ID], CONF_USERS: users}
-        )
-
-    assert result["type"] == "create_entry"
-    assert result["data"][CONF_LOCKS] == [LOCK_1_ENTITY_ID]
-    # Answering no is what undoes it, so the entry stops declaring anything.
-    assert result["data"][CONF_MEMBERS] == {}
-
-
-async def test_a_declared_member_a_provider_now_claims_is_still_asked_about(
-    hass: HomeAssistant, mock_lock_config_entry
-) -> None:
-    """
-    A declaration must have an exit even after its platform gains a provider.
-
-    Dispatch never takes a declared member back -- deliberately, so an
-    upgrade cannot move somebody's credentials onto a device they never
-    agreed to write to -- which leaves the form as the only way out. Asking
-    only about the locks nothing claims made that exit unreachable: the
-    member kept resolving to the Lock Code Manager store while no form ever
-    mentioned it.
+    Should Lock Code Manager gain a provider for a platform somebody already
+    declared codeless -- or should an mqtt bridge it did not recognise become
+    supported -- the member goes on resolving to the Lock Code Manager store
+    (``resolve_member_provider_class`` reads the declaration first).
+    Excluding it from the field it is selected in would leave that entry
+    unable to save any edit at all, while its way out is to move the lock to
+    the other field.
     """
     claimed = er.async_get(hass).async_get(LOCK_1_ENTITY_ID)
     entry = MockConfigEntry(
@@ -2949,33 +2805,349 @@ async def test_a_declared_member_a_provider_now_claims_is_still_asked_about(
         data={**BASE_CONFIG, CONF_MEMBERS: {claimed.id: {CONF_CODELESS: True}}},
     )
     entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    config = _field_config(result, CONF_CODELESS_LOCKS)
+
+    assert LOCK_1_ENTITY_ID not in config["exclude_entities"]
+    # The other claimed lock, which nobody declared anything about, is still
+    # kept out -- so this is the declaration being honoured rather than the
+    # exclusion being dropped.
+    assert LOCK_2_ENTITY_ID in config["exclude_entities"]
+
+
+async def test_the_two_pickers_merge_into_one_roster(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """
+    Both fields are the entry's locks; which one they came from is the declaration.
+
+    The entry stores one roster, so a lock picked in either field has to be
+    set up, entity-created and allocated against like any other. What the
+    second field adds is the record that Lock Code Manager holds this one's
+    codes.
+    """
+    codeless = register_codeless_lock(hass)
+    flow_id = await _init_flow_to_user_step(hass)
+
+    result = await hass.config_entries.flow.async_configure(
+        flow_id,
+        {
+            CONF_NAME: "test",
+            CONF_LOCKS: [LOCK_1_ENTITY_ID],
+            CONF_CODELESS_LOCKS: [codeless.entity_id],
+        },
+    )
+
+    assert result["step_id"] == "choose_path"
+
+    await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
+    await hass.config_entries.flow.async_configure(flow_id, {CONF_NUM_USERS: 1})
+    with _holding():
+        result = await hass.config_entries.flow.async_configure(
+            flow_id, {CONF_NAME: "User 1", CONF_ENABLED: True, CONF_PIN: "1234"}
+        )
+
+    assert result["type"] == "create_entry"
+    assert result["data"][CONF_LOCKS] == [LOCK_1_ENTITY_ID, codeless.entity_id]
+    # Read the way dispatch reads it, not as a dict: what the second field
+    # buys is the member resolving to the Lock Code Manager store, which an
+    # assertion on the stored shape alone would not settle.
+    config = EntryConfig.from_mapping(result["data"])
+    dev_reg = dr.async_get(hass)
+    assert resolve_member_provider_class(dev_reg, config, codeless) is CodelessLock
+    assert (
+        resolve_member_provider_class(
+            dev_reg, config, er.async_get(hass).async_get(LOCK_1_ENTITY_ID)
+        )
+        is MockLCMLock
+    )
+
+
+async def test_a_declared_lock_is_set_up_and_holds_its_codes(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """
+    The declaration reaches a running entry, not just storage.
+
+    A test that stops at the stored dict passes while the entry refuses to
+    load: the roster still contains a lock platform dispatch answers None
+    for, and only the declaration makes the factory build anything at all.
+    """
+    codeless = register_codeless_lock(hass)
+    flow_id = await _init_flow_to_user_step(hass)
+
+    await hass.config_entries.flow.async_configure(
+        flow_id,
+        {
+            CONF_NAME: "test",
+            CONF_LOCKS: [],
+            CONF_CODELESS_LOCKS: [codeless.entity_id],
+        },
+    )
+    await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
+    await hass.config_entries.flow.async_configure(flow_id, {CONF_NUM_USERS: 1})
+    result = await hass.config_entries.flow.async_configure(
+        flow_id, {CONF_NAME: "User 1", CONF_ENABLED: True, CONF_PIN: "1234"}
+    )
+
+    assert result["type"] == "create_entry"
+
+
+async def test_an_unclaimed_lock_in_the_ordinary_field_points_at_the_other(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """
+    The refusal a lock nothing claims gets is no longer a dead end.
+
+    The picker cannot put one here -- it allowlists the platforms that
+    resolve -- but a YAML import or a direct submission can, and the answer
+    is not "you cannot use this lock" any more. It is "select it in the
+    other field", which the message says.
+    """
+    codeless = register_codeless_lock(hass)
+    flow_id = await _init_flow_to_user_step(hass)
+
+    result = await hass.config_entries.flow.async_configure(
+        flow_id,
+        {
+            CONF_NAME: "test",
+            CONF_LOCKS: [LOCK_1_ENTITY_ID, codeless.entity_id],
+            CONF_CODELESS_LOCKS: [],
+        },
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["errors"] == {CONF_LOCKS: "unclaimed_lock"}
+    assert result["description_placeholders"] == {"locks": codeless.entity_id}
+
+    # Moving it to the other field is what clears it.
+    result = await hass.config_entries.flow.async_configure(
+        flow_id,
+        {
+            CONF_NAME: "test",
+            CONF_LOCKS: [LOCK_1_ENTITY_ID],
+            CONF_CODELESS_LOCKS: [codeless.entity_id],
+        },
+    )
+
+    assert result["step_id"] == "choose_path"
+
+
+async def test_a_claimed_lock_in_the_codeless_field_is_refused(
+    hass: HomeAssistant, mock_lock_config_entry, mqtt_mock, mqtt_teardown
+) -> None:
+    """
+    Lock Code Manager must not hold codes for a lock that holds its own.
+
+    The picker's exclusions are a snapshot taken when the form was built, and
+    the selector enforces that same snapshot on submit -- so what gets past
+    both is a lock that became claimable in between. An mqtt bridge is where
+    that really happens: the device is rediscovered under an identifier Lock
+    Code Manager does recognize, and the lock the user is about to declare
+    now has code storage of its own. Accepted, its codes would go to a Lock
+    Code Manager store and never reach the device, while the lock went on
+    opening to whatever it already held.
+    """
+    unclaimed = await async_discover_unclaimed_mqtt_lock(hass)
+    flow_id = await _init_flow_to_user_step(hass)
+    # Render the form while nothing claims it, so the picker offers it.
+    await hass.config_entries.flow.async_configure(flow_id)
+
+    dr.async_get(hass).async_update_device(
+        unclaimed.device_id,
+        new_identifiers={("mqtt", "zigbee2mqtt_0x00158d0001abcdef")},
+    )
+
+    result = await hass.config_entries.flow.async_configure(
+        flow_id,
+        {
+            CONF_NAME: "test",
+            CONF_LOCKS: [],
+            CONF_CODELESS_LOCKS: [unclaimed.entity_id],
+        },
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["errors"] == {CONF_CODELESS_LOCKS: "codeless_lock_claimed"}
+    assert result["description_placeholders"] == {"codeless_locks": unclaimed.entity_id}
+    assert not hass.config_entries.async_entries(DOMAIN)
+
+
+async def test_a_lock_in_both_fields_is_refused(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """
+    One lock, one field. The two say opposite things about where its codes live.
+
+    An mqtt lock from an unrecognised bridge really is offered in both
+    pickers, so this is reachable from the UI rather than only from a
+    hand-written submission -- and merging the fields without checking would
+    hand the same entity two providers.
+    """
+    codeless = register_codeless_lock(hass)
+    flow_id = await _init_flow_to_user_step(hass)
+
+    result = await hass.config_entries.flow.async_configure(
+        flow_id,
+        {
+            CONF_NAME: "test",
+            CONF_LOCKS: [codeless.entity_id],
+            CONF_CODELESS_LOCKS: [codeless.entity_id],
+        },
+    )
+
+    assert result["type"] == "form"
+    # The ordinary field refuses it as well, on its own key, so one round
+    # trip says both things.
+    assert result["errors"] == {
+        CONF_LOCKS: "unclaimed_lock",
+        CONF_CODELESS_LOCKS: "lock_in_both_fields",
+    }
+    assert result["description_placeholders"]["codeless_locks"] == codeless.entity_id
+
+
+async def test_an_unregistered_lock_is_refused_from_the_codeless_field_too(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """
+    A declaration is keyed by registry id, so an entity without one cannot carry it.
+
+    Checked over both fields rather than only the one the ordinary locks come
+    from: an entity with no registry row selected here would be stored in the
+    roster with nothing declared about it, and the entry would fail to load
+    over a lock the user believed they had declared.
+    """
+    hass.states.async_set("lock.yaml_only", LockState.LOCKED)
+    flow_id = await _init_flow_to_user_step(hass)
+
+    result = await hass.config_entries.flow.async_configure(
+        flow_id,
+        {
+            CONF_NAME: "test",
+            CONF_LOCKS: [],
+            CONF_CODELESS_LOCKS: ["lock.yaml_only"],
+        },
+    )
+
+    assert result["type"] == "form"
+    assert result["errors"] == {"base": "lock_not_registered"}
+    assert result["description_placeholders"]["unregistered_locks"] == "lock.yaml_only"
+
+
+async def test_every_lock_refusal_renders_from_one_submission(
+    hass: HomeAssistant, mock_lock_config_entry, mqtt_mock, mqtt_teardown
+) -> None:
+    """
+    A selection wrong in three ways says so once, not over three visits.
+
+    Refusing on the first and returning hid the rest entirely: the user fixed
+    what they were shown, submitted again, and was refused again for
+    something that had been wrong all along. The three keys -- base and one
+    per field -- are what makes rendering them together possible, and their
+    placeholders are named apart so one flat mapping carries all three.
+    """
+    hass.states.async_set("lock.yaml_only", LockState.LOCKED)
+    unclaimed = await async_discover_unclaimed_mqtt_lock(hass)
+    flow_id = await _init_flow_to_user_step(hass)
+
+    result = await hass.config_entries.flow.async_configure(
+        flow_id,
+        {
+            CONF_NAME: "test",
+            CONF_LOCKS: [LOCK_1_ENTITY_ID, "lock.yaml_only", unclaimed.entity_id],
+            CONF_CODELESS_LOCKS: [unclaimed.entity_id],
+        },
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["errors"] == {
+        "base": "lock_not_registered",
+        CONF_LOCKS: "unsupported_mqtt_lock",
+        CONF_CODELESS_LOCKS: "lock_in_both_fields",
+    }
+    assert result["description_placeholders"]["unregistered_locks"] == "lock.yaml_only"
+    assert result["description_placeholders"]["locks"] == unclaimed.entity_id
+    assert result["description_placeholders"]["codeless_locks"] == unclaimed.entity_id
+
+
+# --- Taking a declaration back ---
+
+
+def _entry_declaring(
+    hass: HomeAssistant, lock_entry: er.RegistryEntry, *others: str
+) -> MockConfigEntry:
+    """Return an entry that holds these locks and declares the first codeless."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="test",
+        unique_id="Mock Title",
+        data={
+            **BASE_CONFIG,
+            CONF_LOCKS: [*others, lock_entry.entity_id],
+            CONF_MEMBERS: {lock_entry.id: {CONF_CODELESS: True}},
+        },
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+async def test_the_options_flow_seeds_each_lock_into_the_field_that_declares_it(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """
+    The form opens showing what the entry says, split the way it says it.
+
+    Seeding both fields from the roster alone -- or all of it into the
+    ordinary field -- would make the very first save move every declared
+    member out, silently discarding the codes Lock Code Manager was holding
+    for it.
+    """
+    codeless = register_codeless_lock(hass)
+    entry = _entry_declaring(hass, codeless, LOCK_1_ENTITY_ID)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    schema = result["data_schema"].schema
+    defaults = {
+        str(key): key.default() for key in schema if key.default is not vol.UNDEFINED
+    }
+    assert defaults[CONF_LOCKS] == [LOCK_1_ENTITY_ID]
+    assert defaults[CONF_CODELESS_LOCKS] == [codeless.entity_id]
+
+
+async def test_moving_a_lock_to_the_ordinary_field_undoes_the_declaration(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """
+    A member handed back stops resolving to the Lock Code Manager store.
+
+    Written with a lock a provider claims, because that is the only case
+    where handing it back leaves something able to manage it. Read through
+    dispatch rather than off the stored dict: the declaration is what picks
+    the provider, and an assertion on the shape passes just as well while
+    the member goes on resolving to the store it was supposed to leave.
+    """
+    claimed = er.async_get(hass).async_get(LOCK_1_ENTITY_ID)
+    entry = _entry_declaring(hass, claimed)
     users = {"test1": {CONF_PIN: "1234", CONF_ENABLED: True}}
 
     started = await hass.config_entries.options.async_init(entry.entry_id)
-    flow_id = started["flow_id"]
 
     with _holding():
         result = await hass.config_entries.options.async_configure(
-            flow_id, user_input={CONF_LOCKS: [LOCK_1_ENTITY_ID], CONF_USERS: users}
-        )
-    # Its own question, not the one a lock nothing claims gets: declining
-    # here hands the lock to the provider that claims it now and saves,
-    # rather than refusing the submission.
-    await _menu_about(result, claimed, "codeless_reconsider")
-
-    with _holding():
-        result = await hass.config_entries.options.async_configure(
-            flow_id, {"next_step_id": "codeless_decline"}
+            started["flow_id"],
+            user_input={
+                CONF_LOCKS: [LOCK_1_ENTITY_ID],
+                CONF_CODELESS_LOCKS: [],
+                CONF_USERS: users,
+            },
         )
 
-    # Not refused: something claims this lock now, so declining hands it to
-    # that provider rather than leaving a lock nothing can manage.
     assert result["type"] == "create_entry"
-    assert result["data"][CONF_LOCKS] == [LOCK_1_ENTITY_ID]
-    # Read the way dispatch reads it, not as a dict. What declining buys is
-    # the provider that claims the lock now taking it back; an assertion on
-    # the stored shape passes just as well while the member goes on
-    # resolving to the Lock Code Manager store.
     assert (
         resolve_member_provider_class(
             dr.async_get(hass), EntryConfig.from_mapping(result["data"]), claimed
@@ -2984,61 +3156,22 @@ async def test_a_declared_member_a_provider_now_claims_is_still_asked_about(
     )
 
 
-async def test_an_answer_about_a_lock_the_same_visit_drops_is_not_stored(
+async def test_handing_back_a_lock_nothing_claims_is_refused(
     hass: HomeAssistant, mock_lock_config_entry
 ) -> None:
     """
-    A yes is not written back about a lock the submission no longer holds.
+    A declared member is not grandfathered into the ordinary field.
 
-    The answer outlives the question it answered: it is cached for the life
-    of the flow, so a re-submission refused for some unrelated reason -- a
-    sibling lock too asleep to report its occupancy -- comes back with the
-    yes still held. Dropping the lock is the obvious reaction to that
-    refusal, and storing the answer anyway leaves a declaration about a
-    member the entry does not have, waiting to decide the provider for
-    whatever is added under that registry id next.
+    The roster grandfathering exists so one unclaimed lock an old entry
+    carries does not refuse every subsequent edit. Applying it to a member
+    the entry declares CODELESS would wave through the one move that has no
+    landing: nothing claims this lock, so there is no provider to hand it
+    to, and the entry would save a member it cannot set up.
     """
     codeless = register_codeless_lock(hass)
-    entry = MockConfigEntry(domain=DOMAIN, data=BASE_CONFIG, unique_id="Mock Title")
-    entry.add_to_hass(hass)
+    entry = _entry_declaring(hass, codeless, LOCK_1_ENTITY_ID)
     users = {"test1": {CONF_PIN: "1234", CONF_ENABLED: True}}
 
-    started = await hass.config_entries.options.async_init(entry.entry_id)
-    flow_id = started["flow_id"]
-
-    with _holding():
-        result = await hass.config_entries.options.async_configure(
-            flow_id,
-            user_input={
-                CONF_LOCKS: [LOCK_1_ENTITY_ID, codeless.entity_id],
-                CONF_USERS: users,
-            },
-        )
-    await _menu_about(result, codeless)
-
-    async def _unreadable(self, slots=None):
-        raise LockCodeManagerError("lock is asleep")
-
-    # Yes -- and the re-submission it causes fails over the sibling lock.
-    with patch.object(MockLCMLock, "async_get_usercodes", _unreadable):
-        result = await hass.config_entries.options.async_configure(
-            flow_id, {"next_step_id": "codeless_confirm"}
-        )
-
-    assert result["errors"] == {"base": "occupancy_unknown"}
-
-    # So the lock that was answered about is dropped instead.
-    with _holding():
-        result = await hass.config_entries.options.async_configure(
-            flow_id, user_input={CONF_LOCKS: [LOCK_1_ENTITY_ID], CONF_USERS: users}
-        )
-
-    assert result["type"] == "create_entry"
-    assert result["data"][CONF_MEMBERS] == {}
-
-    # And the lock re-added later is a lock nobody has answered for, rather
-    # than one that resolves to the Lock Code Manager store unasked.
-    hass.config_entries.async_update_entry(entry, data=result["data"], options={})
     started = await hass.config_entries.options.async_init(entry.entry_id)
 
     with _holding():
@@ -3046,11 +3179,16 @@ async def test_an_answer_about_a_lock_the_same_visit_drops_is_not_stored(
             started["flow_id"],
             user_input={
                 CONF_LOCKS: [LOCK_1_ENTITY_ID, codeless.entity_id],
+                CONF_CODELESS_LOCKS: [],
                 CONF_USERS: users,
             },
         )
 
-    await _menu_about(result, codeless)
+    assert result["type"] == "form"
+    assert result["errors"] == {CONF_LOCKS: "unclaimed_lock"}
+    assert result["description_placeholders"]["locks"] == codeless.entity_id
+    # Nothing was written, so the member is still what it was.
+    assert get_entry_config(entry).is_codeless(codeless)
 
 
 async def test_dropping_a_lock_drops_what_was_declared_about_it(
@@ -3060,19 +3198,11 @@ async def test_dropping_a_lock_drops_what_was_declared_about_it(
     A declaration about a member the entry no longer holds is not carried forward.
 
     Nothing reads it while the lock is gone, so the cost is invisible until
-    the entry has collected one husk per lock anybody ever removed.
+    the entry has collected one husk per lock anybody ever removed -- and
+    then re-adding that lock finds a declaration nobody made this time.
     """
     codeless = register_codeless_lock(hass)
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        title="test",
-        data={
-            **BASE_CONFIG,
-            CONF_LOCKS: [LOCK_1_ENTITY_ID, codeless.entity_id],
-            CONF_MEMBERS: {codeless.id: {CONF_CODELESS: True}},
-        },
-    )
-    entry.add_to_hass(hass)
+    entry = _entry_declaring(hass, codeless, LOCK_1_ENTITY_ID)
     users = {"test1": {CONF_PIN: "1234", CONF_ENABLED: True}}
 
     started = await hass.config_entries.options.async_init(entry.entry_id)
@@ -3080,11 +3210,13 @@ async def test_dropping_a_lock_drops_what_was_declared_about_it(
     with _holding():
         result = await hass.config_entries.options.async_configure(
             started["flow_id"],
-            user_input={CONF_LOCKS: [LOCK_1_ENTITY_ID], CONF_USERS: users},
+            user_input={
+                CONF_LOCKS: [LOCK_1_ENTITY_ID],
+                CONF_CODELESS_LOCKS: [],
+                CONF_USERS: users,
+            },
         )
 
-    # Nothing was asked -- the lock simply left -- and the declaration left
-    # with it.
     assert result["type"] == "create_entry"
     assert result["data"][CONF_MEMBERS] == {}
 
@@ -3093,15 +3225,12 @@ async def test_re_adding_a_dropped_lock_does_not_resurrect_its_declaration(
     hass: HomeAssistant, mock_lock_config_entry
 ) -> None:
     """
-    A lock the entry forgot about comes back as a lock nobody has answered for.
+    A lock the entry forgot about comes back as a lock nobody declared.
 
-    Written with a lock a provider claims, because that is where the stale
+    Written with a lock a provider claims, because that is where a stale
     declaration has teeth: dispatch reads the declaration FIRST, so one left
-    behind decides the provider for a lock with real code storage. It is
-    survivable only because the flow now asks about declared members too --
-    which is the tell this test reads. A lock re-added with nothing declared
-    about it saves in one round trip; one carrying a husk stops to ask a
-    question the user already answered, about a lock they never declared.
+    behind would decide the provider for a lock with real code storage and
+    quietly move its codes into Lock Code Manager.
     """
     reused = er.async_get(hass).async_get(LOCK_2_ENTITY_ID)
     entry = MockConfigEntry(
@@ -3116,7 +3245,11 @@ async def test_re_adding_a_dropped_lock_does_not_resurrect_its_declaration(
     with _holding():
         result = await hass.config_entries.options.async_configure(
             dropped["flow_id"],
-            user_input={CONF_LOCKS: [LOCK_1_ENTITY_ID], CONF_USERS: users},
+            user_input={
+                CONF_LOCKS: [LOCK_1_ENTITY_ID],
+                CONF_CODELESS_LOCKS: [],
+                CONF_USERS: users,
+            },
         )
     assert result["data"][CONF_MEMBERS] == {}
     hass.config_entries.async_update_entry(entry, data=result["data"], options={})
@@ -3127,157 +3260,32 @@ async def test_re_adding_a_dropped_lock_does_not_resurrect_its_declaration(
             re_added["flow_id"],
             user_input={
                 CONF_LOCKS: [LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID],
+                CONF_CODELESS_LOCKS: [],
                 CONF_USERS: users,
             },
         )
 
     assert result["type"] == "create_entry"
     assert result["data"][CONF_MEMBERS] == {}
-
-
-async def test_the_options_flow_asks_nothing_when_no_lock_needs_it(
-    hass: HomeAssistant, mock_lock_config_entry
-) -> None:
-    """Editing users on an entry of ordinary locks is one round trip, as before."""
-    entry = MockConfigEntry(domain=DOMAIN, data=BASE_CONFIG, unique_id="Mock Title")
-    entry.add_to_hass(hass)
-
-    started = await hass.config_entries.options.async_init(entry.entry_id)
-
-    with _holding():
-        result = await hass.config_entries.options.async_configure(
-            started["flow_id"],
-            user_input={
-                CONF_LOCKS: [LOCK_1_ENTITY_ID],
-                CONF_USERS: {"test1": {CONF_PIN: "1234", CONF_ENABLED: True}},
-            },
-        )
-
-    assert result["type"] == "create_entry"
-
-
-async def test_reauth_asks_about_a_lock_nothing_claims(
-    hass: HomeAssistant, mock_lock_config_entry
-) -> None:
-    """
-    Reauth renders the same picker, so it is a third way in.
-
-    Without the question, somebody repairing one broken lock could swap in a
-    codeless one and land straight back in reauth, with nothing telling them
-    why.
-    """
-    codeless = register_codeless_lock(hass)
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        title="test",
-        data={
-            CONF_LOCKS: [LOCK_1_ENTITY_ID],
-            CONF_USERS: {"User 1": {CONF_ENABLED: True, CONF_PIN: "1234"}},
-            CONF_SLOT_ASSIGNMENT: {"user 1": 1},
-        },
-    )
-    entry.add_to_hass(hass)
-    entry.async_start_reauth(hass, context={"lock_entity_id": LOCK_1_ENTITY_ID})
-    await hass.async_block_till_done()
-    [flow] = entry.async_get_active_flows(hass, {SOURCE_REAUTH})
-
-    result = await hass.config_entries.flow.async_configure(
-        flow["flow_id"], {CONF_LOCKS: [codeless.entity_id]}
-    )
-    await _menu_about(result, codeless)
-
-    result = await hass.config_entries.flow.async_configure(
-        flow["flow_id"], {"next_step_id": "codeless_confirm"}
-    )
-    await hass.async_block_till_done()
-
-    assert result["type"] == "abort"
-    assert result["reason"] == "locks_updated"
-    assert entry.data[CONF_LOCKS] == [codeless.entity_id]
-    assert entry.data[CONF_MEMBERS] == {codeless.id: {CONF_CODELESS: True}}
-
-
-async def test_an_answer_applies_only_to_the_member_it_was_asked_about(
-    hass: HomeAssistant, mock_lock_config_entry
-) -> None:
-    """
-    Declining a lock just added leaves an unrelated declared member alone.
-
-    The set asked about mixes two populations: a lock nothing claims that
-    this submission adds, and every member the entry already declares. One
-    Yes/No over both meant an answer aimed at the newcomer was recorded
-    against the other member too -- so saying "no, don't manage that new
-    lock" stripped the declaration off a lock somebody had said must never
-    be written to, and handed it straight back to its provider.
-    """
-    claimed = er.async_get(hass).async_get(LOCK_1_ENTITY_ID)
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        title="test",
-        data={**BASE_CONFIG, CONF_MEMBERS: {claimed.id: {CONF_CODELESS: True}}},
-    )
-    entry.add_to_hass(hass)
-    newcomer = register_codeless_lock(hass)
-    users = {"test1": {CONF_PIN: "1234", CONF_ENABLED: True}}
-
-    started = await hass.config_entries.options.async_init(entry.entry_id)
-    flow_id = started["flow_id"]
-
-    # Both locks are asked about, one question each, in the order submitted.
-    with _holding():
-        result = await hass.config_entries.options.async_configure(
-            flow_id,
-            user_input={
-                CONF_LOCKS: [LOCK_1_ENTITY_ID, newcomer.entity_id],
-                CONF_USERS: users,
-            },
-        )
-    await _menu_about(result, claimed, "codeless_reconsider")
-
-    with _holding():
-        result = await hass.config_entries.options.async_configure(
-            flow_id, {"next_step_id": "codeless_confirm"}
-        )
-    await _menu_about(result, newcomer)
-
-    with _holding():
-        result = await hass.config_entries.options.async_configure(
-            flow_id, {"next_step_id": "codeless_decline"}
-        )
-
-    # The refusal names the newcomer and nothing else.
-    assert result["errors"] == {CONF_LOCKS: "codeless_declined"}
-    assert result["description_placeholders"]["locks"] == newcomer.entity_id
-
-    with _holding():
-        result = await hass.config_entries.options.async_configure(
-            flow_id, user_input={CONF_LOCKS: [LOCK_1_ENTITY_ID], CONF_USERS: users}
-        )
-
-    # Read the way dispatch reads it: what matters is that the untouched
-    # member still resolves to the Lock Code Manager store, which an
-    # assertion on the stored shape alone would not settle.
-    assert result["type"] == "create_entry"
     assert (
         resolve_member_provider_class(
-            dr.async_get(hass), EntryConfig.from_mapping(result["data"]), claimed
+            dr.async_get(hass), EntryConfig.from_mapping(result["data"]), reused
         )
-        is CodelessLock
+        is MockLCMLock
     )
 
 
-async def test_taking_a_declaration_back_is_sized_against_the_real_lock(
+async def test_handing_a_member_back_is_sized_against_the_real_lock(
     hass: HomeAssistant, mock_lock_config_entry
 ) -> None:
     """
     Capacity is checked against the provider the lock is about to become.
 
-    Reading the STORED declaration made a pending answer invisible to the
-    very validation the answer triggers a re-run of: the lock still resolved
-    to the Lock Code Manager store -- no capacity and nothing in it -- so a
-    configuration far too large for the real lock saved without a word, and
-    every user past the lock's last slot silently failed to be written from
-    then on.
+    Reading the STORED declaration made the pending move invisible to the
+    very validation the move triggers: the lock still resolved to the Lock
+    Code Manager store -- no capacity and nothing in it -- so a configuration
+    far too large for the real lock saved without a word, and every user past
+    the lock's last slot silently failed to be written from then on.
     """
     claimed = er.async_get(hass).async_get(LOCK_1_ENTITY_ID)
     users = {
@@ -3297,20 +3305,18 @@ async def test_taking_a_declaration_back_is_sized_against_the_real_lock(
     entry.add_to_hass(hass)
 
     started = await hass.config_entries.options.async_init(entry.entry_id)
-    flow_id = started["flow_id"]
     # Two slots is fewer than the three users, so only a check that reaches
     # the real lock can refuse this.
     probe = _capacity_probe(return_value=_capabilities_with_slots(2))
 
     with probe, _holding():
         result = await hass.config_entries.options.async_configure(
-            flow_id, user_input={CONF_LOCKS: [LOCK_1_ENTITY_ID], CONF_USERS: users}
-        )
-    await _menu_about(result, claimed, "codeless_reconsider")
-
-    with probe, _holding():
-        result = await hass.config_entries.options.async_configure(
-            flow_id, {"next_step_id": "codeless_decline"}
+            started["flow_id"],
+            user_input={
+                CONF_LOCKS: [LOCK_1_ENTITY_ID],
+                CONF_CODELESS_LOCKS: [],
+                CONF_USERS: users,
+            },
         )
 
     assert result["type"] == "form"
@@ -3320,37 +3326,92 @@ async def test_taking_a_declaration_back_is_sized_against_the_real_lock(
     assert get_entry_config(entry).is_codeless(claimed)
 
 
-async def test_both_lock_refusals_render_from_one_submission(
-    hass: HomeAssistant, mock_lock_config_entry, mqtt_mock, mqtt_teardown
+async def test_the_options_flow_is_one_round_trip_when_nothing_is_declared(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """Editing users on an entry of ordinary locks saves without a detour."""
+    entry = MockConfigEntry(domain=DOMAIN, data=BASE_CONFIG, unique_id="Mock Title")
+    entry.add_to_hass(hass)
+
+    started = await hass.config_entries.options.async_init(entry.entry_id)
+
+    with _holding():
+        result = await hass.config_entries.options.async_configure(
+            started["flow_id"],
+            user_input={
+                CONF_LOCKS: [LOCK_1_ENTITY_ID],
+                CONF_CODELESS_LOCKS: [],
+                CONF_USERS: {"test1": {CONF_PIN: "1234", CONF_ENABLED: True}},
+            },
+        )
+
+    assert result["type"] == "create_entry"
+
+
+async def test_reauth_can_declare_a_lock_codeless(
+    hass: HomeAssistant, mock_lock_config_entry
 ) -> None:
     """
-    A selection with one of each problem says so once, not over two visits.
+    Reauth renders both pickers, so it is a third way to declare.
 
-    Refusing on the first and returning hid the second entirely: the user
-    fixed what they were shown, submitted again, and was refused again for
-    something that had been wrong all along.
+    Without the second field, somebody repairing a broken lock would have
+    nowhere to put the codeless one they are replacing it with, and would
+    land straight back in reauth.
     """
-    hass.states.async_set("lock.yaml_only", LockState.LOCKED)
-    unclaimed = await async_discover_unclaimed_mqtt_lock(hass)
-    flow_id = await _init_flow_to_user_step(hass)
-
-    result = await hass.config_entries.flow.async_configure(
-        flow_id,
-        {
-            CONF_NAME: "test",
-            CONF_LOCKS: [LOCK_1_ENTITY_ID, "lock.yaml_only", unclaimed.entity_id],
+    codeless = register_codeless_lock(hass)
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="test",
+        data={
+            CONF_LOCKS: [LOCK_1_ENTITY_ID],
+            CONF_USERS: {"User 1": {CONF_ENABLED: True, CONF_PIN: "1234"}},
+            CONF_SLOT_ASSIGNMENT: {"user 1": 1},
         },
     )
+    entry.add_to_hass(hass)
+    entry.async_start_reauth(hass, context={"lock_entity_id": LOCK_1_ENTITY_ID})
+    await hass.async_block_till_done()
+    [flow] = entry.async_get_active_flows(hass, {SOURCE_REAUTH})
 
-    assert result["type"] == "form"
-    assert result["step_id"] == "user"
-    assert result["errors"] == {
-        "base": "lock_not_registered",
-        CONF_LOCKS: "unsupported_mqtt_lock",
-    }
-    # Named apart, so one flat mapping renders both messages.
-    assert result["description_placeholders"]["unregistered_locks"] == "lock.yaml_only"
-    assert result["description_placeholders"]["locks"] == unclaimed.entity_id
+    result = await hass.config_entries.flow.async_configure(
+        flow["flow_id"],
+        {CONF_LOCKS: [], CONF_CODELESS_LOCKS: [codeless.entity_id]},
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "locks_updated"
+    assert entry.data[CONF_LOCKS] == [codeless.entity_id]
+    assert (
+        resolve_member_provider_class(
+            dr.async_get(hass), get_entry_config(entry), codeless
+        )
+        is CodelessLock
+    )
+
+
+async def test_reauth_seeds_each_lock_into_the_field_that_declares_it(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """
+    Reauth opens on the entry's own split, like the options form.
+
+    A user repairing one lock submits the form largely unchanged, so a
+    declared member seeded into the wrong field would be handed back by a
+    repair that was never about it.
+    """
+    codeless = register_codeless_lock(hass)
+    entry = _entry_declaring(hass, codeless, LOCK_1_ENTITY_ID)
+    entry.async_start_reauth(hass, context={"lock_entity_id": LOCK_1_ENTITY_ID})
+    await hass.async_block_till_done()
+    [flow] = entry.async_get_active_flows(hass, {SOURCE_REAUTH})
+
+    result = await hass.config_entries.flow.async_configure(flow["flow_id"])
+
+    schema = result["data_schema"].schema
+    defaults = {str(key): key.default() for key in schema}
+    assert defaults[CONF_LOCKS] == [LOCK_1_ENTITY_ID]
+    assert defaults[CONF_CODELESS_LOCKS] == [codeless.entity_id]
 
 
 # --- One lock, one answer, however many configurations manage it ---
@@ -3381,29 +3442,30 @@ def _sibling_declaring(
     return entry
 
 
-async def test_a_lock_another_entry_declares_is_asked_about_here_too(
+async def test_agreeing_with_a_sibling_is_a_selection_this_entry_can_make(
     hass: HomeAssistant, mock_lock_config_entry
 ) -> None:
     """
-    Agreeing has to be an answer this entry can give.
+    A lock another entry declares stays selectable in the codeless field here.
 
-    A lock a provider claims is otherwise never asked about, so an entry
-    adding one that another entry declares codeless could only ever
-    contradict it -- and would then be refused with no answer available that
-    was not. The question is asked because a sibling already answered it,
-    not because dispatch came up empty.
+    Excluding it -- it is claimed, after all -- would leave an entry adding
+    that lock only able to contradict its sibling, and then be refused with
+    no selection available that was not. Agreeing has to be expressible.
     """
     claimed = er.async_get(hass).async_get(LOCK_1_ENTITY_ID)
     _sibling_declaring(hass, claimed, declares=True)
+
+    config = await _codeless_field(hass)
+    assert LOCK_1_ENTITY_ID not in config["exclude_entities"]
+
     flow_id = await _init_flow_to_user_step(hass)
-
-    result = await hass.config_entries.flow.async_configure(
-        flow_id, {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
-    )
-    await _menu_about(result, claimed, "codeless_reconsider")
-
-    result = await hass.config_entries.flow.async_configure(
-        flow_id, {"next_step_id": "codeless_confirm"}
+    await hass.config_entries.flow.async_configure(
+        flow_id,
+        {
+            CONF_NAME: "test",
+            CONF_LOCKS: [],
+            CONF_CODELESS_LOCKS: [LOCK_1_ENTITY_ID],
+        },
     )
     await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
     await hass.config_entries.flow.async_configure(flow_id, {CONF_NUM_USERS: 1})
@@ -3413,8 +3475,6 @@ async def test_a_lock_another_entry_declares_is_asked_about_here_too(
         )
 
     assert result["type"] == "create_entry"
-    # Read the way dispatch reads it: the entry agrees with its sibling
-    # about what the member IS, not merely about what to store.
     assert (
         resolve_member_provider_class(
             dr.async_get(hass), EntryConfig.from_mapping(result["data"]), claimed
@@ -3427,12 +3487,12 @@ async def test_a_second_configuration_may_not_contradict_the_first(
     hass: HomeAssistant, mock_lock_config_entry
 ) -> None:
     """
-    Two entries answering differently is refused, and the other one is named.
+    Two entries disagreeing is refused, and the other one is named.
 
     Whether a lock keeps codes of its own is a fact about the device, so the
     disagreement is not a configuration but a contradiction -- and one with
-    teeth, because the two answers resolve to two credential stores over one
-    entity and a Personal Identification Number lands in whichever the
+    teeth, because the two selections resolve to two credential stores over
+    one entity and a Personal Identification Number lands in whichever the
     caller happened to reach. The refusal names the other configuration
     because reconciling it is the only way through.
     """
@@ -3440,18 +3500,20 @@ async def test_a_second_configuration_may_not_contradict_the_first(
     _sibling_declaring(hass, claimed, declares=True)
     flow_id = await _init_flow_to_user_step(hass)
 
-    await hass.config_entries.flow.async_configure(
-        flow_id, {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
-    )
     result = await hass.config_entries.flow.async_configure(
-        flow_id, {"next_step_id": "codeless_decline"}
+        flow_id,
+        {
+            CONF_NAME: "test",
+            CONF_LOCKS: [LOCK_1_ENTITY_ID],
+            CONF_CODELESS_LOCKS: [],
+        },
     )
 
     assert result["type"] == "form"
     assert result["step_id"] == "user"
-    assert result["errors"] == {CONF_LOCKS: "codeless_conflict"}
+    assert result["errors"] == {CONF_CODELESS_LOCKS: "codeless_conflict"}
     assert result["description_placeholders"] == {
-        "locks": f"{LOCK_1_ENTITY_ID} (Upstairs Codes)"
+        "codeless_locks": f"{LOCK_1_ENTITY_ID} (Upstairs Codes)"
     }
     # Nothing was created, so there is no second store for the refusal to
     # have been merely cosmetic about.
@@ -3474,16 +3536,18 @@ async def test_declaring_a_lock_another_entry_holds_undeclared_is_refused(
     _sibling_declaring(hass, codeless, declares=False)
     flow_id = await _init_flow_to_user_step(hass)
 
-    await hass.config_entries.flow.async_configure(
-        flow_id, {CONF_NAME: "test", CONF_LOCKS: [codeless.entity_id]}
-    )
     result = await hass.config_entries.flow.async_configure(
-        flow_id, {"next_step_id": "codeless_confirm"}
+        flow_id,
+        {
+            CONF_NAME: "test",
+            CONF_LOCKS: [],
+            CONF_CODELESS_LOCKS: [codeless.entity_id],
+        },
     )
 
-    assert result["errors"] == {CONF_LOCKS: "codeless_conflict"}
+    assert result["errors"] == {CONF_CODELESS_LOCKS: "codeless_conflict"}
     assert result["description_placeholders"] == {
-        "locks": f"{codeless.entity_id} (Upstairs Codes)"
+        "codeless_locks": f"{codeless.entity_id} (Upstairs Codes)"
     }
 
 
@@ -3493,36 +3557,29 @@ async def test_the_options_flow_may_not_take_back_what_a_sibling_declares(
     """
     Handing a shared lock back is a decision both configurations have to make.
 
-    Taking the declaration back here alone would leave the sibling holding
-    the lock's codes in Lock Code Manager while this entry started writing
-    them to the device -- the same entity, two stores. Removing the lock
-    from one of the two is the way through, which is what the refusal says.
+    Moving it out here alone would leave the sibling holding the lock's codes
+    in Lock Code Manager while this entry started writing them to the device
+    -- the same entity, two stores. Removing the lock from one of the two is
+    the way through, which is what the refusal says.
     """
     claimed = er.async_get(hass).async_get(LOCK_1_ENTITY_ID)
     _sibling_declaring(hass, claimed, declares=True)
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        title="test",
-        data={**BASE_CONFIG, CONF_MEMBERS: {claimed.id: {CONF_CODELESS: True}}},
-    )
-    entry.add_to_hass(hass)
+    entry = _entry_declaring(hass, claimed)
     users = {"test1": {CONF_PIN: "1234", CONF_ENABLED: True}}
 
     started = await hass.config_entries.options.async_init(entry.entry_id)
-    flow_id = started["flow_id"]
     with _holding():
         result = await hass.config_entries.options.async_configure(
-            flow_id, user_input={CONF_LOCKS: [LOCK_1_ENTITY_ID], CONF_USERS: users}
-        )
-    await _menu_about(result, claimed, "codeless_reconsider")
-
-    with _holding():
-        result = await hass.config_entries.options.async_configure(
-            flow_id, {"next_step_id": "codeless_decline"}
+            started["flow_id"],
+            user_input={
+                CONF_LOCKS: [LOCK_1_ENTITY_ID],
+                CONF_CODELESS_LOCKS: [],
+                CONF_USERS: users,
+            },
         )
 
     assert result["type"] == "form"
-    assert result["errors"] == {CONF_LOCKS: "codeless_conflict"}
+    assert result["errors"] == {CONF_CODELESS_LOCKS: "codeless_conflict"}
     # The declaration is still the one the entry runs on, so the member
     # keeps resolving to the store the sibling is also reading.
     assert get_entry_config(entry).is_codeless(claimed)
@@ -3532,30 +3589,25 @@ async def test_the_entry_being_edited_does_not_contradict_itself(
     hass: HomeAssistant, mock_lock_config_entry
 ) -> None:
     """
-    An entry's own stored answer is the one being replaced, not an obstacle.
+    An entry's own stored declaration is the one being replaced, not an obstacle.
 
     The sibling scan reads every OTHER entry; reading this one too would
-    refuse every answer that changed anything, so a declaration could never
-    be taken back at all -- the exit the menu exists to offer.
+    refuse every submission that changed anything, so a declaration could
+    never be taken back at all -- the exit the second field exists to offer.
     """
     claimed = er.async_get(hass).async_get(LOCK_1_ENTITY_ID)
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        title="test",
-        data={**BASE_CONFIG, CONF_MEMBERS: {claimed.id: {CONF_CODELESS: True}}},
-    )
-    entry.add_to_hass(hass)
+    entry = _entry_declaring(hass, claimed)
     users = {"test1": {CONF_PIN: "1234", CONF_ENABLED: True}}
 
     started = await hass.config_entries.options.async_init(entry.entry_id)
-    flow_id = started["flow_id"]
-    with _holding():
-        await hass.config_entries.options.async_configure(
-            flow_id, user_input={CONF_LOCKS: [LOCK_1_ENTITY_ID], CONF_USERS: users}
-        )
     with _holding():
         result = await hass.config_entries.options.async_configure(
-            flow_id, {"next_step_id": "codeless_decline"}
+            started["flow_id"],
+            user_input={
+                CONF_LOCKS: [LOCK_1_ENTITY_ID],
+                CONF_CODELESS_LOCKS: [],
+                CONF_USERS: users,
+            },
         )
 
     assert result["type"] == "create_entry"
@@ -3571,11 +3623,11 @@ async def test_reauth_may_not_contradict_a_sibling_either(
     hass: HomeAssistant, mock_lock_config_entry
 ) -> None:
     """
-    Reauth renders the same picker, so it is a third way to introduce the pair.
+    Reauth renders the same pickers, so it is a third way to introduce the pair.
 
     The entry being repaired is left out of the scan the way the edited entry
-    is -- it is the one whose answer is being rewritten -- so what refuses
-    here is genuinely another configuration.
+    is -- it is the one whose declaration is being rewritten -- so what
+    refuses here is genuinely another configuration.
     """
     codeless = register_codeless_lock(hass)
     _sibling_declaring(hass, codeless, declares=False)
@@ -3593,15 +3645,13 @@ async def test_reauth_may_not_contradict_a_sibling_either(
     await hass.async_block_till_done()
     [flow] = entry.async_get_active_flows(hass, {SOURCE_REAUTH})
 
-    await hass.config_entries.flow.async_configure(
-        flow["flow_id"], {CONF_LOCKS: [codeless.entity_id]}
-    )
     result = await hass.config_entries.flow.async_configure(
-        flow["flow_id"], {"next_step_id": "codeless_confirm"}
+        flow["flow_id"],
+        {CONF_LOCKS: [], CONF_CODELESS_LOCKS: [codeless.entity_id]},
     )
 
     assert result["type"] == "form"
-    assert result["errors"] == {CONF_LOCKS: "codeless_conflict"}
+    assert result["errors"] == {CONF_CODELESS_LOCKS: "codeless_conflict"}
     # The repair did not land, so the entry still holds the lock it came in
     # with rather than one two configurations disagree about.
     assert entry.data[CONF_LOCKS] == [LOCK_1_ENTITY_ID]
@@ -3614,18 +3664,23 @@ async def test_a_configuration_that_does_not_manage_the_lock_has_no_say(
     Only entries that HOLD the member answer for it.
 
     A declaration left behind by an entry that no longer lists the lock is
-    not an opinion about anything -- nothing resolves it -- so reading one
-    would refuse an answer no live provider contradicts, and a lock nothing
-    else manages could never be declared while any other configuration
-    existed.
+    not an opinion about anything -- nothing resolves it, so no store exists
+    to disagree with. Read anyway, a husk in some unrelated configuration
+    would refuse a selection no live provider contradicts, and the lock it
+    names could never be added to anything again.
+
+    The leftover is about a lock this flow puts in the ORDINARY field,
+    because that is the direction a stale "yes" contradicts: agreeing with a
+    husk is indistinguishable from ignoring it.
     """
-    codeless = register_codeless_lock(hass)
+    stale = er.async_get(hass).async_get(LOCK_1_ENTITY_ID)
     elsewhere = MockConfigEntry(
         domain=DOMAIN,
         title="Garage Codes",
         unique_id="garage_codes",
         data={
             CONF_LOCKS: [LOCK_2_ENTITY_ID],
+            CONF_MEMBERS: {stale.id: {CONF_CODELESS: True}},
             CONF_USERS: {"Ada": {CONF_PIN: "1111", CONF_ENABLED: True}},
             CONF_SLOT_ASSIGNMENT: {"ada": 9},
         },
@@ -3633,11 +3688,13 @@ async def test_a_configuration_that_does_not_manage_the_lock_has_no_say(
     elsewhere.add_to_hass(hass)
     flow_id = await _init_flow_to_user_step(hass)
 
-    await hass.config_entries.flow.async_configure(
-        flow_id, {CONF_NAME: "test", CONF_LOCKS: [codeless.entity_id]}
-    )
     result = await hass.config_entries.flow.async_configure(
-        flow_id, {"next_step_id": "codeless_confirm"}
+        flow_id,
+        {
+            CONF_NAME: "test",
+            CONF_LOCKS: [LOCK_1_ENTITY_ID],
+            CONF_CODELESS_LOCKS: [],
+        },
     )
 
     assert result["type"] == "menu"

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -3306,3 +3306,294 @@ async def test_both_lock_refusals_render_from_one_submission(
     # Named apart, so one flat mapping renders both messages.
     assert result["description_placeholders"]["unregistered_locks"] == "lock.yaml_only"
     assert result["description_placeholders"]["locks"] == unclaimed.entity_id
+
+
+# --- One lock, one answer, however many configurations manage it ---
+
+
+def _sibling_declaring(
+    hass: HomeAssistant, lock_entry: er.RegistryEntry, *, declares: bool
+) -> MockConfigEntry:
+    """
+    Add a second entry that holds a lock, declaring it or not.
+
+    Its user sits well clear of the slot numbers the entries under test use,
+    so what refuses a submission here is the disagreement about the lock
+    rather than the slot both entries wanted.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Upstairs Codes",
+        unique_id="upstairs_codes",
+        data={
+            CONF_LOCKS: [lock_entry.entity_id],
+            CONF_MEMBERS: {lock_entry.id: {CONF_CODELESS: True}} if declares else {},
+            CONF_USERS: {"Ada": {CONF_PIN: "1111", CONF_ENABLED: True}},
+            CONF_SLOT_ASSIGNMENT: {"ada": 9},
+        },
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+async def test_a_lock_another_entry_declares_is_asked_about_here_too(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """
+    Agreeing has to be an answer this entry can give.
+
+    A lock a provider claims is otherwise never asked about, so an entry
+    adding one that another entry declares codeless could only ever
+    contradict it -- and would then be refused with no answer available that
+    was not. The question is asked because a sibling already answered it,
+    not because dispatch came up empty.
+    """
+    claimed = er.async_get(hass).async_get(LOCK_1_ENTITY_ID)
+    _sibling_declaring(hass, claimed, declares=True)
+    flow_id = await _init_flow_to_user_step(hass)
+
+    result = await hass.config_entries.flow.async_configure(
+        flow_id, {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
+    )
+    await _menu_about(result, claimed, "codeless_reconsider")
+
+    result = await hass.config_entries.flow.async_configure(
+        flow_id, {"next_step_id": "codeless_confirm"}
+    )
+    await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
+    await hass.config_entries.flow.async_configure(flow_id, {CONF_NUM_USERS: 1})
+    with _holding():
+        result = await hass.config_entries.flow.async_configure(
+            flow_id, {CONF_NAME: "Bea", CONF_ENABLED: True, CONF_PIN: "1234"}
+        )
+
+    assert result["type"] == "create_entry"
+    # Read the way dispatch reads it: the entry agrees with its sibling
+    # about what the member IS, not merely about what to store.
+    assert (
+        resolve_member_provider_class(
+            dr.async_get(hass), EntryConfig.from_mapping(result["data"]), claimed
+        )
+        is CodelessLock
+    )
+
+
+async def test_a_second_configuration_may_not_contradict_the_first(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """
+    Two entries answering differently is refused, and the other one is named.
+
+    Whether a lock keeps codes of its own is a fact about the device, so the
+    disagreement is not a configuration but a contradiction -- and one with
+    teeth, because the two answers resolve to two credential stores over one
+    entity and a Personal Identification Number lands in whichever the
+    caller happened to reach. The refusal names the other configuration
+    because reconciling it is the only way through.
+    """
+    claimed = er.async_get(hass).async_get(LOCK_1_ENTITY_ID)
+    _sibling_declaring(hass, claimed, declares=True)
+    flow_id = await _init_flow_to_user_step(hass)
+
+    await hass.config_entries.flow.async_configure(
+        flow_id, {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        flow_id, {"next_step_id": "codeless_decline"}
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["errors"] == {CONF_LOCKS: "codeless_conflict"}
+    assert result["description_placeholders"] == {
+        "locks": f"{LOCK_1_ENTITY_ID} (Upstairs Codes)"
+    }
+    # Nothing was created, so there is no second store for the refusal to
+    # have been merely cosmetic about.
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
+
+
+async def test_declaring_a_lock_another_entry_holds_undeclared_is_refused(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """
+    The refusal runs in both directions, because the contradiction does.
+
+    A lock another entry manages through its own integration is one that has
+    code storage, whatever this entry is about to say -- so declaring it here
+    would leave the same entity resolving two ways round. The sibling is
+    built by hand because no flow will produce this pair; it is the shape
+    storage can still carry, and the guard has to hold for it.
+    """
+    codeless = register_codeless_lock(hass)
+    _sibling_declaring(hass, codeless, declares=False)
+    flow_id = await _init_flow_to_user_step(hass)
+
+    await hass.config_entries.flow.async_configure(
+        flow_id, {CONF_NAME: "test", CONF_LOCKS: [codeless.entity_id]}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        flow_id, {"next_step_id": "codeless_confirm"}
+    )
+
+    assert result["errors"] == {CONF_LOCKS: "codeless_conflict"}
+    assert result["description_placeholders"] == {
+        "locks": f"{codeless.entity_id} (Upstairs Codes)"
+    }
+
+
+async def test_the_options_flow_may_not_take_back_what_a_sibling_declares(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """
+    Handing a shared lock back is a decision both configurations have to make.
+
+    Taking the declaration back here alone would leave the sibling holding
+    the lock's codes in Lock Code Manager while this entry started writing
+    them to the device -- the same entity, two stores. Removing the lock
+    from one of the two is the way through, which is what the refusal says.
+    """
+    claimed = er.async_get(hass).async_get(LOCK_1_ENTITY_ID)
+    _sibling_declaring(hass, claimed, declares=True)
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="test",
+        data={**BASE_CONFIG, CONF_MEMBERS: {claimed.id: {CONF_CODELESS: True}}},
+    )
+    entry.add_to_hass(hass)
+    users = {"test1": {CONF_PIN: "1234", CONF_ENABLED: True}}
+
+    started = await hass.config_entries.options.async_init(entry.entry_id)
+    flow_id = started["flow_id"]
+    with _holding():
+        result = await hass.config_entries.options.async_configure(
+            flow_id, user_input={CONF_LOCKS: [LOCK_1_ENTITY_ID], CONF_USERS: users}
+        )
+    await _menu_about(result, claimed, "codeless_reconsider")
+
+    with _holding():
+        result = await hass.config_entries.options.async_configure(
+            flow_id, {"next_step_id": "codeless_decline"}
+        )
+
+    assert result["type"] == "form"
+    assert result["errors"] == {CONF_LOCKS: "codeless_conflict"}
+    # The declaration is still the one the entry runs on, so the member
+    # keeps resolving to the store the sibling is also reading.
+    assert get_entry_config(entry).is_codeless(claimed)
+
+
+async def test_the_entry_being_edited_does_not_contradict_itself(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """
+    An entry's own stored answer is the one being replaced, not an obstacle.
+
+    The sibling scan reads every OTHER entry; reading this one too would
+    refuse every answer that changed anything, so a declaration could never
+    be taken back at all -- the exit the menu exists to offer.
+    """
+    claimed = er.async_get(hass).async_get(LOCK_1_ENTITY_ID)
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="test",
+        data={**BASE_CONFIG, CONF_MEMBERS: {claimed.id: {CONF_CODELESS: True}}},
+    )
+    entry.add_to_hass(hass)
+    users = {"test1": {CONF_PIN: "1234", CONF_ENABLED: True}}
+
+    started = await hass.config_entries.options.async_init(entry.entry_id)
+    flow_id = started["flow_id"]
+    with _holding():
+        await hass.config_entries.options.async_configure(
+            flow_id, user_input={CONF_LOCKS: [LOCK_1_ENTITY_ID], CONF_USERS: users}
+        )
+    with _holding():
+        result = await hass.config_entries.options.async_configure(
+            flow_id, {"next_step_id": "codeless_decline"}
+        )
+
+    assert result["type"] == "create_entry"
+    assert (
+        resolve_member_provider_class(
+            dr.async_get(hass), EntryConfig.from_mapping(result["data"]), claimed
+        )
+        is MockLCMLock
+    )
+
+
+async def test_reauth_may_not_contradict_a_sibling_either(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """
+    Reauth renders the same picker, so it is a third way to introduce the pair.
+
+    The entry being repaired is left out of the scan the way the edited entry
+    is -- it is the one whose answer is being rewritten -- so what refuses
+    here is genuinely another configuration.
+    """
+    codeless = register_codeless_lock(hass)
+    _sibling_declaring(hass, codeless, declares=False)
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="test",
+        data={
+            CONF_LOCKS: [LOCK_1_ENTITY_ID],
+            CONF_USERS: {"User 1": {CONF_ENABLED: True, CONF_PIN: "1234"}},
+            CONF_SLOT_ASSIGNMENT: {"user 1": 1},
+        },
+    )
+    entry.add_to_hass(hass)
+    entry.async_start_reauth(hass, context={"lock_entity_id": LOCK_1_ENTITY_ID})
+    await hass.async_block_till_done()
+    [flow] = entry.async_get_active_flows(hass, {SOURCE_REAUTH})
+
+    await hass.config_entries.flow.async_configure(
+        flow["flow_id"], {CONF_LOCKS: [codeless.entity_id]}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        flow["flow_id"], {"next_step_id": "codeless_confirm"}
+    )
+
+    assert result["type"] == "form"
+    assert result["errors"] == {CONF_LOCKS: "codeless_conflict"}
+    # The repair did not land, so the entry still holds the lock it came in
+    # with rather than one two configurations disagree about.
+    assert entry.data[CONF_LOCKS] == [LOCK_1_ENTITY_ID]
+
+
+async def test_a_configuration_that_does_not_manage_the_lock_has_no_say(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """
+    Only entries that HOLD the member answer for it.
+
+    A declaration left behind by an entry that no longer lists the lock is
+    not an opinion about anything -- nothing resolves it -- so reading one
+    would refuse an answer no live provider contradicts, and a lock nothing
+    else manages could never be declared while any other configuration
+    existed.
+    """
+    codeless = register_codeless_lock(hass)
+    elsewhere = MockConfigEntry(
+        domain=DOMAIN,
+        title="Garage Codes",
+        unique_id="garage_codes",
+        data={
+            CONF_LOCKS: [LOCK_2_ENTITY_ID],
+            CONF_USERS: {"Ada": {CONF_PIN: "1111", CONF_ENABLED: True}},
+            CONF_SLOT_ASSIGNMENT: {"ada": 9},
+        },
+    )
+    elsewhere.add_to_hass(hass)
+    flow_id = await _init_flow_to_user_step(hass)
+
+    await hass.config_entries.flow.async_configure(
+        flow_id, {CONF_NAME: "test", CONF_LOCKS: [codeless.entity_id]}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        flow_id, {"next_step_id": "codeless_confirm"}
+    )
+
+    assert result["type"] == "menu"
+    assert result["step_id"] == "choose_path"

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -48,6 +48,7 @@ from custom_components.lock_code_manager.domain.queries import get_entry_config
 from custom_components.lock_code_manager.domain.slot_assignment import (
     CONF_SLOT_ASSIGNMENT,
 )
+from custom_components.lock_code_manager.providers.codeless import CodelessLock
 
 from .common import (
     BASE_CONFIG,
@@ -2303,8 +2304,10 @@ async def test_user_step_rejects_a_lock_the_entity_registry_does_not_know(
 
     assert result["type"] == "form"
     assert result["step_id"] == "user"
-    assert result["errors"] == {CONF_LOCKS: "lock_not_registered"}
-    assert result["description_placeholders"] == {"locks": "lock.yaml_only"}
+    assert result["errors"] == {"base": "lock_not_registered"}
+    assert result["description_placeholders"] == {
+        "unregistered_locks": "lock.yaml_only"
+    }
     assert _suggested_values(result) == {
         CONF_NAME: "test",
         CONF_LOCKS: [LOCK_1_ENTITY_ID, "lock.yaml_only"],
@@ -2341,8 +2344,8 @@ async def test_reauth_rejects_a_lock_the_entity_registry_does_not_know(
     )
 
     assert result["type"] == "form"
-    assert result["errors"] == {CONF_LOCKS: "lock_not_registered"}
-    assert result["description_placeholders"]["locks"] == "lock.yaml_only"
+    assert result["errors"] == {"base": "lock_not_registered"}
+    assert result["description_placeholders"]["unregistered_locks"] == "lock.yaml_only"
 
     result = await hass.config_entries.flow.async_configure(
         flow["flow_id"], {CONF_LOCKS: [LOCK_1_ENTITY_ID]}
@@ -2653,11 +2656,11 @@ async def test_options_flow_preserves_member_declarations(
 # --- Locks nothing claims, that the user declares codeless (issue #1484) ---
 
 
-async def _menu_about(result, lock_entry) -> None:
-    """Assert a flow result is the codeless question, naming this lock."""
+async def _menu_about(result, lock_entry, step_id: str = "codeless") -> None:
+    """Assert a flow result is the codeless question, naming this one lock."""
     assert result["type"] == "menu"
-    assert result["step_id"] == "codeless"
-    assert result["description_placeholders"] == {"locks": lock_entry.entity_id}
+    assert result["step_id"] == step_id
+    assert result["description_placeholders"] == {"lock": lock_entry.entity_id}
 
 
 async def test_the_lock_picker_offers_every_lock(
@@ -2910,7 +2913,10 @@ async def test_a_declared_member_a_provider_now_claims_is_still_asked_about(
         result = await hass.config_entries.options.async_configure(
             flow_id, user_input={CONF_LOCKS: [LOCK_1_ENTITY_ID], CONF_USERS: users}
         )
-    await _menu_about(result, claimed)
+    # Its own question, not the one a lock nothing claims gets: declining
+    # here hands the lock to the provider that claims it now and saves,
+    # rather than refusing the submission.
+    await _menu_about(result, claimed, "codeless_reconsider")
 
     with _holding():
         result = await hass.config_entries.options.async_configure(
@@ -3144,3 +3150,159 @@ async def test_reauth_asks_about_a_lock_nothing_claims(
     assert result["reason"] == "locks_updated"
     assert entry.data[CONF_LOCKS] == [codeless.entity_id]
     assert entry.data[CONF_MEMBERS] == {codeless.id: {CONF_CODELESS: True}}
+
+
+async def test_an_answer_applies_only_to_the_member_it_was_asked_about(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """
+    Declining a lock just added leaves an unrelated declared member alone.
+
+    The set asked about mixes two populations: a lock nothing claims that
+    this submission adds, and every member the entry already declares. One
+    Yes/No over both meant an answer aimed at the newcomer was recorded
+    against the other member too -- so saying "no, don't manage that new
+    lock" stripped the declaration off a lock somebody had said must never
+    be written to, and handed it straight back to its provider.
+    """
+    claimed = er.async_get(hass).async_get(LOCK_1_ENTITY_ID)
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="test",
+        data={**BASE_CONFIG, CONF_MEMBERS: {claimed.id: {CONF_CODELESS: True}}},
+    )
+    entry.add_to_hass(hass)
+    newcomer = register_codeless_lock(hass)
+    users = {"test1": {CONF_PIN: "1234", CONF_ENABLED: True}}
+
+    started = await hass.config_entries.options.async_init(entry.entry_id)
+    flow_id = started["flow_id"]
+
+    # Both locks are asked about, one question each, in the order submitted.
+    with _holding():
+        result = await hass.config_entries.options.async_configure(
+            flow_id,
+            user_input={
+                CONF_LOCKS: [LOCK_1_ENTITY_ID, newcomer.entity_id],
+                CONF_USERS: users,
+            },
+        )
+    await _menu_about(result, claimed, "codeless_reconsider")
+
+    with _holding():
+        result = await hass.config_entries.options.async_configure(
+            flow_id, {"next_step_id": "codeless_confirm"}
+        )
+    await _menu_about(result, newcomer)
+
+    with _holding():
+        result = await hass.config_entries.options.async_configure(
+            flow_id, {"next_step_id": "codeless_decline"}
+        )
+
+    # The refusal names the newcomer and nothing else.
+    assert result["errors"] == {CONF_LOCKS: "codeless_declined"}
+    assert result["description_placeholders"]["locks"] == newcomer.entity_id
+
+    with _holding():
+        result = await hass.config_entries.options.async_configure(
+            flow_id, user_input={CONF_LOCKS: [LOCK_1_ENTITY_ID], CONF_USERS: users}
+        )
+
+    # Read the way dispatch reads it: what matters is that the untouched
+    # member still resolves to the Lock Code Manager store, which an
+    # assertion on the stored shape alone would not settle.
+    assert result["type"] == "create_entry"
+    assert (
+        resolve_member_provider_class(
+            dr.async_get(hass), EntryConfig.from_mapping(result["data"]), claimed
+        )
+        is CodelessLock
+    )
+
+
+async def test_taking_a_declaration_back_is_sized_against_the_real_lock(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """
+    Capacity is checked against the provider the lock is about to become.
+
+    Reading the STORED declaration made a pending answer invisible to the
+    very validation the answer triggers a re-run of: the lock still resolved
+    to the Lock Code Manager store -- no capacity and nothing in it -- so a
+    configuration far too large for the real lock saved without a word, and
+    every user past the lock's last slot silently failed to be written from
+    then on.
+    """
+    claimed = er.async_get(hass).async_get(LOCK_1_ENTITY_ID)
+    users = {
+        name: {CONF_PIN: pin, CONF_ENABLED: True}
+        for name, pin in (("Ada", "1111"), ("Bea", "2222"), ("Cal", "3333"))
+    }
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="test",
+        data={
+            CONF_LOCKS: [LOCK_1_ENTITY_ID],
+            CONF_MEMBERS: {claimed.id: {CONF_CODELESS: True}},
+            CONF_USERS: users,
+            CONF_SLOT_ASSIGNMENT: {"ada": 1, "bea": 2, "cal": 3},
+        },
+    )
+    entry.add_to_hass(hass)
+
+    started = await hass.config_entries.options.async_init(entry.entry_id)
+    flow_id = started["flow_id"]
+    # Two slots is fewer than the three users, so only a check that reaches
+    # the real lock can refuse this.
+    probe = _capacity_probe(return_value=_capabilities_with_slots(2))
+
+    with probe, _holding():
+        result = await hass.config_entries.options.async_configure(
+            flow_id, user_input={CONF_LOCKS: [LOCK_1_ENTITY_ID], CONF_USERS: users}
+        )
+    await _menu_about(result, claimed, "codeless_reconsider")
+
+    with probe, _holding():
+        result = await hass.config_entries.options.async_configure(
+            flow_id, {"next_step_id": "codeless_decline"}
+        )
+
+    assert result["type"] == "form"
+    assert result["errors"] == {"base": "too_many_users"}
+    assert result["description_placeholders"]["num_slots"] == "2"
+    # Nothing was written, so the member is still what it was.
+    assert get_entry_config(entry).is_codeless(claimed)
+
+
+async def test_both_lock_refusals_render_from_one_submission(
+    hass: HomeAssistant, mock_lock_config_entry, mqtt_mock, mqtt_teardown
+) -> None:
+    """
+    A selection with one of each problem says so once, not over two visits.
+
+    Refusing on the first and returning hid the second entirely: the user
+    fixed what they were shown, submitted again, and was refused again for
+    something that had been wrong all along.
+    """
+    hass.states.async_set("lock.yaml_only", LockState.LOCKED)
+    unclaimed = await async_discover_unclaimed_mqtt_lock(hass)
+    flow_id = await _init_flow_to_user_step(hass)
+
+    result = await hass.config_entries.flow.async_configure(
+        flow_id,
+        {
+            CONF_NAME: "test",
+            CONF_LOCKS: [LOCK_1_ENTITY_ID, "lock.yaml_only", unclaimed.entity_id],
+        },
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["errors"] == {
+        "base": "lock_not_registered",
+        CONF_LOCKS: "unsupported_mqtt_lock",
+    }
+    # Named apart, so one flat mapping renders both messages.
+    assert result["description_placeholders"]["unregistered_locks"] == "lock.yaml_only"
+    assert result["description_placeholders"]["locks"] == unclaimed.entity_id

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, PropertyMock, patch
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
 from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_USER
 from homeassistant.const import CONF_CONDITION, CONF_ENABLED, CONF_NAME, CONF_PIN
 from homeassistant.core import HomeAssistant
@@ -16,6 +17,7 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from custom_components.lock_code_manager.config_flow import _check_common_slots
 from custom_components.lock_code_manager.const import (
+    CONF_CODELESS,
     CONF_LOCKS,
     CONF_MEMBERS,
     CONF_NUM_USERS,
@@ -50,6 +52,7 @@ from .common import (
     MockLCMLock,
     async_discover_unclaimed_mqtt_lock,
     reading_for,
+    register_codeless_lock,
 )
 from .providers.zigbee2mqtt.conftest import async_discover_z2m_lock
 
@@ -2567,3 +2570,296 @@ async def test_options_flow_preserves_member_declarations(
     assert result["data"][CONF_MEMBERS] == {lock_1.id: {"placeholder": True}}
     # The edit the declaration had to survive actually landed.
     assert set(result["data"][CONF_USERS]) == {"test1"}
+
+
+# --- Locks nothing claims, that the user declares codeless (issue #1484) ---
+
+
+async def _menu_about(result, lock_entry) -> None:
+    """Assert a flow result is the codeless question, naming this lock."""
+    assert result["type"] == "menu"
+    assert result["step_id"] == "codeless"
+    assert result["description_placeholders"] == {"locks": lock_entry.entity_id}
+
+
+async def test_the_lock_picker_offers_every_lock(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """
+    The picker is not an allowlist of the platforms that resolve to a provider.
+
+    A lock nothing claims may still be one Lock Code Manager can manage by
+    holding its codes, and the question that settles it is asked after the
+    submission -- which a picker that hides the lock makes unaskable.
+    """
+    flow_id = await _init_flow_to_user_step(hass)
+    result = await hass.config_entries.flow.async_configure(flow_id)
+
+    [locks_field] = [
+        key for key in result["data_schema"].schema if str(key) == CONF_LOCKS
+    ]
+    config = result["data_schema"].schema[locks_field].config
+
+    assert config["domain"] == [LOCK_DOMAIN]
+    assert "filter" not in config
+
+
+async def test_the_user_step_asks_about_a_lock_nothing_claims(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """Confirming records the declaration on the entry it creates."""
+    codeless = register_codeless_lock(hass)
+    flow_id = await _init_flow_to_user_step(hass)
+
+    result = await hass.config_entries.flow.async_configure(
+        flow_id, {CONF_NAME: "test", CONF_LOCKS: [codeless.entity_id]}
+    )
+    await _menu_about(result, codeless)
+
+    result = await hass.config_entries.flow.async_configure(
+        flow_id, {"next_step_id": "codeless_confirm"}
+    )
+
+    # The answer re-submits what it was asked about, so the flow carries on
+    # from where it would have been.
+    assert result["type"] == "menu"
+    assert result["step_id"] == "choose_path"
+
+    await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
+    await hass.config_entries.flow.async_configure(flow_id, {CONF_NUM_USERS: 1})
+    result = await hass.config_entries.flow.async_configure(
+        flow_id, {CONF_NAME: "User 1", CONF_ENABLED: True, CONF_PIN: "1234"}
+    )
+
+    assert result["type"] == "create_entry"
+    assert result["data"][CONF_MEMBERS] == {codeless.id: {CONF_CODELESS: True}}
+
+
+async def test_a_lock_a_provider_claims_is_never_asked_about(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """The question is only for the locks whose answer is not already known."""
+    flow_id = await _init_flow_to_user_step(hass)
+
+    result = await hass.config_entries.flow.async_configure(
+        flow_id, {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
+    )
+
+    assert result["step_id"] == "choose_path"
+
+
+async def test_an_unclaimed_mqtt_lock_is_refused_rather_than_asked_about(
+    hass: HomeAssistant, mock_lock_config_entry, mqtt_mock, mqtt_teardown
+) -> None:
+    """
+    mqtt keeps its own refusal.
+
+    Its dispatch is per device, so an unclaimed one means "this bridge is
+    not one Lock Code Manager speaks" -- a gap that may close later, not a
+    lock with no code storage. Offering the declaration there would strand
+    that lock's credentials in a Lock Code Manager store on the day its
+    bridge became supported.
+    """
+    unclaimed = await async_discover_unclaimed_mqtt_lock(hass)
+    flow_id = await _init_flow_to_user_step(hass)
+
+    result = await hass.config_entries.flow.async_configure(
+        flow_id, {CONF_NAME: "test", CONF_LOCKS: [unclaimed.entity_id]}
+    )
+
+    assert result["type"] == "form"
+    assert result["errors"] == {CONF_LOCKS: "unsupported_mqtt_lock"}
+
+
+async def test_declining_lands_back_on_the_form_that_asked(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """
+    Declining is not a dead end: the way out is to choose different locks.
+
+    The refusal names them and the form comes back holding what was
+    submitted, so the selection can be changed rather than retyped.
+    """
+    codeless = register_codeless_lock(hass)
+    flow_id = await _init_flow_to_user_step(hass)
+
+    await hass.config_entries.flow.async_configure(
+        flow_id,
+        {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID, codeless.entity_id]},
+    )
+    result = await hass.config_entries.flow.async_configure(
+        flow_id, {"next_step_id": "codeless_decline"}
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["errors"] == {CONF_LOCKS: "codeless_declined"}
+    assert result["description_placeholders"] == {"locks": codeless.entity_id}
+    assert _suggested_values(result) == {
+        CONF_NAME: "test",
+        CONF_LOCKS: [LOCK_1_ENTITY_ID, codeless.entity_id],
+    }
+
+    # Submitting the same locks again asks nothing new -- the answer stands
+    # for this flow -- and refuses again. Dropping the lock is what clears it.
+    result = await hass.config_entries.flow.async_configure(
+        flow_id,
+        {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID, codeless.entity_id]},
+    )
+
+    assert result["errors"] == {CONF_LOCKS: "codeless_declined"}
+
+    result = await hass.config_entries.flow.async_configure(
+        flow_id, {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
+    )
+
+    assert result["type"] == "menu"
+    assert result["step_id"] == "choose_path"
+
+
+async def test_the_options_flow_asks_about_a_lock_added_later(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """A lock that arrives after setup gets the same question setup would ask."""
+    codeless = register_codeless_lock(hass)
+    entry = MockConfigEntry(domain=DOMAIN, data=BASE_CONFIG, unique_id="Mock Title")
+    entry.add_to_hass(hass)
+    users = {"test1": {CONF_PIN: "1234", CONF_ENABLED: True}}
+    locks = [LOCK_1_ENTITY_ID, codeless.entity_id]
+
+    started = await hass.config_entries.options.async_init(entry.entry_id)
+    flow_id = started["flow_id"]
+
+    with _holding():
+        result = await hass.config_entries.options.async_configure(
+            flow_id, user_input={CONF_LOCKS: locks, CONF_USERS: users}
+        )
+    await _menu_about(result, codeless)
+
+    with _holding():
+        result = await hass.config_entries.options.async_configure(
+            flow_id, {"next_step_id": "codeless_confirm"}
+        )
+
+    assert result["type"] == "create_entry"
+    assert result["data"][CONF_LOCKS] == locks
+    assert result["data"][CONF_MEMBERS] == {codeless.id: {CONF_CODELESS: True}}
+
+
+async def test_the_options_flow_lets_a_declaration_be_taken_back(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """
+    An entry that already declares a lock is asked again, and can answer no.
+
+    Asking only about locks nobody has answered for would leave a
+    declaration with no way back: there is no second provider to hand the
+    lock to, so taking it back means dropping the lock, and the user has to
+    be able to reach that decision from the form.
+    """
+    codeless = register_codeless_lock(hass)
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="test",
+        data={
+            **BASE_CONFIG,
+            CONF_LOCKS: [LOCK_1_ENTITY_ID, codeless.entity_id],
+            CONF_MEMBERS: {codeless.id: {CONF_CODELESS: True}},
+        },
+    )
+    entry.add_to_hass(hass)
+    users = {"test1": {CONF_PIN: "1234", CONF_ENABLED: True}}
+
+    started = await hass.config_entries.options.async_init(entry.entry_id)
+    flow_id = started["flow_id"]
+
+    with _holding():
+        result = await hass.config_entries.options.async_configure(
+            flow_id,
+            user_input={
+                CONF_LOCKS: [LOCK_1_ENTITY_ID, codeless.entity_id],
+                CONF_USERS: users,
+            },
+        )
+    await _menu_about(result, codeless)
+
+    with _holding():
+        result = await hass.config_entries.options.async_configure(
+            flow_id, {"next_step_id": "codeless_decline"}
+        )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "init"
+    assert result["errors"] == {CONF_LOCKS: "codeless_declined"}
+
+    with _holding():
+        result = await hass.config_entries.options.async_configure(
+            flow_id, user_input={CONF_LOCKS: [LOCK_1_ENTITY_ID], CONF_USERS: users}
+        )
+
+    assert result["type"] == "create_entry"
+    assert result["data"][CONF_LOCKS] == [LOCK_1_ENTITY_ID]
+    # Answering no is what undoes it, so the entry stops declaring anything.
+    assert result["data"][CONF_MEMBERS] == {}
+
+
+async def test_the_options_flow_asks_nothing_when_no_lock_needs_it(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """Editing users on an entry of ordinary locks is one round trip, as before."""
+    entry = MockConfigEntry(domain=DOMAIN, data=BASE_CONFIG, unique_id="Mock Title")
+    entry.add_to_hass(hass)
+
+    started = await hass.config_entries.options.async_init(entry.entry_id)
+
+    with _holding():
+        result = await hass.config_entries.options.async_configure(
+            started["flow_id"],
+            user_input={
+                CONF_LOCKS: [LOCK_1_ENTITY_ID],
+                CONF_USERS: {"test1": {CONF_PIN: "1234", CONF_ENABLED: True}},
+            },
+        )
+
+    assert result["type"] == "create_entry"
+
+
+async def test_reauth_asks_about_a_lock_nothing_claims(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """
+    Reauth renders the same picker, so it is a third way in.
+
+    Without the question, somebody repairing one broken lock could swap in a
+    codeless one and land straight back in reauth, with nothing telling them
+    why.
+    """
+    codeless = register_codeless_lock(hass)
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="test",
+        data={
+            CONF_LOCKS: [LOCK_1_ENTITY_ID],
+            CONF_USERS: {"User 1": {CONF_ENABLED: True, CONF_PIN: "1234"}},
+            CONF_SLOT_ASSIGNMENT: {"user 1": 1},
+        },
+    )
+    entry.add_to_hass(hass)
+    entry.async_start_reauth(hass, context={"lock_entity_id": LOCK_1_ENTITY_ID})
+    await hass.async_block_till_done()
+    [flow] = entry.async_get_active_flows(hass, {SOURCE_REAUTH})
+
+    result = await hass.config_entries.flow.async_configure(
+        flow["flow_id"], {CONF_LOCKS: [codeless.entity_id]}
+    )
+    await _menu_about(result, codeless)
+
+    result = await hass.config_entries.flow.async_configure(
+        flow["flow_id"], {"next_step_id": "codeless_confirm"}
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "locks_updated"
+    assert entry.data[CONF_LOCKS] == [codeless.entity_id]
+    assert entry.data[CONF_MEMBERS] == {codeless.id: {CONF_CODELESS: True}}

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -16,7 +16,10 @@ from homeassistant.const import CONF_CONDITION, CONF_ENABLED, CONF_NAME, CONF_PI
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
-from custom_components.lock_code_manager.config_flow import _check_common_slots
+from custom_components.lock_code_manager.config_flow import (
+    WIKI_EXTERNAL_KEYPADS,
+    _check_common_slots,
+)
 from custom_components.lock_code_manager.const import (
     CONF_CODELESS,
     CONF_CODELESS_LOCKS,
@@ -2309,7 +2312,8 @@ async def test_user_step_rejects_a_lock_the_entity_registry_does_not_know(
     assert result["step_id"] == "user"
     assert result["errors"] == {"base": "lock_not_registered"}
     assert result["description_placeholders"] == {
-        "unregistered_locks": "lock.yaml_only"
+        "unregistered_locks": "lock.yaml_only",
+        "wiki_url": WIKI_EXTERNAL_KEYPADS,
     }
     assert _suggested_values(result) == {
         CONF_NAME: "test",
@@ -2381,7 +2385,10 @@ async def test_user_step_rejects_unclaimed_mqtt_lock(
     assert result["type"] == "form"
     assert result["step_id"] == "user"
     assert result["errors"] == {CONF_LOCKS: "unsupported_mqtt_lock"}
-    assert result["description_placeholders"] == {"locks": unclaimed.entity_id}
+    assert result["description_placeholders"] == {
+        "locks": unclaimed.entity_id,
+        "wiki_url": WIKI_EXTERNAL_KEYPADS,
+    }
     # The refusal comes back holding the name, which means the check ran
     # before the step consumed it.
     assert _suggested_values(result) == {
@@ -2920,7 +2927,10 @@ async def test_an_unclaimed_lock_in_the_ordinary_field_points_at_the_other(
     assert result["type"] == "form"
     assert result["step_id"] == "user"
     assert result["errors"] == {CONF_LOCKS: "unclaimed_lock"}
-    assert result["description_placeholders"] == {"locks": codeless.entity_id}
+    assert result["description_placeholders"] == {
+        "locks": codeless.entity_id,
+        "wiki_url": WIKI_EXTERNAL_KEYPADS,
+    }
 
     # Moving it to the other field is what clears it.
     result = await hass.config_entries.flow.async_configure(
@@ -2972,7 +2982,10 @@ async def test_a_claimed_lock_in_the_codeless_field_is_refused(
     assert result["type"] == "form"
     assert result["step_id"] == "user"
     assert result["errors"] == {CONF_CODELESS_LOCKS: "codeless_lock_claimed"}
-    assert result["description_placeholders"] == {"codeless_locks": unclaimed.entity_id}
+    assert result["description_placeholders"] == {
+        "codeless_locks": unclaimed.entity_id,
+        "wiki_url": WIKI_EXTERNAL_KEYPADS,
+    }
     assert not hass.config_entries.async_entries(DOMAIN)
 
 
@@ -3513,7 +3526,8 @@ async def test_a_second_configuration_may_not_contradict_the_first(
     assert result["step_id"] == "user"
     assert result["errors"] == {CONF_CODELESS_LOCKS: "codeless_conflict"}
     assert result["description_placeholders"] == {
-        "codeless_locks": f"{LOCK_1_ENTITY_ID} (Upstairs Codes)"
+        "codeless_locks": f"{LOCK_1_ENTITY_ID} (Upstairs Codes)",
+        "wiki_url": WIKI_EXTERNAL_KEYPADS,
     }
     # Nothing was created, so there is no second store for the refusal to
     # have been merely cosmetic about.
@@ -3547,7 +3561,8 @@ async def test_declaring_a_lock_another_entry_holds_undeclared_is_refused(
 
     assert result["errors"] == {CONF_CODELESS_LOCKS: "codeless_conflict"}
     assert result["description_placeholders"] == {
-        "codeless_locks": f"{codeless.entity_id} (Upstairs Codes)"
+        "codeless_locks": f"{codeless.entity_id} (Upstairs Codes)",
+        "wiki_url": WIKI_EXTERNAL_KEYPADS,
     }
 
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, PropertyMock, patch
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
+from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN, LockState
 from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_USER
 from homeassistant.const import CONF_CONDITION, CONF_ENABLED, CONF_NAME, CONF_PIN
 from homeassistant.core import HomeAssistant
@@ -337,7 +337,7 @@ async def test_config_flow_yaml(hass: HomeAssistant, mock_lock_config_entry):
     }
 
 
-async def test_config_flow_yaml_error(hass: HomeAssistant):
+async def test_config_flow_yaml_error(hass: HomeAssistant, mock_lock_config_entry):
     """Test error handling in YAML based config flow."""
     flow_id = await _start_yaml_config_flow(hass)
 
@@ -2275,6 +2275,80 @@ def _suggested_values(result) -> dict[str, object]:
     }
 
 
+async def test_user_step_rejects_a_lock_the_entity_registry_does_not_know(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """
+    A lock with no registry row is refused where it is chosen, not after setup.
+
+    The picker offers every lock entity now, which puts an entity with no
+    registry row -- a YAML lock with no unique ID -- in front of the user for
+    the first time. It can never work: the entry keys declarations and
+    devices by registry id, and setup refuses the roster over exactly this.
+    Accepted here it did not even reach that refusal; it got three steps
+    further and failed with ``occupancy_unknown``, telling the user to go
+    wake a lock that was never going to answer.
+    """
+    hass.states.async_set("lock.yaml_only", LockState.LOCKED)
+    flow_id = await _init_flow_to_user_step(hass)
+
+    result = await hass.config_entries.flow.async_configure(
+        flow_id,
+        {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID, "lock.yaml_only"]},
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["errors"] == {CONF_LOCKS: "lock_not_registered"}
+    assert result["description_placeholders"] == {"locks": "lock.yaml_only"}
+    assert _suggested_values(result) == {
+        CONF_NAME: "test",
+        CONF_LOCKS: [LOCK_1_ENTITY_ID, "lock.yaml_only"],
+    }
+
+
+async def test_reauth_rejects_a_lock_the_entity_registry_does_not_know(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """
+    Reauth refuses it too, including the one it was started over.
+
+    This is the one refusal that is not grandfathered. A missing lock is why
+    setup failed and why reauth is open, so waving through the lock the entry
+    already holds would let the user submit the form unchanged, save, reload,
+    fail again and land back in reauth with nothing said.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="test",
+        data={
+            CONF_LOCKS: ["lock.yaml_only"],
+            CONF_USERS: {"User 1": {CONF_ENABLED: True, CONF_PIN: "1234"}},
+            CONF_SLOT_ASSIGNMENT: {"user 1": 1},
+        },
+    )
+    entry.add_to_hass(hass)
+    entry.async_start_reauth(hass, context={"lock_entity_id": "lock.yaml_only"})
+    await hass.async_block_till_done()
+    [flow] = entry.async_get_active_flows(hass, {SOURCE_REAUTH})
+
+    result = await hass.config_entries.flow.async_configure(
+        flow["flow_id"], {CONF_LOCKS: ["lock.yaml_only"]}
+    )
+
+    assert result["type"] == "form"
+    assert result["errors"] == {CONF_LOCKS: "lock_not_registered"}
+    assert result["description_placeholders"]["locks"] == "lock.yaml_only"
+
+    result = await hass.config_entries.flow.async_configure(
+        flow["flow_id"], {CONF_LOCKS: [LOCK_1_ENTITY_ID]}
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "locks_updated"
+
+
 async def test_user_step_rejects_unclaimed_mqtt_lock(
     hass: HomeAssistant, mock_lock_config_entry, mqtt_mock, mqtt_teardown
 ) -> None:
@@ -2800,6 +2874,131 @@ async def test_the_options_flow_lets_a_declaration_be_taken_back(
     assert result["type"] == "create_entry"
     assert result["data"][CONF_LOCKS] == [LOCK_1_ENTITY_ID]
     # Answering no is what undoes it, so the entry stops declaring anything.
+    assert result["data"][CONF_MEMBERS] == {}
+
+
+async def test_a_declared_member_a_provider_now_claims_is_still_asked_about(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """
+    A declaration must have an exit even after its platform gains a provider.
+
+    Dispatch never takes a declared member back -- deliberately, so an
+    upgrade cannot move somebody's credentials onto a device they never
+    agreed to write to -- which leaves the form as the only way out. Asking
+    only about the locks nothing claims made that exit unreachable: the
+    member kept resolving to the Lock Code Manager store while no form ever
+    mentioned it.
+    """
+    claimed = er.async_get(hass).async_get(LOCK_1_ENTITY_ID)
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="test",
+        data={**BASE_CONFIG, CONF_MEMBERS: {claimed.id: {CONF_CODELESS: True}}},
+    )
+    entry.add_to_hass(hass)
+    users = {"test1": {CONF_PIN: "1234", CONF_ENABLED: True}}
+
+    started = await hass.config_entries.options.async_init(entry.entry_id)
+    flow_id = started["flow_id"]
+
+    with _holding():
+        result = await hass.config_entries.options.async_configure(
+            flow_id, user_input={CONF_LOCKS: [LOCK_1_ENTITY_ID], CONF_USERS: users}
+        )
+    await _menu_about(result, claimed)
+
+    with _holding():
+        result = await hass.config_entries.options.async_configure(
+            flow_id, {"next_step_id": "codeless_decline"}
+        )
+
+    # Not refused: something claims this lock now, so declining hands it to
+    # that provider rather than leaving a lock nothing can manage.
+    assert result["type"] == "create_entry"
+    assert result["data"][CONF_LOCKS] == [LOCK_1_ENTITY_ID]
+    assert result["data"][CONF_MEMBERS] == {}
+
+
+async def test_dropping_a_lock_drops_what_was_declared_about_it(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """
+    A declaration about a member the entry no longer holds is not carried forward.
+
+    Nothing reads it while the lock is gone, so the cost is invisible until
+    the entry has collected one husk per lock anybody ever removed.
+    """
+    codeless = register_codeless_lock(hass)
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="test",
+        data={
+            **BASE_CONFIG,
+            CONF_LOCKS: [LOCK_1_ENTITY_ID, codeless.entity_id],
+            CONF_MEMBERS: {codeless.id: {CONF_CODELESS: True}},
+        },
+    )
+    entry.add_to_hass(hass)
+    users = {"test1": {CONF_PIN: "1234", CONF_ENABLED: True}}
+
+    started = await hass.config_entries.options.async_init(entry.entry_id)
+
+    with _holding():
+        result = await hass.config_entries.options.async_configure(
+            started["flow_id"],
+            user_input={CONF_LOCKS: [LOCK_1_ENTITY_ID], CONF_USERS: users},
+        )
+
+    # Nothing was asked -- the lock simply left -- and the declaration left
+    # with it.
+    assert result["type"] == "create_entry"
+    assert result["data"][CONF_MEMBERS] == {}
+
+
+async def test_re_adding_a_dropped_lock_does_not_resurrect_its_declaration(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """
+    A lock the entry forgot about comes back as a lock nobody has answered for.
+
+    Written with a lock a provider claims, because that is where the stale
+    declaration has teeth: dispatch reads the declaration FIRST, so one left
+    behind decides the provider for a lock with real code storage. It is
+    survivable only because the flow now asks about declared members too --
+    which is the tell this test reads. A lock re-added with nothing declared
+    about it saves in one round trip; one carrying a husk stops to ask a
+    question the user already answered, about a lock they never declared.
+    """
+    reused = er.async_get(hass).async_get(LOCK_2_ENTITY_ID)
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="test",
+        data={**BASE_CONFIG, CONF_MEMBERS: {reused.id: {CONF_CODELESS: True}}},
+    )
+    entry.add_to_hass(hass)
+    users = {"test1": {CONF_PIN: "1234", CONF_ENABLED: True}}
+
+    dropped = await hass.config_entries.options.async_init(entry.entry_id)
+    with _holding():
+        result = await hass.config_entries.options.async_configure(
+            dropped["flow_id"],
+            user_input={CONF_LOCKS: [LOCK_1_ENTITY_ID], CONF_USERS: users},
+        )
+    assert result["data"][CONF_MEMBERS] == {}
+    hass.config_entries.async_update_entry(entry, data=result["data"], options={})
+
+    re_added = await hass.config_entries.options.async_init(entry.entry_id)
+    with _holding():
+        result = await hass.config_entries.options.async_configure(
+            re_added["flow_id"],
+            user_input={
+                CONF_LOCKS: [LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID],
+                CONF_USERS: users,
+            },
+        )
+
+    assert result["type"] == "create_entry"
     assert result["data"][CONF_MEMBERS] == {}
 
 

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -1,43 +1,21 @@
 """Test the helpers module."""
 
 import pytest
-from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import (
     ATTR_AREA_ID,
     ATTR_DEVICE_ID,
     ATTR_ENTITY_ID,
-    CONF_ENABLED,
-    CONF_PIN,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import area_registry as ar, entity_registry as er
 
-from custom_components.lock_code_manager.const import (
-    ATTR_CODE_SLOT,
-    ATTR_LOCK_ENTITY_ID,
-    ATTR_USERCODE,
-    CONF_CODELESS,
-    CONF_LOCKS,
-    CONF_MEMBERS,
-    CONF_USERS,
-    DOMAIN,
-    SERVICE_HARD_REFRESH_USERCODES,
-    SERVICE_SET_USERCODE,
-)
-from custom_components.lock_code_manager.domain.locks import (
-    get_locks_from_targets,
-    get_managed_locks_for_entity,
-)
+from custom_components.lock_code_manager.domain.locks import get_locks_from_targets
 from custom_components.lock_code_manager.domain.queries import get_loaded_config_entry
-from custom_components.lock_code_manager.domain.slot_assignment import (
-    CONF_SLOT_ASSIGNMENT,
-)
-from custom_components.lock_code_manager.providers.codeless import CodelessLock
 
-from .common import LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID, MockLCMLock
+from .common import LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID
 
 
 async def test_get_locks_from_targets_with_entity_ids(
@@ -191,141 +169,3 @@ async def test_get_loaded_config_entry_requires_an_identifier(
     """
     with pytest.raises(ServiceValidationError, match="Neither"):
         get_loaded_config_entry(hass)
-
-
-# --- One entity id, two credential stores (issue #1484 review) ---
-
-
-@pytest.fixture(name="divergent_entries")
-async def divergent_entries_fixture(hass: HomeAssistant, mock_lock_config_entry):
-    """
-    Two loaded entries that resolve one lock entity to different providers.
-
-    Representable because a declaration is per entry: one says the lock keeps
-    no codes of its own, so Lock Code Manager holds them, and the other says
-    nothing, so the platform provider does. The two credential stores have
-    nothing to do with each other, and nothing collapses them.
-    """
-    lock_entry = er.async_get(hass).async_get(LOCK_1_ENTITY_ID)
-    assert lock_entry is not None
-    declaring = MockConfigEntry(
-        domain=DOMAIN,
-        title="declaring",
-        data={
-            CONF_LOCKS: [LOCK_1_ENTITY_ID],
-            CONF_MEMBERS: {lock_entry.id: {CONF_CODELESS: True}},
-            CONF_USERS: {"Ada": {CONF_PIN: "1111", CONF_ENABLED: True}},
-            CONF_SLOT_ASSIGNMENT: {"ada": 1},
-        },
-        unique_id="declaring",
-    )
-    plain = MockConfigEntry(
-        domain=DOMAIN,
-        title="plain",
-        data={
-            CONF_LOCKS: [LOCK_1_ENTITY_ID],
-            CONF_USERS: {"Bea": {CONF_PIN: "2222", CONF_ENABLED: True}},
-            CONF_SLOT_ASSIGNMENT: {"bea": 2},
-        },
-        unique_id="plain",
-    )
-    for entry in (declaring, plain):
-        entry.add_to_hass(hass)
-        assert await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
-
-    yield declaring, plain
-
-    for entry in (declaring, plain):
-        await hass.config_entries.async_unload(entry.entry_id)
-
-
-async def test_each_entrys_own_provider_is_the_one_it_holds(
-    hass: HomeAssistant, divergent_entries
-):
-    """
-    Two entries that disagree hold two providers, and both are reachable.
-
-    The old lookups keyed a flat mapping on the entity id, which was
-    well-defined only while sharing guaranteed one instance per lock. A
-    declaration broke that guarantee, and the flat mapping went on answering
-    -- with whichever entry happened to be iterated first.
-    """
-    declaring, plain = divergent_entries
-
-    found = get_managed_locks_for_entity(hass, LOCK_1_ENTITY_ID)
-
-    # Identity, not class: the point is that each entry gets back the object
-    # it is actually driving, and comparing types passes just as well while
-    # a caller is handed the other entry's instance.
-    assert [id(lock) for lock in found] == [
-        id(declaring.runtime_data.locks[LOCK_1_ENTITY_ID]),
-        id(plain.runtime_data.locks[LOCK_1_ENTITY_ID]),
-    ]
-    assert isinstance(declaring.runtime_data.locks[LOCK_1_ENTITY_ID], CodelessLock)
-    assert isinstance(plain.runtime_data.locks[LOCK_1_ENTITY_ID], MockLCMLock)
-
-
-async def test_a_lock_two_entries_disagree_about_is_refused_not_guessed(
-    hass: HomeAssistant, divergent_entries
-):
-    """
-    Writing a raw slot refuses rather than picking one of the two stores.
-
-    The action names a lock and nothing else, so with two stores behind that
-    name there is no answer it can stand behind. Guessing is not a harmless
-    tie-break: the Personal Identification Number lands in a store nobody
-    goes on to read, and the codes on screen belong to the other one.
-    """
-    declaring, plain = divergent_entries
-    held_by_lcm = declaring.runtime_data.locks[LOCK_1_ENTITY_ID]
-    on_the_device = plain.runtime_data.locks[LOCK_1_ENTITY_ID]
-    before = dict(on_the_device.codes)
-
-    with pytest.raises(ServiceValidationError):
-        await hass.services.async_call(
-            DOMAIN,
-            SERVICE_SET_USERCODE,
-            {
-                ATTR_LOCK_ENTITY_ID: LOCK_1_ENTITY_ID,
-                ATTR_CODE_SLOT: 7,
-                ATTR_USERCODE: "9999",
-            },
-            blocking=True,
-        )
-
-    # Neither store moved, which is the whole of what refusing buys.
-    assert on_the_device.codes == before
-    assert (await held_by_lcm.async_get_usercodes()).get(7) is None
-
-
-async def test_a_hard_refresh_reaches_every_provider_for_the_lock(
-    hass: HomeAssistant, divergent_entries
-):
-    """
-    An action aimed at a lock reaches both of its credential stores.
-
-    A ``set`` of providers collapsed them, because ``BaseLock`` equality keys
-    on the entity id -- so one of the two went on serving whatever it had
-    cached, with no sign that it had been skipped.
-    """
-    declaring, plain = divergent_entries
-    held_by_lcm = declaring.runtime_data.locks[LOCK_1_ENTITY_ID]
-    on_the_device = plain.runtime_data.locks[LOCK_1_ENTITY_ID]
-
-    # Each provider is left differing from what backs it, so only actually
-    # re-reading brings it into line.
-    await held_by_lcm._store.async_save({"1": {"code": "1111", "name": "Ada"}})
-    held_by_lcm._data = {}
-    assert (await held_by_lcm.async_get_usercodes())[1].readable_pin is None
-    on_the_device.service_calls["hard_refresh_codes"].clear()
-
-    await hass.services.async_call(
-        DOMAIN,
-        SERVICE_HARD_REFRESH_USERCODES,
-        {ATTR_ENTITY_ID: LOCK_1_ENTITY_ID},
-        blocking=True,
-    )
-
-    assert (await held_by_lcm.async_get_usercodes())[1].readable_pin == "1111"
-    assert on_the_device.service_calls["hard_refresh_codes"]

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -1,17 +1,43 @@
 """Test the helpers module."""
 
 import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import ATTR_AREA_ID, ATTR_DEVICE_ID, ATTR_ENTITY_ID
+from homeassistant.const import (
+    ATTR_AREA_ID,
+    ATTR_DEVICE_ID,
+    ATTR_ENTITY_ID,
+    CONF_ENABLED,
+    CONF_PIN,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import area_registry as ar, entity_registry as er
 
-from custom_components.lock_code_manager.domain.locks import get_locks_from_targets
+from custom_components.lock_code_manager.const import (
+    ATTR_CODE_SLOT,
+    ATTR_LOCK_ENTITY_ID,
+    ATTR_USERCODE,
+    CONF_CODELESS,
+    CONF_LOCKS,
+    CONF_MEMBERS,
+    CONF_USERS,
+    DOMAIN,
+    SERVICE_HARD_REFRESH_USERCODES,
+    SERVICE_SET_USERCODE,
+)
+from custom_components.lock_code_manager.domain.locks import (
+    get_locks_from_targets,
+    get_managed_locks_for_entity,
+)
 from custom_components.lock_code_manager.domain.queries import get_loaded_config_entry
+from custom_components.lock_code_manager.domain.slot_assignment import (
+    CONF_SLOT_ASSIGNMENT,
+)
+from custom_components.lock_code_manager.providers.codeless import CodelessLock
 
-from .common import LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID
+from .common import LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID, MockLCMLock
 
 
 async def test_get_locks_from_targets_with_entity_ids(
@@ -165,3 +191,141 @@ async def test_get_loaded_config_entry_requires_an_identifier(
     """
     with pytest.raises(ServiceValidationError, match="Neither"):
         get_loaded_config_entry(hass)
+
+
+# --- One entity id, two credential stores (issue #1484 review) ---
+
+
+@pytest.fixture(name="divergent_entries")
+async def divergent_entries_fixture(hass: HomeAssistant, mock_lock_config_entry):
+    """
+    Two loaded entries that resolve one lock entity to different providers.
+
+    Representable because a declaration is per entry: one says the lock keeps
+    no codes of its own, so Lock Code Manager holds them, and the other says
+    nothing, so the platform provider does. The two credential stores have
+    nothing to do with each other, and nothing collapses them.
+    """
+    lock_entry = er.async_get(hass).async_get(LOCK_1_ENTITY_ID)
+    assert lock_entry is not None
+    declaring = MockConfigEntry(
+        domain=DOMAIN,
+        title="declaring",
+        data={
+            CONF_LOCKS: [LOCK_1_ENTITY_ID],
+            CONF_MEMBERS: {lock_entry.id: {CONF_CODELESS: True}},
+            CONF_USERS: {"Ada": {CONF_PIN: "1111", CONF_ENABLED: True}},
+            CONF_SLOT_ASSIGNMENT: {"ada": 1},
+        },
+        unique_id="declaring",
+    )
+    plain = MockConfigEntry(
+        domain=DOMAIN,
+        title="plain",
+        data={
+            CONF_LOCKS: [LOCK_1_ENTITY_ID],
+            CONF_USERS: {"Bea": {CONF_PIN: "2222", CONF_ENABLED: True}},
+            CONF_SLOT_ASSIGNMENT: {"bea": 2},
+        },
+        unique_id="plain",
+    )
+    for entry in (declaring, plain):
+        entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    yield declaring, plain
+
+    for entry in (declaring, plain):
+        await hass.config_entries.async_unload(entry.entry_id)
+
+
+async def test_each_entrys_own_provider_is_the_one_it_holds(
+    hass: HomeAssistant, divergent_entries
+):
+    """
+    Two entries that disagree hold two providers, and both are reachable.
+
+    The old lookups keyed a flat mapping on the entity id, which was
+    well-defined only while sharing guaranteed one instance per lock. A
+    declaration broke that guarantee, and the flat mapping went on answering
+    -- with whichever entry happened to be iterated first.
+    """
+    declaring, plain = divergent_entries
+
+    found = get_managed_locks_for_entity(hass, LOCK_1_ENTITY_ID)
+
+    # Identity, not class: the point is that each entry gets back the object
+    # it is actually driving, and comparing types passes just as well while
+    # a caller is handed the other entry's instance.
+    assert [id(lock) for lock in found] == [
+        id(declaring.runtime_data.locks[LOCK_1_ENTITY_ID]),
+        id(plain.runtime_data.locks[LOCK_1_ENTITY_ID]),
+    ]
+    assert isinstance(declaring.runtime_data.locks[LOCK_1_ENTITY_ID], CodelessLock)
+    assert isinstance(plain.runtime_data.locks[LOCK_1_ENTITY_ID], MockLCMLock)
+
+
+async def test_a_lock_two_entries_disagree_about_is_refused_not_guessed(
+    hass: HomeAssistant, divergent_entries
+):
+    """
+    Writing a raw slot refuses rather than picking one of the two stores.
+
+    The action names a lock and nothing else, so with two stores behind that
+    name there is no answer it can stand behind. Guessing is not a harmless
+    tie-break: the Personal Identification Number lands in a store nobody
+    goes on to read, and the codes on screen belong to the other one.
+    """
+    declaring, plain = divergent_entries
+    held_by_lcm = declaring.runtime_data.locks[LOCK_1_ENTITY_ID]
+    on_the_device = plain.runtime_data.locks[LOCK_1_ENTITY_ID]
+    before = dict(on_the_device.codes)
+
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_USERCODE,
+            {
+                ATTR_LOCK_ENTITY_ID: LOCK_1_ENTITY_ID,
+                ATTR_CODE_SLOT: 7,
+                ATTR_USERCODE: "9999",
+            },
+            blocking=True,
+        )
+
+    # Neither store moved, which is the whole of what refusing buys.
+    assert on_the_device.codes == before
+    assert (await held_by_lcm.async_get_usercodes()).get(7) is None
+
+
+async def test_a_hard_refresh_reaches_every_provider_for_the_lock(
+    hass: HomeAssistant, divergent_entries
+):
+    """
+    An action aimed at a lock reaches both of its credential stores.
+
+    A ``set`` of providers collapsed them, because ``BaseLock`` equality keys
+    on the entity id -- so one of the two went on serving whatever it had
+    cached, with no sign that it had been skipped.
+    """
+    declaring, plain = divergent_entries
+    held_by_lcm = declaring.runtime_data.locks[LOCK_1_ENTITY_ID]
+    on_the_device = plain.runtime_data.locks[LOCK_1_ENTITY_ID]
+
+    # Each provider is left differing from what backs it, so only actually
+    # re-reading brings it into line.
+    await held_by_lcm._store.async_save({"1": {"code": "1111", "name": "Ada"}})
+    held_by_lcm._data = {}
+    assert (await held_by_lcm.async_get_usercodes())[1].readable_pin is None
+    on_the_device.service_calls["hard_refresh_codes"].clear()
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_HARD_REFRESH_USERCODES,
+        {ATTR_ENTITY_ID: LOCK_1_ENTITY_ID},
+        blocking=True,
+    )
+
+    assert (await held_by_lcm.async_get_usercodes())[1].readable_pin == "1111"
+    assert on_the_device.service_calls["hard_refresh_codes"]

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -7,6 +7,7 @@ import logging
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 from pytest_homeassistant_custom_component.typing import WebSocketGenerator
 
 from homeassistant.components.calendar import (
@@ -64,11 +65,13 @@ from custom_components.lock_code_manager.const import (
     ATTR_USER_ENTITY_ID,
     ATTR_USERCODE,
     BACKOFF_FAILURE_THRESHOLD,
+    CONF_CODELESS,
     CONF_CONDITIONS,
     CONF_CONFIG_ENTRY,
     CONF_ENABLED,
     CONF_ENTITIES,
     CONF_LOCKS,
+    CONF_MEMBERS,
     CONF_PIN,
     CONF_SLOTS,
     CONF_USERS,
@@ -677,6 +680,55 @@ async def test_subscribe_lock_codes_lock_not_found(
     msg = await ws_client.receive_json()
     assert not msg["success"]
     assert msg["error"]["code"] == "not_found"
+
+
+async def test_subscribe_lock_codes_refuses_a_lock_two_entries_disagree_about(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """
+    A lock with two credential stores behind it is not displayed arbitrarily.
+
+    One entry declares the lock codeless, so Lock Code Manager holds its
+    codes; the other declares nothing, so its platform provider does.
+    Showing either store's contents would put codes on screen that a
+    subsequent edit does not touch -- and the edit refuses for the same
+    reason, so the card would offer an action that cannot run.
+    """
+    lock_entry = er.async_get(hass).async_get(LOCK_1_ENTITY_ID)
+    for unique_id, members, user, slot in (
+        ("declaring", {lock_entry.id: {CONF_CODELESS: True}}, "Ada", 1),
+        ("plain", {}, "Bea", 2),
+    ):
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title=unique_id,
+            data={
+                CONF_LOCKS: [LOCK_1_ENTITY_ID],
+                CONF_MEMBERS: members,
+                CONF_USERS: {user: {CONF_PIN: "1234", CONF_ENABLED: True}},
+                CONF_SLOT_ASSIGNMENT: {user.casefold(): slot},
+            },
+            unique_id=unique_id,
+        )
+        entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    ws_client = await hass_ws_client(hass)
+    await ws_client.send_json(
+        {
+            "id": 1,
+            "type": "lock_code_manager/subscribe_lock_codes",
+            ATTR_LOCK_ENTITY_ID: LOCK_1_ENTITY_ID,
+        }
+    )
+
+    msg = await ws_client.receive_json()
+    assert not msg["success"]
+    assert msg["error"]["code"] == "not_supported"
+    assert "more than one" in msg["error"]["message"]
 
 
 async def test_subscribe_code_slot_state_change(

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -7,7 +7,6 @@ import logging
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from pytest_homeassistant_custom_component.common import MockConfigEntry
 from pytest_homeassistant_custom_component.typing import WebSocketGenerator
 
 from homeassistant.components.calendar import (
@@ -65,13 +64,11 @@ from custom_components.lock_code_manager.const import (
     ATTR_USER_ENTITY_ID,
     ATTR_USERCODE,
     BACKOFF_FAILURE_THRESHOLD,
-    CONF_CODELESS,
     CONF_CONDITIONS,
     CONF_CONFIG_ENTRY,
     CONF_ENABLED,
     CONF_ENTITIES,
     CONF_LOCKS,
-    CONF_MEMBERS,
     CONF_PIN,
     CONF_SLOTS,
     CONF_USERS,
@@ -680,55 +677,6 @@ async def test_subscribe_lock_codes_lock_not_found(
     msg = await ws_client.receive_json()
     assert not msg["success"]
     assert msg["error"]["code"] == "not_found"
-
-
-async def test_subscribe_lock_codes_refuses_a_lock_two_entries_disagree_about(
-    hass: HomeAssistant,
-    mock_lock_config_entry,
-    hass_ws_client: WebSocketGenerator,
-) -> None:
-    """
-    A lock with two credential stores behind it is not displayed arbitrarily.
-
-    One entry declares the lock codeless, so Lock Code Manager holds its
-    codes; the other declares nothing, so its platform provider does.
-    Showing either store's contents would put codes on screen that a
-    subsequent edit does not touch -- and the edit refuses for the same
-    reason, so the card would offer an action that cannot run.
-    """
-    lock_entry = er.async_get(hass).async_get(LOCK_1_ENTITY_ID)
-    for unique_id, members, user, slot in (
-        ("declaring", {lock_entry.id: {CONF_CODELESS: True}}, "Ada", 1),
-        ("plain", {}, "Bea", 2),
-    ):
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            title=unique_id,
-            data={
-                CONF_LOCKS: [LOCK_1_ENTITY_ID],
-                CONF_MEMBERS: members,
-                CONF_USERS: {user: {CONF_PIN: "1234", CONF_ENABLED: True}},
-                CONF_SLOT_ASSIGNMENT: {user.casefold(): slot},
-            },
-            unique_id=unique_id,
-        )
-        entry.add_to_hass(hass)
-        assert await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
-
-    ws_client = await hass_ws_client(hass)
-    await ws_client.send_json(
-        {
-            "id": 1,
-            "type": "lock_code_manager/subscribe_lock_codes",
-            ATTR_LOCK_ENTITY_ID: LOCK_1_ENTITY_ID,
-        }
-    )
-
-    msg = await ws_client.receive_json()
-    assert not msg["success"]
-    assert msg["error"]["code"] == "not_supported"
-    assert "more than one" in msg["error"]["message"]
 
 
 async def test_subscribe_code_slot_state_change(


### PR DESCRIPTION
## Proposed change

A lock from an integration with no code support — an ESPHome lock, say — could not be added to an entry at all: dispatch keys on the platform, and Lock Code Manager never guesses a provider. It can manage those locks by holding the credentials itself, if somebody says so.

**The form now has two lock pickers.**

| | Offers | Means |
|---|---|---|
| **Locks** | The platforms dispatch resolves (`CONFIG_FLOW_PLATFORMS`) | The lock's own integration stores the codes; Lock Code Manager writes them |
| **Locks with no code storage** | Every `lock` entity except the ones a provider claims | Lock Code Manager stores the codes; nothing is written to the lock |

They are disjoint by construction — the first is integration-filtered, the second sets `exclude_entities` to the claimed locks, recomputed from the entity registry each time the form is built — so each lock is offered in exactly one field and the concept is taught where the lock is chosen, in the second field's description, rather than afterwards. Both fields merge into `CONF_LOCKS`; membership in the second is what records the declaration (`EntryConfig.is_codeless`, `declare_codeless`, keyed by `er.RegistryEntry.id`).

All three surfaces — config flow, reauth, options — render both, seeded by `_stored_selection` so a lock opens in the field that expresses what the entry already declares about it.

**Taking it back.** Move a lock to the ordinary picker, or remove it from the entry, and it stops being codeless — and the codes Lock Code Manager was holding are discarded there and then, by the flow rather than by the update listener, which an unloaded, disabled or failed entry does not have. Gated on whether another configuration still declares that member, because a dropped lock is outside what any refusal looks at.

**mqtt gets no special case.** The ordinary picker allowlists the mqtt *platform* (dispatch there is per device, which a selector cannot express), and the codeless picker excludes what a provider actually claims — so a lock from an unrecognised bridge appears in **both**. That is expected: the user is the one who knows whether the door has a keypad. The existing unclaimed-mqtt refusal and its grandfathering still guard the ordinary field.

## Validation

Selector filters are UI-only, so `_check_lock_selection` stays as a backstop — but it is no longer how a normal user discovers the rule. One message per key, so refusals that can render together are accumulated and ones that cannot are guarded:

| Key | Refusal | Grandfathered |
|---|---|---|
| `base` | `lock_not_registered` — either field | No: an entry holding one does not load |
| `locks` | `unsupported_mqtt_lock`, else `unclaimed_lock` | Against what the entry holds in the **ordinary** field |
| `codeless_locks` | `lock_in_both_fields`, else `codeless_conflict`, else `codeless_lock_claimed` | `codeless_lock_claimed` against what any configuration already declares |

- `unclaimed_lock` replaces the setup-time dead end ("No Lock Code Manager provider claims `lock.x`") and points at the other field.
- The grandfathering splits deliberately: an unclaimed lock an old entry carries in the ordinary field must not refuse every later edit, but moving a **declared** member there is exactly the one move with no landing, so it is refused.
- `codeless_lock_claimed` is not reachable by a hand-written submission — `EntitySelector` validates its own `exclude_entities` — but it is reachable when dispatch starts claiming a lock **between** the form render and the submit (an mqtt bridge rediscovered under a recognised identifier). That is what its test does.
- `codeless_conflict` is now plain field validation: two entries still must not disagree about one device. A member a sibling declares stays selectable here so that agreeing is a selection this entry can make.

## What went away

The `codeless` and `codeless_reconsider` menu steps and their strings, the per-flow answer cache, `_codeless_candidates`, `_async_check_codeless`, the `CodelessDeclarationFlow` mixin, and the `codeless_declined` refusal — all of it existed only because the question was asked after the fact.

`_sibling_declarations` stays, with a second reason to: it is what refuses a contradiction, and what keeps a sibling's declared member offered in the codeless picker.

## How it works

- `CodelessLock` is `VirtualLock` with a different `domain` — which is both what diagnostics reports per lock and what the store key is built from, so a member's credentials stay in one place and never share a file with the virtual provider's.
- `domain.locks.resolve_member_provider_class` is what both factories call, **declaration first**: a provider added later for that platform must not silently move a member's credentials off Lock Code Manager and onto a device nobody agreed to write to. `_declared_codeless` is the picker's and the refusal's matching exception, so a member in that position is never stranded.
- Every lock a flow reads goes through `_pending_config` — the entry's configuration as this submission would leave it — so capacity and allocation size a member against the provider it is about to become.
- One lock entity resolves to one provider everywhere, so two entries holding one lock share a single `BaseLock` keyed on the entity id. Release asks after the object being given up, staying the exact inverse of the share.
- Deleting an entry takes its codeless (and virtual) members' stored codes with it, unless another entry still lists the lock.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #1484
- This PR is related to issue: #1480, #1485, #1486
- Full suite: 2340 passed, 3 skipped, 100% coverage on `custom_components`.
- 30 hand-written mutants against every new behaviour, all killed — including dropping either picker's filter, dropping the picker's declaration exception, each of the five refusals, either half of the grandfathering split, seeding both fields from the roster alone, merging only one picker into the roster, skipping the discard on either surface, dropping the discard's sibling gate, discarding what the submission keeps, reading the stored declaration instead of the pending one, and letting an entry answer for a lock it does not hold.
- `lock_not_registered` sits on `base` and its placeholder is `unregistered_locks`; the users refusals sit on the `users` field. Both so all three lock refusals can render beside each other and beside the users block.
- **Known, not fixed here:** #1491 — the store outliving a lock dropped from the roster — is fixed for a **codeless** member on every flow surface, and for entry deletion. A dropped **virtual** member still orphans its store when no update listener is registered.
- Needs a wiki page before release: "External Keypads" (the second field's description links to it), and a note on the Unsupported-Integrations page that a lock with no code storage is now covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
