### PR TITLE
fix: a wedged capability probe no longer disables the lock for good

### DIFF
--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -833,11 +833,20 @@ class BaseLock:
                 # "no", this means it did not answer at all. A lock that is
                 # merely still coming up raises LockDisconnected instead of
                 # going quiet, so silence here is a wedge, not a slow boot.
+                # Re-armed, or nothing ever retries. `_async_run_provider_setup`
+                # clears this on the way in, and it is the only thing
+                # `_handle_connection_transition` checks -- while the LOADED
+                # transition the state listener waits for never comes for an
+                # integration that was already loaded and then wedged. Without
+                # it the lock is permanently un-set-up: sync stays gated on
+                # `provider_setup_succeeded` and refuses to write anything
+                # until somebody reloads by hand.
+                self._setup_deferred = True
                 LOGGER.warning(
                     "Capability probe for %s got no answer within %.0fs; its "
                     "integration is likely wedged rather than slow. Entities "
                     "will be created but unavailable, and setup is retried "
-                    "when that integration reloads or reconnects.",
+                    "once that integration answers again.",
                     self.lock.entity_id,
                     self.operation_timeout_seconds,
                 )

--- a/tests/providers/test_base.py
+++ b/tests/providers/test_base.py
@@ -2824,6 +2824,11 @@ async def test_setup_does_not_hang_on_a_capability_probe_that_never_answers(
     # Degraded, not dropped: setup finished and the retry path is armed.
     assert lock._setup_succeeded is False
     assert lock._setup_complete.is_set()
+    # The flag IS the retry path. `_handle_connection_transition` checks
+    # nothing else, and the LOADED transition the state listener waits for
+    # never arrives for an integration that was already loaded and then went
+    # quiet -- so without this the lock never gets set up again.
+    assert lock._setup_deferred is True
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Proposed change

Regression in 5.5.2, from #1525.

The `except TimeoutError` around the bounded capability probe logs a warning and moves on without re-arming `_setup_deferred`.

That flag is the only thing `_handle_connection_transition` checks, and `_async_run_provider_setup` clears it on the way in. The state listener's other route needs a transition *into* `LOADED` — which never comes for an integration that was already loaded and then went quiet, which is exactly what a probe timeout describes.

So a lock whose integration wedges during initial setup is **permanently un-set-up**: no capability validation, no provider setup, and sync — gated on `provider_setup_succeeded` — refuses to write anything to it until the user reloads by hand.

The reconnect handler re-arms the flag for precisely this reason. The rework that moved the probe onto the setup path didn't carry it across, and the warning text promised a retry that couldn't happen.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue: #1523
- #1525's own test asserted "the retry path is armed" in its docstring and nothing about it in its body, which is why the suite stayed green through the regression. It asserts the flag now; mutation-verified — removing the re-arm fails it.
- Full suite green at 100% coverage (2343); `prek` clean.