### PR TITLE
fix: condition linker blueprint called a removed action

### DIFF
--- a/BLUEPRINTS.md
+++ b/BLUEPRINTS.md
@@ -252,7 +252,7 @@ use was against.
 ### Condition Linker
 
 A one-shot automation that assigns a condition entity to a user via
-the `lock_code_manager.set_slot_condition` service. Run it once from
+the `lock_code_manager.set_condition` service. Run it once from
 the Automations page, then delete or keep for reference.
 
 - Uses a synthetic event trigger that never fires automatically
@@ -263,7 +263,7 @@ the Automations page, then delete or keep for reference.
 | Input | Description | Default |
 | ----- | ----------- | ------- |
 | Lock Code Manager config entry | Config entry holding the user | Required |
-| Slot number | The user to assign the condition to (see [Finding a slot number](#finding-a-slot-number)) | Required |
+| Name | The person to assign the condition to, exactly as they are named in the config entry | Required |
 | Condition entity | Entity to use as the condition | Required |
 
 ---

--- a/blueprints/automation/lock_code_manager/condition_linker.yaml
+++ b/blueprints/automation/lock_code_manager/condition_linker.yaml
@@ -2,8 +2,8 @@
 blueprint:
   name: "Lock Code Manager: Condition Linker"
   description: >
-    A one-shot automation that calls `lock_code_manager.set_slot_condition`
-    to wire a condition entity to a code slot. This blueprint provides a
+    A one-shot automation that calls `lock_code_manager.set_condition`
+    to wire a condition entity to one person. This blueprint provides a
     UI-friendly way to assign condition entities without editing YAML.
 
 
@@ -11,12 +11,13 @@ blueprint:
 
     1. Import this blueprint and create an automation from it.
 
-    2. Configure the LCM config entry, slot number, and condition entity.
+    2. Configure the LCM config entry, the person's name, and the
+       condition entity.
 
     3. Manually run the automation once from the Automations page
        (three-dot menu -> Run).
 
-    4. The condition entity is now assigned to the slot. You can delete
+    4. The condition entity is now assigned to that person. You can delete
        the automation afterward or keep it for reference.
 
 
@@ -32,18 +33,17 @@ blueprint:
       selector:
         config_entry:
           integration: lock_code_manager
-    slot_number:
-      name: Slot number
-      description: The code slot number to assign the condition entity to (1-9999).
+    user_name:
+      name: Name
+      description: >
+        The person to assign the condition entity to, exactly as they are
+        named in the config entry.
       selector:
-        number:
-          min: 1
-          max: 9999
-          mode: box
+        text:
     condition_entity:
       name: Condition entity
       description: >
-        The entity to use as the condition for this slot. The slot's PIN
+        The entity to use as the condition for this person. Their PIN
         will only be active when this entity's state is `on`.
       selector:
         entity:
@@ -63,8 +63,8 @@ triggers:
     event_type: lock_code_manager_condition_linker
 
 actions:
-  - action: lock_code_manager.set_slot_condition
+  - action: lock_code_manager.set_condition
     data:
       config_entry_id: !input config_entry
-      slot: !input slot_number
+      name: !input user_name
       entity_id: !input condition_entity

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 import pathlib
+from typing import Any
 
 import pytest
 
 from homeassistant.components.blueprint import BLUEPRINT_SCHEMA, models
 from homeassistant.util import yaml as yaml_util
+
+from custom_components.lock_code_manager.const import DOMAIN
 
 BLUEPRINT_ROOT = pathlib.Path(__file__).resolve().parent.parent / "blueprints"
 
@@ -32,3 +36,55 @@ def test_blueprint_schema(domain: str, blueprint_path: pathlib.Path) -> None:
         path=str(blueprint_path),
         schema=BLUEPRINT_SCHEMA,
     )
+
+
+def _iter_actions(node: Any) -> Iterator[tuple[str, dict]]:
+    """Yield every (action, data) pair anywhere in a blueprint's structure."""
+    if isinstance(node, dict):
+        for key in ("action", "service"):
+            if isinstance(name := node.get(key), str):
+                yield name, node.get("data") or {}
+        for value in node.values():
+            yield from _iter_actions(value)
+    elif isinstance(node, list):
+        for item in node:
+            yield from _iter_actions(item)
+
+
+@pytest.mark.parametrize(("domain", "blueprint_path"), _discover_blueprints())
+def test_blueprint_calls_only_actions_that_exist(
+    domain: str, blueprint_path: pathlib.Path
+) -> None:
+    """
+    Every Lock Code Manager action a blueprint calls is one the integration has,
+    with each of that action's required fields supplied.
+
+    A blueprint is shipped configuration that nothing else type-checks: removing
+    or resharing an action leaves the YAML parsing perfectly and failing at run
+    time, in somebody's imported automation. That is how
+    ``condition_linker`` came to call ``set_slot_condition`` after it was
+    removed, and to address a slot number after the action started taking a
+    name.
+    """
+    services = yaml_util.load_yaml(
+        pathlib.Path(__file__).resolve().parent.parent
+        / "custom_components"
+        / "lock_code_manager"
+        / "services.yaml"
+    )
+    data = yaml_util.load_yaml(blueprint_path)
+
+    for action, supplied in _iter_actions(data):
+        if not action.startswith(f"{DOMAIN}."):
+            continue
+        name = action.removeprefix(f"{DOMAIN}.")
+        assert name in services, f"{blueprint_path.name} calls unknown action {action}"
+        required = {
+            field
+            for field, spec in (services[name].get("fields") or {}).items()
+            if isinstance(spec, dict) and spec.get("required")
+        }
+        assert required <= set(supplied), (
+            f"{blueprint_path.name} calls {action} without "
+            f"{sorted(required - set(supplied))}"
+        )


### PR DESCRIPTION
# Breaking change

The **Condition Linker** blueprint now takes the person's **Name** instead of a **Slot number**. An automation already created from it has to be reconfigured — or, since it is a one-shot, simply recreated and run.

## Proposed change

`blueprints/automation/lock_code_manager/condition_linker.yaml` still called `lock_code_manager.set_slot_condition`, removed in #1507. Anyone who had imported it got an automation that parses fine and fails at run time.

Its replacement, `set_condition`, addresses a person by name rather than a slot number, so the blueprint's input changes with it.

### Why this shipped

Nothing type-checks a blueprint. `test_blueprints.py` validated the schema and `test_blueprint_docs.py` cross-checked the documented inputs, but neither knew whether the actions being called existed. So #1507 removed four actions with a green suite while leaving a caller behind.

This adds that check: every `lock_code_manager.*` action a blueprint calls must exist in `services.yaml`, with all of that action's `required` fields supplied. Verified against both failure modes by mutation:

- restoring `set_slot_condition` → *"condition_linker.yaml calls unknown action lock_code_manager.set_slot_condition"*
- passing `slot:` instead of `name:` → *"condition_linker.yaml calls lock_code_manager.set_condition without ['name']"*

The second is the one worth having. An action that keeps its name but changes how it addresses its subject is exactly the change a schema test sees nothing wrong with.

I checked the other six blueprints: `calendar_pin_setter` and `calendar_condition` still take a slot number, but they use it to *locate an entity* by its `code_slot` attribute rather than to call a slot-addressed action, so both are unaffected.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- Follow-up to #1507.
- `BLUEPRINTS.md` updated to match; the wiki's Blueprints page is staged alongside the other v6 wiki changes.
- Full suite green at 100% coverage; `prek` clean.
