### PR TITLE
fix: give the PIN field a validator the frontend can serialize

### DIFF
--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -506,7 +506,7 @@ async def async_setup(hass: HomeAssistant, config: Config) -> bool:
                     vol.Coerce(int), vol.Range(min=1)
                 ),
                 vol.Required(ATTR_USERCODE): vol.All(
-                    cv.string, str.strip, vol.Length(min=1)
+                    cv.string, vol.Strip, vol.Length(min=1)
                 ),
             }
         ),
@@ -604,7 +604,7 @@ async def async_setup(hass: HomeAssistant, config: Config) -> bool:
                 # Stripped here as the config flow strips its own field: a
                 # submitted code is stripped before it is matched, so a PIN
                 # stored with padding matches nothing anybody can type.
-                vol.Optional(CONF_PIN): vol.All(cv.string, str.strip),
+                vol.Optional(CONF_PIN): vol.All(cv.string, vol.Strip),
                 vol.Optional(CONF_ENABLED, default=True): cv.boolean,
                 vol.Optional(CONF_CONDITION): cv.entity_domain(
                     CONDITION_ENTITY_DOMAINS
@@ -698,7 +698,7 @@ async def async_setup(hass: HomeAssistant, config: Config) -> bool:
         schema=_entry_schema(
             {
                 vol.Required(ATTR_CODE): vol.All(
-                    cv.string, str.strip, vol.Length(min=1)
+                    cv.string, vol.Strip, vol.Length(min=1)
                 ),
                 # Any domain, both of them: a credential is rarely entered
                 # on a lock, and what it was used against can be a cover, an

--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -48,7 +48,10 @@ _LOGGER = logging.getLogger(__name__)
 # compares a submitted code stripped, so a PIN stored with padding is one
 # nothing anybody can type will ever match. Not vol.Length(min=1) -- an
 # empty PIN is how a user without one is expressed.
-STRIPPED_PIN = vol.All(cv.string, str.strip)
+# vol.Strip rather than str.strip because this schema is also rendered: a
+# form is serialized for the frontend, and a bare callable has no JSON form
+# to serialize into.
+STRIPPED_PIN = vol.All(cv.string, vol.Strip)
 
 CODE_SLOT_SCHEMA = vol.Schema(
     {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import AsyncGenerator, Generator
+from contextlib import ExitStack
 from datetime import timedelta
 import os
 from typing import Any
@@ -19,6 +20,7 @@ from pytest_homeassistant_custom_component.common import (
     mock_integration,
     mock_platform,
 )
+import voluptuous_serialize
 
 from homeassistant.components.calendar import DOMAIN as CALENDAR_DOMAIN
 from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
@@ -26,10 +28,13 @@ from homeassistant.components.lovelace import DOMAIN as LL_DOMAIN
 from homeassistant.config_entries import ConfigEntry, ConfigFlow
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowHandler
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
+from custom_components.lock_code_manager import config_flow, repairs
 from custom_components.lock_code_manager.const import DOMAIN
 from custom_components.lock_code_manager.domain.models import SyncState
 from custom_components.lock_code_manager.providers import INTEGRATIONS_CLASS_MAP
@@ -71,6 +76,60 @@ def auto_setup_mock_lock():
         "custom_components.lock_code_manager.providers.INTEGRATIONS_CLASS_MAP",
         {"test": MockLCMLock, **INTEGRATIONS_CLASS_MAP},
     ):
+        yield
+
+
+def _flow_classes() -> list[type[FlowHandler]]:
+    """
+    Every flow this integration defines.
+
+    Discovered rather than listed so a flow added later is covered the day
+    it is written -- an unguarded flow is exactly the gap this checks for.
+    """
+    return [
+        obj
+        for module in (config_flow, repairs)
+        for obj in vars(module).values()
+        if isinstance(obj, type)
+        and issubclass(obj, FlowHandler)
+        and obj.__module__ == module.__name__
+    ]
+
+
+@pytest.fixture(autouse=True)
+def assert_flow_forms_serialize() -> Generator[None]:
+    """
+    Convert every form a flow shows the way the HTTP layer will.
+
+    A flow driven through ``async_configure`` gets the schema object back
+    untouched, so a validator the frontend has no representation for reaches
+    a real browser as an unknown error and never a failing test. Converting
+    here makes every test that shows a form the test that catches it.
+    """
+
+    def checked(cls: type[FlowHandler]) -> Any:
+        """
+        Wrap one class's own ``async_show_form``.
+
+        Resolved per class rather than once: these classes inherit different
+        implementations, and each uses a zero-argument ``super()`` bound to
+        the class that defines it.
+        """
+        original = cls.async_show_form
+
+        def _converted(self, **kwargs: Any):
+            result = original(self, **kwargs)
+            if schema := result.get("data_schema"):
+                voluptuous_serialize.convert(
+                    schema, custom_serializer=cv.custom_serializer
+                )
+            return result
+
+        return patch.object(cls, "async_show_form", _converted)
+
+    with ExitStack() as stack:
+        for cls in _flow_classes():
+            stack.enter_context(checked(cls))
         yield
 
 


### PR DESCRIPTION
## Proposed change

A fresh install could not get past the code slot step. Naming the entry, picking locks, and leaving the user count at its default all worked; the next form never rendered, and the UI said only "Unknown error has occurred".

`CODE_SLOT_SCHEMA` stripped its PIN with `str.strip`. Every schema handed to `async_show_form` is walked by `voluptuous_serialize.convert()` in `helpers/data_entry_flow.py` on its way to the browser, and that converter handles voluptuous's own vocabulary — `vol.All`, `vol.Range`, `vol.Length`, selectors, and the transformers `vol.Strip`/`vol.Lower`/`vol.Upper`/`vol.Title` — not arbitrary callables. A bare `str.strip` has no JSON representation, so the conversion raised and took the whole form with it.

`vol.Strip` strips identically (`str(v).strip()`, and `cv.string` runs first) and serializes to `{"strip": true}`. The field's behavior is unchanged; it can now be rendered.

### Why the tests missed it

The flow tests drove that step and passed. A flow driven through `hass.config_entries.flow.async_configure()` gets the schema object handed straight back — only the HTTP layer serializes it, so nothing in the suite crossed the boundary every browser crosses.

`tests/conftest.py` gains an autouse fixture that converts every form the integration's flows show, using the same serializer the HTTP layer uses. It made 23 already-existing tests fail on this bug without a single new assertion being written, and passes with the fix. It discovers flow classes across `config_flow.py` and `repairs.py` rather than listing them, so a flow added later is covered the day it is written — an unguarded flow being exactly the gap this checks for. The wrapper resolves `async_show_form` per class deliberately: `ConfigFlow` overrides it with a zero-argument `super()` bound to `ConfigFlow`, so one class's bound method cannot be reused on `OptionsFlow`.

### Service schemas

The same spelling appeared in the `set_usercode`, `add_user`, and `use_credential` schemas. Those cannot fail this way — Home Assistant never runs `voluptuous_serialize` over service schemas; the frontend reads `services.yaml`. They are switched anyway so there is one spelling of "strip a string in a schema" and the pattern that caused this is gone.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #1495
- This PR is related to issue:

Verified against Home Assistant 2026.8.3, the version in the report:

- Reproduced the reported `ValueError: Unable to convert schema: <method 'strip' of 'str' objects>` before the change.
- Mutation check: reverting `vol.Strip` to `str.strip` fails 23 tests with that exact error; restoring it passes.
- Confirmed the field still strips (`'  1234  '` → `'1234'`) and the serialized form carries `"strip": true`.
- Full suite: 2243 passed, 3 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)