### PR TITLE
feat: set_credential and clear_credential, addressed to a user

### DIFF
--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -67,6 +67,7 @@ from .const import (
     ATTR_CODE,
     ATTR_CODE_SLOT,
     ATTR_CREDENTIAL_TYPE,
+    ATTR_ENABLE,
     ATTR_LENGTH,
     ATTR_LOCK_ENTITY_ID,
     ATTR_SLOT,
@@ -617,6 +618,7 @@ async def async_setup(hass: HomeAssistant, config: Config) -> bool:
             service.data[CONF_NAME],
             credential_type=service.data[ATTR_CREDENTIAL_TYPE],
             value=service.data[ATTR_VALUE],
+            enable=service.data[ATTR_ENABLE],
             config_entry_id=service.data.get("config_entry_id"),
             config_entry_title=service.data.get("config_entry_title"),
         )
@@ -639,6 +641,7 @@ async def async_setup(hass: HomeAssistant, config: Config) -> bool:
                 vol.Required(ATTR_VALUE): vol.All(
                     cv.string, vol.Strip, vol.Length(min=1)
                 ),
+                vol.Optional(ATTR_ENABLE, default=False): cv.boolean,
             }
         ),
     )

--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -67,7 +67,7 @@ from .const import (
     ATTR_CODE,
     ATTR_CODE_SLOT,
     ATTR_CREDENTIAL_TYPE,
-    ATTR_ENABLE,
+    ATTR_ENABLE_IF_DISABLED,
     ATTR_LENGTH,
     ATTR_LOCK_ENTITY_ID,
     ATTR_SLOT,
@@ -618,7 +618,7 @@ async def async_setup(hass: HomeAssistant, config: Config) -> bool:
             service.data[CONF_NAME],
             credential_type=service.data[ATTR_CREDENTIAL_TYPE],
             value=service.data[ATTR_VALUE],
-            enable=service.data[ATTR_ENABLE],
+            enable_if_disabled=service.data[ATTR_ENABLE_IF_DISABLED],
             config_entry_id=service.data.get("config_entry_id"),
             config_entry_title=service.data.get("config_entry_title"),
         )
@@ -641,7 +641,7 @@ async def async_setup(hass: HomeAssistant, config: Config) -> bool:
                 vol.Required(ATTR_VALUE): vol.All(
                     cv.string, vol.Strip, vol.Length(min=1)
                 ),
-                vol.Optional(ATTR_ENABLE, default=False): cv.boolean,
+                vol.Optional(ATTR_ENABLE_IF_DISABLED, default=False): cv.boolean,
             }
         ),
     )

--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -66,6 +66,7 @@ from .const import (
     ATTR_CLEAR_CREDENTIALS,
     ATTR_CODE,
     ATTR_CODE_SLOT,
+    ATTR_CREDENTIAL_TYPE,
     ATTR_LENGTH,
     ATTR_LOCK_ENTITY_ID,
     ATTR_SLOT,
@@ -73,6 +74,7 @@ from .const import (
     ATTR_TARGET,
     ATTR_TEXT,
     ATTR_USERCODE,
+    ATTR_VALUE,
     CONDITION_ENTITY_DOMAINS,
     CONF_CALENDAR,
     CONF_SLOTS,
@@ -84,12 +86,14 @@ from .const import (
     PLATFORMS,
     RENAMES_KEY,
     SERVICE_ADD_USER,
+    SERVICE_CLEAR_CREDENTIAL,
     SERVICE_CLEAR_SLOT_CONDITION,
     SERVICE_CLEAR_USERCODE,
     SERVICE_DELETE_USER,
     SERVICE_DEOBFUSCATE_LOG,
     SERVICE_GENERATE_PIN,
     SERVICE_HARD_REFRESH_USERCODES,
+    SERVICE_SET_CREDENTIAL,
     SERVICE_SET_SLOT_CONDITION,
     SERVICE_SET_USERCODE,
     SERVICE_USE_CREDENTIAL,
@@ -104,6 +108,7 @@ from .domain.config import (
     parse_slot_device_identifier,
     parse_slot_unique_id,
 )
+from .domain.credentials import CredentialType
 from .domain.exceptions import (
     LockDisconnected,
     LockOperationFailed,
@@ -124,9 +129,11 @@ from .domain.queries import get_entry_config
 from .domain.references import async_notify_moved
 from .domain.services import (
     async_add_user,
+    async_clear_credential,
     async_clear_slot_condition,
     async_clear_usercode,
     async_delete_user,
+    async_set_credential,
     async_set_slot_condition,
     async_set_usercode,
     async_use_credential,
@@ -486,8 +493,28 @@ async def async_setup(hass: HomeAssistant, config: Config) -> bool:
         ),
     )
 
+    def _warn_deprecated(old: str, new: str) -> None:
+        """
+        Say that a released action has a replacement, once per call.
+
+        Warning rather than info because the caller has something to do about
+        it: these write straight to a device, so a code they set is one Lock
+        Code Manager does not know about and the sync may clear back out.
+        """
+        _LOGGER.warning(
+            "%s.%s is deprecated and will be removed in a future major "
+            "version. Use %s.%s, which addresses a user rather than a lock "
+            "slot and puts the credential in the configuration so it is "
+            "synced rather than treated as unmanaged",
+            DOMAIN,
+            old,
+            DOMAIN,
+            new,
+        )
+
     async def _set_usercode(service: ServiceCall) -> None:
         """Set a usercode on a lock slot."""
+        _warn_deprecated(SERVICE_SET_USERCODE, SERVICE_SET_CREDENTIAL)
         await async_set_usercode(
             hass,
             service.data[ATTR_LOCK_ENTITY_ID],
@@ -514,6 +541,7 @@ async def async_setup(hass: HomeAssistant, config: Config) -> bool:
 
     async def _clear_usercode(service: ServiceCall) -> None:
         """Clear a usercode from a lock slot."""
+        _warn_deprecated(SERVICE_CLEAR_USERCODE, SERVICE_CLEAR_CREDENTIAL)
         await async_clear_usercode(
             hass,
             service.data[ATTR_LOCK_ENTITY_ID],
@@ -578,6 +606,61 @@ async def async_setup(hass: HomeAssistant, config: Config) -> bool:
                 vol.Required(ATTR_SLOT): vol.All(
                     vol.Coerce(int), vol.Range(min=1, max=9999)
                 ),
+            }
+        ),
+    )
+
+    async def _set_credential(service: ServiceCall) -> None:
+        """Set one of a user's credentials."""
+        await async_set_credential(
+            hass,
+            service.data[CONF_NAME],
+            credential_type=service.data[ATTR_CREDENTIAL_TYPE],
+            value=service.data[ATTR_VALUE],
+            config_entry_id=service.data.get("config_entry_id"),
+            config_entry_title=service.data.get("config_entry_title"),
+        )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SET_CREDENTIAL,
+        _set_credential,
+        schema=_entry_schema(
+            {
+                vol.Required(CONF_NAME): cv.string,
+                # The whole vocabulary, not just what can be stored today.
+                # A kind this integration cannot yet write is refused by the
+                # handler with a message saying so, which reads better than
+                # the schema calling a real credential kind invalid.
+                vol.Required(ATTR_CREDENTIAL_TYPE): vol.Coerce(CredentialType),
+                # Stripped for the reason every other credential field is: a
+                # submitted code is stripped before it is matched, so padding
+                # kept here makes a credential nothing typed can match.
+                vol.Required(ATTR_VALUE): vol.All(
+                    cv.string, vol.Strip, vol.Length(min=1)
+                ),
+            }
+        ),
+    )
+
+    async def _clear_credential(service: ServiceCall) -> None:
+        """Clear one of a user's credentials."""
+        await async_clear_credential(
+            hass,
+            service.data[CONF_NAME],
+            credential_type=service.data[ATTR_CREDENTIAL_TYPE],
+            config_entry_id=service.data.get("config_entry_id"),
+            config_entry_title=service.data.get("config_entry_title"),
+        )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_CLEAR_CREDENTIAL,
+        _clear_credential,
+        schema=_entry_schema(
+            {
+                vol.Required(CONF_NAME): cv.string,
+                vol.Required(ATTR_CREDENTIAL_TYPE): vol.Coerce(CredentialType),
             }
         ),
     )

--- a/custom_components/lock_code_manager/const.py
+++ b/custom_components/lock_code_manager/const.py
@@ -24,6 +24,8 @@ SERVICE_DELETE_USER = "delete_user"
 SERVICE_GENERATE_PIN = "generate_pin"
 SERVICE_DEOBFUSCATE_LOG = "deobfuscate_log"
 SERVICE_USE_CREDENTIAL = "use_credential"
+SERVICE_SET_CREDENTIAL = "set_credential"
+SERVICE_CLEAR_CREDENTIAL = "clear_credential"
 
 ATTR_TEXT = "text"
 
@@ -35,6 +37,9 @@ ATTR_CREDENTIAL_TYPE = "credential_type"
 # shape depends on the user's name and on the language it was created in.
 ATTR_SLOT_FIELD = "slot_field"
 ATTR_USERCODE = "usercode"
+# The credential itself on set_credential. Not ``usercode``: that name is
+# PIN-shaped, and this field carries whatever the credential type is.
+ATTR_VALUE = "value"
 ATTR_FROM = "from"
 ATTR_TO = "to"
 ATTR_LCM_CONFIG_ENTRY_ID = "lock_code_manager_config_entry_id"

--- a/custom_components/lock_code_manager/const.py
+++ b/custom_components/lock_code_manager/const.py
@@ -41,9 +41,11 @@ ATTR_USERCODE = "usercode"
 # PIN-shaped, and this field carries whatever the credential type is.
 ATTR_VALUE = "value"
 # Opt-in on set_credential: turn the user on once the credential is set.
-# A verb, not a state -- omitting it leaves the user however they were,
-# where ``enabled: false`` would read as a request to disable them.
-ATTR_ENABLE = "enable"
+# Named for the effect rather than the state -- ``enabled: false`` would read
+# as a request to disable somebody, which this never does. Enabling a user who
+# already is costs nothing, so there is no guard behind the name: the write is
+# a no-op when the value has not changed.
+ATTR_ENABLE_IF_DISABLED = "enable_if_disabled"
 ATTR_FROM = "from"
 ATTR_TO = "to"
 ATTR_LCM_CONFIG_ENTRY_ID = "lock_code_manager_config_entry_id"

--- a/custom_components/lock_code_manager/const.py
+++ b/custom_components/lock_code_manager/const.py
@@ -40,6 +40,10 @@ ATTR_USERCODE = "usercode"
 # The credential itself on set_credential. Not ``usercode``: that name is
 # PIN-shaped, and this field carries whatever the credential type is.
 ATTR_VALUE = "value"
+# Opt-in on set_credential: turn the user on once the credential is set.
+# A verb, not a state -- omitting it leaves the user however they were,
+# where ``enabled: false`` would read as a request to disable them.
+ATTR_ENABLE = "enable"
 ATTR_FROM = "from"
 ATTR_TO = "to"
 ATTR_LCM_CONFIG_ENTRY_ID = "lock_code_manager_config_entry_id"

--- a/custom_components/lock_code_manager/domain/services.py
+++ b/custom_components/lock_code_manager/domain/services.py
@@ -21,7 +21,7 @@ from ..const import (
 )
 from .allocation import SlotAllocationError, async_allocate_for
 from .config import EntryConfig
-from .credentials import CredentialType
+from .credentials import MANAGED_CREDENTIAL_TYPES, CredentialType
 from .events import (
     CredentialOperation,
     async_fire_credential_used,
@@ -29,6 +29,7 @@ from .events import (
 from .locks import get_managed_lock
 from .names import identity, name_error, normalize_name
 from .queries import get_entry_config, get_loaded_config_entry
+from .slot_coordinator import SlotEntityCoordinator
 from .validation import validate_credential
 
 _LOGGER = logging.getLogger(__name__)
@@ -95,6 +96,116 @@ async def async_clear_usercode(
     """Clear a usercode from a lock slot."""
     lock = get_managed_lock(hass, lock_entity_id)
     await lock.async_internal_clear_usercode(code_slot)
+
+
+def _slot_coordinator_for(
+    hass: HomeAssistant,
+    name: str,
+    config_entry_id: str | None,
+    config_entry_title: str | None,
+) -> SlotEntityCoordinator:
+    """
+    Return the coordinator for the user ``name`` names in the given entry.
+
+    Matched the way a user is recognized everywhere else -- whitespace
+    normalized and casefolded -- so the caller may spell the name the way
+    they say it rather than the way it was stored.
+    """
+    config_entry = get_loaded_config_entry(hass, config_entry_id, config_entry_title)
+    config = get_entry_config(config_entry)
+
+    stored = next(
+        (known for known in config.users if identity(known) == identity(name)), None
+    )
+    if stored is None:
+        raise ServiceValidationError(f"No user named {name!r} in this config entry")
+
+    # One condition for two ways to hold nothing: a user with no number was
+    # never placed, and a number with no coordinator is an entry whose slots
+    # and configuration disagree. Both mean there is no slot here to write to
+    # or clear, and neither is worth telling apart in the message.
+    slot_num = config.assignment.slot(stored)
+    coordinators = config_entry.runtime_data.slot_coordinators
+    if slot_num is None or (coordinator := coordinators.get(slot_num)) is None:
+        raise ServiceValidationError(f"{stored!r} holds no slot in this config entry")
+    return coordinator
+
+
+def _managed_credential_type(credential_type: str) -> CredentialType:
+    """
+    Return the credential type, refusing kinds this integration cannot write.
+
+    Every member of ``CredentialType`` is accepted by the schema so the
+    vocabulary is the providers' rather than this action's, and the ones Lock
+    Code Manager cannot yet store are refused here instead -- the caller
+    learns that RFID is a real kind that is not supported yet, rather than
+    that the word is invalid.
+    """
+    kind = CredentialType(credential_type)
+    if kind not in MANAGED_CREDENTIAL_TYPES:
+        supported = ", ".join(sorted(MANAGED_CREDENTIAL_TYPES))
+        raise ServiceValidationError(
+            f"Lock Code Manager cannot store a {kind} credential. "
+            f"Supported: {supported}"
+        )
+    return kind
+
+
+async def async_set_credential(
+    hass: HomeAssistant,
+    name: str,
+    *,
+    credential_type: str,
+    value: str,
+    config_entry_id: str | None = None,
+    config_entry_title: str | None = None,
+) -> None:
+    """
+    Set one of a user's credentials, and let the sync carry it to the locks.
+
+    Addresses the user rather than a lock and a slot number. What that buys
+    over ``set_usercode`` is that the credential ends up in the
+    configuration: a code written straight to a device is one Lock Code
+    Manager does not know about, which the sync may clear back out, and which
+    cannot reach a member holding its credentials here rather than on a
+    device.
+
+    Routed through the slot's coordinator rather than written to the entry,
+    because that is the authoritative gate for a credential write -- it strips
+    whitespace and validates the length against every bound lock. Writing the
+    configuration directly here would be a second path that skips both.
+    """
+    # Not checked for emptiness here: the schema strips and requires at least
+    # one character, so an empty value never reaches this. Repeating that gate
+    # would be a branch nothing can take.
+    _managed_credential_type(credential_type)
+    coordinator = _slot_coordinator_for(hass, name, config_entry_id, config_entry_title)
+    await coordinator.async_request_pin_update(value)
+
+
+async def async_clear_credential(
+    hass: HomeAssistant,
+    name: str,
+    *,
+    credential_type: str,
+    config_entry_id: str | None = None,
+    config_entry_title: str | None = None,
+) -> None:
+    """
+    Clear one of a user's credentials from the configuration and the locks.
+
+    The type is named rather than assumed because one user may eventually
+    hold more than one kind, and clearing their PIN must not take their tag
+    with it.
+
+    **This disables the user**, which is the same thing emptying their PIN
+    field on the dashboard does: a user with no credential and nothing
+    disabled would read as active while holding nothing anybody could
+    present.
+    """
+    _managed_credential_type(credential_type)
+    coordinator = _slot_coordinator_for(hass, name, config_entry_id, config_entry_title)
+    await coordinator.async_request_pin_update("")
 
 
 async def async_use_credential(

--- a/custom_components/lock_code_manager/domain/services.py
+++ b/custom_components/lock_code_manager/domain/services.py
@@ -157,7 +157,7 @@ async def async_set_credential(
     *,
     credential_type: str,
     value: str,
-    enable: bool = False,
+    enable_if_disabled: bool = False,
     config_entry_id: str | None = None,
     config_entry_title: str | None = None,
 ) -> None:
@@ -176,7 +176,7 @@ async def async_set_credential(
     whitespace and validates the length against every bound lock. Writing the
     configuration directly here would be a second path that skips both.
 
-    ``enable`` turns the user on afterwards, which is what makes this the
+    ``enable_if_disabled`` turns the user on afterwards, which is what makes this the
     inverse of :func:`async_clear_credential` rather than half of it: clearing
     a credential disables the user, so setting one on somebody cleared earlier
     would otherwise leave a code that is present and inert. Off by default,
@@ -193,7 +193,7 @@ async def async_set_credential(
     _managed_credential_type(credential_type)
     coordinator = _slot_coordinator_for(hass, name, config_entry_id, config_entry_title)
     await coordinator.async_request_pin_update(value)
-    if enable:
+    if enable_if_disabled:
         # Safe in this order, and only in this order: the write above refreshes
         # the entry's cached config before returning, so the PIN this checks
         # for is the one just set.

--- a/custom_components/lock_code_manager/domain/services.py
+++ b/custom_components/lock_code_manager/domain/services.py
@@ -157,6 +157,7 @@ async def async_set_credential(
     *,
     credential_type: str,
     value: str,
+    enable: bool = False,
     config_entry_id: str | None = None,
     config_entry_title: str | None = None,
 ) -> None:
@@ -174,6 +175,17 @@ async def async_set_credential(
     because that is the authoritative gate for a credential write -- it strips
     whitespace and validates the length against every bound lock. Writing the
     configuration directly here would be a second path that skips both.
+
+    ``enable`` turns the user on afterwards, which is what makes this the
+    inverse of :func:`async_clear_credential` rather than half of it: clearing
+    a credential disables the user, so setting one on somebody cleared earlier
+    would otherwise leave a code that is present and inert. Off by default,
+    because giving a user a credential and letting them in are different
+    decisions and only the caller knows whether they are making both.
+
+    Not a field written alongside the PIN: enabling has its own rules -- it
+    refuses a user with no credential and clears the repair issue raised when
+    that happened -- and the second call is what runs them.
     """
     # Not checked for emptiness here: the schema strips and requires at least
     # one character, so an empty value never reaches this. Repeating that gate
@@ -181,6 +193,11 @@ async def async_set_credential(
     _managed_credential_type(credential_type)
     coordinator = _slot_coordinator_for(hass, name, config_entry_id, config_entry_title)
     await coordinator.async_request_pin_update(value)
+    if enable:
+        # Safe in this order, and only in this order: the write above refreshes
+        # the entry's cached config before returning, so the PIN this checks
+        # for is the one just set.
+        await coordinator.async_request_active_toggle(True)
 
 
 async def async_clear_credential(

--- a/custom_components/lock_code_manager/icons.json
+++ b/custom_components/lock_code_manager/icons.json
@@ -42,12 +42,14 @@
   },
   "services": {
     "add_user": "mdi:account-plus",
+    "clear_credential": "mdi:key-remove",
     "clear_slot_condition": "mdi:calendar-remove",
     "clear_usercode": "mdi:key-remove",
     "delete_user": "mdi:account-remove",
     "deobfuscate_log": "mdi:incognito-off",
     "generate_pin": "mdi:dice-multiple",
     "hard_refresh_usercodes": "mdi:refresh",
+    "set_credential": "mdi:key-plus",
     "set_slot_condition": "mdi:calendar-edit",
     "set_usercode": "mdi:key-plus",
     "use_credential": "mdi:shield-key"

--- a/custom_components/lock_code_manager/services.yaml
+++ b/custom_components/lock_code_manager/services.yaml
@@ -169,3 +169,61 @@ use_credential:
       required: true
       selector:
         entity:
+
+set_credential:
+  fields:
+    config_entry_id:
+      selector:
+        config_entry:
+          integration: lock_code_manager
+    config_entry_title:
+      selector:
+        text:
+    name:
+      required: true
+      selector:
+        text:
+    credential_type:
+      required: true
+      default: pin
+      selector:
+        select:
+          translation_key: credential_type
+          options:
+            - pin
+            - rfid
+            - fingerprint
+            - face
+            - password
+            - nfc
+    value:
+      required: true
+      selector:
+        text:
+
+clear_credential:
+  fields:
+    config_entry_id:
+      selector:
+        config_entry:
+          integration: lock_code_manager
+    config_entry_title:
+      selector:
+        text:
+    name:
+      required: true
+      selector:
+        text:
+    credential_type:
+      required: true
+      default: pin
+      selector:
+        select:
+          translation_key: credential_type
+          options:
+            - pin
+            - rfid
+            - fingerprint
+            - face
+            - password
+            - nfc

--- a/custom_components/lock_code_manager/services.yaml
+++ b/custom_components/lock_code_manager/services.yaml
@@ -200,7 +200,7 @@ set_credential:
       required: true
       selector:
         text:
-    enable:
+    enable_if_disabled:
       default: false
       selector:
         boolean:

--- a/custom_components/lock_code_manager/services.yaml
+++ b/custom_components/lock_code_manager/services.yaml
@@ -200,6 +200,10 @@ set_credential:
       required: true
       selector:
         text:
+    enable:
+      default: false
+      selector:
+        boolean:
 
 clear_credential:
   fields:

--- a/custom_components/lock_code_manager/strings.json
+++ b/custom_components/lock_code_manager/strings.json
@@ -310,9 +310,9 @@
           "name": "Value",
           "description": "The credential itself — the PIN, for a PIN credential. Surrounding whitespace is stripped."
         },
-        "enable": {
-          "name": "Enable",
-          "description": "Also turn this person on once the credential is set. Off by default, so somebody disabled stays disabled and their new credential is inert until you enable them."
+        "enable_if_disabled": {
+          "name": "Enable if disabled",
+          "description": "Turn this person on once the credential is set. Off by default, so somebody disabled stays disabled and their new credential is inert until you enable them. Never disables anybody."
         }
       }
     },

--- a/custom_components/lock_code_manager/strings.json
+++ b/custom_components/lock_code_manager/strings.json
@@ -186,6 +186,28 @@
         }
       }
     },
+    "clear_credential": {
+      "name": "Clear credential",
+      "description": "Remove one of a person's credentials from a Lock Code Manager config entry and from every lock in it. This also disables the person, the same as emptying their PIN on the dashboard does.",
+      "fields": {
+        "config_entry_id": {
+          "name": "Config entry",
+          "description": "The Lock Code Manager entry the person belongs to."
+        },
+        "config_entry_title": {
+          "name": "Config entry title",
+          "description": "The Lock Code Manager entry, named by its title instead of its ID. Matched ignoring case and punctuation. Use this or the config entry, not both."
+        },
+        "name": {
+          "name": "Name",
+          "description": "The person whose credential this is. Matched ignoring case and surrounding whitespace, so it need not be spelled exactly as stored."
+        },
+        "credential_type": {
+          "name": "Credential type",
+          "description": "Which kind of credential. Only PIN can be stored today; the others are refused with a message saying so."
+        }
+      }
+    },
     "clear_slot_condition": {
       "name": "Clear slot condition",
       "description": "Remove a code slot's condition entity, leaving its PIN active whenever the slot is enabled.",
@@ -263,6 +285,32 @@
     "hard_refresh_usercodes": {
       "description": "If Lock Code Manager supports the lock's integration, and the lock's integration supports it, this will query the lock for all usercodes. This is potentially useful for integrations that cache data from the lock and a usercode(s) is configured outside of Home Assistant.",
       "name": "Hard refresh usercodes"
+    },
+    "set_credential": {
+      "name": "Set credential",
+      "description": "Set one of a person's credentials in a Lock Code Manager config entry. The credential is stored in the configuration and synced to every lock in the entry, so it is managed rather than treated as an unknown code somebody programmed.",
+      "fields": {
+        "config_entry_id": {
+          "name": "Config entry",
+          "description": "The Lock Code Manager entry the person belongs to."
+        },
+        "config_entry_title": {
+          "name": "Config entry title",
+          "description": "The Lock Code Manager entry, named by its title instead of its ID. Matched ignoring case and punctuation. Use this or the config entry, not both."
+        },
+        "name": {
+          "name": "Name",
+          "description": "The person whose credential this is. Matched ignoring case and surrounding whitespace, so it need not be spelled exactly as stored."
+        },
+        "credential_type": {
+          "name": "Credential type",
+          "description": "Which kind of credential. Only PIN can be stored today; the others are refused with a message saying so."
+        },
+        "value": {
+          "name": "Value",
+          "description": "The credential itself — the PIN, for a PIN credential. Surrounding whitespace is stripped."
+        }
+      }
     },
     "set_slot_condition": {
       "name": "Set slot condition",
@@ -429,6 +477,18 @@
     },
     "slot_out_of_range": {
       "message": "Lock {lock} reports only {num_slots} PIN code slots, so these slot numbers are out of range for it: {out_of_range_slots}."
+    }
+  },
+  "selector": {
+    "credential_type": {
+      "options": {
+        "pin": "PIN",
+        "rfid": "RFID tag or card",
+        "fingerprint": "Fingerprint",
+        "face": "Face",
+        "password": "Password",
+        "nfc": "NFC tag"
+      }
     }
   }
 }

--- a/custom_components/lock_code_manager/strings.json
+++ b/custom_components/lock_code_manager/strings.json
@@ -309,6 +309,10 @@
         "value": {
           "name": "Value",
           "description": "The credential itself — the PIN, for a PIN credential. Surrounding whitespace is stripped."
+        },
+        "enable": {
+          "name": "Enable",
+          "description": "Also turn this person on once the credential is set. Off by default, so somebody disabled stays disabled and their new credential is inert until you enable them."
         }
       }
     },

--- a/custom_components/lock_code_manager/translations/en.json
+++ b/custom_components/lock_code_manager/translations/en.json
@@ -310,9 +310,9 @@
           "name": "Value",
           "description": "The credential itself — the PIN, for a PIN credential. Surrounding whitespace is stripped."
         },
-        "enable": {
-          "name": "Enable",
-          "description": "Also turn this person on once the credential is set. Off by default, so somebody disabled stays disabled and their new credential is inert until you enable them."
+        "enable_if_disabled": {
+          "name": "Enable if disabled",
+          "description": "Turn this person on once the credential is set. Off by default, so somebody disabled stays disabled and their new credential is inert until you enable them. Never disables anybody."
         }
       }
     },

--- a/custom_components/lock_code_manager/translations/en.json
+++ b/custom_components/lock_code_manager/translations/en.json
@@ -186,6 +186,28 @@
         }
       }
     },
+    "clear_credential": {
+      "name": "Clear credential",
+      "description": "Remove one of a person's credentials from a Lock Code Manager config entry and from every lock in it. This also disables the person, the same as emptying their PIN on the dashboard does.",
+      "fields": {
+        "config_entry_id": {
+          "name": "Config entry",
+          "description": "The Lock Code Manager entry the person belongs to."
+        },
+        "config_entry_title": {
+          "name": "Config entry title",
+          "description": "The Lock Code Manager entry, named by its title instead of its ID. Matched ignoring case and punctuation. Use this or the config entry, not both."
+        },
+        "name": {
+          "name": "Name",
+          "description": "The person whose credential this is. Matched ignoring case and surrounding whitespace, so it need not be spelled exactly as stored."
+        },
+        "credential_type": {
+          "name": "Credential type",
+          "description": "Which kind of credential. Only PIN can be stored today; the others are refused with a message saying so."
+        }
+      }
+    },
     "clear_slot_condition": {
       "name": "Clear slot condition",
       "description": "Remove a code slot's condition entity, leaving its PIN active whenever the slot is enabled.",
@@ -263,6 +285,32 @@
     "hard_refresh_usercodes": {
       "description": "If Lock Code Manager supports the lock's integration, and the lock's integration supports it, this will query the lock for all usercodes. This is potentially useful for integrations that cache data from the lock and a usercode(s) is configured outside of Home Assistant.",
       "name": "Hard refresh usercodes"
+    },
+    "set_credential": {
+      "name": "Set credential",
+      "description": "Set one of a person's credentials in a Lock Code Manager config entry. The credential is stored in the configuration and synced to every lock in the entry, so it is managed rather than treated as an unknown code somebody programmed.",
+      "fields": {
+        "config_entry_id": {
+          "name": "Config entry",
+          "description": "The Lock Code Manager entry the person belongs to."
+        },
+        "config_entry_title": {
+          "name": "Config entry title",
+          "description": "The Lock Code Manager entry, named by its title instead of its ID. Matched ignoring case and punctuation. Use this or the config entry, not both."
+        },
+        "name": {
+          "name": "Name",
+          "description": "The person whose credential this is. Matched ignoring case and surrounding whitespace, so it need not be spelled exactly as stored."
+        },
+        "credential_type": {
+          "name": "Credential type",
+          "description": "Which kind of credential. Only PIN can be stored today; the others are refused with a message saying so."
+        },
+        "value": {
+          "name": "Value",
+          "description": "The credential itself — the PIN, for a PIN credential. Surrounding whitespace is stripped."
+        }
+      }
     },
     "set_slot_condition": {
       "name": "Set slot condition",
@@ -429,6 +477,18 @@
     },
     "slot_out_of_range": {
       "message": "Lock {lock} reports only {num_slots} PIN code slots, so these slot numbers are out of range for it: {out_of_range_slots}."
+    }
+  },
+  "selector": {
+    "credential_type": {
+      "options": {
+        "pin": "PIN",
+        "rfid": "RFID tag or card",
+        "fingerprint": "Fingerprint",
+        "face": "Face",
+        "password": "Password",
+        "nfc": "NFC tag"
+      }
     }
   }
 }

--- a/custom_components/lock_code_manager/translations/en.json
+++ b/custom_components/lock_code_manager/translations/en.json
@@ -309,6 +309,10 @@
         "value": {
           "name": "Value",
           "description": "The credential itself — the PIN, for a PIN credential. Surrounding whitespace is stripped."
+        },
+        "enable": {
+          "name": "Enable",
+          "description": "Also turn this person on once the credential is set. Off by default, so somebody disabled stays disabled and their new credential is inert until you enable them."
         }
       }
     },

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -51,9 +51,11 @@ from custom_components.lock_code_manager.const import (
     ATTR_USER,
     ATTR_USERCODE,
     ATTR_VALID,
+    ATTR_VALUE,
     BUS_EVENT_CREDENTIAL_USED,
     CONF_LOCKS,
     CONF_SLOTS,
+    CONF_USERS,
     DOMAIN,
     EVENT_CREDENTIAL_USED,
     EVENT_LOCK_STATE_CHANGED,
@@ -61,11 +63,13 @@ from custom_components.lock_code_manager.const import (
     REASON_UNKNOWN_CODE,
     REASON_USER_DISABLED,
     SERVICE_ADD_USER,
+    SERVICE_CLEAR_CREDENTIAL,
     SERVICE_CLEAR_SLOT_CONDITION,
     SERVICE_CLEAR_USERCODE,
     SERVICE_DELETE_USER,
     SERVICE_DEOBFUSCATE_LOG,
     SERVICE_GENERATE_PIN,
+    SERVICE_SET_CREDENTIAL,
     SERVICE_SET_SLOT_CONDITION,
     SERVICE_SET_USERCODE,
     SERVICE_USE_CREDENTIAL,
@@ -1779,4 +1783,225 @@ async def test_use_credential_requires_both_attribution_fields(
     with pytest.raises(vol.Invalid):
         await hass.services.async_call(
             DOMAIN, SERVICE_USE_CREDENTIAL, data, blocking=True
+        )
+
+
+async def test_set_credential_updates_the_user_not_just_the_device(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+) -> None:
+    """
+    The credential lands in the configuration, which is the whole point.
+
+    ``set_usercode`` writes straight to a device, so the code it sets is one
+    Lock Code Manager does not know about. This addresses the user, so the
+    entry holds it and the sync carries it to every lock.
+    """
+    entry = lock_code_manager_config_entry
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_CREDENTIAL,
+        {
+            "config_entry_id": entry.entry_id,
+            CONF_NAME: "test1",
+            ATTR_CREDENTIAL_TYPE: "pin",
+            ATTR_VALUE: "4321",
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    config = get_entry_config(hass.config_entries.async_get_entry(entry.entry_id))
+    assert config.users["test1"][CONF_PIN] == "4321"
+
+
+async def test_set_credential_matches_a_name_the_way_it_is_said(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+) -> None:
+    """Case and surrounding whitespace do not have to match what was stored."""
+    entry = lock_code_manager_config_entry
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_CREDENTIAL,
+        {
+            "config_entry_id": entry.entry_id,
+            CONF_NAME: "  TEST1 ",
+            ATTR_CREDENTIAL_TYPE: "pin",
+            ATTR_VALUE: "4321",
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    config = get_entry_config(hass.config_entries.async_get_entry(entry.entry_id))
+    # Stored under the name it already had, not re-keyed under what was typed.
+    assert config.users["test1"][CONF_PIN] == "4321"
+
+
+async def test_clear_credential_clears_and_disables(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+) -> None:
+    """
+    Clearing takes the credential and the user's active state together.
+
+    A user with no credential who still read as enabled would be advertised
+    as able to get in while holding nothing anybody could present. This is
+    the same pairing emptying the PIN field on the dashboard produces.
+    """
+    entry = lock_code_manager_config_entry
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_CLEAR_CREDENTIAL,
+        {
+            "config_entry_title": entry.title,
+            CONF_NAME: "test1",
+            ATTR_CREDENTIAL_TYPE: "pin",
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    config = get_entry_config(hass.config_entries.async_get_entry(entry.entry_id))
+    assert not config.users["test1"][CONF_PIN]
+    assert config.users["test1"][CONF_ENABLED] is False
+
+
+@pytest.mark.parametrize(
+    "service,extra",
+    [
+        (SERVICE_SET_CREDENTIAL, {ATTR_VALUE: "4321"}),
+        (SERVICE_CLEAR_CREDENTIAL, {}),
+    ],
+)
+async def test_credential_actions_refuse_an_unknown_user(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+    service: str,
+    extra: dict,
+) -> None:
+    """Naming nobody is the caller's mistake, not a silent no-op."""
+    with pytest.raises(ServiceValidationError, match="No user named"):
+        await hass.services.async_call(
+            DOMAIN,
+            service,
+            {
+                "config_entry_id": lock_code_manager_config_entry.entry_id,
+                CONF_NAME: "Nobody",
+                ATTR_CREDENTIAL_TYPE: "pin",
+                **extra,
+            },
+            blocking=True,
+        )
+
+
+async def test_set_credential_refuses_a_kind_it_cannot_store(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+) -> None:
+    """
+    A real credential kind that is not supported yet says so.
+
+    RFID is in the vocabulary because providers report it; Lock Code Manager
+    has nowhere to keep one. The caller should learn that rather than that
+    the word was invalid.
+    """
+    with pytest.raises(ServiceValidationError, match="cannot store"):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_CREDENTIAL,
+            {
+                "config_entry_id": lock_code_manager_config_entry.entry_id,
+                CONF_NAME: "test1",
+                ATTR_CREDENTIAL_TYPE: "rfid",
+                ATTR_VALUE: "abc123",
+            },
+            blocking=True,
+        )
+
+
+@pytest.mark.parametrize(
+    "service,data,replacement",
+    [
+        (
+            SERVICE_SET_USERCODE,
+            {ATTR_CODE_SLOT: 1, ATTR_USERCODE: "4321"},
+            "set_credential",
+        ),
+        (SERVICE_CLEAR_USERCODE, {ATTR_CODE_SLOT: 1}, "clear_credential"),
+    ],
+)
+async def test_the_device_level_actions_say_they_are_deprecated(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+    caplog: pytest.LogCaptureFixture,
+    service: str,
+    data: dict,
+    replacement: str,
+) -> None:
+    """
+    They still work, and they say what to use instead.
+
+    A warning rather than a note, because the caller has something to do
+    about it: these write straight to a device, so the code they set is one
+    Lock Code Manager treats as unmanaged.
+    """
+    caplog.clear()
+    await hass.services.async_call(
+        DOMAIN,
+        service,
+        {ATTR_LOCK_ENTITY_ID: LOCK_1_ENTITY_ID, **data},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    deprecations = [
+        record
+        for record in caplog.records
+        if record.levelname == "WARNING" and "deprecated" in record.getMessage()
+    ]
+    assert len(deprecations) == 1
+    assert replacement in deprecations[0].getMessage()
+
+
+async def test_credential_actions_refuse_a_user_holding_no_slot(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+) -> None:
+    """
+    A user the configuration never numbered has no credential to change.
+
+    Reachable from stored configuration: a users block with no slot
+    assignment beside it leaves everybody unnumbered, which is exactly the
+    shape ``EntryConfig`` skips when it builds its slot view.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_LOCKS: [LOCK_1_ENTITY_ID],
+            CONF_USERS: {"Unplaced": {CONF_PIN: "1234", CONF_ENABLED: True}},
+        },
+        unique_id="unplaced",
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    with pytest.raises(ServiceValidationError, match="holds no slot"):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_CLEAR_CREDENTIAL,
+            {
+                "config_entry_id": entry.entry_id,
+                CONF_NAME: "Unplaced",
+                ATTR_CREDENTIAL_TYPE: "pin",
+            },
+            blocking=True,
         )

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -40,7 +40,7 @@ from custom_components.lock_code_manager.const import (
     ATTR_CONFIG_ENTRY_ID,
     ATTR_CONFIG_ENTRY_TITLE,
     ATTR_CREDENTIAL_TYPE,
-    ATTR_ENABLE,
+    ATTR_ENABLE_IF_DISABLED,
     ATTR_LENGTH,
     ATTR_LOCK_ENTITY_ID,
     ATTR_OPERATION,
@@ -2062,7 +2062,12 @@ async def test_set_credential_can_enable_in_the_same_call(
     await hass.services.async_call(
         DOMAIN,
         SERVICE_SET_CREDENTIAL,
-        {**common, CONF_NAME: "test1", ATTR_VALUE: "4321", ATTR_ENABLE: True},
+        {
+            **common,
+            CONF_NAME: "test1",
+            ATTR_VALUE: "4321",
+            ATTR_ENABLE_IF_DISABLED: True,
+        },
         blocking=True,
     )
     await hass.async_block_till_done()

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -40,6 +40,7 @@ from custom_components.lock_code_manager.const import (
     ATTR_CONFIG_ENTRY_ID,
     ATTR_CONFIG_ENTRY_TITLE,
     ATTR_CREDENTIAL_TYPE,
+    ATTR_ENABLE,
     ATTR_LENGTH,
     ATTR_LOCK_ENTITY_ID,
     ATTR_OPERATION,
@@ -2005,3 +2006,67 @@ async def test_credential_actions_refuse_a_user_holding_no_slot(
             },
             blocking=True,
         )
+
+
+async def test_set_credential_leaves_the_user_alone_by_default(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+) -> None:
+    """
+    Giving somebody a credential is not the same as letting them in.
+
+    A user cleared earlier stays off until somebody says otherwise, so a
+    credential set on them is present and inert rather than quietly live.
+    """
+    entry = lock_code_manager_config_entry
+    common = {"config_entry_id": entry.entry_id, ATTR_CREDENTIAL_TYPE: "pin"}
+
+    await hass.services.async_call(
+        DOMAIN, SERVICE_CLEAR_CREDENTIAL, {**common, CONF_NAME: "test1"}, blocking=True
+    )
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_CREDENTIAL,
+        {**common, CONF_NAME: "test1", ATTR_VALUE: "4321"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    config = get_entry_config(hass.config_entries.async_get_entry(entry.entry_id))
+    assert config.users["test1"][CONF_PIN] == "4321"
+    assert config.users["test1"][CONF_ENABLED] is False
+
+
+async def test_set_credential_can_enable_in_the_same_call(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+) -> None:
+    """
+    ``enable`` makes this the inverse of clearing rather than half of it.
+
+    Clearing disables, so without this a caller undoing a clear needs a
+    second action against a different entity to finish the job.
+    """
+    entry = lock_code_manager_config_entry
+    common = {"config_entry_id": entry.entry_id, ATTR_CREDENTIAL_TYPE: "pin"}
+
+    await hass.services.async_call(
+        DOMAIN, SERVICE_CLEAR_CREDENTIAL, {**common, CONF_NAME: "test1"}, blocking=True
+    )
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_CREDENTIAL,
+        {**common, CONF_NAME: "test1", ATTR_VALUE: "4321", ATTR_ENABLE: True},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    config = get_entry_config(hass.config_entries.async_get_entry(entry.entry_id))
+    assert config.users["test1"][CONF_PIN] == "4321"
+    assert config.users["test1"][CONF_ENABLED] is True


### PR DESCRIPTION
## Proposed change

Two config-level, credential-typed actions:

```yaml
lock_code_manager.set_credential:
  config_entry_id / config_entry_title
  name              # matched ignoring case and surrounding whitespace
  credential_type   # pin today
  value
  enable_if_disabled  # optional, default false

lock_code_manager.clear_credential:
  config_entry_id / config_entry_title
  name
  credential_type
```

`set_usercode` and `clear_usercode` are PIN-shaped and device-level — they write straight to a lock slot and never touch the configuration. A code written that way is one Lock Code Manager doesn't know about, so the sync may clear it back out, and it can't reach a member that keeps its credentials here rather than on a device. The new pair names the **user**, so the credential lands in the configuration and syncs to every lock in the entry.

### Routed through the coordinator, not written to the entry

Both call `SlotEntityCoordinator.async_request_pin_update`, which the code documents as "the authoritative gate for BOTH ends". That carries three behaviours a direct config write would silently skip: whitespace stripping, per-lock length validation, and **disabling a user whose credential was cleared** — the same pairing that emptying a PIN on the dashboard produces.

`clear_credential` disabling the user is therefore not a new rule; it's the existing one, reached from a second entrance.

### `enable_if_disabled` on set

Because clearing disables, setting a credential on somebody cleared earlier would leave a code that is present and inert — finishing the job needed a second action against a different entity. `enable_if_disabled` closes that, and is **off by default**: giving a user a credential and letting them in are different decisions, and only the caller knows whether they're making both.

It is named for the effect rather than the state — `enabled: false` would read as a request to disable somebody, which this never does. There is no guard behind the name: enabling a user who already is costs nothing, since `async_update_entry` returns `False` when the value hasn't changed and no listener runs, so a conditional would be a branch no test could distinguish.

It calls the coordinator's enable path rather than writing `enabled` alongside the PIN, so it inherits that path's rules — it refuses a user with no credential, and clears the `pin_required` repair issue raised when that happened. The order is load-bearing: the PIN write refreshes the entry's cached config before returning, so the enable check sees the credential just set. Reversing the two is covered by a test.

### `credential_type` takes the whole vocabulary

The schema accepts every `CredentialType`, and the handler refuses the ones that can't be stored yet against `MANAGED_CREDENTIAL_TYPES` (PIN only). A caller asking for RFID learns it's a real kind that isn't supported, rather than that the word is invalid — and adding a kind later is a one-line change to the set the code already names as the single source of truth.

### Deprecation

`set_usercode` and `clear_usercode` behave **exactly as before** and now log a warning naming their replacement. No remapping — nothing that currently works changes.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue: #1493

Tests: 2288 passed, 100% coverage held, all hooks pass. Six mutations, all killed — exact-match instead of identity matching, clear writing a value instead of emptying, accepting unmanaged credential kinds, the flag ignored, the flag always applied, and enabling before the PIN write rather than after.

Two guards were deliberately **not** written: an empty-value check (the schema strips then requires ≥1 character, so it can't be reached) and a separate no-coordinator branch (unreachable when the slot map and configuration agree, so it's folded into the no-slot check). Both would have been branches no test could take.


