### PR TITLE
fix: release a lock's credential store when reauth swaps it out

### DIFF
--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -930,6 +930,45 @@ async def async_unload_lock(
                 await lock.coordinator.async_shutdown()
 
 
+async def async_release_locks(
+    hass: HomeAssistant,
+    config_entry: LockCodeManagerConfigEntry,
+    lock_entity_ids: Iterable[str],
+) -> None:
+    """
+    Take locks out of an entry for good.
+
+    Everything that has to happen when a lock stops being this entry's, in one
+    place because there is more than one way for that to happen: the options
+    flow reaches it through the update listener's diff, and reauth reaches it
+    by swapping a lock out. A second copy of this would drift, and what it
+    would drop first is the repair deletion -- the step with no visible
+    symptom when it is missed.
+
+    Requires the entry to be loaded. Reauth can run against an entry that
+    failed setup, where there is no runtime data to release anything from;
+    such an entry never built lock instances, so there is nothing here to do.
+    """
+    if (runtime_data := getattr(config_entry, "runtime_data", None)) is None:
+        return
+    for lock_entity_id in lock_entity_ids:
+        runtime_data.callbacks.invoke_lock_removed_handlers(lock_entity_id)
+        if not _lock_managed_by_other_entry(hass, config_entry, lock_entity_id):
+            # A lock that never got an instance has no teardown to clear its
+            # repair, and removing it from the entry is exactly what that
+            # repair asks the user to do.
+            async_delete_issue(
+                hass, DOMAIN, per_lock_issue_id("lock_dropped", lock_entity_id)
+            )
+        # LCM no longer adds its config entry to the lock's device (its
+        # per-lock entities link to the device via ``device_entry``), so
+        # there is no config-entry association to unmerge here; the per-lock
+        # entities are torn down by ``async_unload_lock`` below.
+        await async_unload_lock(
+            hass, config_entry, lock_entity_id=lock_entity_id, remove_permanently=True
+        )
+
+
 async def async_unload_entry(
     hass: HomeAssistant, config_entry: LockCodeManagerConfigEntry
 ) -> bool:
@@ -1741,22 +1780,7 @@ async def _async_apply_entry_update(
         _LOGGER.debug(
             "%s (%s): Removing locks %s", entry_id, entry_title, locks_to_remove
         )
-    for lock_entity_id in locks_to_remove:
-        callbacks.invoke_lock_removed_handlers(lock_entity_id)
-        if not _lock_managed_by_other_entry(hass, config_entry, lock_entity_id):
-            # A lock that never got an instance has no teardown to clear its
-            # repair, and removing it from the entry is exactly what that
-            # repair asks the user to do.
-            async_delete_issue(
-                hass, DOMAIN, per_lock_issue_id("lock_dropped", lock_entity_id)
-            )
-        # LCM no longer adds its config entry to the lock's device (its
-        # per-lock entities link to the device via ``device_entry``), so
-        # there is no config-entry association to unmerge here; the per-lock
-        # entities are torn down by ``async_unload_lock`` below.
-        await async_unload_lock(
-            hass, config_entry, lock_entity_id=lock_entity_id, remove_permanently=True
-        )
+    await async_release_locks(hass, config_entry, locks_to_remove)
 
     # Create per-slot coordinators for new slots BEFORE setting up new
     # locks. _async_setup_new_locks awaits per-lock connection checks,

--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -22,6 +22,7 @@ from homeassistant.helpers import (
 )
 from homeassistant.util import slugify
 
+from . import async_release_locks
 from .const import (
     CONDITION_ENTITY_DOMAINS,
     CONF_LOCKS,
@@ -565,6 +566,20 @@ class LockCodeManagerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 # Resolved through EntryConfig, not by merging raw dicts: the
                 # two sides may be in different shapes, and a raw merge carries
                 # both, discarding the very save this block exists to consume.
+                # Released before the entry is rewritten, while the roster
+                # still names them. This does not reach the update listener
+                # the options flow relies on: the write below leaves empty
+                # options, which is the same shape the listener's own settle
+                # write leaves, so the listener returns early and its removal
+                # pass never runs. For a provider whose store IS the
+                # credentials, that left a cleartext PIN on disk for a lock
+                # no entry referenced any more.
+                dropped = [
+                    lock_entity_id
+                    for lock_entity_id in get_entry_config(config_entry).locks
+                    if lock_entity_id not in user_input[CONF_LOCKS]
+                ]
+                await async_release_locks(self.hass, config_entry, dropped)
                 self.hass.config_entries.async_update_entry(
                     config_entry,
                     data={

--- a/tests/providers/virtual/test_e2e.py
+++ b/tests/providers/virtual/test_e2e.py
@@ -17,7 +17,7 @@ from homeassistant.components.text import (
     DOMAIN as TEXT_DOMAIN,
     SERVICE_SET_VALUE,
 )
-from homeassistant.config_entries import ConfigEntryState
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     CONF_ENABLED,
@@ -26,6 +26,8 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.storage import Store
 from homeassistant.util import dt as dt_util
 
 from custom_components.lock_code_manager.const import CONF_LOCKS, CONF_SLOTS, DOMAIN
@@ -343,3 +345,52 @@ class TestCredentialUseRecording:
         state = hass.states.get(SLOT_1_PIN_ENTITY)
         assert state
         assert state.state == pin
+
+
+class TestReauthLockSwap:
+    """A lock swapped out during reauth must lose its credential store."""
+
+    async def test_reauth_swap_removes_the_dropped_locks_store(
+        self,
+        hass: HomeAssistant,
+        lcm_config_entry,
+        virtual_provider_entry,
+    ) -> None:
+        """
+        Swapping a lock out via reauth takes its stored credentials with it.
+
+        For a Virtual lock the store IS the credentials, so a store that
+        outlives every entry referencing it is a cleartext PIN left on disk.
+        Reauth writes the entry and reloads it wholesale, which is a different
+        path from the options flow's per-lock removal -- this asserts the two
+        agree about what leaving an entry means.
+        """
+        ent_reg = er.async_get(hass)
+        replacement = ent_reg.async_get_or_create(
+            "lock",
+            "virtual",
+            "test_virtual_replacement",
+            config_entry=virtual_provider_entry,
+        )
+        hass.states.async_set(replacement.entity_id, "locked")
+
+        lock = get_virtual_lock(hass, lcm_config_entry)
+        await lock.async_internal_set_usercode(1, "1234")
+
+        def _fresh_store() -> Store:
+            return Store(hass, 1, f"{lock.domain}_{DOMAIN}_{VIRTUAL_LOCK_ENTITY_ID}")
+
+        lcm_config_entry.async_start_reauth(
+            hass, context={"lock_entity_id": VIRTUAL_LOCK_ENTITY_ID}
+        )
+        await hass.async_block_till_done()
+        [flow] = lcm_config_entry.async_get_active_flows(hass, {SOURCE_REAUTH})
+
+        result = await hass.config_entries.flow.async_configure(
+            flow["flow_id"], {CONF_LOCKS: [replacement.entity_id]}
+        )
+        assert result["type"] == "abort"
+        assert result["reason"] == "locks_updated"
+        await hass.async_block_till_done()
+
+        assert await _fresh_store().async_load() is None


### PR DESCRIPTION
## Proposed change

Reauth writes the entry with `options={}` and reloads. That is the **same shape the update listener leaves when it settles**, so the listener cannot tell the two apart, hits its `if not config_entry.options: return` early return, and never runs the per-lock removal pass the options flow relies on.

A lock swapped out during reauth therefore kept everything that leaving an entry is supposed to discard: the lock-removed handlers, the `lock_dropped` repair, and the provider's stored codes. For `VirtualLock` the store **is** the credentials, so the teardown didn't merely leave the file behind — it *saved* it. A cleartext PIN survived on disk for a lock no entry referenced any more.

Confirmed on `main` before fixing:

```
assert {'1': {'code': '1234', 'name': None}} is None
```

The removal pass is now one function both callers share rather than a second copy in the flow. What a second copy drops first is the repair deletion — the one step with no visible symptom when it's missed.

**Not covered:** an entry that failed setup has no runtime data and never built lock instances, so there is nothing to release. Reauth runs against such entries routinely (it's started from `async_setup_entry` when a lock entity has vanished from the registry, before `runtime_data` is assigned), and that path returns early. A store orphaned that way is orphaned by the entity deletion itself, before reauth is involved — a separate problem.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #1491

Tests: 2244 passed, 100% coverage held. Four mutations, all killed — dropping the release call (reproduces the original bug), `remove_permanently=False`, skipping the lock-removed handlers, and skipping the repair deletion.
