### PR TITLE
feat: name-addressed actions for enabling users and gating them

### DIFF
--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -92,6 +92,8 @@ from .const import (
     SERVICE_CLEAR_USERCODE,
     SERVICE_DELETE_USER,
     SERVICE_DEOBFUSCATE_LOG,
+    SERVICE_DISABLE_USER,
+    SERVICE_ENABLE_USER,
     SERVICE_GENERATE_PIN,
     SERVICE_HARD_REFRESH_USERCODES,
     SERVICE_SET_CREDENTIAL,
@@ -134,6 +136,8 @@ from .domain.services import (
     async_clear_slot_condition,
     async_clear_usercode,
     async_delete_user,
+    async_disable_user,
+    async_enable_user,
     async_set_credential,
     async_set_slot_condition,
     async_set_usercode,
@@ -667,6 +671,35 @@ async def async_setup(hass: HomeAssistant, config: Config) -> bool:
             }
         ),
     )
+
+    async def _enable_user(service: ServiceCall) -> None:
+        """Turn a user on."""
+        await async_enable_user(
+            hass,
+            service.data[CONF_NAME],
+            config_entry_id=service.data.get("config_entry_id"),
+            config_entry_title=service.data.get("config_entry_title"),
+        )
+
+    async def _disable_user(service: ServiceCall) -> None:
+        """Turn a user off."""
+        await async_disable_user(
+            hass,
+            service.data[CONF_NAME],
+            config_entry_id=service.data.get("config_entry_id"),
+            config_entry_title=service.data.get("config_entry_title"),
+        )
+
+    for _service_name, _handler in (
+        (SERVICE_ENABLE_USER, _enable_user),
+        (SERVICE_DISABLE_USER, _disable_user),
+    ):
+        hass.services.async_register(
+            DOMAIN,
+            _service_name,
+            _handler,
+            schema=_entry_schema({vol.Required(CONF_NAME): cv.string}),
+        )
 
     async def _add_user(service: ServiceCall) -> None:
         """Add a user to an entry."""

--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -87,6 +87,7 @@ from .const import (
     PLATFORMS,
     RENAMES_KEY,
     SERVICE_ADD_USER,
+    SERVICE_CLEAR_CONDITION,
     SERVICE_CLEAR_CREDENTIAL,
     SERVICE_CLEAR_SLOT_CONDITION,
     SERVICE_CLEAR_USERCODE,
@@ -96,6 +97,7 @@ from .const import (
     SERVICE_ENABLE_USER,
     SERVICE_GENERATE_PIN,
     SERVICE_HARD_REFRESH_USERCODES,
+    SERVICE_SET_CONDITION,
     SERVICE_SET_CREDENTIAL,
     SERVICE_SET_SLOT_CONDITION,
     SERVICE_SET_USERCODE,
@@ -132,12 +134,14 @@ from .domain.queries import get_entry_config
 from .domain.references import async_notify_moved
 from .domain.services import (
     async_add_user,
+    async_clear_condition,
     async_clear_credential,
     async_clear_slot_condition,
     async_clear_usercode,
     async_delete_user,
     async_disable_user,
     async_enable_user,
+    async_set_condition,
     async_set_credential,
     async_set_slot_condition,
     async_set_usercode,
@@ -498,28 +502,32 @@ async def async_setup(hass: HomeAssistant, config: Config) -> bool:
         ),
     )
 
-    def _warn_deprecated(old: str, new: str) -> None:
+    def _warn_deprecated(old: str, new: str, reason: str) -> None:
         """
         Say that a released action has a replacement, once per call.
 
         Warning rather than info because the caller has something to do about
-        it: these write straight to a device, so a code they set is one Lock
-        Code Manager does not know about and the sync may clear back out.
+        it, and ``reason`` says what: each of these addresses a lock slot,
+        which is internal bookkeeping the caller should not have to hold.
         """
         _LOGGER.warning(
             "%s.%s is deprecated and will be removed in a future major "
-            "version. Use %s.%s, which addresses a user rather than a lock "
-            "slot and puts the credential in the configuration so it is "
-            "synced rather than treated as unmanaged",
+            "version. Use %s.%s instead, which %s",
             DOMAIN,
             old,
             DOMAIN,
             new,
+            reason,
         )
 
     async def _set_usercode(service: ServiceCall) -> None:
         """Set a usercode on a lock slot."""
-        _warn_deprecated(SERVICE_SET_USERCODE, SERVICE_SET_CREDENTIAL)
+        _warn_deprecated(
+            SERVICE_SET_USERCODE,
+            SERVICE_SET_CREDENTIAL,
+            "names the user and puts the credential in the configuration, so it is "
+            "synced to every lock rather than treated as a code nobody manages",
+        )
         await async_set_usercode(
             hass,
             service.data[ATTR_LOCK_ENTITY_ID],
@@ -546,7 +554,12 @@ async def async_setup(hass: HomeAssistant, config: Config) -> bool:
 
     async def _clear_usercode(service: ServiceCall) -> None:
         """Clear a usercode from a lock slot."""
-        _warn_deprecated(SERVICE_CLEAR_USERCODE, SERVICE_CLEAR_CREDENTIAL)
+        _warn_deprecated(
+            SERVICE_CLEAR_USERCODE,
+            SERVICE_CLEAR_CREDENTIAL,
+            "names the user and puts the credential in the configuration, so it is "
+            "synced to every lock rather than treated as a code nobody manages",
+        )
         await async_clear_usercode(
             hass,
             service.data[ATTR_LOCK_ENTITY_ID],
@@ -567,8 +580,54 @@ async def async_setup(hass: HomeAssistant, config: Config) -> bool:
         ),
     )
 
+    async def _set_condition(service: ServiceCall) -> None:
+        """Attach a condition entity to a user."""
+        await async_set_condition(
+            hass,
+            service.data[CONF_NAME],
+            service.data[CONF_ENTITY_ID],
+            config_entry_id=service.data.get("config_entry_id"),
+            config_entry_title=service.data.get("config_entry_title"),
+        )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SET_CONDITION,
+        _set_condition,
+        schema=_entry_schema(
+            {
+                vol.Required(CONF_NAME): cv.string,
+                vol.Required(CONF_ENTITY_ID): cv.entity_domain(
+                    CONDITION_ENTITY_DOMAINS
+                ),
+            }
+        ),
+    )
+
+    async def _clear_condition(service: ServiceCall) -> None:
+        """Detach a user's condition entity."""
+        await async_clear_condition(
+            hass,
+            service.data[CONF_NAME],
+            config_entry_id=service.data.get("config_entry_id"),
+            config_entry_title=service.data.get("config_entry_title"),
+        )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_CLEAR_CONDITION,
+        _clear_condition,
+        schema=_entry_schema({vol.Required(CONF_NAME): cv.string}),
+    )
+
     async def _set_slot_condition(service: ServiceCall) -> None:
         """Set a condition entity for a slot."""
+        _warn_deprecated(
+            SERVICE_SET_SLOT_CONDITION,
+            SERVICE_SET_CONDITION,
+            "names the user a condition gates, rather than a slot number that can "
+            "come to hold somebody else",
+        )
         await async_set_slot_condition(
             hass,
             service.data[ATTR_SLOT],
@@ -595,6 +654,12 @@ async def async_setup(hass: HomeAssistant, config: Config) -> bool:
 
     async def _clear_slot_condition(service: ServiceCall) -> None:
         """Clear the condition entity from a slot."""
+        _warn_deprecated(
+            SERVICE_CLEAR_SLOT_CONDITION,
+            SERVICE_CLEAR_CONDITION,
+            "names the user a condition gates, rather than a slot number that can "
+            "come to hold somebody else",
+        )
         await async_clear_slot_condition(
             hass,
             service.data[ATTR_SLOT],

--- a/custom_components/lock_code_manager/const.py
+++ b/custom_components/lock_code_manager/const.py
@@ -28,6 +28,8 @@ SERVICE_SET_CREDENTIAL = "set_credential"
 SERVICE_CLEAR_CREDENTIAL = "clear_credential"
 SERVICE_ENABLE_USER = "enable_user"
 SERVICE_DISABLE_USER = "disable_user"
+SERVICE_SET_CONDITION = "set_condition"
+SERVICE_CLEAR_CONDITION = "clear_condition"
 
 ATTR_TEXT = "text"
 

--- a/custom_components/lock_code_manager/const.py
+++ b/custom_components/lock_code_manager/const.py
@@ -26,6 +26,8 @@ SERVICE_DEOBFUSCATE_LOG = "deobfuscate_log"
 SERVICE_USE_CREDENTIAL = "use_credential"
 SERVICE_SET_CREDENTIAL = "set_credential"
 SERVICE_CLEAR_CREDENTIAL = "clear_credential"
+SERVICE_ENABLE_USER = "enable_user"
+SERVICE_DISABLE_USER = "disable_user"
 
 ATTR_TEXT = "text"
 

--- a/custom_components/lock_code_manager/domain/services.py
+++ b/custom_components/lock_code_manager/domain/services.py
@@ -29,7 +29,7 @@ from .events import (
 from .locks import get_managed_lock
 from .names import identity, name_error, normalize_name
 from .queries import get_entry_config, get_loaded_config_entry
-from .slot_coordinator import SlotEntityCoordinator
+from .slot_coordinator import PinRequiredError, SlotEntityCoordinator
 from .validation import validate_credential
 
 _LOGGER = logging.getLogger(__name__)
@@ -336,6 +336,51 @@ async def async_clear_slot_condition(
 
     new_config = config.with_slot_field_removed(slot, CONF_CONDITION)
     await _async_write_and_settle(hass, config_entry, new_config.to_dict())
+
+
+async def async_enable_user(
+    hass: HomeAssistant,
+    name: str,
+    *,
+    config_entry_id: str | None = None,
+    config_entry_title: str | None = None,
+) -> None:
+    """
+    Turn a user on, so their credential is written to the entry's locks.
+
+    Refuses a user holding no credential, because enabling one would
+    advertise somebody as able to get in while they hold nothing anybody
+    could present. That rule lives in the coordinator, which is also what
+    clears the repair issue raised the last time it was hit -- so this goes
+    through the same path the dashboard switch does rather than writing the
+    field itself.
+    """
+    coordinator = _slot_coordinator_for(hass, name, config_entry_id, config_entry_title)
+    try:
+        await coordinator.async_request_active_toggle(True)
+    except PinRequiredError as err:
+        # Not a HomeAssistantError, so it would surface as an internal error
+        # rather than as the caller's problem, which is what it is.
+        raise ServiceValidationError(str(err)) from err
+
+
+async def async_disable_user(
+    hass: HomeAssistant,
+    name: str,
+    *,
+    config_entry_id: str | None = None,
+    config_entry_title: str | None = None,
+) -> None:
+    """
+    Turn a user off, and clear their credential from the entry's locks.
+
+    Unconditional, unlike enabling: there is no state a user can be in that
+    makes turning them off invalid. Their credential stays in the
+    configuration, so enabling them again restores it without anybody
+    having to remember what it was.
+    """
+    coordinator = _slot_coordinator_for(hass, name, config_entry_id, config_entry_title)
+    await coordinator.async_request_active_toggle(False)
 
 
 async def async_add_user(

--- a/custom_components/lock_code_manager/domain/services.py
+++ b/custom_components/lock_code_manager/domain/services.py
@@ -98,27 +98,47 @@ async def async_clear_usercode(
     await lock.async_internal_clear_usercode(code_slot)
 
 
+def _stored_user(config: EntryConfig, name: str) -> str:
+    """
+    Return the name an entry stores for the person ``name`` names.
+
+    Matched the way a user is recognized everywhere else -- whitespace
+    normalized and casefolded -- so a caller may spell the name the way they
+    say it rather than the way it was stored.
+    """
+    stored = next(
+        (known for known in config.users if identity(known) == identity(name)), None
+    )
+    if stored is None:
+        raise ServiceValidationError(f"No user named {name!r} in this config entry")
+    return stored
+
+
+def _slot_for_user(
+    hass: HomeAssistant,
+    name: str,
+    config_entry_id: str | None,
+    config_entry_title: str | None,
+) -> tuple[ConfigEntry, int]:
+    """Return the entry and the slot number the named user occupies."""
+    config_entry = get_loaded_config_entry(hass, config_entry_id, config_entry_title)
+    config = get_entry_config(config_entry)
+    stored = _stored_user(config, name)
+    if (slot_num := config.assignment.slot(stored)) is None:
+        raise ServiceValidationError(f"{stored!r} holds no slot in this config entry")
+    return config_entry, slot_num
+
+
 def _slot_coordinator_for(
     hass: HomeAssistant,
     name: str,
     config_entry_id: str | None,
     config_entry_title: str | None,
 ) -> SlotEntityCoordinator:
-    """
-    Return the coordinator for the user ``name`` names in the given entry.
-
-    Matched the way a user is recognized everywhere else -- whitespace
-    normalized and casefolded -- so the caller may spell the name the way
-    they say it rather than the way it was stored.
-    """
+    """Return the coordinator for the slot the named user occupies."""
     config_entry = get_loaded_config_entry(hass, config_entry_id, config_entry_title)
     config = get_entry_config(config_entry)
-
-    stored = next(
-        (known for known in config.users if identity(known) == identity(name)), None
-    )
-    if stored is None:
-        raise ServiceValidationError(f"No user named {name!r} in this config entry")
+    stored = _stored_user(config, name)
 
     # One condition for two ways to hold nothing: a user with no number was
     # never placed, and a number with no coordinator is an entry whose slots
@@ -299,6 +319,55 @@ def _async_validate_condition(hass: HomeAssistant, condition: str) -> None:
             "https://github.com/raman325/lock_code_manager/wiki/"
             "Unsupported-Condition-Entity-Integrations"
         )
+
+
+async def async_set_condition(
+    hass: HomeAssistant,
+    name: str,
+    entity_id: str,
+    *,
+    config_entry_id: str | None = None,
+    config_entry_title: str | None = None,
+) -> None:
+    """
+    Attach a condition entity to a user.
+
+    A condition gates a person -- their credential works while it is on --
+    so the person is what this names. ``set_slot_condition`` named the slot
+    number instead, which is internal bookkeeping: an automation holding one
+    goes on addressing that number after somebody else comes to occupy it.
+    """
+    config_entry, slot_num = _slot_for_user(
+        hass, name, config_entry_id, config_entry_title
+    )
+    _async_validate_condition(hass, entity_id)
+
+    new_config = get_entry_config(config_entry).with_slot_field_set(
+        slot_num, CONF_CONDITION, entity_id
+    )
+    await _async_write_and_settle(hass, config_entry, new_config.to_dict())
+
+
+async def async_clear_condition(
+    hass: HomeAssistant,
+    name: str,
+    *,
+    config_entry_id: str | None = None,
+    config_entry_title: str | None = None,
+) -> None:
+    """
+    Detach a user's condition entity, leaving their credential ungated.
+
+    Removing the gate does not disable anybody: a user with no condition is
+    one whose credential simply always applies, which is the ordinary case.
+    """
+    config_entry, slot_num = _slot_for_user(
+        hass, name, config_entry_id, config_entry_title
+    )
+    new_config = get_entry_config(config_entry).with_slot_field_removed(
+        slot_num, CONF_CONDITION
+    )
+    await _async_write_and_settle(hass, config_entry, new_config.to_dict())
 
 
 async def async_set_slot_condition(

--- a/custom_components/lock_code_manager/icons.json
+++ b/custom_components/lock_code_manager/icons.json
@@ -47,6 +47,8 @@
     "clear_usercode": "mdi:key-remove",
     "delete_user": "mdi:account-remove",
     "deobfuscate_log": "mdi:incognito-off",
+    "disable_user": "mdi:account-cancel",
+    "enable_user": "mdi:account-check",
     "generate_pin": "mdi:dice-multiple",
     "hard_refresh_usercodes": "mdi:refresh",
     "set_credential": "mdi:key-plus",

--- a/custom_components/lock_code_manager/icons.json
+++ b/custom_components/lock_code_manager/icons.json
@@ -42,6 +42,7 @@
   },
   "services": {
     "add_user": "mdi:account-plus",
+    "clear_condition": "mdi:calendar-remove",
     "clear_credential": "mdi:key-remove",
     "clear_slot_condition": "mdi:calendar-remove",
     "clear_usercode": "mdi:key-remove",
@@ -51,6 +52,7 @@
     "enable_user": "mdi:account-check",
     "generate_pin": "mdi:dice-multiple",
     "hard_refresh_usercodes": "mdi:refresh",
+    "set_condition": "mdi:calendar-edit",
     "set_credential": "mdi:key-plus",
     "set_slot_condition": "mdi:calendar-edit",
     "set_usercode": "mdi:key-plus",

--- a/custom_components/lock_code_manager/services.yaml
+++ b/custom_components/lock_code_manager/services.yaml
@@ -231,3 +231,31 @@ clear_credential:
             - face
             - password
             - nfc
+
+enable_user:
+  fields:
+    config_entry_id:
+      selector:
+        config_entry:
+          integration: lock_code_manager
+    config_entry_title:
+      selector:
+        text:
+    name:
+      required: true
+      selector:
+        text:
+
+disable_user:
+  fields:
+    config_entry_id:
+      selector:
+        config_entry:
+          integration: lock_code_manager
+    config_entry_title:
+      selector:
+        text:
+    name:
+      required: true
+      selector:
+        text:

--- a/custom_components/lock_code_manager/services.yaml
+++ b/custom_components/lock_code_manager/services.yaml
@@ -259,3 +259,41 @@ disable_user:
       required: true
       selector:
         text:
+
+set_condition:
+  fields:
+    config_entry_id:
+      selector:
+        config_entry:
+          integration: lock_code_manager
+    config_entry_title:
+      selector:
+        text:
+    name:
+      required: true
+      selector:
+        text:
+    entity_id:
+      required: true
+      selector:
+        entity:
+          domain:
+            - binary_sensor
+            - calendar
+            - input_boolean
+            - schedule
+            - switch
+
+clear_condition:
+  fields:
+    config_entry_id:
+      selector:
+        config_entry:
+          integration: lock_code_manager
+    config_entry_title:
+      selector:
+        text:
+    name:
+      required: true
+      selector:
+        text:

--- a/custom_components/lock_code_manager/strings.json
+++ b/custom_components/lock_code_manager/strings.json
@@ -272,6 +272,42 @@
         }
       }
     },
+    "disable_user": {
+      "name": "Disable user",
+      "description": "Turn a person off and clear their credential from the entry's locks. Their credential stays in the configuration, so enabling them again restores it.",
+      "fields": {
+        "config_entry_id": {
+          "name": "Config entry",
+          "description": "The Lock Code Manager entry the person belongs to."
+        },
+        "config_entry_title": {
+          "name": "Config entry title",
+          "description": "The Lock Code Manager entry, named by its title instead of its ID. Matched ignoring case and punctuation. Use this or the config entry, not both."
+        },
+        "name": {
+          "name": "Name",
+          "description": "The person. Matched ignoring case and surrounding whitespace, so it need not be spelled exactly as stored."
+        }
+      }
+    },
+    "enable_user": {
+      "name": "Enable user",
+      "description": "Turn a person on, so their credential is written to the entry's locks. Refused if they hold no credential — there would be nothing to write.",
+      "fields": {
+        "config_entry_id": {
+          "name": "Config entry",
+          "description": "The Lock Code Manager entry the person belongs to."
+        },
+        "config_entry_title": {
+          "name": "Config entry title",
+          "description": "The Lock Code Manager entry, named by its title instead of its ID. Matched ignoring case and punctuation. Use this or the config entry, not both."
+        },
+        "name": {
+          "name": "Name",
+          "description": "The person. Matched ignoring case and surrounding whitespace, so it need not be spelled exactly as stored."
+        }
+      }
+    },
     "generate_pin": {
       "description": "Generate a random PIN that avoids known unsafe patterns (all-same digits, sequential digits, repeating sub-sequences, and common weak PINs). Returns the PIN via response_variable.",
       "name": "Generate PIN",

--- a/custom_components/lock_code_manager/strings.json
+++ b/custom_components/lock_code_manager/strings.json
@@ -186,6 +186,24 @@
         }
       }
     },
+    "clear_condition": {
+      "name": "Clear condition",
+      "description": "Detach a person's condition entity, so their credential always applies. Does not disable them. Replaces Clear slot condition, which named a slot number rather than the person.",
+      "fields": {
+        "config_entry_id": {
+          "name": "Config entry",
+          "description": "The Lock Code Manager entry the person belongs to."
+        },
+        "config_entry_title": {
+          "name": "Config entry title",
+          "description": "The Lock Code Manager entry, named by its title instead of its ID. Matched ignoring case and punctuation. Use this or the config entry, not both."
+        },
+        "name": {
+          "name": "Name",
+          "description": "The person whose credential the condition gates. Matched ignoring case and surrounding whitespace."
+        }
+      }
+    },
     "clear_credential": {
       "name": "Clear credential",
       "description": "Remove one of a person's credentials from a Lock Code Manager config entry and from every lock in it. This also disables the person, the same as emptying their PIN on the dashboard does.",
@@ -210,7 +228,7 @@
     },
     "clear_slot_condition": {
       "name": "Clear slot condition",
-      "description": "Remove a code slot's condition entity, leaving its PIN active whenever the slot is enabled.",
+      "description": "Deprecated — use Clear condition instead, which names the person rather than a slot number that can come to hold somebody else. Still works, and logs a warning. Remove a code slot's condition entity, leaving its PIN active whenever the slot is enabled.",
       "fields": {
         "config_entry_id": {
           "name": "Config entry",
@@ -322,6 +340,28 @@
       "description": "If Lock Code Manager supports the lock's integration, and the lock's integration supports it, this will query the lock for all usercodes. This is potentially useful for integrations that cache data from the lock and a usercode(s) is configured outside of Home Assistant.",
       "name": "Hard refresh usercodes"
     },
+    "set_condition": {
+      "name": "Set condition",
+      "description": "Attach a condition entity to a person. Their credential works while the condition is on. Replaces Set slot condition, which named a slot number rather than the person.",
+      "fields": {
+        "config_entry_id": {
+          "name": "Config entry",
+          "description": "The Lock Code Manager entry the person belongs to."
+        },
+        "config_entry_title": {
+          "name": "Config entry title",
+          "description": "The Lock Code Manager entry, named by its title instead of its ID. Matched ignoring case and punctuation. Use this or the config entry, not both."
+        },
+        "name": {
+          "name": "Name",
+          "description": "The person whose credential the condition gates. Matched ignoring case and surrounding whitespace."
+        },
+        "entity_id": {
+          "name": "Condition entity",
+          "description": "The calendar, schedule, switch or binary sensor that gates this person's credential."
+        }
+      }
+    },
     "set_credential": {
       "name": "Set credential",
       "description": "Set one of a person's credentials in a Lock Code Manager config entry. The credential is stored in the configuration and synced to every lock in the entry, so it is managed rather than treated as an unknown code somebody programmed.",
@@ -354,7 +394,7 @@
     },
     "set_slot_condition": {
       "name": "Set slot condition",
-      "description": "Attach a condition entity to a code slot. The slot's PIN is active only while that entity says so.",
+      "description": "Deprecated — use Set condition instead, which names the person rather than a slot number that can come to hold somebody else. Still works, and logs a warning. Attach a condition entity to a code slot. The slot's PIN is active only while that entity says so.",
       "fields": {
         "config_entry_id": {
           "name": "Config entry",

--- a/custom_components/lock_code_manager/translations/en.json
+++ b/custom_components/lock_code_manager/translations/en.json
@@ -272,6 +272,42 @@
         }
       }
     },
+    "disable_user": {
+      "name": "Disable user",
+      "description": "Turn a person off and clear their credential from the entry's locks. Their credential stays in the configuration, so enabling them again restores it.",
+      "fields": {
+        "config_entry_id": {
+          "name": "Config entry",
+          "description": "The Lock Code Manager entry the person belongs to."
+        },
+        "config_entry_title": {
+          "name": "Config entry title",
+          "description": "The Lock Code Manager entry, named by its title instead of its ID. Matched ignoring case and punctuation. Use this or the config entry, not both."
+        },
+        "name": {
+          "name": "Name",
+          "description": "The person. Matched ignoring case and surrounding whitespace, so it need not be spelled exactly as stored."
+        }
+      }
+    },
+    "enable_user": {
+      "name": "Enable user",
+      "description": "Turn a person on, so their credential is written to the entry's locks. Refused if they hold no credential — there would be nothing to write.",
+      "fields": {
+        "config_entry_id": {
+          "name": "Config entry",
+          "description": "The Lock Code Manager entry the person belongs to."
+        },
+        "config_entry_title": {
+          "name": "Config entry title",
+          "description": "The Lock Code Manager entry, named by its title instead of its ID. Matched ignoring case and punctuation. Use this or the config entry, not both."
+        },
+        "name": {
+          "name": "Name",
+          "description": "The person. Matched ignoring case and surrounding whitespace, so it need not be spelled exactly as stored."
+        }
+      }
+    },
     "generate_pin": {
       "description": "Generate a random PIN that avoids known unsafe patterns (all-same digits, sequential digits, repeating sub-sequences, and common weak PINs). Returns the PIN via response_variable.",
       "name": "Generate PIN",

--- a/custom_components/lock_code_manager/translations/en.json
+++ b/custom_components/lock_code_manager/translations/en.json
@@ -186,6 +186,24 @@
         }
       }
     },
+    "clear_condition": {
+      "name": "Clear condition",
+      "description": "Detach a person's condition entity, so their credential always applies. Does not disable them. Replaces Clear slot condition, which named a slot number rather than the person.",
+      "fields": {
+        "config_entry_id": {
+          "name": "Config entry",
+          "description": "The Lock Code Manager entry the person belongs to."
+        },
+        "config_entry_title": {
+          "name": "Config entry title",
+          "description": "The Lock Code Manager entry, named by its title instead of its ID. Matched ignoring case and punctuation. Use this or the config entry, not both."
+        },
+        "name": {
+          "name": "Name",
+          "description": "The person whose credential the condition gates. Matched ignoring case and surrounding whitespace."
+        }
+      }
+    },
     "clear_credential": {
       "name": "Clear credential",
       "description": "Remove one of a person's credentials from a Lock Code Manager config entry and from every lock in it. This also disables the person, the same as emptying their PIN on the dashboard does.",
@@ -210,7 +228,7 @@
     },
     "clear_slot_condition": {
       "name": "Clear slot condition",
-      "description": "Remove a code slot's condition entity, leaving its PIN active whenever the slot is enabled.",
+      "description": "Deprecated — use Clear condition instead, which names the person rather than a slot number that can come to hold somebody else. Still works, and logs a warning. Remove a code slot's condition entity, leaving its PIN active whenever the slot is enabled.",
       "fields": {
         "config_entry_id": {
           "name": "Config entry",
@@ -322,6 +340,28 @@
       "description": "If Lock Code Manager supports the lock's integration, and the lock's integration supports it, this will query the lock for all usercodes. This is potentially useful for integrations that cache data from the lock and a usercode(s) is configured outside of Home Assistant.",
       "name": "Hard refresh usercodes"
     },
+    "set_condition": {
+      "name": "Set condition",
+      "description": "Attach a condition entity to a person. Their credential works while the condition is on. Replaces Set slot condition, which named a slot number rather than the person.",
+      "fields": {
+        "config_entry_id": {
+          "name": "Config entry",
+          "description": "The Lock Code Manager entry the person belongs to."
+        },
+        "config_entry_title": {
+          "name": "Config entry title",
+          "description": "The Lock Code Manager entry, named by its title instead of its ID. Matched ignoring case and punctuation. Use this or the config entry, not both."
+        },
+        "name": {
+          "name": "Name",
+          "description": "The person whose credential the condition gates. Matched ignoring case and surrounding whitespace."
+        },
+        "entity_id": {
+          "name": "Condition entity",
+          "description": "The calendar, schedule, switch or binary sensor that gates this person's credential."
+        }
+      }
+    },
     "set_credential": {
       "name": "Set credential",
       "description": "Set one of a person's credentials in a Lock Code Manager config entry. The credential is stored in the configuration and synced to every lock in the entry, so it is managed rather than treated as an unknown code somebody programmed.",
@@ -354,7 +394,7 @@
     },
     "set_slot_condition": {
       "name": "Set slot condition",
-      "description": "Attach a condition entity to a code slot. The slot's PIN is active only while that entity says so.",
+      "description": "Deprecated — use Set condition instead, which names the person rather than a slot number that can come to hold somebody else. Still works, and logs a warning. Attach a condition entity to a code slot. The slot's PIN is active only while that entity says so.",
       "fields": {
         "config_entry_id": {
           "name": "Config entry",

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -69,6 +69,8 @@ from custom_components.lock_code_manager.const import (
     SERVICE_CLEAR_USERCODE,
     SERVICE_DELETE_USER,
     SERVICE_DEOBFUSCATE_LOG,
+    SERVICE_DISABLE_USER,
+    SERVICE_ENABLE_USER,
     SERVICE_GENERATE_PIN,
     SERVICE_SET_CREDENTIAL,
     SERVICE_SET_SLOT_CONDITION,
@@ -2075,3 +2077,81 @@ async def test_set_credential_can_enable_in_the_same_call(
     config = get_entry_config(hass.config_entries.async_get_entry(entry.entry_id))
     assert config.users["test1"][CONF_PIN] == "4321"
     assert config.users["test1"][CONF_ENABLED] is True
+
+
+async def test_disable_and_enable_a_user_round_trip(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+) -> None:
+    """
+    Turning somebody off keeps their credential, so turning them on restores it.
+
+    The point of a disable that is not a delete: nobody has to remember what
+    the code was to give it back.
+    """
+    entry = lock_code_manager_config_entry
+    common = {"config_entry_id": entry.entry_id, CONF_NAME: "test1"}
+
+    await hass.services.async_call(DOMAIN, SERVICE_DISABLE_USER, common, blocking=True)
+    await hass.async_block_till_done()
+
+    config = get_entry_config(hass.config_entries.async_get_entry(entry.entry_id))
+    assert config.users["test1"][CONF_ENABLED] is False
+    assert config.users["test1"][CONF_PIN] == "1234"
+
+    await hass.services.async_call(DOMAIN, SERVICE_ENABLE_USER, common, blocking=True)
+    await hass.async_block_till_done()
+
+    config = get_entry_config(hass.config_entries.async_get_entry(entry.entry_id))
+    assert config.users["test1"][CONF_ENABLED] is True
+    assert config.users["test1"][CONF_PIN] == "1234"
+
+
+async def test_enable_user_refuses_somebody_holding_no_credential(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+) -> None:
+    """
+    Enabling a user with nothing to present is refused, not silently allowed.
+
+    Otherwise the configuration would advertise somebody as able to get in
+    while holding no credential. The refusal has to arrive as the caller's
+    problem: the coordinator raises a bare exception, which would surface as
+    an internal error if it were not translated.
+    """
+    entry = lock_code_manager_config_entry
+    common = {"config_entry_id": entry.entry_id, CONF_NAME: "test1"}
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_CLEAR_CREDENTIAL,
+        {**common, ATTR_CREDENTIAL_TYPE: "pin"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    with pytest.raises(ServiceValidationError, match="Set a PIN"):
+        await hass.services.async_call(
+            DOMAIN, SERVICE_ENABLE_USER, common, blocking=True
+        )
+
+
+async def test_user_actions_match_a_name_the_way_it_is_said(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+) -> None:
+    """Addressing the person by name means not needing their entity IDs."""
+    entry = lock_code_manager_config_entry
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_DISABLE_USER,
+        {"config_entry_title": entry.title, CONF_NAME: "  TEST1 "},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    config = get_entry_config(hass.config_entries.async_get_entry(entry.entry_id))
+    assert config.users["test1"][CONF_ENABLED] is False

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -64,6 +64,7 @@ from custom_components.lock_code_manager.const import (
     REASON_UNKNOWN_CODE,
     REASON_USER_DISABLED,
     SERVICE_ADD_USER,
+    SERVICE_CLEAR_CONDITION,
     SERVICE_CLEAR_CREDENTIAL,
     SERVICE_CLEAR_SLOT_CONDITION,
     SERVICE_CLEAR_USERCODE,
@@ -72,6 +73,7 @@ from custom_components.lock_code_manager.const import (
     SERVICE_DISABLE_USER,
     SERVICE_ENABLE_USER,
     SERVICE_GENERATE_PIN,
+    SERVICE_SET_CONDITION,
     SERVICE_SET_CREDENTIAL,
     SERVICE_SET_SLOT_CONDITION,
     SERVICE_SET_USERCODE,
@@ -1997,6 +1999,8 @@ async def test_credential_actions_refuse_a_user_holding_no_slot(
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
+    # Both name-addressed paths: the one that resolves a coordinator, and
+    # the one that only needs the number.
     with pytest.raises(ServiceValidationError, match="holds no slot"):
         await hass.services.async_call(
             DOMAIN,
@@ -2006,6 +2010,14 @@ async def test_credential_actions_refuse_a_user_holding_no_slot(
                 CONF_NAME: "Unplaced",
                 ATTR_CREDENTIAL_TYPE: "pin",
             },
+            blocking=True,
+        )
+
+    with pytest.raises(ServiceValidationError, match="holds no slot"):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_CLEAR_CONDITION,
+            {"config_entry_id": entry.entry_id, CONF_NAME: "Unplaced"},
             blocking=True,
         )
 
@@ -2155,3 +2167,123 @@ async def test_user_actions_match_a_name_the_way_it_is_said(
 
     config = get_entry_config(hass.config_entries.async_get_entry(entry.entry_id))
     assert config.users["test1"][CONF_ENABLED] is False
+
+
+async def test_set_and_clear_condition_by_name(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+) -> None:
+    """
+    A condition gates a person, so the person is what names it.
+
+    The slot number the condition lands on is bookkeeping the caller never
+    sees or supplies.
+    """
+    hass.states.async_set("binary_sensor.test_condition", STATE_ON)
+    entry = lock_code_manager_config_entry
+    common = {"config_entry_id": entry.entry_id, CONF_NAME: "test1"}
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_CONDITION,
+        {**common, CONF_ENTITY_ID: "binary_sensor.test_condition"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    config = get_entry_config(hass.config_entries.async_get_entry(entry.entry_id))
+    assert config.users["test1"][CONF_CONDITION] == "binary_sensor.test_condition"
+
+    await hass.services.async_call(
+        DOMAIN, SERVICE_CLEAR_CONDITION, common, blocking=True
+    )
+    await hass.async_block_till_done()
+
+    config = get_entry_config(hass.config_entries.async_get_entry(entry.entry_id))
+    assert CONF_CONDITION not in config.users["test1"]
+    # Clearing the gate is not disabling the person.
+    assert config.users["test1"][CONF_ENABLED] is True
+
+
+async def test_set_condition_refuses_an_unknown_user(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+) -> None:
+    """Naming nobody is the caller's mistake, not a silent no-op."""
+    with pytest.raises(ServiceValidationError, match="No user named"):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_CONDITION,
+            {
+                "config_entry_id": lock_code_manager_config_entry.entry_id,
+                CONF_NAME: "Nobody",
+                CONF_ENTITY_ID: "binary_sensor.test_condition",
+            },
+            blocking=True,
+        )
+
+
+@pytest.mark.parametrize(
+    "service,data,replacement",
+    [
+        (
+            SERVICE_SET_SLOT_CONDITION,
+            {ATTR_SLOT: 1, CONF_ENTITY_ID: "binary_sensor.test_condition"},
+            "set_condition",
+        ),
+        (SERVICE_CLEAR_SLOT_CONDITION, {ATTR_SLOT: 1}, "clear_condition"),
+    ],
+)
+async def test_the_slot_keyed_condition_actions_say_they_are_deprecated(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+    caplog: pytest.LogCaptureFixture,
+    service: str,
+    data: dict,
+    replacement: str,
+) -> None:
+    """They still work, and they name what replaces them."""
+    hass.states.async_set("binary_sensor.test_condition", STATE_ON)
+    caplog.clear()
+    await hass.services.async_call(
+        DOMAIN,
+        service,
+        {"config_entry_id": lock_code_manager_config_entry.entry_id, **data},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    deprecations = [
+        record
+        for record in caplog.records
+        if record.levelname == "WARNING" and "deprecated" in record.getMessage()
+    ]
+    assert len(deprecations) == 1
+    assert replacement in deprecations[0].getMessage()
+
+
+async def test_set_condition_refuses_an_entity_that_does_not_exist(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+) -> None:
+    """
+    A condition Lock Code Manager cannot read is refused, not stored.
+
+    Storing it would leave the user gated on something that never reports,
+    which reads as a credential that simply stopped working.
+    """
+    with pytest.raises(ServiceValidationError, match="not found"):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_CONDITION,
+            {
+                "config_entry_id": lock_code_manager_config_entry.entry_id,
+                CONF_NAME: "test1",
+                CONF_ENTITY_ID: "binary_sensor.nonexistent",
+            },
+            blocking=True,
+        )


### PR DESCRIPTION
## Proposed change

Four actions that address a **person by name**, closing the gap between what the dashboard can do per user and what a service (and therefore REST) can.

```yaml
lock_code_manager.enable_user:     config_entry + name
lock_code_manager.disable_user:    config_entry + name
lock_code_manager.set_condition:   config_entry + name + entity_id
lock_code_manager.clear_condition: config_entry + name
```

**Addressed by name, not entity ID or slot number** — which is the point rather than a convenience. Entity IDs derive from the user's name, so `switch.all_locks_sarah_chen_enabled` moves the moment somebody is renamed and an automation holding it silently stops working. A slot number is worse: it stays valid and comes to address *whoever occupies that slot later*, so the automation keeps working on the wrong person.

### enable_user / disable_user

**Enable** goes through the coordinator's toggle rather than writing `enabled` itself, inheriting that path's rules: it refuses a user holding no credential, and clears the `pin_required` repair issue raised when that last happened. That refusal is a bare `Exception`, translated here so it reaches the caller as their problem rather than as an internal error.

**Disable** is unconditional and **keeps the credential in the configuration**, so enabling again restores it without anybody having to remember what it was.

### set_condition / clear_condition

Same shape as `set_credential` before them: `set_slot_condition` and `clear_slot_condition` keep working **unchanged** and now log a warning naming their replacement.

`clear_condition` removes the gate without disabling anybody — a user with no condition is one whose credential simply always applies.

The deprecation warning takes its reason as an argument rather than restating one message for both pairs, because they're deprecated for different reasons: the usercode pair wrote past the configuration, this pair addresses bookkeeping.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

Tests: 2316 passed, 100% coverage held, all hooks pass.

Five mutations run. Four died immediately; **one survived and found a real gap** — removing `set_condition`'s validation of the condition entity broke nothing, because the released action had that test and the new one hadn't inherited it. Added, and it dies now.

**Still not reachable by action: renaming a user.** After this, that is the only writable per-user surface the UI has and the services don't. It is more delicate than these — a rename moves every one of that user's entity IDs, and the recorder follows it only when the new name is free — so it deserves its own change.
