### PR TITLE
fix: keep reported credential uses visible, and stop the limiter miscounting

### DIFF
--- a/blueprints/automation/lock_code_manager/slot_usage_limiter.yaml
+++ b/blueprints/automation/lock_code_manager/slot_usage_limiter.yaml
@@ -148,6 +148,15 @@ triggers:
   - trigger: state
     entity_id: !input pin_used_entity
     id: pin_used
+    # A use is a new timestamp; neither of these is one. Belt to the
+    # conditions' braces, and deliberately not removed as redundant: Home
+    # Assistant drops extra attributes from an unavailable state, so the
+    # `operation` check below rejects these only because the attribute is
+    # missing. That stops being true the day someone gives that template a
+    # `default()`, and this says the intent outright.
+    not_to:
+      - unknown
+      - unavailable
   - trigger: state
     entity_id: !input enabled_switch
     id: slot_enabled
@@ -180,7 +189,9 @@ actions:
           # `event_type` is the kind of credential and names no entity.
           - condition: template
             value_template: >-
-              {{ trigger.to_state is not none
+              {{ trigger.from_state is not none
+                 and trigger.to_state is not none
+                 and trigger.from_state.state != 'unavailable'
                  and trigger.to_state.attributes.operation
                      in counted_operations
                  and (locks | count == 0

--- a/custom_components/lock_code_manager/event.py
+++ b/custom_components/lock_code_manager/event.py
@@ -116,6 +116,28 @@ class LockCodeManagerCodeSlotEventEntity(BaseLockCodeManagerEntity, EventEntity)
         }
         return sorted(advertised | MANAGED_CREDENTIAL_TYPES | self._recorded_types)
 
+    @property
+    def available(self) -> bool:
+        """
+        Return True whenever the entry is loaded.
+
+        Deliberately not the shared per-slot rule, which asks whether any of
+        the entry's locks is reachable. A use recorded here need not have
+        come from a lock at all: ``use_credential`` carries uses this
+        integration cannot observe, and refuses nothing when every lock is
+        unreachable -- which is a likely reason to be using it.
+
+        Gating on lock reachability hid those uses twice. The entity read
+        ``unavailable`` while holding the use, and when a lock recovered the
+        use surfaced as an ``unavailable -> <timestamp>`` transition, which
+        consumers discard on purpose as lock recovery rather than a use.
+
+        What a lock being down actually means is reported by that lock's own
+        entity and by the slot's in-sync sensor, neither of which this
+        answer speaks for.
+        """
+        return True
+
     @callback
     def _credential_used_filter(self, event_data: dict[str, Any]) -> bool:
         """

--- a/tests/test_blueprint_behavior.py
+++ b/tests/test_blueprint_behavior.py
@@ -23,7 +23,7 @@ from pytest_homeassistant_custom_component.common import (
 from homeassistant.components import automation
 from homeassistant.components.blueprint import models
 from homeassistant.components.template import config as template_config
-from homeassistant.const import ATTR_FRIENDLY_NAME
+from homeassistant.const import ATTR_FRIENDLY_NAME, STATE_UNAVAILABLE
 from homeassistant.core import Event, HomeAssistant, ServiceCall, State, callback
 from homeassistant.helpers import entity_registry as er, template
 from homeassistant.setup import async_setup_component
@@ -1270,3 +1270,158 @@ async def test_credential_used_config_entry_filter(
     await hass.async_block_till_done()
 
     assert len(captured) == (1 if matches else 0)
+
+
+async def test_limiter_ignores_recovery_from_unavailable(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+) -> None:
+    """
+    Coming back from `unavailable` is not a use.
+
+    The state object still carries the LAST recorded use's attributes when
+    the entity returns, so an `operation` filter alone cannot tell a
+    recovery from a fresh use -- it reads the old use's operation and
+    passes. Nobody entered a code here, so nothing may be spent.
+    """
+    counter = await _setup_counter(hass, initial=3)
+    await _setup_blueprint_automation(
+        hass,
+        LIMITER_PATH,
+        {
+            "pin_used_entity": SLOT_1_EVENT_ENTITY,
+            "enabled_switch": SLOT_1_ENABLED_ENTITY,
+            "uses_counter": counter,
+        },
+    )
+
+    _fire_pin_used(lock_code_manager_config_entry, LOCK_1_ENTITY_ID, 1, to_locked=False)
+    await hass.async_block_till_done()
+    assert float(hass.states.get(counter).state) == 2
+
+    # Driven directly rather than through lock availability: this pins the
+    # blueprint's contract about the transition, whatever produced it.
+    recorded = hass.states.get(SLOT_1_EVENT_ENTITY)
+    hass.states.async_set(SLOT_1_EVENT_ENTITY, STATE_UNAVAILABLE)
+    await hass.async_block_till_done()
+    hass.states.async_set(
+        SLOT_1_EVENT_ENTITY, recorded.state, dict(recorded.attributes)
+    )
+    await hass.async_block_till_done()
+
+    assert float(hass.states.get(counter).state) == 2
+
+
+async def test_limiter_ignores_first_appearance(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+) -> None:
+    """
+    An entity appearing for the first time is not a use.
+
+    After a restart or a reload the entity is restored with the last use it
+    recorded, which arrives as a transition from nothing. The notifier
+    guards `from_state is None`; the limiter has to as well or every reload
+    spends a use.
+    """
+    counter = await _setup_counter(hass, initial=3)
+    await _setup_blueprint_automation(
+        hass,
+        LIMITER_PATH,
+        {
+            "pin_used_entity": SLOT_1_EVENT_ENTITY,
+            "enabled_switch": SLOT_1_ENABLED_ENTITY,
+            "uses_counter": counter,
+        },
+    )
+
+    _fire_pin_used(lock_code_manager_config_entry, LOCK_1_ENTITY_ID, 1, to_locked=False)
+    await hass.async_block_till_done()
+    recorded = hass.states.get(SLOT_1_EVENT_ENTITY)
+    assert float(hass.states.get(counter).state) == 2
+
+    hass.states.async_remove(SLOT_1_EVENT_ENTITY)
+    await hass.async_block_till_done()
+    hass.states.async_set(
+        SLOT_1_EVENT_ENTITY, recorded.state, dict(recorded.attributes)
+    )
+    await hass.async_block_till_done()
+
+    assert float(hass.states.get(counter).state) == 2
+
+
+async def test_reported_use_is_visible_while_every_lock_is_down(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+) -> None:
+    """
+    A use reported while no lock is reachable still reaches consumers.
+
+    ``use_credential`` exists for uses this integration cannot observe, and
+    it refuses nothing when the locks are unreachable -- so gating the
+    entity that carries those uses on lock reachability hides them exactly
+    when the mechanism is most likely to be in use. It hides them twice
+    over: the use arrives later as an ``unavailable -> <timestamp>``
+    transition, which consumers deliberately discard as lock recovery.
+    """
+    captured = async_mock_service(hass, "test", "captured")
+    await _setup_blueprint_automation(
+        hass,
+        NOTIFIER_PATH,
+        {
+            "event_entity": [SLOT_1_EVENT_ENTITY],
+            "notify_actions": [{"service": "test.captured", "data": {}}],
+        },
+    )
+
+    for lock_entity_id in (LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID):
+        hass.states.async_set(lock_entity_id, STATE_UNAVAILABLE)
+    await hass.async_block_till_done()
+
+    await _use_credential(hass, lock_code_manager_config_entry)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(SLOT_1_EVENT_ENTITY)
+    assert state is not None
+    assert state.state != STATE_UNAVAILABLE
+    assert len(captured) == 1
+
+
+async def test_lock_recovery_notifies_nobody(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+) -> None:
+    """
+    A lock coming back is not a use, and must reach no consumer as one.
+
+    This is the property the entity's old lock-following availability was
+    protecting, kept after that availability was removed: the guarantee is
+    now that a recovering lock produces no transition on this entity at
+    all, rather than one the blueprints have to recognise and discard.
+    """
+    captured = async_mock_service(hass, "test", "captured")
+    await _setup_blueprint_automation(
+        hass,
+        NOTIFIER_PATH,
+        {
+            "event_entity": [SLOT_1_EVENT_ENTITY],
+            "notify_actions": [{"service": "test.captured", "data": {}}],
+        },
+    )
+
+    _fire_pin_used(lock_code_manager_config_entry, LOCK_1_ENTITY_ID, 1)
+    await hass.async_block_till_done()
+    assert len(captured) == 1
+
+    for lock_entity_id in (LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID):
+        hass.states.async_set(lock_entity_id, STATE_UNAVAILABLE)
+    await hass.async_block_till_done()
+    for lock_entity_id in (LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID):
+        hass.states.async_set(lock_entity_id, "locked")
+    await hass.async_block_till_done()
+
+    assert len(captured) == 1

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -458,23 +458,31 @@ async def test_available_when_no_lock_reports_code_slot_events(
         await hass.config_entries.async_unload(config_entry.entry_id)
 
 
-async def test_unavailable_when_every_lock_is(
+async def test_available_even_when_every_lock_is_not(
     hass: HomeAssistant,
     mock_lock_config_entry,
     lock_code_manager_config_entry,
 ):
     """
-    The entity follows its entry's locks, the same as every other slot entity.
+    This entity does NOT follow its entry's locks, unlike every other slot entity.
 
-    Blueprint authors rely on that shape: the shipped notifier explicitly
-    rejects the ``unavailable`` -> timestamp transition a recovering lock
-    produces, and would fire spuriously if this entity never went there.
+    A use recorded here need not have come from a lock: ``use_credential``
+    carries uses this integration cannot observe and refuses nothing while
+    the locks are unreachable, so following them would blank the entity
+    exactly when it is holding a use nothing else can report.
+
+    This used to go ``unavailable``, and the shipped blueprints grew guards
+    against the ``unavailable`` -> timestamp transition that produced. Those
+    guards stay -- an entity can still be blanked on reload or removal --
+    but the transition they were written for no longer happens at all. That
+    a recovering lock now notifies nobody is pinned by
+    ``test_lock_recovery_notifies_nobody`` rather than argued from here.
     """
     for lock_entity_id in (LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID):
         hass.states.async_set(lock_entity_id, STATE_UNAVAILABLE)
     await hass.async_block_till_done()
 
-    assert hass.states.get(SLOT_1_EVENT_ENTITY).state == STATE_UNAVAILABLE
+    assert hass.states.get(SLOT_1_EVENT_ENTITY).state != STATE_UNAVAILABLE
 
 
 async def test_the_event_says_which_kind_of_credential_was_used(


### PR DESCRIPTION
## Proposed change

Two defects on the same seam.

**1. Uses reported while every lock is down were invisible.** The credential-used entity followed the shared per-slot rule — available only while one of the entry's locks is reachable. But a use recorded here need not have come from a lock: `use_credential` carries uses this integration cannot observe, and refuses nothing when every lock is down, which is a likely reason to be using it.

So the entity blanked exactly when it held a use nothing else could report — and the use then surfaced as an `unavailable → <timestamp>` transition, which the shipped notifier discards *on purpose* as lock recovery. Invisible twice over. Reproduced before fixing:

```
assert 'unavailable' != 'unavailable'
```

Its availability no longer follows the locks. What a lock being down means is reported by that lock's own entity and the slot's in-sync sensor, neither of which this answer speaks for.

**2. The Slot Usage Limiter decremented on transitions nobody caused.** It had a bare state trigger where the notifier has three guards. The `operation` filter added in #1487 did not close it: a recovering entity still carries the *last* use's attributes, so a previous `unlock` passed the filter and spent a use. First appearance after a restart did the same. Its guards now mirror the notifier's.

### One existing test changed meaning

`test_unavailable_when_every_lock_is` asserted the old behaviour, reasoning that the notifier "would fire spuriously if this entity never went there." That's circular — the guard exists *because* of the unavailability. The property it was protecting is real, so it is now pinned directly by `test_lock_recovery_notifies_nobody`, which verifies a recovering lock reaches no consumer, rather than asserting it via a proxy.

### On the trigger's `not_to` guard

Removing it kills no test, and that is not a weak mutation — Home Assistant's `__async_calculate_state` only merges `extra_state_attributes` `if available:`, so a real `→ unavailable` transition loses `operation` and the condition rejects it incidentally. It is kept deliberately: without it the rejection depends on a template erroring on a missing attribute, which disappears the day someone gives that template a `default()`.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #1488

Targets `feature/credential-store-model` rather than `main`: both files diverge there, and defect 1 lives in a property `main` still has but the feature branch has already deleted — a fix written against `main` would be discarded at merge resolution. The blueprint half cherry-picks cleanly to `main` if released users should get it sooner.

Tests: 2287 passed, 100% coverage held.
