### PR TITLE
feat: add_user and delete_user take lists

### DIFF
--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -79,6 +79,7 @@ from .const import (
     CONDITION_ENTITY_DOMAINS,
     CONF_CALENDAR,
     CONF_SLOTS,
+    CONF_USERS,
     DOMAIN,
     EVENT_CREDENTIAL_USED,
     LEGACY_EVENT_PIN_USED,
@@ -133,12 +134,12 @@ from .domain.pin_generator import (
 from .domain.queries import get_entry_config
 from .domain.references import async_notify_moved
 from .domain.services import (
-    async_add_user,
+    async_add_users,
     async_clear_condition,
     async_clear_credential,
     async_clear_slot_condition,
     async_clear_usercode,
-    async_delete_user,
+    async_delete_users,
     async_disable_user,
     async_enable_user,
     async_set_condition,
@@ -172,6 +173,49 @@ _ENTRY_SELECTOR = {
     vol.Exclusive("config_entry_id", "entry"): cv.string,
     vol.Exclusive("config_entry_title", "entry"): cv.string,
 }
+
+
+# One user, as `add_user` takes them.
+USER_ENTRY_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_NAME): cv.string,
+        # Stripped here as the config flow strips its own field: a submitted
+        # code is stripped before it is matched, so a PIN stored with padding
+        # matches nothing anybody can type.
+        vol.Optional(CONF_PIN): vol.All(cv.string, vol.Strip),
+        vol.Optional(CONF_ENABLED, default=True): cv.boolean,
+        vol.Optional(CONF_CONDITION): cv.entity_domain(CONDITION_ENTITY_DOMAINS),
+    }
+)
+
+# The fields a pre-6.0 `add_user` call carried at the top level.
+_FLAT_USER_FIELDS = (CONF_NAME, CONF_PIN, CONF_ENABLED, CONF_CONDITION)
+
+
+def _flat_user_to_list(data: dict[str, Any]) -> dict[str, Any]:
+    """
+    Accept the released flat shape as a one-user list.
+
+    ``add_user`` used to take ``name``/``pin``/``enabled``/``condition`` at the
+    top level. Those calls have no ``users`` key for ``ensure_list`` to reach,
+    so they are folded into one here -- before validation, so everything after
+    this point sees a list and nothing has to know two shapes.
+
+    A call already using ``users`` is left alone. Both keys together is a
+    caller mixing shapes, which is refused rather than guessed at.
+    """
+    if CONF_USERS in data:
+        if any(field in data for field in _FLAT_USER_FIELDS):
+            raise vol.Invalid(
+                f"Use either {CONF_USERS} or the individual user fields, not both"
+            )
+        return data
+    if CONF_NAME not in data:
+        # Nothing to fold. Let the schema below report what is missing.
+        return data
+    user = {field: data[field] for field in _FLAT_USER_FIELDS if field in data}
+    rest = {key: value for key, value in data.items() if key not in _FLAT_USER_FIELDS}
+    return {**rest, CONF_USERS: [user]}
 
 
 def _entry_schema(fields: dict[Any, Any]) -> vol.Schema:
@@ -767,39 +811,38 @@ async def async_setup(hass: HomeAssistant, config: Config) -> bool:
         )
 
     async def _add_user(service: ServiceCall) -> None:
-        """Add a user to an entry."""
-        await async_add_user(
+        """Add one or more users to an entry."""
+        await async_add_users(
             hass,
-            service.data[CONF_NAME],
+            service.data[CONF_USERS],
             config_entry_id=service.data.get("config_entry_id"),
             config_entry_title=service.data.get("config_entry_title"),
-            pin=service.data.get(CONF_PIN),
-            enabled=service.data[CONF_ENABLED],
-            condition=service.data.get(CONF_CONDITION),
         )
 
     hass.services.async_register(
         DOMAIN,
         SERVICE_ADD_USER,
         _add_user,
-        schema=_entry_schema(
-            {
-                vol.Required(CONF_NAME): cv.string,
-                # Stripped here as the config flow strips its own field: a
-                # submitted code is stripped before it is matched, so a PIN
-                # stored with padding matches nothing anybody can type.
-                vol.Optional(CONF_PIN): vol.All(cv.string, vol.Strip),
-                vol.Optional(CONF_ENABLED, default=True): cv.boolean,
-                vol.Optional(CONF_CONDITION): cv.entity_domain(
-                    CONDITION_ENTITY_DOMAINS
-                ),
-            }
+        schema=vol.All(
+            # Before validation, so there is exactly one shape from here on.
+            _flat_user_to_list,
+            _entry_schema(
+                {
+                    # ``ensure_list`` so a single user may be given as one
+                    # mapping rather than a list of one. NOT vol.Coerce(list),
+                    # which on a mapping returns its KEYS -- a user dict would
+                    # silently become users named "name" and "pin".
+                    vol.Required(CONF_USERS): vol.All(
+                        cv.ensure_list, [USER_ENTRY_SCHEMA]
+                    ),
+                }
+            ),
         ),
     )
 
     async def _delete_user(service: ServiceCall) -> None:
-        """Remove a user from an entry."""
-        await async_delete_user(
+        """Remove one or more users from an entry."""
+        await async_delete_users(
             hass,
             service.data[CONF_NAME],
             config_entry_id=service.data.get("config_entry_id"),
@@ -813,7 +856,9 @@ async def async_setup(hass: HomeAssistant, config: Config) -> bool:
         _delete_user,
         schema=_entry_schema(
             {
-                vol.Required(CONF_NAME): cv.string,
+                # The field keeps its name, so a released call passing a single
+                # string still validates -- it just arrives as a one-item list.
+                vol.Required(CONF_NAME): vol.All(cv.ensure_list, [cv.string]),
                 vol.Optional(ATTR_CLEAR_CREDENTIALS, default=True): cv.boolean,
             }
         ),

--- a/custom_components/lock_code_manager/domain/services.py
+++ b/custom_components/lock_code_manager/domain/services.py
@@ -7,7 +7,7 @@ import logging
 from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_CONDITION, CONF_ENABLED, CONF_PIN
+from homeassistant.const import CONF_CONDITION, CONF_ENABLED, CONF_NAME, CONF_PIN
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import entity_registry as er
@@ -452,52 +452,66 @@ async def async_disable_user(
     await coordinator.async_request_active_toggle(False)
 
 
-async def async_add_user(
+async def async_add_users(
     hass: HomeAssistant,
-    name: str,
+    users: list[dict[str, Any]],
     *,
     config_entry_id: str | None = None,
     config_entry_title: str | None = None,
-    pin: str | None = None,
-    enabled: bool = True,
-    condition: str | None = None,
 ) -> None:
     """
-    Add a user to an entry, on a slot number chosen by reading the locks.
+    Add one or more users to an entry, numbering them by reading the locks.
 
-    The caller names the person and nothing else. Allocation runs against
-    the entry's own locks, through the same path the config flow uses, so a
-    user added by service and one added in the editor cannot land on
-    different numbers or disagree about which are free.
+    All or nothing. Every name is validated, one allocation covers the whole
+    batch, and one write lands it. Partial success would leave the caller
+    working out which of a list arrived, and nothing here needs it: every way
+    this can fail -- a name that means somebody already here, a batch that
+    will not fit -- is knowable before anything is written.
+
+    Adding N users one call at a time would read the locks N times, which on a
+    battery lock is the difference between usable and not, and would settle
+    the entry N times over.
     """
     config_entry = get_loaded_config_entry(hass, config_entry_id, config_entry_title)
     config = get_entry_config(config_entry)
 
-    if error := name_error(name):
-        raise ServiceValidationError(f"Invalid name {name!r}: {error}")
-    name = normalize_name(name)
-    # Two names meaning one person would collapse into a single key on the
-    # way into storage, taking one of their credentials with it.
-    if any(identity(known) == identity(name) for known in config.users):
-        raise ServiceValidationError(f"A user named {name!r} already exists")
+    additions: dict[str, dict[str, Any]] = {}
+    for entry in users:
+        name = entry[CONF_NAME]
+        if error := name_error(name):
+            raise ServiceValidationError(f"Invalid name {name!r}: {error}")
+        name = normalize_name(name)
+        # Checked against the batch as well as the entry: two names in one
+        # call meaning one person would collapse into a single key on the way
+        # into storage, taking one of their credentials with it.
+        if any(
+            identity(known) == identity(name) for known in (*config.users, *additions)
+        ):
+            raise ServiceValidationError(f"A user named {name!r} already exists")
 
-    # The same rule the editor enforces: a slot cannot be programmed without
-    # something to program.
-    if enabled and not pin:
-        raise ServiceValidationError(f"{name!r} cannot be enabled without a PIN")
+        pin = entry.get(CONF_PIN)
+        enabled = entry.get(CONF_ENABLED, True)
+        condition = entry.get(CONF_CONDITION)
 
-    if condition:
-        _async_validate_condition(hass, condition)
+        # The same rule the editor enforces: a slot cannot be programmed
+        # without something to program.
+        if enabled and not pin:
+            raise ServiceValidationError(f"{name!r} cannot be enabled without a PIN")
+        if condition:
+            _async_validate_condition(hass, condition)
 
-    user: dict[str, Any] = {CONF_ENABLED: enabled}
-    if pin:
-        user[CONF_PIN] = pin
-    if condition:
-        user[CONF_CONDITION] = condition
+        user: dict[str, Any] = {CONF_ENABLED: enabled}
+        if pin:
+            user[CONF_PIN] = pin
+        if condition:
+            user[CONF_CONDITION] = condition
+        additions[name] = user
 
     try:
+        # One read of the locks for the whole batch, sized to what the entry
+        # will hold once it lands.
         unavailable = await async_allocate_for(
-            hass, config_entry, config.locks, len(config.users) + 1
+            hass, config_entry, config.locks, len(config.users) + len(additions)
         )
     except SlotAllocationError as err:
         raise ServiceValidationError(
@@ -509,57 +523,69 @@ async def async_add_user(
         ) from err
 
     # Reconciled against the whole set rather than issued directly: everyone
-    # already here keeps their number by tenure, and only the newcomer is
+    # already here keeps their number by tenure, and only the newcomers are
     # given one.
     assignment = config.assignment.reconcile(
-        [*config.users, name], start=1, unavailable=unavailable
+        [*config.users, *additions], start=1, unavailable=unavailable
     )
     await _async_write_and_settle(
         hass,
         config_entry,
         EntryConfig(
             locks=config.locks,
-            users={**config.users, name: user},
+            users={**config.users, **additions},
             assignment=assignment,
             extra=config.extra,
         ).to_dict(),
     )
 
 
-async def async_delete_user(
+async def async_delete_users(
     hass: HomeAssistant,
-    name: str,
+    names: list[str],
     *,
     config_entry_id: str | None = None,
     config_entry_title: str | None = None,
     clear_credentials: bool = True,
 ) -> None:
     """
-    Remove a user from an entry, and by default from the locks.
+    Remove one or more users from an entry, and by default from the locks.
 
-    ``clear_credentials=False`` hands the credential over rather than
-    deleting it: Lock Code Manager stops managing the slot and whatever is
-    programmed there keeps working. The intent cannot ride in the new
-    configuration, because the user it concerns is precisely what the new
-    configuration no longer has, so it is left for the update listener to
-    pick up as it processes this write.
+    All or nothing, and for the same reason as adding: an unknown name is the
+    caller's mistake, and reporting it after removing the others would leave
+    them working out what happened.
+
+    ``clear_credentials=False`` hands the credentials over rather than
+    deleting them: Lock Code Manager stops managing those slots and whatever
+    is programmed there keeps working. The intent cannot ride in the new
+    configuration, because the users it concerns are precisely what the new
+    configuration no longer has, so it is left for the update listener to pick
+    up as it processes this write.
     """
     config_entry = get_loaded_config_entry(hass, config_entry_id, config_entry_title)
     config = get_entry_config(config_entry)
 
-    stored = next(
-        (known for known in config.users if identity(known) == identity(name)), None
-    )
-    if stored is None:
-        raise ServiceValidationError(f"No user named {name!r} in this config entry")
-
-    if not clear_credentials and (slot_num := config.assignment.slot(stored)):
-        config_entry.runtime_data.retained_pairs.update(
-            (lock_entity_id, slot_num) for lock_entity_id in config.locks
+    departing: set[str] = set()
+    for name in names:
+        stored = next(
+            (known for known in config.users if identity(known) == identity(name)),
+            None,
         )
+        if stored is None:
+            raise ServiceValidationError(f"No user named {name!r} in this config entry")
+        departing.add(stored)
+
+    if not clear_credentials:
+        for stored in departing:
+            if slot_num := config.assignment.slot(stored):
+                config_entry.runtime_data.retained_pairs.update(
+                    (lock_entity_id, slot_num) for lock_entity_id in config.locks
+                )
 
     remaining = {
-        known: fields for known, fields in config.users.items() if known != stored
+        known: fields
+        for known, fields in config.users.items()
+        if known not in departing
     }
     # No unavailable set and so no lock read: a departure issues no numbers,
     # and everyone remaining keeps theirs by tenure.

--- a/custom_components/lock_code_manager/services.yaml
+++ b/custom_components/lock_code_manager/services.yaml
@@ -89,27 +89,43 @@ add_user:
     config_entry_title:
       selector:
         text:
-    name:
+    users:
       required: true
+      example: |
+        - name: Sarah Chen
+          pin: "1234"
+        - name: Courier
+          pin: "9876"
+          enabled: false
       selector:
-        text:
-    pin:
-      selector:
-        text:
-    enabled:
-      default: true
-      selector:
-        boolean:
-    condition:
-      selector:
-        entity:
-          domain:
-            - binary_sensor
-            - calendar
-            - input_boolean
-            - schedule
-            - switch
-
+        object:
+          multiple: true
+          label_field: name
+          description_field: pin
+          fields:
+            name:
+              label: Name
+              required: true
+              selector:
+                text:
+            pin:
+              label: PIN
+              selector:
+                text:
+            enabled:
+              label: Enabled
+              selector:
+                boolean:
+            condition:
+              label: Condition entity
+              selector:
+                entity:
+                  domain:
+                    - binary_sensor
+                    - calendar
+                    - input_boolean
+                    - schedule
+                    - switch
 delete_user:
   fields:
     config_entry_id:
@@ -121,8 +137,10 @@ delete_user:
         text:
     name:
       required: true
+      example: '[\"Sarah Chen\", \"Courier\"]'
       selector:
         text:
+          multiple: true
     clear_credentials:
       default: true
       selector:

--- a/custom_components/lock_code_manager/strings.json
+++ b/custom_components/lock_code_manager/strings.json
@@ -158,7 +158,7 @@
   "services": {
     "add_user": {
       "name": "Add user",
-      "description": "Add a person to a Lock Code Manager config entry. Their slot number is chosen by reading the entry's locks for a free one, so nothing already programmed is overwritten.",
+      "description": "Add one or more people to a Lock Code Manager config entry. Slot numbers are chosen by reading the entry's locks for free ones, so nothing already programmed is overwritten. All or nothing: if any person cannot be added, none are.",
       "fields": {
         "config_entry_id": {
           "name": "Config entry",
@@ -168,21 +168,9 @@
           "name": "Config entry title",
           "description": "The Lock Code Manager entry, named by its title instead of its ID. Matched ignoring case and punctuation. Use this or the config entry, not both."
         },
-        "name": {
-          "name": "Name",
-          "description": "What to call this person. Must be unique within the entry, and cannot contain '|'."
-        },
-        "pin": {
-          "name": "PIN",
-          "description": "The PIN this person uses. Required if they are enabled."
-        },
-        "enabled": {
-          "name": "Enabled",
-          "description": "Whether to program the PIN onto the locks straight away. Defaults to yes."
-        },
-        "condition": {
-          "name": "Condition entity",
-          "description": "An entity whose state decides when this person's PIN works."
+        "users": {
+          "name": "Users",
+          "description": "The people to add. Each takes a name, and optionally a PIN, whether they are enabled, and a condition entity. A single person may be given on their own rather than as a list."
         }
       }
     },
@@ -260,7 +248,7 @@
     },
     "delete_user": {
       "name": "Delete user",
-      "description": "Remove a person from a Lock Code Manager config entry, and by default clear their credentials from its locks.",
+      "description": "Remove one or more people from a Lock Code Manager config entry, clearing their credentials from its locks by default. All or nothing: if any name is not found, none are removed.",
       "fields": {
         "config_entry_id": {
           "name": "Config entry",
@@ -272,7 +260,7 @@
         },
         "name": {
           "name": "Name",
-          "description": "The person to remove."
+          "description": "The people to remove, by name. Matched ignoring case and surrounding whitespace. A single name may be given on its own rather than as a list."
         },
         "clear_credentials": {
           "name": "Clear credentials",

--- a/custom_components/lock_code_manager/translations/en.json
+++ b/custom_components/lock_code_manager/translations/en.json
@@ -158,7 +158,7 @@
   "services": {
     "add_user": {
       "name": "Add user",
-      "description": "Add a person to a Lock Code Manager config entry. Their slot number is chosen by reading the entry's locks for a free one, so nothing already programmed is overwritten.",
+      "description": "Add one or more people to a Lock Code Manager config entry. Slot numbers are chosen by reading the entry's locks for free ones, so nothing already programmed is overwritten. All or nothing: if any person cannot be added, none are.",
       "fields": {
         "config_entry_id": {
           "name": "Config entry",
@@ -168,21 +168,9 @@
           "name": "Config entry title",
           "description": "The Lock Code Manager entry, named by its title instead of its ID. Matched ignoring case and punctuation. Use this or the config entry, not both."
         },
-        "name": {
-          "name": "Name",
-          "description": "What to call this person. Must be unique within the entry, and cannot contain '|'."
-        },
-        "pin": {
-          "name": "PIN",
-          "description": "The PIN this person uses. Required if they are enabled."
-        },
-        "enabled": {
-          "name": "Enabled",
-          "description": "Whether to program the PIN onto the locks straight away. Defaults to yes."
-        },
-        "condition": {
-          "name": "Condition entity",
-          "description": "An entity whose state decides when this person's PIN works."
+        "users": {
+          "name": "Users",
+          "description": "The people to add. Each takes a name, and optionally a PIN, whether they are enabled, and a condition entity. A single person may be given on their own rather than as a list."
         }
       }
     },
@@ -260,7 +248,7 @@
     },
     "delete_user": {
       "name": "Delete user",
-      "description": "Remove a person from a Lock Code Manager config entry, and by default clear their credentials from its locks.",
+      "description": "Remove one or more people from a Lock Code Manager config entry, clearing their credentials from its locks by default. All or nothing: if any name is not found, none are removed.",
       "fields": {
         "config_entry_id": {
           "name": "Config entry",
@@ -272,7 +260,7 @@
         },
         "name": {
           "name": "Name",
-          "description": "The person to remove."
+          "description": "The people to remove, by name. Matched ignoring case and surrounding whitespace. A single name may be given on its own rather than as a list."
         },
         "clear_credentials": {
           "name": "Clear credentials",

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -2287,3 +2287,310 @@ async def test_set_condition_refuses_an_entity_that_does_not_exist(
             },
             blocking=True,
         )
+
+
+async def test_add_user_takes_a_list_and_places_all_of_them(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+) -> None:
+    """Several people arrive in one call, each with their own number."""
+    entry = lock_code_manager_config_entry
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_ADD_USER,
+        {
+            "config_entry_id": entry.entry_id,
+            CONF_USERS: [
+                {CONF_NAME: "Newcomer", CONF_PIN: "9876"},
+                {CONF_NAME: "Second", CONF_PIN: "5432"},
+            ],
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    config = get_entry_config(hass.config_entries.async_get_entry(entry.entry_id))
+    assert config.users["Newcomer"][CONF_PIN] == "9876"
+    assert config.users["Second"][CONF_PIN] == "5432"
+    numbers = {config.assignment.slot(n) for n in ("Newcomer", "Second")}
+    assert None not in numbers
+    assert len(numbers) == 2
+
+
+async def test_adding_a_batch_reads_the_locks_no_more_than_adding_one(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+) -> None:
+    """
+    The batch is allocated once, not once per person.
+
+    Allocation reads every lock to find free numbers. Doing that per user
+    would make a five-guest booking five round trips to a battery lock, which
+    is the difference between usable and not.
+    """
+    entry = lock_code_manager_config_entry
+
+    def _add(users: list[dict]) -> int:
+        return len(users)
+
+    with reading_for() as read_for:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_ADD_USER,
+            {
+                "config_entry_id": entry.entry_id,
+                CONF_USERS: [{CONF_NAME: "Solo", CONF_PIN: "1111"}],
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        for_one = len(read_for)
+
+    with reading_for() as read_for:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_ADD_USER,
+            {
+                "config_entry_id": entry.entry_id,
+                CONF_USERS: [
+                    {CONF_NAME: f"Batch{n}", CONF_PIN: f"222{n}"} for n in range(4)
+                ],
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        for_four = len(read_for)
+
+    assert for_four == for_one
+
+
+async def test_add_user_is_all_or_nothing(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+) -> None:
+    """
+    One bad name in a batch writes none of it.
+
+    Every way this can fail is knowable before anything is written, so a
+    partial write would be a choice rather than a necessity.
+    """
+    entry = lock_code_manager_config_entry
+    before = set(get_entry_config(entry).users)
+
+    with pytest.raises(ServiceValidationError, match="already exists"):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_ADD_USER,
+            {
+                "config_entry_id": entry.entry_id,
+                CONF_USERS: [
+                    {CONF_NAME: "Fine", CONF_PIN: "9876"},
+                    {CONF_NAME: "test1", CONF_PIN: "5432"},
+                ],
+            },
+            blocking=True,
+        )
+    await hass.async_block_till_done()
+
+    assert set(get_entry_config(entry).users) == before
+
+
+async def test_add_user_refuses_two_names_meaning_one_person_in_one_call(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+) -> None:
+    """
+    The batch is checked against itself, not just against the entry.
+
+    Two spellings of one person would collapse into a single key on the way
+    into storage, taking one of their credentials with it.
+    """
+    with pytest.raises(ServiceValidationError, match="already exists"):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_ADD_USER,
+            {
+                "config_entry_id": lock_code_manager_config_entry.entry_id,
+                CONF_USERS: [
+                    {CONF_NAME: "Sarah Chen", CONF_PIN: "9876"},
+                    {CONF_NAME: "  sarah chen ", CONF_PIN: "5432"},
+                ],
+            },
+            blocking=True,
+        )
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param({CONF_NAME: "Newcomer", CONF_PIN: "9876"}, id="released-flat"),
+        pytest.param(
+            {CONF_USERS: {CONF_NAME: "Newcomer", CONF_PIN: "9876"}}, id="single-mapping"
+        ),
+        pytest.param(
+            {CONF_USERS: [{CONF_NAME: "Newcomer", CONF_PIN: "9876"}]}, id="list-of-one"
+        ),
+    ],
+)
+async def test_add_user_accepts_the_released_shape_and_the_list(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+    payload: dict,
+) -> None:
+    """
+    All three spellings land the same person.
+
+    The flat shape is what every released automation sends; it is folded into
+    a list before validation so nothing downstream knows two shapes.
+    """
+    entry = lock_code_manager_config_entry
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_ADD_USER,
+        {"config_entry_id": entry.entry_id, **payload},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    config = get_entry_config(hass.config_entries.async_get_entry(entry.entry_id))
+    assert config.users["Newcomer"][CONF_PIN] == "9876"
+
+
+async def test_add_user_refuses_both_shapes_at_once(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+) -> None:
+    """Mixing the shapes is a caller error, not something to guess at."""
+    with pytest.raises(vol.Invalid):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_ADD_USER,
+            {
+                "config_entry_id": lock_code_manager_config_entry.entry_id,
+                CONF_NAME: "Flat",
+                CONF_USERS: [{CONF_NAME: "Listed", CONF_PIN: "9876"}],
+            },
+            blocking=True,
+        )
+
+
+@pytest.mark.parametrize(
+    "names",
+    [
+        pytest.param("test1", id="released-single-string"),
+        pytest.param(["test1"], id="list-of-one"),
+    ],
+)
+async def test_delete_user_accepts_a_name_or_a_list(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+    names,
+) -> None:
+    """The field kept its name, so released calls validate unchanged."""
+    entry = lock_code_manager_config_entry
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_DELETE_USER,
+        {"config_entry_id": entry.entry_id, CONF_NAME: names},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert "test1" not in get_entry_config(entry).users
+
+
+async def test_delete_user_removes_several_and_is_all_or_nothing(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+) -> None:
+    """A name that is not here stops the whole removal."""
+    entry = lock_code_manager_config_entry
+    before = set(get_entry_config(entry).users)
+
+    with pytest.raises(ServiceValidationError, match="No user named"):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_DELETE_USER,
+            {"config_entry_id": entry.entry_id, CONF_NAME: ["test1", "Nobody"]},
+            blocking=True,
+        )
+    await hass.async_block_till_done()
+    assert set(get_entry_config(entry).users) == before
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_DELETE_USER,
+        {"config_entry_id": entry.entry_id, CONF_NAME: ["test1", "test2"]},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    assert not get_entry_config(entry).users
+
+
+async def test_the_batch_is_allocated_for_everyone_it_will_add(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+) -> None:
+    """
+    Allocation is sized to the whole batch, not to one person.
+
+    Asking for one number and then handing out four would place users past
+    what the locks reported they can hold -- the refusal that exists for
+    exactly that case would never fire, because it was asked the wrong
+    question.
+    """
+    entry = lock_code_manager_config_entry
+    existing = len(get_entry_config(entry).users)
+    asked_for: list[int] = []
+
+    async def _spy(hass, config_entry, locks, num_users, config=None):
+        asked_for.append(num_users)
+        return frozenset()
+
+    with patch(
+        "custom_components.lock_code_manager.domain.services.async_allocate_for",
+        _spy,
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_ADD_USER,
+            {
+                "config_entry_id": entry.entry_id,
+                CONF_USERS: [
+                    {CONF_NAME: f"Batch{n}", CONF_PIN: f"111{n}"} for n in range(4)
+                ],
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    assert asked_for == [existing + 4]
+
+
+async def test_add_user_with_nobody_named_reports_the_missing_field(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+) -> None:
+    """
+    A call naming nobody falls through to the schema.
+
+    The normalizer has nothing to fold, and saying so is the schema's job --
+    inventing an error here would give two different messages for one mistake.
+    """
+    with pytest.raises(vol.Invalid, match="users"):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_ADD_USER,
+            {"config_entry_id": lock_code_manager_config_entry.entry_id},
+            blocking=True,
+        )


### PR DESCRIPTION
## Proposed change

`add_user` and `delete_user` take lists.

```yaml
action: lock_code_manager.add_user
data:
  config_entry_title: All Locks
  users:
    - name: Sarah Chen
      pin: "1234"
    - name: Courier
      pin: "9876"
      enabled: false
```

Adding five guests was five calls, and **each one read every lock** to find free numbers and settled the entry afterwards. A list does it once — which on a battery lock is the difference between usable and not.

The UI gets a repeatable typed form from `ObjectSelector`, with a real entity picker for `condition` and a toggle for `enabled`. That is a straight upgrade on the options flow, which edits users as a single hand-typed YAML blob.

### All or nothing

Every name is validated — against the entry **and against the rest of the batch**, since two spellings of one person in one call would collapse into a single key on the way into storage — then one allocation covers the batch and one write lands it. Every failure mode here is knowable before anything is written, so a partial write would be a choice rather than a necessity.

### Neither service breaks

- **`delete_user`** keeps its field called `name` and wraps it in `cv.ensure_list`. A released call passing `name: "Sarah"` still validates; it just arrives as a one-item list. Nothing to migrate.
- **`add_user`** needs a `users` field, which a released flat call has no key for `ensure_list` to reach — so a normalizer folds `name`/`pin`/`enabled`/`condition` into `users` **before** validation. Everything after that point sees one shape.

Mixing both shapes in one call is refused rather than guessed at.

> **Not `vol.Coerce(list)`.** On a mapping it returns the *keys*, so `{"name": "Sarah", "pin": "1234"}` becomes `["name", "pin"]` — silently adding two users called "name" and "pin". `cv.ensure_list` is the correct helper.

### Why this, now

This is step 3 of the subentry design, brought forward deliberately. Moving users to subentries costs the options flow's YAML blob, which is the only bulk affordance today. Shipping the list first means the bulk path exists **before** the blob goes away, rather than after.

Being non-breaking, it targets `main` rather than `v6`.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

Tests: 2329 passed, 100% coverage held, all hooks pass. **The 17 existing `add_user`/`delete_user` tests were not touched** — they all use the released flat shape, so they are the compatibility proof.

Five mutations run. Four died; **one survived and found a real gap**: allocating for `len(users) + 1` instead of `+ len(batch)` broke nothing, because the fixture's locks have enough slots for the under-sized ask to succeed anyway. That is precisely the bug that would let a batch overflow a lock's capacity without the refusal firing. Added a test pinning the size allocation is asked for; it dies now.
