### PR TITLE
refactor: name the use_credential member field for the question it asks

### DIFF
--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -68,6 +68,7 @@ from .const import (
     ATTR_CODE_SLOT,
     ATTR_LENGTH,
     ATTR_LOCK_ENTITY_ID,
+    ATTR_MEMBER_ENTITY_ID,
     ATTR_SLOT,
     ATTR_SOURCE,
     ATTR_TARGET,
@@ -689,7 +690,7 @@ async def async_setup(hass: HomeAssistant, config: Config) -> bool:
             target=call.data[ATTR_TARGET],
             config_entry_id=call.data.get("config_entry_id"),
             config_entry_title=call.data.get("config_entry_title"),
-            lock_entity_id=call.data.get(ATTR_LOCK_ENTITY_ID),
+            member_entity_id=call.data.get(ATTR_MEMBER_ENTITY_ID),
         )
 
     hass.services.async_register(
@@ -701,11 +702,15 @@ async def async_setup(hass: HomeAssistant, config: Config) -> bool:
                 {
                     **_ENTRY_SELECTOR,
                     # A third way to name the entry, in the same exclusive
-                    # group: a caller that knows the lock but not which
-                    # configuration manages it hands that lookup over. Two
+                    # group: a caller that knows the member but not which
+                    # configuration holds it hands that lookup over. Two
                     # ways of naming one entry can disagree, so the schema
                     # takes one and the action never has to choose.
-                    vol.Exclusive(ATTR_LOCK_ENTITY_ID, "entry"): cv.entity_domain(
+                    #
+                    # Every member is a lock today, so the domain stays
+                    # pinned; the field is named for the question it asks
+                    # rather than for what happens to answer it now.
+                    vol.Exclusive(ATTR_MEMBER_ENTITY_ID, "entry"): cv.entity_domain(
                         "lock"
                     ),
                     vol.Required(ATTR_CODE): vol.All(
@@ -719,7 +724,7 @@ async def async_setup(hass: HomeAssistant, config: Config) -> bool:
                     vol.Required(ATTR_TARGET): cv.entity_id,
                 },
                 cv.has_at_least_one_key(
-                    "config_entry_id", "config_entry_title", ATTR_LOCK_ENTITY_ID
+                    "config_entry_id", "config_entry_title", ATTR_MEMBER_ENTITY_ID
                 ),
             )
         ),

--- a/custom_components/lock_code_manager/const.py
+++ b/custom_components/lock_code_manager/const.py
@@ -63,6 +63,12 @@ ATTR_CODE_LENGTH = "code_length"
 ATTR_CONFIGURED_CODE = "configured_code"
 ATTR_CONFIGURED_CODE_LENGTH = "configured_code_length"
 ATTR_LOCK_ENTITY_ID = "lock_entity_id"
+# Deliberately not ATTR_LOCK_ENTITY_ID: that one names a lock being operated
+# on -- a device a code is written to or read from -- while this one names a
+# member whose configuration should answer a question about a credential.
+# The two happen to accept the same entities today and stop being the same
+# question the moment a member is something other than a lock.
+ATTR_MEMBER_ENTITY_ID = "member_entity_id"
 ATTR_LOCK_NAME = "lock_name"
 ATTR_PIN_LENGTH = "pin_length"
 ATTR_LENGTH = "length"

--- a/custom_components/lock_code_manager/domain/services.py
+++ b/custom_components/lock_code_manager/domain/services.py
@@ -110,7 +110,7 @@ async def async_use_credential(
     target: str,
     config_entry_id: str | None = None,
     config_entry_title: str | None = None,
-    lock_entity_id: str | None = None,
+    member_entity_id: str | None = None,
 ) -> dict[str, Any]:
     """
     Report a credential use to one entry, and answer whether it was valid.
@@ -127,23 +127,25 @@ async def async_use_credential(
     An entry's users are what a code is checked against, so the answer always
     comes from an entry -- and a code that no lock has ever been programmed
     with still has one. The caller names that entry one of three ways, and
-    ``lock_entity_id`` is there for the one that cannot name it at all: a
+    ``member_entity_id`` is there for the one that cannot name it at all: a
     keypad calling this action directly knows its own entities and nothing
-    about which configuration holds the credentials. Naming the lock hands
-    that lookup over, and the entry it resolved comes back in the response.
+    about which configuration holds the credentials. Naming a member of that
+    configuration hands the lookup over, and the entry it resolved comes back
+    in the response. Every member is a lock today, which is what the schema
+    accepts; the parameter is named for the question rather than for that.
 
-    ``lock_entity_id`` is not ``target``. The lock a credential is kept on
-    and the thing a credential was used against are routinely different --
+    ``member_entity_id`` is not ``target``. The member a credential is kept
+    on and the thing a credential was used against are routinely different --
     the documented garage recipe targets a cover, which is a member of
     nothing -- so the entry cannot be recovered from the attribution fields.
     """
     config_entries = (
-        get_loaded_config_entries_for_lock(hass, lock_entity_id)
-        if lock_entity_id is not None
+        get_loaded_config_entries_for_lock(hass, member_entity_id)
+        if member_entity_id is not None
         else [get_loaded_config_entry(hass, config_entry_id, config_entry_title)]
     )
     # One code path for both, so a caller that named the entry and one that
-    # named its lock cannot get different answers about the same entry.
+    # named a member of it cannot get different answers about the same entry.
     config_entry, result = validate_across_entries(config_entries, code)
 
     # The entry and the user are set together, exactly when the credential

--- a/custom_components/lock_code_manager/services.yaml
+++ b/custom_components/lock_code_manager/services.yaml
@@ -157,7 +157,7 @@ use_credential:
     config_entry_title:
       selector:
         text:
-    lock_entity_id:
+    member_entity_id:
       selector:
         entity:
           domain: lock

--- a/custom_components/lock_code_manager/strings.json
+++ b/custom_components/lock_code_manager/strings.json
@@ -314,11 +314,11 @@
         },
         "config_entry_title": {
           "name": "Config entry title",
-          "description": "The Lock Code Manager entry, named by its title instead of its ID. Matched ignoring case and punctuation. Supply exactly one of the config entry, the config entry title, or the lock."
+          "description": "The Lock Code Manager entry, named by its title instead of its ID. Matched ignoring case and punctuation. Supply exactly one of the config entry, the config entry title, or the member."
         },
-        "lock_entity_id": {
-          "name": "Lock",
-          "description": "A lock, named instead of the entry: Lock Code Manager works out which of its configurations manages that lock and checks the code against them, and the response names the one the code is valid in. For a caller that knows the lock but not the configuration — a keypad calling this action directly, for one. Supply exactly one of the config entry, the config entry title, or the lock. If several configurations manage the lock, the one the code is valid in answers, and if two of them accept it the one Home Assistant lists first does; if none accepts it, the response names no configuration and reports the most restrictive reason. Not the same as the target: the lock the credential is kept on is often not what it was used against."
+        "member_entity_id": {
+          "name": "Member",
+          "description": "A member of a Lock Code Manager configuration — a lock, today — named instead of the entry: Lock Code Manager works out which of its configurations holds that member and checks the code against them, and the response names the one the code is valid in. For a caller that knows the lock but not the configuration — a keypad calling this action directly, for one. Supply exactly one of the config entry, the config entry title, or the member. If several configurations hold the member, the one the code is valid in answers, and if two of them accept it the one Home Assistant lists first does; if none accepts it, the response names no configuration and reports the most restrictive reason. Not the same as the target: the member the credential is kept on is often not what it was used against."
         },
         "code": {
           "name": "Code",

--- a/custom_components/lock_code_manager/translations/en.json
+++ b/custom_components/lock_code_manager/translations/en.json
@@ -314,11 +314,11 @@
         },
         "config_entry_title": {
           "name": "Config entry title",
-          "description": "The Lock Code Manager entry, named by its title instead of its ID. Matched ignoring case and punctuation. Supply exactly one of the config entry, the config entry title, or the lock."
+          "description": "The Lock Code Manager entry, named by its title instead of its ID. Matched ignoring case and punctuation. Supply exactly one of the config entry, the config entry title, or the member."
         },
-        "lock_entity_id": {
-          "name": "Lock",
-          "description": "A lock, named instead of the entry: Lock Code Manager works out which of its configurations manages that lock and checks the code against them, and the response names the one the code is valid in. For a caller that knows the lock but not the configuration — a keypad calling this action directly, for one. Supply exactly one of the config entry, the config entry title, or the lock. If several configurations manage the lock, the one the code is valid in answers, and if two of them accept it the one Home Assistant lists first does; if none accepts it, the response names no configuration and reports the most restrictive reason. Not the same as the target: the lock the credential is kept on is often not what it was used against."
+        "member_entity_id": {
+          "name": "Member",
+          "description": "A member of a Lock Code Manager configuration — a lock, today — named instead of the entry: Lock Code Manager works out which of its configurations holds that member and checks the code against them, and the response names the one the code is valid in. For a caller that knows the lock but not the configuration — a keypad calling this action directly, for one. Supply exactly one of the config entry, the config entry title, or the member. If several configurations hold the member, the one the code is valid in answers, and if two of them accept it the one Home Assistant lists first does; if none accepts it, the response names no configuration and reports the most restrictive reason. Not the same as the target: the member the credential is kept on is often not what it was used against."
         },
         "code": {
           "name": "Code",

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -42,6 +42,7 @@ from custom_components.lock_code_manager.const import (
     ATTR_CREDENTIAL_TYPE,
     ATTR_LENGTH,
     ATTR_LOCK_ENTITY_ID,
+    ATTR_MEMBER_ENTITY_ID,
     ATTR_OPERATION,
     ATTR_REASON,
     ATTR_SLOT,
@@ -1996,7 +1997,7 @@ async def _call_use_credential_for_shared_lock(
     return await _call_use_credential(
         hass,
         {
-            ATTR_LOCK_ENTITY_ID: SHARED_LOCK_ENTITY_ID,
+            ATTR_MEMBER_ENTITY_ID: SHARED_LOCK_ENTITY_ID,
             ATTR_TARGET: SHARED_LOCK_ENTITY_ID,
             ATTR_CODE: code,
         },
@@ -2016,7 +2017,7 @@ async def test_use_credential_resolves_the_entry_from_the_lock(
     unified = async_capture_events(hass, BUS_EVENT_CREDENTIAL_USED)
 
     response = await _call_use_credential(
-        hass, {ATTR_LOCK_ENTITY_ID: VALIDATE_LOCK_ENTITY_ID, ATTR_CODE: "1234"}
+        hass, {ATTR_MEMBER_ENTITY_ID: VALIDATE_LOCK_ENTITY_ID, ATTR_CODE: "1234"}
     )
     await hass.async_block_till_done()
 
@@ -2140,7 +2141,7 @@ async def test_use_credential_rejects_a_lock_no_entry_manages(
     with pytest.raises(ServiceValidationError, match="lock.not_managed_at_all"):
         await _call_use_credential(
             hass,
-            {ATTR_LOCK_ENTITY_ID: "lock.not_managed_at_all", ATTR_CODE: "1234"},
+            {ATTR_MEMBER_ENTITY_ID: "lock.not_managed_at_all", ATTR_CODE: "1234"},
         )
 
 
@@ -2148,15 +2149,18 @@ async def test_use_credential_rejects_a_lock_no_entry_manages(
     "selector",
     [
         pytest.param(
-            {"config_entry_id": "an_id", ATTR_LOCK_ENTITY_ID: VALIDATE_LOCK_ENTITY_ID},
-            id="id_and_lock",
+            {
+                "config_entry_id": "an_id",
+                ATTR_MEMBER_ENTITY_ID: VALIDATE_LOCK_ENTITY_ID,
+            },
+            id="id_and_member",
         ),
         pytest.param(
             {
                 "config_entry_title": "a title",
-                ATTR_LOCK_ENTITY_ID: VALIDATE_LOCK_ENTITY_ID,
+                ATTR_MEMBER_ENTITY_ID: VALIDATE_LOCK_ENTITY_ID,
             },
-            id="title_and_lock",
+            id="title_and_member",
         ),
     ],
 )


### PR DESCRIPTION
## Proposed change

Rename `use_credential`'s `lock_entity_id` field to `member_entity_id`.

That field names the member whose configuration should answer — a credential-store question, not a lock-operation one. Every member happens to be a lock today, but that is a fact about today, not about the field; a later phase of #1480 ends it, and by then the name would be wrong on a released field.

**Why now:** the field arrived in #1492, which is merged to `feature/credential-store-model` but has never shipped. Renaming it here costs nothing. Renaming it after a release would need a deprecation window.

**The released lock-named fields are deliberately untouched.** `ATTR_LOCK_ENTITY_ID` is shared with `set_usercode`, `clear_usercode` and `hard_refresh_usercodes`, which are long released and genuinely do mean a lock being operated on — they write codes to a device. Those keep `lock_entity_id` and keep using that constant, so this adds a new `ATTR_MEMBER_ENTITY_ID` rather than renaming the shared one.

The selector stays pinned to `domain: lock`. Widening what a member may be belongs with the wider rename in #1480, not here.

No behaviour change: the existing entity-resolution tests pass with only the field name updated.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue: #1480

🤖 Generated with [Claude Code](https://claude.com/claude-code)