### PR TITLE
fix: releasing a slot no longer adopts a user LCM never created

### DIFF
--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -1290,7 +1290,9 @@ class BaseLock:
         if result.changed and self.coordinator and not self.supports_push:
             await self.coordinator.async_request_refresh()
 
-    async def async_clear_usercode(self, code_slot: int) -> bool:
+    async def async_clear_usercode(
+        self, code_slot: int, *, adopt_untagged: bool = True
+    ) -> bool:
         """
         Clear a usercode on a code slot via the User->Credential primitives.
 
@@ -1308,6 +1310,14 @@ class BaseLock:
         -- and True when the provider cannot determine whether a change
         occurred, so the coordinator refreshes and verifies the actual
         state.
+
+        ``adopt_untagged`` is what separates a clear from a release. Clearing
+        a slot LCM still manages may adopt an untagged owner: the slot is
+        ours, adoption is how a pre-tag install is taken over, and the write
+        that follows corrects a wrong guess. Releasing a slot LCM no longer
+        manages may not -- the premise has inverted, nothing follows to
+        correct anything, and the untagged user at that index is as likely to
+        be somebody else's as ours.
         """
         if not self.supports_native_users:
             ref = CredentialRef(
@@ -1341,15 +1351,19 @@ class BaseLock:
                 if credential.slot == code_slot
             )
         except StopIteration:
-            owner_user_id = next(
-                (
-                    user.user_id
-                    for user in users
-                    if parse_tag(user.name or "")[0] is None
-                    for credential in user.pin_credentials
-                    if credential.slot == code_slot
-                ),
-                None,
+            owner_user_id = (
+                next(
+                    (
+                        user.user_id
+                        for user in users
+                        if parse_tag(user.name or "")[0] is None
+                        for credential in user.pin_credentials
+                        if credential.slot == code_slot
+                    ),
+                    None,
+                )
+                if adopt_untagged
+                else None
             )
         if owner_user_id is None:
             # No user owns this slot's credential -- nothing to clear.
@@ -1365,6 +1379,8 @@ class BaseLock:
         self,
         code_slot: int,
         source: Literal["sync", "direct"] = "direct",
+        *,
+        adopt_untagged: bool = True,
     ) -> bool:
         """
         Clear a usercode on a code slot.
@@ -1384,7 +1400,9 @@ class BaseLock:
         # keys PENDING_CONFIRMATION on this dict).
         self._pending_writes.pop(pin_address(code_slot), None)
         changed = await self._execute_rate_limited(
-            "clear", self.async_clear_usercode, code_slot
+            "clear",
+            partial(self.async_clear_usercode, adopt_untagged=adopt_untagged),
+            code_slot,
         )
         # Only a clear that changed something is evidence about the slot. A
         # provider that found nothing to clear has said nothing about what is
@@ -1770,7 +1788,9 @@ class BaseLock:
         that user instead; the cascade defined by the lock's protocol
         removes its credentials, so they must not also clear here.
         """
-        await self.async_internal_clear_usercode(slot)
+        # Never adopts: see ``async_clear_usercode``. A slot LCM no longer
+        # manages has no claim on whoever owns the credential at that index.
+        await self.async_internal_clear_usercode(slot, adopt_untagged=False)
 
     async def async_set_user(self, user: User) -> SetUserResult:
         """

--- a/custom_components/lock_code_manager/providers/matter.py
+++ b/custom_components/lock_code_manager/providers/matter.py
@@ -769,7 +769,9 @@ class MatterLock(BaseLock):
                 return slot
         return user.user_id
 
-    async def _find_user_index_for_slot(self, slot: int) -> int | None:
+    async def _find_user_index_for_slot(
+        self, slot: int, *, adopt_untagged: bool = True
+    ) -> int | None:
         """
         Return the ``user_index`` of the user LCM owns for ``slot``, if any.
 
@@ -795,6 +797,14 @@ class MatterLock(BaseLock):
            PIN at index ``B``; matching on ``cred.slot == slot`` alone
            would mis-adopt slot-A's user as slot-B's anchor.
 
+        ``adopt_untagged`` turns the second lookup off. The set path wants it:
+        the slot is ours, and the write that follows rewrites the name to the
+        tagged form, so a wrong guess corrects itself. The release path must
+        not have it -- ``ClearUser`` cascades to the user's credentials,
+        nothing follows to correct anything, and the untagged user holding a
+        PIN at that index is as likely to be one the homeowner made in the
+        vendor's app as one of ours.
+
         Returns ``None`` when neither lookup matches.
         """
         users = await self.async_get_users()
@@ -805,6 +815,8 @@ class MatterLock(BaseLock):
                 if existing.name and parse_tag(existing.name)[0] == slot
             )
         except StopIteration:
+            if not adopt_untagged:
+                return None
             return next(
                 (
                     existing.user_id
@@ -834,9 +846,11 @@ class MatterLock(BaseLock):
 
         Called by the base teardown path when the slot is removed from
         LCM config (see ``__init__.py``'s ``pairs_removed`` loop). Looks
-        up the lock-side user via the same find-or-adopt logic the set
-        path uses, then deletes it. Matter's ClearUser cascade then
-        removes the user's PIN credential automatically.
+        up the lock-side user by its ``lcm:<slot>:`` tag ONLY, never by
+        adoption, then deletes it. Matter's ClearUser cascade then removes
+        the user's PIN credential automatically -- which is exactly why
+        adoption is forbidden here: it would irreversibly delete a
+        credential this integration never created.
 
         Tolerates "no user found": the slot may have never had an LCM
         user on this lock (e.g. the user was already removed out-of-band,
@@ -844,7 +858,7 @@ class MatterLock(BaseLock):
         transport failures bubble up so the base wraps them in a warning
         and the teardown still completes.
         """
-        user_index = await self._find_user_index_for_slot(slot)
+        user_index = await self._find_user_index_for_slot(slot, adopt_untagged=False)
         if user_index is None:
             LOGGER.debug(
                 "Lock %s: no LCM-owned user to release for slot %s",

--- a/tests/common.py
+++ b/tests/common.py
@@ -280,11 +280,17 @@ class MockLCMLock(BaseLock):
         self.service_calls["set_usercode"].append((code_slot, usercode, name))
         return WriteResult.CONFIRMED
 
-    async def async_clear_usercode(self, code_slot: int) -> bool:
+    async def async_clear_usercode(
+        self, code_slot: int, *, adopt_untagged: bool = True
+    ) -> bool:
         """
         Clear a usercode on a code slot.
 
         Returns True if the value was changed, False if already cleared.
+
+        ``adopt_untagged`` is accepted and ignored: this lock is slot-only, so
+        it has no users to adopt. Matching the base signature is what lets the
+        release path pass it without special-casing the double.
         """
         if code_slot not in self.codes:
             return False

--- a/tests/providers/matter/test_provider.py
+++ b/tests/providers/matter/test_provider.py
@@ -2906,10 +2906,25 @@ class TestReleaseManagedSlot:
         call = mock_clear_user.call_args
         assert 42 in call.args or call.kwargs.get("user_index") == 42
 
-    async def test_release_adopts_legacy_untagged_user_at_credential_index(
+    async def test_release_leaves_an_untagged_user_alone(
         self, hass: HomeAssistant, matter_lock: MatterLock
     ) -> None:
-        """A legacy user owning a PIN at credential_index=slot is treated as the slot's owner."""
+        """
+        Releasing never adopts, because ClearUser cannot be undone.
+
+        An untagged user owning a PIN at this credential index is as likely to
+        be one the homeowner made in the vendor's app as a pre-tag LCM user --
+        the index alone cannot tell them apart. The set path may adopt,
+        because the write that follows retags a wrong guess; the release path
+        may not, because ClearUser cascades to the user's credentials and
+        nothing follows to correct anything.
+
+        The accepted cost is the mirror case: a pre-tag LCM user whose slot
+        was never re-written since upgrading keeps their PIN when the user is
+        removed. That is recoverable and visible -- the code shows on the lock
+        card as unmanaged and can be cleared there -- whereas deleting a
+        credential this integration never wrote is neither.
+        """
         mock_clear_user = AsyncMock(return_value=None)
         with (
             self._patch_users(
@@ -2925,9 +2940,7 @@ class TestReleaseManagedSlot:
         ):
             await matter_lock.async_release_managed_slot(3)
 
-        mock_clear_user.assert_called_once()
-        call = mock_clear_user.call_args
-        assert 99 in call.args or call.kwargs.get("user_index") == 99
+        mock_clear_user.assert_not_called()
 
     async def test_release_no_op_when_no_lcm_user(
         self, hass: HomeAssistant, matter_lock: MatterLock

--- a/tests/providers/test_base.py
+++ b/tests/providers/test_base.py
@@ -44,9 +44,11 @@ from custom_components.lock_code_manager.domain.coordinator import (
     LockUsercodeUpdateCoordinator,
 )
 from custom_components.lock_code_manager.domain.credentials import (
+    Credential,
     CredentialType,
     CredentialTypeCapability,
     LockCapabilities,
+    User,
     pin_address,
 )
 from custom_components.lock_code_manager.domain.events import CredentialOperation
@@ -59,6 +61,9 @@ from custom_components.lock_code_manager.domain.exceptions import (
 )
 from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers._base import BaseLock
+from custom_components.lock_code_manager.providers._util import (
+    make_tagged_name,
+)
 from tests.common import BASE_CONFIG, LOCK_1_ENTITY_ID, MockLCMLock
 
 TEST_OPERATION_DELAY = 0.01
@@ -2528,3 +2533,116 @@ async def test_a_lock_that_was_set_up_is_not_set_up_again_on_every_check(
 
     await lock.coordinator.async_shutdown()
     await lock.async_unload(False)
+
+
+class _NativeUserOwnerResolutionLock(MockNativeUserLock):
+    """
+    A native-user lock that uses the BASE's owner resolution.
+
+    ``MockLCMLock`` overrides ``async_clear_usercode`` with a slot-only
+    shortcut, which is what most tests want and what makes it useless for
+    exercising the two-pass owner lookup. This delegates back to the base so
+    the resolution under test is the real one.
+    """
+
+    async def async_get_capabilities(self) -> LockCapabilities:
+        """Advertise PIN support so the base's write paths engage."""
+        return _pin_capabilities()
+
+    async def async_clear_usercode(
+        self, code_slot: int, *, adopt_untagged: bool = True
+    ) -> bool:
+        """Resolve the owner the way a real native-user provider does."""
+        return await BaseLock.async_clear_usercode(
+            self, code_slot, adopt_untagged=adopt_untagged
+        )
+
+
+def _lock_user(user_id: int, name: str | None, pin_slot: int) -> User:
+    """Build a lock-side user owning one PIN credential."""
+    return User(
+        user_id=user_id,
+        name=name,
+        credentials=(Credential(type=CredentialType.PIN, slot=pin_slot, state=None),),
+    )
+
+
+async def test_releasing_a_slot_does_not_delete_an_untagged_users_credential(
+    hass: HomeAssistant,
+):
+    """
+    Releasing never adopts an untagged owner.
+
+    The clear path may: the slot is still LCM's, adoption is how a pre-tag
+    install is taken over, and the write that follows corrects a wrong guess.
+    Releasing has the opposite premise -- the slot is no longer LCM's, and
+    nothing follows -- so an untagged user holding a PIN at that index, which
+    is as likely to be one somebody else made, must be left alone.
+    """
+    lock = _make_base_test_lock(
+        hass, "release_untagged", _NativeUserOwnerResolutionLock
+    )
+    deleted = AsyncMock(return_value=True)
+    with (
+        patch.object(
+            lock,
+            "async_get_users",
+            AsyncMock(
+                return_value=[
+                    _lock_user(99, "Alice", 3),  # untagged: not ours to delete
+                ]
+            ),
+        ),
+        patch.object(lock, "async_delete_credential", deleted),
+    ):
+        await lock.async_release_managed_slot(3)
+
+    deleted.assert_not_called()
+
+
+async def test_releasing_a_slot_deletes_the_credential_of_its_tagged_user(
+    hass: HomeAssistant,
+):
+    """The user LCM demonstrably created is still torn down."""
+    lock = _make_base_test_lock(hass, "release_tagged", _NativeUserOwnerResolutionLock)
+    deleted = AsyncMock(return_value=True)
+    with (
+        patch.object(
+            lock,
+            "async_get_users",
+            AsyncMock(
+                return_value=[
+                    _lock_user(99, make_tagged_name(3, "Raman"), 3),
+                ]
+            ),
+        ),
+        patch.object(lock, "async_delete_credential", deleted),
+    ):
+        await lock.async_release_managed_slot(3)
+
+    deleted.assert_called_once()
+    assert deleted.call_args.args[0].user_id == 99
+
+
+async def test_clearing_a_managed_slot_still_adopts_an_untagged_owner(
+    hass: HomeAssistant,
+):
+    """The upgrade path this scoping must not break: a clear may still adopt."""
+    lock = _make_base_test_lock(hass, "clear_adopts", _NativeUserOwnerResolutionLock)
+    deleted = AsyncMock(return_value=True)
+    with (
+        patch.object(
+            lock,
+            "async_get_users",
+            AsyncMock(
+                return_value=[
+                    _lock_user(99, "Alice", 3),
+                ]
+            ),
+        ),
+        patch.object(lock, "async_delete_credential", deleted),
+    ):
+        await lock.async_clear_usercode(3)
+
+    deleted.assert_called_once()
+    assert deleted.call_args.args[0].user_id == 99


### PR DESCRIPTION
## Proposed change

Fixes #1518.

`async_release_managed_slot` — the only route by which a departing user's lock-side state is torn down — resolved the user to delete with the **same find-or-adopt logic the write path uses**.

Adoption is correct on the write path: the slot is ours, adoption is how a pre-tag install is taken over, and the `set_lock_user` that follows rewrites the name to the tagged form, so a wrong guess corrects itself immediately.

On the release path every part of that premise inverts. The slot is **no longer** ours, nothing follows to correct anything, and the untagged user holding a PIN at that index is as likely to be one somebody else created as one of ours.

### What it did

On Matter, adoption leads to `ClearUser`, whose spec cascade removes the user **and every credential it owns**:

1. A homeowner adds a PIN through the lock vendor's app or Apple Home. Matter auto-allocates it credential index 1; its user is untagged.
2. In Lock Code Manager you add "Guest", who is issued slot 1, and never give them a PIN — so no `lcm:1:` user is ever created on that lock.
3. You delete "Guest".

`pairs_removed` is derived purely from configuration, so the release fires for a slot that never held anything. The canonical pass finds no `lcm:1:` user, adoption matches the homeowner's user, and it is destroyed. Nothing reports why that person is locked out. The release loop runs for **every lock in the entry**, and a repeat release falls through to adoption again.

`_base.py` had the same shape one layer down, deleting the credential rather than the whole user. Under Z-Wave User Credential CC, `credential_index_follows_slot` makes the collision likely.

### The fix

An `adopt_untagged` parameter on the **shared** resolution — not a second resolver — so the two paths cannot drift, and the release path cannot silently miss a repair the shared one gains later. The write path keeps its default; release passes `False`.

### The cost, stated plainly

The mirror case is now possible: a **pre-tag LCM** user is also untagged, so one whose slot was never re-written since upgrading keeps their PIN when removed.

I took that trade deliberately. That window is narrow — the write path retags on the first write after upgrading — and its cost is **recoverable and visible**: the code shows on the lock card as unmanaged and can be cleared there. Deleting a credential this integration never wrote is neither recoverable nor visible.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- Pre-existing on `main`, not a v6 regression — targeting `main` so it ships to current users.
- One existing test asserted the old behaviour (`test_release_adopts_legacy_untagged_user_at_credential_index`). It is replaced by one asserting the safe contract, with the trade documented in the docstring rather than buried here.
- Both layers' new guards are mutation-verified: restoring adoption fails them. The set path's adoption test still passes, which is what proves the upgrade path is intact.
- Full suite green at 100% coverage (2332); `prek` clean.
