### PR TITLE
test: a keypad press reaches the bus, not just the funnel

### DIFF
--- a/custom_components/lock_code_manager/providers/zwave_js_ui.py
+++ b/custom_components/lock_code_manager/providers/zwave_js_ui.py
@@ -578,7 +578,7 @@ class ZWaveJSUILock(BaseMqttLock):
         if command_class in USER_CODE_CC_SEGMENTS:
             self._process_user_code_value(property_name, property_key, payload)
         elif command_class in NOTIFICATION_CC_SEGMENTS:
-            self._process_notification(topic, property_name, property_key, payload)
+            self._process_notification(property_name, property_key, payload)
 
     @callback
     def _process_user_code_value(
@@ -645,7 +645,6 @@ class ZWaveJSUILock(BaseMqttLock):
     @callback
     def _process_notification(
         self,
-        topic: str,
         label: str,
         event_label: str,
         payload: bytes | str,

--- a/tests/providers/zwave_js/test_events.py
+++ b/tests/providers/zwave_js/test_events.py
@@ -13,15 +13,23 @@ from zwave_js_server.const.command_class.lock import CodeSlotStatus
 from zwave_js_server.event import Event as ZwaveEvent
 from zwave_js_server.model.node import Node
 
-from homeassistant.core import HomeAssistant
+from homeassistant.const import ATTR_NAME
+from homeassistant.core import Event, HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
 from custom_components.lock_code_manager.const import (
+    ATTR_CREDENTIAL_TYPE,
+    ATTR_OPERATION,
+    BUS_EVENT_CREDENTIAL_USED,
     CONF_LOCKS,
     CONF_SLOTS,
     DOMAIN,
 )
-from custom_components.lock_code_manager.domain.credentials import pin_address
+from custom_components.lock_code_manager.domain.credentials import (
+    CredentialType,
+    pin_address,
+)
+from custom_components.lock_code_manager.domain.events import CredentialOperation
 from custom_components.lock_code_manager.domain.exceptions import LockDisconnected
 from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers.zwave_js import ZWaveJSLock
@@ -248,6 +256,51 @@ async def test_event_filter_matches_correct_node(
 # ---------------------------------------------------------------------------
 # Notification event tests (operation events — lock/unlock)
 # ---------------------------------------------------------------------------
+
+
+async def test_a_keypad_press_reaches_the_bus_as_a_credential_used_event(
+    hass: HomeAssistant,
+    lcm_config_entry: MockConfigEntry,
+    lock_schlage_be469: Node,
+) -> None:
+    """
+    A keypad press on a configured slot produces the event consumers subscribe to.
+
+    The tests below stop at ``async_fire_code_slot_event``, which proves this
+    provider's notification decoding calls the funnel but not that anything
+    reaches the bus -- and the funnel stays silent for a slot no entry
+    manages, which is what those tests configure. This one goes the whole
+    way, on the provider whose decoding is the most intricate.
+    """
+    events: list[Event] = []
+    hass.bus.async_listen(BUS_EVENT_CREDENTIAL_USED, events.append)
+
+    lock_schlage_be469.receive_event(
+        ZwaveEvent(
+            type="notification",
+            data={
+                "source": "node",
+                "event": "notification",
+                "nodeId": lock_schlage_be469.node_id,
+                "endpointIndex": 0,
+                "ccId": 113,
+                "args": {
+                    "type": 6,  # ACCESS_CONTROL
+                    "event": 6,  # KEYPAD_UNLOCK_OPERATION
+                    "label": "Access Control",
+                    "eventLabel": "Keypad unlock operation",
+                    "parameters": {"userId": 1},
+                },
+            },
+        )
+    )
+    await hass.async_block_till_done()
+
+    assert len(events) == 1
+    # The person, not the number they occupy.
+    assert events[0].data[ATTR_NAME] == "slot1"
+    assert events[0].data[ATTR_OPERATION] == CredentialOperation.UNLOCK
+    assert events[0].data[ATTR_CREDENTIAL_TYPE] == CredentialType.PIN
 
 
 async def test_notification_event_keypad_lock_fires_a_code_slot_event(


### PR DESCRIPTION
# Breaking change

None.

## Proposed change

Two loose ends from a provider-layer review of #1514, both artifacts of the `lock_state_changed` removal.

**A keypad press is now tested to the bus, not just to the funnel.** The three zwave_js notification tests were converted in this PR from capturing a real event to `zwave_js_lock.async_fire_code_slot_event = MagicMock()`. That proves the provider's notification decoding calls the funnel, but not that anything reaches the bus — and the funnel is deliberately silent for a slot no entry manages, which is exactly what those tests configure (`CONF_SLOTS: {}`). So after that change, nothing anywhere proved a zwave_js keypad press produces a `credential_used` event.

This adds one end-to-end test on the existing fully-set-up `lcm_config_entry` fixture. It asserts the payload names the **person**, so a mis-decoded slot surfaces as the wrong user's name rather than a number — mutation-verified by offsetting the decoded `userId`, which fails with `assert 'slot2' == 'slot1'`.

I did not convert the other three back: they cover the decoding branches cheaply and correctly at that level. The gap was that nothing sat above them.

**`_process_notification`'s `topic` parameter is dead.** Its only use was `source_data={"topic": topic, ...}`, deleted with the event. Sibling of the `OPERATION_SOURCE_NAMES` constant already removed; an unused-argument diff across all nine providers between `main` and `v6` says this is the last one.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- Full suite green at 100% coverage (2311); `prek` clean.
- A separate, more serious provider finding from the same review is **pre-existing on `main`**, not a v6 regression, and is filed separately rather than bundled here.
