### PR TITLE
feat: name the lock instead of the entry on use_credential

### DIFF
--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -689,24 +689,39 @@ async def async_setup(hass: HomeAssistant, config: Config) -> bool:
             target=call.data[ATTR_TARGET],
             config_entry_id=call.data.get("config_entry_id"),
             config_entry_title=call.data.get("config_entry_title"),
+            lock_entity_id=call.data.get(ATTR_LOCK_ENTITY_ID),
         )
 
     hass.services.async_register(
         DOMAIN,
         SERVICE_USE_CREDENTIAL,
         _use_credential,
-        schema=_entry_schema(
-            {
-                vol.Required(ATTR_CODE): vol.All(
-                    cv.string, str.strip, vol.Length(min=1)
+        schema=vol.Schema(
+            vol.All(
+                {
+                    **_ENTRY_SELECTOR,
+                    # A third way to name the entry, in the same exclusive
+                    # group: a caller that knows the lock but not which
+                    # configuration manages it hands that lookup over. Two
+                    # ways of naming one entry can disagree, so the schema
+                    # takes one and the action never has to choose.
+                    vol.Exclusive(ATTR_LOCK_ENTITY_ID, "entry"): cv.entity_domain(
+                        "lock"
+                    ),
+                    vol.Required(ATTR_CODE): vol.All(
+                        cv.string, str.strip, vol.Length(min=1)
+                    ),
+                    # Any domain, both of them: a credential is rarely entered
+                    # on a lock, and what it was used against can be a cover, an
+                    # alarm panel, or anything else the caller associates it
+                    # with. Nothing here dereferences either one.
+                    vol.Required(ATTR_SOURCE): cv.entity_id,
+                    vol.Required(ATTR_TARGET): cv.entity_id,
+                },
+                cv.has_at_least_one_key(
+                    "config_entry_id", "config_entry_title", ATTR_LOCK_ENTITY_ID
                 ),
-                # Any domain, both of them: a credential is rarely entered
-                # on a lock, and what it was used against can be a cover, an
-                # alarm panel, or anything else the caller associates it
-                # with. Nothing here dereferences either one.
-                vol.Required(ATTR_SOURCE): cv.entity_id,
-                vol.Required(ATTR_TARGET): cv.entity_id,
-            }
+            )
         ),
         # OPTIONAL, not ONLY, even though the response is the only thing
         # this produces: ONLY makes Home Assistant reject a caller that

--- a/custom_components/lock_code_manager/domain/queries.py
+++ b/custom_components/lock_code_manager/domain/queries.py
@@ -112,6 +112,33 @@ def find_config_entry_by_title(hass: HomeAssistant, title: str) -> ConfigEntry |
     )
 
 
+def get_loaded_config_entries_for_lock(
+    hass: HomeAssistant, lock_entity_id: str
+) -> list[ConfigEntry]:
+    """
+    Get every loaded LCM entry that holds a lock as a member.
+
+    Plural on purpose: one lock can be managed by several Lock Code Manager
+    configurations, so a caller that names the lock rather than an entry is
+    asking about all of them and has to decide between the answers itself.
+
+    Raises rather than returning nothing, the way its by-identifier sibling
+    does. Naming a lock no configuration manages is the same class of
+    mistake as naming an entry that does not exist, and an empty list would
+    let a typo in an automation read as a perfectly ordinary "no".
+    """
+    config_entries = [
+        entry
+        for entry in iter_loaded_lcm_entries(hass)
+        if get_entry_config(entry).has_lock(lock_entity_id)
+    ]
+    if not config_entries:
+        raise ServiceValidationError(
+            f"No loaded lock code manager config entry manages `{lock_entity_id}`"
+        )
+    return config_entries
+
+
 def get_loaded_config_entry(
     hass: HomeAssistant,
     config_entry_id: str | None = None,

--- a/custom_components/lock_code_manager/domain/services.py
+++ b/custom_components/lock_code_manager/domain/services.py
@@ -13,6 +13,7 @@ from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import entity_registry as er
 
 from ..const import (
+    ATTR_CONFIG_ENTRY_ID,
     ATTR_REASON,
     ATTR_USER,
     ATTR_VALID,
@@ -28,8 +29,12 @@ from .events import (
 )
 from .locks import get_managed_lock
 from .names import identity, name_error, normalize_name
-from .queries import get_entry_config, get_loaded_config_entry
-from .validation import validate_credential
+from .queries import (
+    get_entry_config,
+    get_loaded_config_entries_for_lock,
+    get_loaded_config_entry,
+)
+from .validation import validate_across_entries
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -105,6 +110,7 @@ async def async_use_credential(
     target: str,
     config_entry_id: str | None = None,
     config_entry_title: str | None = None,
+    lock_entity_id: str | None = None,
 ) -> dict[str, Any]:
     """
     Report a credential use to one entry, and answer whether it was valid.
@@ -118,16 +124,32 @@ async def async_use_credential(
     so an automation that wants to react to a rejection does so from the
     response rather than from an event anyone else could see.
 
-    The entry is the target rather than a lock because an entry's users are
-    what a code is checked against, and a code that no lock has ever been
-    programmed with still has an answer here.
-    """
-    config_entry = get_loaded_config_entry(hass, config_entry_id, config_entry_title)
-    result = validate_credential(config_entry, code)
+    An entry's users are what a code is checked against, so the answer always
+    comes from an entry -- and a code that no lock has ever been programmed
+    with still has one. The caller names that entry one of three ways, and
+    ``lock_entity_id`` is there for the one that cannot name it at all: a
+    keypad calling this action directly knows its own entities and nothing
+    about which configuration holds the credentials. Naming the lock hands
+    that lookup over, and the entry it resolved comes back in the response.
 
-    # ``user`` is set exactly when the credential validated; reading it
-    # rather than ``valid`` is also what tells the type checker it is there.
-    if result.user is not None:
+    ``lock_entity_id`` is not ``target``. The lock a credential is kept on
+    and the thing a credential was used against are routinely different --
+    the documented garage recipe targets a cover, which is a member of
+    nothing -- so the entry cannot be recovered from the attribution fields.
+    """
+    config_entries = (
+        get_loaded_config_entries_for_lock(hass, lock_entity_id)
+        if lock_entity_id is not None
+        else [get_loaded_config_entry(hass, config_entry_id, config_entry_title)]
+    )
+    # One code path for both, so a caller that named the entry and one that
+    # named its lock cannot get different answers about the same entry.
+    config_entry, result = validate_across_entries(config_entries, code)
+
+    # The entry and the user are set together, exactly when the credential
+    # validated; reading them rather than ``valid`` is also what tells the
+    # type checker they are there.
+    if config_entry is not None and (user := result.user) is not None:
         # One event, whatever the target is. The entry's per-slot event
         # entity reads this off the bus and records every use it names, so
         # nothing here has to know what a target is or whether Lock Code
@@ -139,7 +161,7 @@ async def async_use_credential(
         async_fire_credential_used(
             hass,
             config_entry,
-            name=result.user,
+            name=user,
             source=source,
             target=target,
             # A PIN is what this action validates against.
@@ -154,6 +176,11 @@ async def async_use_credential(
         ATTR_VALID: result.valid,
         ATTR_USER: result.user,
         ATTR_REASON: result.reason,
+        # Set exactly when ``user`` is, and by the same rule: it names the
+        # entry the credential is valid in. A rejection has no such entry --
+        # every candidate turned it down -- so naming one of them would claim
+        # a credential lives somewhere it does not.
+        ATTR_CONFIG_ENTRY_ID: config_entry.entry_id if config_entry else None,
     }
 
 

--- a/custom_components/lock_code_manager/domain/validation.py
+++ b/custom_components/lock_code_manager/domain/validation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 
 from homeassistant.const import CONF_CONDITION
@@ -90,3 +91,53 @@ def validate_credential(
 
     name = get_entry_config(config_entry).name_for(active.slot_num)
     return ValidationResult(valid=True, user=name, reason=None)
+
+
+@callback
+def validate_across_entries(
+    config_entries: Sequence[LockCodeManagerConfigEntry], code: str
+) -> tuple[LockCodeManagerConfigEntry | None, ValidationResult]:
+    """
+    Validate ``code`` against several entries, and say which one answered.
+
+    For a caller that named a lock rather than an entry: several entries can
+    manage one lock, and the credential belongs to whichever of them accepts
+    it. The entry is returned alongside the verdict so the caller can report
+    where the answer came from, and so the use is recorded against the
+    configuration that owns the user rather than against a neighbour.
+
+    One submission gets one verdict however many entries are asked. The
+    first entry the credential is valid in wins; two entries that both
+    accept a code are equally correct answers, so the rule only has to be
+    stable, and the caller's order -- Home Assistant's own entry order --
+    is what every other cross-entry pass here already walks.
+
+    When no entry accepts it there is no entry to name. The reasons are
+    aggregated by the same precedence each entry applies among its own
+    slots, most restrictive winning, so a credential that is merely waiting
+    on a condition in one configuration is not reported as waiting when
+    another has turned it off outright.
+
+    Every entry is asked before anything acts on an answer. ``validate_credential``
+    is a pure query, so nothing can change between deciding and acting, and
+    the caller cannot announce a use against an entry that was only ever a
+    candidate.
+
+    At least one entry is required: with none there is neither a verdict to
+    give nor a reason to give it. Callers resolve the candidates first and
+    refuse an empty set there, where they can say what the caller named.
+    """
+    results = [
+        (config_entry, validate_credential(config_entry, code))
+        for config_entry in config_entries
+    ]
+    if matched := next((pair for pair in results if pair[1].valid), None):
+        return matched
+
+    reason = max(
+        # Every result here is a failure, so every reason is set; the filter
+        # is what says so to the type checker.
+        (result.reason for _, result in results if result.reason is not None),
+        key=REASON_PRECEDENCE.index,
+    )
+    return None, ValidationResult(valid=False, user=None, reason=reason)

--- a/custom_components/lock_code_manager/services.yaml
+++ b/custom_components/lock_code_manager/services.yaml
@@ -157,6 +157,10 @@ use_credential:
     config_entry_title:
       selector:
         text:
+    lock_entity_id:
+      selector:
+        entity:
+          domain: lock
     code:
       required: true
       selector:

--- a/custom_components/lock_code_manager/strings.json
+++ b/custom_components/lock_code_manager/strings.json
@@ -306,7 +306,7 @@
     },
     "use_credential": {
       "name": "Use credential",
-      "description": "Report that a credential was used, for the keypads and door controllers Lock Code Manager cannot watch itself. The response says whether the code would work, for which user, and the reason when it would not. A valid code fires the Lock Code Manager credential used event; an invalid one fires nothing, so react to a rejection from the response. It touches no lock and changes nothing. It performs no rate limiting and no logging, and the reason tells a real credential that is merely inactive apart from one that is unknown, so do not expose it to untrusted input.",
+      "description": "Report that a credential was used, for the keypads and door controllers Lock Code Manager cannot watch itself. The response says whether the code would work, for which user, the reason when it would not, and which Lock Code Manager configuration answered. A valid code fires the Lock Code Manager credential used event; an invalid one fires nothing, so react to a rejection from the response. It touches no lock and changes nothing. It performs no rate limiting and no logging, and the reason tells a real credential that is merely inactive apart from one that is unknown, so do not expose it to untrusted input.",
       "fields": {
         "config_entry_id": {
           "name": "Config entry",
@@ -314,7 +314,11 @@
         },
         "config_entry_title": {
           "name": "Config entry title",
-          "description": "The Lock Code Manager entry, named by its title instead of its ID. Matched ignoring case and punctuation. Use this or the config entry, not both."
+          "description": "The Lock Code Manager entry, named by its title instead of its ID. Matched ignoring case and punctuation. Supply exactly one of the config entry, the config entry title, or the lock."
+        },
+        "lock_entity_id": {
+          "name": "Lock",
+          "description": "A lock, named instead of the entry: Lock Code Manager works out which of its configurations manages that lock and checks the code against them, and the response names the one the code is valid in. For a caller that knows the lock but not the configuration — a keypad calling this action directly, for one. Supply exactly one of the config entry, the config entry title, or the lock. If several configurations manage the lock, the one the code is valid in answers, and if two of them accept it the one Home Assistant lists first does; if none accepts it, the response names no configuration and reports the most restrictive reason. Not the same as the target: the lock the credential is kept on is often not what it was used against."
         },
         "code": {
           "name": "Code",

--- a/custom_components/lock_code_manager/translations/en.json
+++ b/custom_components/lock_code_manager/translations/en.json
@@ -306,7 +306,7 @@
     },
     "use_credential": {
       "name": "Use credential",
-      "description": "Report that a credential was used, for the keypads and door controllers Lock Code Manager cannot watch itself. The response says whether the code would work, for which user, and the reason when it would not. A valid code fires the Lock Code Manager credential used event; an invalid one fires nothing, so react to a rejection from the response. It touches no lock and changes nothing. It performs no rate limiting and no logging, and the reason tells a real credential that is merely inactive apart from one that is unknown, so do not expose it to untrusted input.",
+      "description": "Report that a credential was used, for the keypads and door controllers Lock Code Manager cannot watch itself. The response says whether the code would work, for which user, the reason when it would not, and which Lock Code Manager configuration answered. A valid code fires the Lock Code Manager credential used event; an invalid one fires nothing, so react to a rejection from the response. It touches no lock and changes nothing. It performs no rate limiting and no logging, and the reason tells a real credential that is merely inactive apart from one that is unknown, so do not expose it to untrusted input.",
       "fields": {
         "config_entry_id": {
           "name": "Config entry",
@@ -314,7 +314,11 @@
         },
         "config_entry_title": {
           "name": "Config entry title",
-          "description": "The Lock Code Manager entry, named by its title instead of its ID. Matched ignoring case and punctuation. Use this or the config entry, not both."
+          "description": "The Lock Code Manager entry, named by its title instead of its ID. Matched ignoring case and punctuation. Supply exactly one of the config entry, the config entry title, or the lock."
+        },
+        "lock_entity_id": {
+          "name": "Lock",
+          "description": "A lock, named instead of the entry: Lock Code Manager works out which of its configurations manages that lock and checks the code against them, and the response names the one the code is valid in. For a caller that knows the lock but not the configuration — a keypad calling this action directly, for one. Supply exactly one of the config entry, the config entry title, or the lock. If several configurations manage the lock, the one the code is valid in answers, and if two of them accept it the one Home Assistant lists first does; if none accepts it, the response names no configuration and reports the most restrictive reason. Not the same as the target: the lock the credential is kept on is often not what it was used against."
         },
         "code": {
           "name": "Code",

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1303,7 +1303,12 @@ async def test_use_credential_valid(hass: HomeAssistant, validate_entry) -> None
         hass,
         {"config_entry_id": validate_entry.entry_id, ATTR_CODE: "1234"},
     )
-    assert response == {ATTR_VALID: True, ATTR_USER: "alice", ATTR_REASON: None}
+    assert response == {
+        ATTR_VALID: True,
+        ATTR_USER: "alice",
+        ATTR_REASON: None,
+        ATTR_CONFIG_ENTRY_ID: validate_entry.entry_id,
+    }
 
 
 async def test_use_credential_valid_by_title(
@@ -1314,7 +1319,12 @@ async def test_use_credential_valid_by_title(
         hass,
         {"config_entry_title": validate_entry.title, ATTR_CODE: "1234"},
     )
-    assert response == {ATTR_VALID: True, ATTR_USER: "alice", ATTR_REASON: None}
+    assert response == {
+        ATTR_VALID: True,
+        ATTR_USER: "alice",
+        ATTR_REASON: None,
+        ATTR_CONFIG_ENTRY_ID: validate_entry.entry_id,
+    }
 
 
 async def test_use_credential_unknown(hass: HomeAssistant, validate_entry) -> None:
@@ -1327,6 +1337,7 @@ async def test_use_credential_unknown(hass: HomeAssistant, validate_entry) -> No
         ATTR_VALID: False,
         ATTR_USER: None,
         ATTR_REASON: REASON_UNKNOWN_CODE,
+        ATTR_CONFIG_ENTRY_ID: None,
     }
 
 
@@ -1342,7 +1353,12 @@ async def test_use_credential_failure_reasons(
         hass,
         {"config_entry_id": validate_entry.entry_id, ATTR_CODE: code},
     )
-    assert response == {ATTR_VALID: False, ATTR_USER: None, ATTR_REASON: reason}
+    assert response == {
+        ATTR_VALID: False,
+        ATTR_USER: None,
+        ATTR_REASON: reason,
+        ATTR_CONFIG_ENTRY_ID: None,
+    }
 
 
 @pytest.mark.parametrize(
@@ -1411,7 +1427,12 @@ async def test_use_credential_strips_padding_at_the_schema(
         hass,
         {"config_entry_id": validate_entry.entry_id, ATTR_CODE: " 1234 "},
     )
-    assert response == {ATTR_VALID: True, ATTR_USER: "alice", ATTR_REASON: None}
+    assert response == {
+        ATTR_VALID: True,
+        ATTR_USER: "alice",
+        ATTR_REASON: None,
+        ATTR_CONFIG_ENTRY_ID: validate_entry.entry_id,
+    }
 
 
 @pytest.mark.parametrize(
@@ -1427,10 +1448,10 @@ async def test_use_credential_requires_exactly_one_entry_selector(
     hass: HomeAssistant, validate_entry, selector: dict
 ) -> None:
     """
-    The entry is named by id or by title, never both and never neither.
+    The entry is named exactly one way: by id, by title, or by its lock.
 
-    Accepting both would leave the action free to pick, and the two can
-    disagree; accepting neither has no entry to answer about.
+    Accepting two would leave the action free to pick, and they can
+    disagree; accepting none has no entry to answer about.
     """
     with pytest.raises(vol.Invalid):
         await _call_use_credential(hass, {**selector, ATTR_CODE: "1234"})
@@ -1472,6 +1493,7 @@ async def test_use_credential_on_an_entry_with_no_slots(hass: HomeAssistant) -> 
         ATTR_VALID: False,
         ATTR_USER: None,
         ATTR_REASON: REASON_UNKNOWN_CODE,
+        ATTR_CONFIG_ENTRY_ID: None,
     }
 
     await hass.config_entries.async_unload(empty_entry.entry_id)
@@ -1515,7 +1537,12 @@ async def test_use_credential_matches_a_padded_stored_pin(hass: HomeAssistant) -
 
     assert await _call_use_credential(
         hass, {"config_entry_id": entry.entry_id, ATTR_CODE: "4321"}
-    ) == {ATTR_VALID: True, ATTR_USER: "dana", ATTR_REASON: None}
+    ) == {
+        ATTR_VALID: True,
+        ATTR_USER: "dana",
+        ATTR_REASON: None,
+        ATTR_CONFIG_ENTRY_ID: entry.entry_id,
+    }
 
     # The whitespace-only slot holds no PIN, so nothing can match it -- least
     # of all a submission that is itself only padding.
@@ -1548,7 +1575,12 @@ async def test_use_credential_records_against_an_in_entry_lock(
         )
         await hass.async_block_till_done()
 
-    assert response == {ATTR_VALID: True, ATTR_USER: "alice", ATTR_REASON: None}
+    assert response == {
+        ATTR_VALID: True,
+        ATTR_USER: "alice",
+        ATTR_REASON: None,
+        ATTR_CONFIG_ENTRY_ID: validate_entry.entry_id,
+    }
     assert [event.data for event in unified] == [
         {
             ATTR_NAME: "alice",
@@ -1658,7 +1690,12 @@ async def test_use_credential_against_an_event_blind_lock_in_the_entry(
         )
         await hass.async_block_till_done()
 
-    assert response == {ATTR_VALID: True, ATTR_USER: "alice", ATTR_REASON: None}
+    assert response == {
+        ATTR_VALID: True,
+        ATTR_USER: "alice",
+        ATTR_REASON: None,
+        ATTR_CONFIG_ENTRY_ID: entry.entry_id,
+    }
     assert [event.data[ATTR_TARGET] for event in unified] == [
         EVENT_BLIND_LOCK_ENTITY_ID
     ]
@@ -1700,7 +1737,12 @@ async def test_use_credential_with_a_target_outside_the_entry(
         )
         await hass.async_block_till_done()
 
-    assert response == {ATTR_VALID: True, ATTR_USER: "alice", ATTR_REASON: None}
+    assert response == {
+        ATTR_VALID: True,
+        ATTR_USER: "alice",
+        ATTR_REASON: None,
+        ATTR_CONFIG_ENTRY_ID: validate_entry.entry_id,
+    }
     assert [event.data[ATTR_TARGET] for event in unified] == ["cover.some_other_door"]
     assert deprecated == []
     recorded = hass.states.get(VALIDATE_EVENT_ENTITY_ID)
@@ -1877,3 +1919,256 @@ async def test_a_declaration_survives_renaming_its_member(
     assert config.member(renamed) == {"placeholder": True}
     # The roster, which is keyed by entity id, is the half that goes stale.
     assert not config.has_lock(renamed.entity_id)
+
+
+SHARED_LOCK_ENTITY_ID = "lock.virtual_shared_by_two_entries"
+SHARED_CONDITION_ENTITY_ID = "input_boolean.shared_entries_gate"
+
+# Two configurations managing one lock, with the codes arranged so that every
+# cross-entry case has exactly one right answer: "1111" validates only in the
+# first, "2222" only in the second, "9999" is held back in both -- by a
+# condition in the first and by the enabled flag in the second, which is the
+# more restrictive of the two -- and "5555" validates in both.
+FIRST_SHARED_CONFIG = {
+    CONF_LOCKS: [SHARED_LOCK_ENTITY_ID],
+    CONF_SLOTS: {
+        1: {CONF_NAME: "amir", CONF_PIN: "1111", CONF_ENABLED: True},
+        2: {
+            CONF_NAME: "cleo",
+            CONF_PIN: "9999",
+            CONF_ENABLED: True,
+            CONF_CONDITION: SHARED_CONDITION_ENTITY_ID,
+        },
+        5: {CONF_NAME: "elena", CONF_PIN: "5555", CONF_ENABLED: True},
+    },
+}
+SECOND_SHARED_CONFIG = {
+    CONF_LOCKS: [SHARED_LOCK_ENTITY_ID],
+    CONF_SLOTS: {
+        3: {CONF_NAME: "bao", CONF_PIN: "2222", CONF_ENABLED: True},
+        4: {CONF_NAME: "dmitri", CONF_PIN: "9999", CONF_ENABLED: False},
+        6: {CONF_NAME: "farid", CONF_PIN: "5555", CONF_ENABLED: True},
+    },
+}
+
+
+@pytest.fixture(name="shared_lock_entries")
+async def shared_lock_entries_fixture(hass: HomeAssistant):
+    """Set up two loaded LCM entries that both manage one lock."""
+    virtual_entry = MockConfigEntry(domain="virtual")
+    virtual_entry.add_to_hass(hass)
+    lock_entity = er.async_get(hass).async_get_or_create(
+        "lock",
+        "virtual",
+        "virtual_shared_by_two_entries",
+        suggested_object_id="virtual_shared_by_two_entries",
+        config_entry=virtual_entry,
+    )
+    assert lock_entity.entity_id == SHARED_LOCK_ENTITY_ID
+    hass.states.async_set(SHARED_LOCK_ENTITY_ID, "locked")
+    hass.states.async_set(SHARED_CONDITION_ENTITY_ID, "off")
+
+    entries = []
+    for index, (title, config) in enumerate(
+        (("Shared First", FIRST_SHARED_CONFIG), ("Shared Second", SECOND_SHARED_CONFIG))
+    ):
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title=title,
+            data=config,
+            unique_id=f"test_shared_lock_{index}",
+        )
+        entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        entries.append(entry)
+    await hass.async_block_till_done()
+
+    yield entries
+
+    for entry in entries:
+        await hass.config_entries.async_unload(entry.entry_id)
+
+
+async def _call_use_credential_for_shared_lock(
+    hass: HomeAssistant, code: str
+) -> dict | None:
+    """Ask about the shared lock by naming it rather than an entry."""
+    return await _call_use_credential(
+        hass,
+        {
+            ATTR_LOCK_ENTITY_ID: SHARED_LOCK_ENTITY_ID,
+            ATTR_TARGET: SHARED_LOCK_ENTITY_ID,
+            ATTR_CODE: code,
+        },
+    )
+
+
+async def test_use_credential_resolves_the_entry_from_the_lock(
+    hass: HomeAssistant, validate_entry
+) -> None:
+    """
+    Naming the lock instead of an entry finds the entry that manages it.
+
+    The caller that needs this -- a keypad calling the action directly --
+    knows its own entities and nothing about which configuration holds the
+    credentials, so the resolved entry is reported back to it.
+    """
+    unified = async_capture_events(hass, BUS_EVENT_CREDENTIAL_USED)
+
+    response = await _call_use_credential(
+        hass, {ATTR_LOCK_ENTITY_ID: VALIDATE_LOCK_ENTITY_ID, ATTR_CODE: "1234"}
+    )
+    await hass.async_block_till_done()
+
+    assert response == {
+        ATTR_VALID: True,
+        ATTR_USER: "alice",
+        ATTR_REASON: None,
+        ATTR_CONFIG_ENTRY_ID: validate_entry.entry_id,
+    }
+    # The use was recorded against the entry it resolved, not merely reported.
+    assert [event.data[ATTR_CONFIG_ENTRY_ID] for event in unified] == [
+        validate_entry.entry_id
+    ]
+    recorded = hass.states.get(VALIDATE_EVENT_ENTITY_ID)
+    assert recorded
+    assert recorded.state != STATE_UNKNOWN
+
+
+async def test_use_credential_by_lock_picks_the_entry_the_code_works_in(
+    hass: HomeAssistant, shared_lock_entries
+) -> None:
+    """
+    With two entries on one lock, the one the code validates in answers.
+
+    The search is validated rather than guessed: an entry that merely holds
+    the lock is not an answer, so the second entry wins here even though the
+    first is asked first.
+    """
+    first, second = shared_lock_entries
+    unified = async_capture_events(hass, BUS_EVENT_CREDENTIAL_USED)
+
+    response = await _call_use_credential_for_shared_lock(hass, "2222")
+    await hass.async_block_till_done()
+
+    assert response == {
+        ATTR_VALID: True,
+        ATTR_USER: "bao",
+        ATTR_REASON: None,
+        ATTR_CONFIG_ENTRY_ID: second.entry_id,
+    }
+    assert [
+        (event.data[ATTR_NAME], event.data[ATTR_CONFIG_ENTRY_ID]) for event in unified
+    ] == [("bao", second.entry_id)]
+    # bao's entity recorded the use and nobody in the other entry did.
+    assert (
+        hass.states.get(_slot_event_entity_id(hass, second, 3)).state != STATE_UNKNOWN
+    )
+    assert hass.states.get(_slot_event_entity_id(hass, first, 1)).state == STATE_UNKNOWN
+
+
+async def test_use_credential_by_lock_aggregates_the_failure_reason(
+    hass: HomeAssistant, shared_lock_entries
+) -> None:
+    """
+    A code held back in every entry reports the most restrictive reason.
+
+    "9999" waits on a condition in the first entry and is disabled outright
+    in the second, and being disabled outranks waiting. Reporting the first
+    entry's answer would tell the caller to come back later about a
+    credential that has been turned off. No entry accepted it, so none is
+    named, and a rejection is not a use.
+    """
+    fired = async_capture_events(hass, MATCH_ALL)
+
+    response = await _call_use_credential_for_shared_lock(hass, "9999")
+    await hass.async_block_till_done()
+
+    assert response == {
+        ATTR_VALID: False,
+        ATTR_USER: None,
+        ATTR_REASON: REASON_USER_DISABLED,
+        ATTR_CONFIG_ENTRY_ID: None,
+    }
+    assert [
+        event.event_type for event in fired if event.event_type.startswith(DOMAIN)
+    ] == []
+
+
+async def test_use_credential_by_lock_answers_once_when_both_entries_accept(
+    hass: HomeAssistant, shared_lock_entries
+) -> None:
+    """
+    A code valid in both entries produces one answer and one use.
+
+    Either entry would be an equally correct answer, so the rule only has to
+    be stable: the earliest entry Home Assistant lists wins. What must not
+    happen is two of anything -- two events would make one submission spend
+    two budgets on a usage limiter, and record the same entry twice.
+    """
+    first, second = shared_lock_entries
+    unified = async_capture_events(hass, BUS_EVENT_CREDENTIAL_USED)
+
+    response = await _call_use_credential_for_shared_lock(hass, "5555")
+    await hass.async_block_till_done()
+
+    assert response == {
+        ATTR_VALID: True,
+        ATTR_USER: "elena",
+        ATTR_REASON: None,
+        ATTR_CONFIG_ENTRY_ID: first.entry_id,
+    }
+    assert [
+        (event.data[ATTR_NAME], event.data[ATTR_CONFIG_ENTRY_ID]) for event in unified
+    ] == [("elena", first.entry_id)]
+    assert hass.states.get(_slot_event_entity_id(hass, first, 5)).state != STATE_UNKNOWN
+    assert (
+        hass.states.get(_slot_event_entity_id(hass, second, 6)).state == STATE_UNKNOWN
+    )
+
+
+async def test_use_credential_rejects_a_lock_no_entry_manages(
+    hass: HomeAssistant, validate_entry
+) -> None:
+    """
+    A lock outside every configuration is refused, not answered.
+
+    Naming a lock nothing manages is the same class of mistake as naming an
+    entry that does not exist, and answering "unknown code" would let a
+    typo in an automation read as a wrong PIN forever.
+    """
+    with pytest.raises(ServiceValidationError, match="lock.not_managed_at_all"):
+        await _call_use_credential(
+            hass,
+            {ATTR_LOCK_ENTITY_ID: "lock.not_managed_at_all", ATTR_CODE: "1234"},
+        )
+
+
+@pytest.mark.parametrize(
+    "selector",
+    [
+        pytest.param(
+            {"config_entry_id": "an_id", ATTR_LOCK_ENTITY_ID: VALIDATE_LOCK_ENTITY_ID},
+            id="id_and_lock",
+        ),
+        pytest.param(
+            {
+                "config_entry_title": "a title",
+                ATTR_LOCK_ENTITY_ID: VALIDATE_LOCK_ENTITY_ID,
+            },
+            id="title_and_lock",
+        ),
+    ],
+)
+async def test_use_credential_refuses_an_entry_and_a_lock_together(
+    hass: HomeAssistant, validate_entry, selector: dict
+) -> None:
+    """
+    The lock is a third way to name the entry, not an extra filter.
+
+    Accepting both would leave the action free to pick, and the two can
+    disagree: a lock the named entry does not manage has no consistent
+    answer at all.
+    """
+    with pytest.raises(vol.Invalid):
+        await _call_use_credential(hass, {**selector, ATTR_CODE: "1234"})


### PR DESCRIPTION
## Proposed change

`use_credential` required `config_entry_id` or `config_entry_title`. A caller that knows the *lock* but not which configuration manages it had to look that up — awkward in an automation, impossible for an ESPHome keypad calling the action through `homeassistant.action`, which knows its own entities and nothing about entry titles.

**New optional field `lock_entity_id`**, in the same exclusive group as the two entry selectors. The entry is named exactly one way: by id, by title, or by its lock. Supplying two is a schema error — they can disagree, and a lock the named entry does not manage has no consistent answer. Supplying none still is.

It is deliberately not `target`: the documented garage recipe targets `cover.garage_door`, which is a member of nothing, so the entry cannot be recovered from the attribution fields.

**Resolution is validated, not guessed.** Every loaded entry holding the lock is asked, and the one the code is valid in answers. Two that both accept it are equally correct, so the tie-break only has to be stable: the earliest in Home Assistant's entry order wins. When none accepts it, the reasons aggregate by the precedence each entry already applies among its own slots (most restrictive wins) and no entry is named.

This reintroduces the cross-entry search deleted in `0335b823`, and with it the **compute-then-fire** pass: every candidate is validated before anything acts on an answer, so one submission can never announce a use against an entry that was only ever a candidate. `validate_credential` is already a pure query, so nothing can change between deciding and acting.

**Response gains `config_entry_id`**, set exactly when `user` is and by the same rule — it names the entry the credential is valid in, and a rejection has none. `valid` / `user` / `reason` are unchanged.

Both addressing modes run the same code path, so a caller that names the entry and one that names its lock cannot get different answers about the same entry.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

Tests cover resolution in the only entry; valid only in the second of two sharing a lock; valid in neither (reason aggregation across entries); a lock no entry manages; neither addressing mode; entry-and-lock together; and exactly one event when both entries accept. Each was run against a mutation of the line it guards.

Full suite: 2287 passed, 3 skipped, 100% coverage on `custom_components`.

The wiki's External Keypads page needs a follow-up pass to document the new field, the resolution rule, and the new response key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)