### PR TITLE
fix: the operation deadline covers every device call, not just the last

### DIFF
--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -318,6 +318,44 @@ class BaseLock:
         # transition handler, then raise the layer-specific message. The two
         # checks are kept distinct for diagnostics; the transition only cares
         # whether the lock is reachable end-to-end.
+        # Inside the deadline, not before it. These are device I/O on some
+        # providers -- Schlage's availability check is a `get_codes` cloud
+        # round trip -- and waiting on `_aio_lock` behind another caller is
+        # the #1523 park itself. Bounding only `func` left both unbounded.
+        try:
+            async with asyncio.timeout(self.operation_timeout_seconds):
+                return await self._execute_bounded(
+                    operation_type, func, *args, pre_execute=pre_execute, **kwargs
+                )
+        except TimeoutError as err:
+            # A disconnection, not an operation failure, and the distinction
+            # decides whether anything happens at all. A failure charges the
+            # SLOT breaker, which is windowed -- three strikes inside five
+            # minutes -- so at a budget longer than that window the count
+            # resets on every retry and it can never trip. A disconnection
+            # charges the LOCK breaker, which counts consecutively: three
+            # trips `unreachable`, the tick gates on it, and backoff stops the
+            # hammering. It self-heals on the next successful poll too, where
+            # a suspended slot would wait for someone to edit the PIN.
+            #
+            # It is the honest word besides: a lock that has answered nothing
+            # in this long is not reachable.
+            raise LockDisconnected(
+                f"Cannot {_OPERATION_MESSAGES[operation_type]} "
+                f"{self.lock.entity_id} - no answer within "
+                f"{self.operation_timeout_seconds:.0f}s"
+            ) from err
+
+    @final
+    async def _execute_bounded(
+        self,
+        operation_type: Literal["get", "set", "clear", "refresh"],
+        func: Callable[..., Any],
+        *args: Any,
+        pre_execute: Callable[[], None] | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Run one operation, with the caller holding the deadline."""
         integration_up = await self.async_is_integration_connected()
         device_up = await self.async_is_device_available()
         self._note_reachability(integration_up and device_up)
@@ -351,28 +389,7 @@ class BaseLock:
                 self.lock.entity_id,
             )
 
-            try:
-                async with asyncio.timeout(self.operation_timeout_seconds):
-                    result = await func(*args, **kwargs)
-            except TimeoutError as err:
-                # A disconnection, not an operation failure, and the
-                # distinction decides whether anything happens at all. A
-                # failure charges the SLOT breaker, which is windowed -- three
-                # strikes inside five minutes -- so at a budget longer than
-                # that window the count resets on every retry and it can never
-                # trip. A disconnection charges the LOCK breaker, which counts
-                # consecutively: three trips `unreachable`, the tick gates on
-                # it, and backoff stops the hammering. It self-heals on the
-                # next successful poll too, where a suspended slot would wait
-                # for someone to edit the PIN.
-                #
-                # It is the honest word besides: a lock that has answered
-                # nothing in this long is not reachable.
-                raise LockDisconnected(
-                    f"Cannot {_OPERATION_MESSAGES[operation_type]} "
-                    f"{self.lock.entity_id} - no answer within "
-                    f"{self.operation_timeout_seconds:.0f}s"
-                ) from err
+            result = await func(*args, **kwargs)
             self._last_operation_time = time.monotonic()
             return result
 
@@ -948,6 +965,18 @@ class BaseLock:
         PIN-support validation once the integration comes up.
         """
         self._setup_deferred = False
+        # One deadline over the whole method: the probe AND `async_setup`,
+        # which is device I/O too -- akuvox and schlage run an unmanaged-code
+        # tagging pass in it, zwave-js-ui subscribes. Setup runs while Home
+        # Assistant holds the entry's lock, so anything unbounded here parks
+        # the entry in `setup_in_progress` and takes reload and remove with
+        # it. A provider that does none of this just returns first.
+        async with asyncio.timeout(self.operation_timeout_seconds):
+            await self._run_provider_setup_bounded(config_entry)
+
+    @final
+    async def _run_provider_setup_bounded(self, config_entry: ConfigEntry) -> None:
+        """Validate capabilities and run provider setup, under a deadline."""
         if self.supports_native_users:
             # Bounded like the initial read, and for the same reason: setup
             # runs while Home Assistant holds the entry's lock, and this probe
@@ -955,8 +984,7 @@ class BaseLock:
             # the provider's own -- `MatterLock.async_get_capabilities` awaits
             # `get_lock_info` bare. A probe is a read, so cancelling it is
             # safe.
-            async with asyncio.timeout(self.operation_timeout_seconds):
-                caps = await self._get_cached_capabilities()
+            caps = await self._get_cached_capabilities()
             if CredentialType.PIN not in caps.credential_types:
                 # A degenerate-but-successful probe was just cached;
                 # invalidate it so the reconnect-path revalidation

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -833,11 +833,20 @@ class BaseLock:
                 # "no", this means it did not answer at all. A lock that is
                 # merely still coming up raises LockDisconnected instead of
                 # going quiet, so silence here is a wedge, not a slow boot.
+                # Re-armed, or nothing ever retries. `_async_run_provider_setup`
+                # clears this on the way in, and it is the only thing
+                # `_handle_connection_transition` checks -- while the LOADED
+                # transition the state listener waits for never comes for an
+                # integration that was already loaded and then wedged. Without
+                # it the lock is permanently un-set-up: sync stays gated on
+                # `provider_setup_succeeded` and refuses to write anything
+                # until somebody reloads by hand.
+                self._setup_deferred = True
                 LOGGER.warning(
                     "Capability probe for %s got no answer within %.0fs; its "
                     "integration is likely wedged rather than slow. Entities "
                     "will be created but unavailable, and setup is retried "
-                    "when that integration reloads or reconnects.",
+                    "once that integration answers again.",
                     self.lock.entity_id,
                     self.operation_timeout_seconds,
                 )

--- a/tests/providers/test_base.py
+++ b/tests/providers/test_base.py
@@ -2731,6 +2731,68 @@ async def test_a_wedged_operation_is_cut_off_and_reported_as_a_disconnect(
     assert entered.is_set()
 
 
+async def test_a_wedged_availability_check_is_cut_off_too(hass: HomeAssistant):
+    """
+    The deadline covers the checks that run before the operation.
+
+    They are device I/O on some providers -- Schlage's availability check is a
+    `get_codes` cloud round trip -- so a wedge there parks the slot in SYNCING
+    exactly as issue #1523 describes, while a deadline placed around `func`
+    alone is never reached.
+    """
+    lock = _make_base_test_lock(hass, "wedged_availability")
+    lock._min_operation_delay = 0
+    never_ran = AsyncMock(return_value="unreachable")
+
+    async def _never_returns():
+        await asyncio.Event().wait()
+
+    with (
+        patch.object(
+            type(lock), "operation_timeout_seconds", property(lambda _s: 0.05)
+        ),
+        patch.object(lock, "async_is_device_available", _never_returns),
+        pytest.raises(LockDisconnected, match="no answer within"),
+    ):
+        await asyncio.wait_for(lock._execute_rate_limited("set", never_ran), timeout=5)
+
+    never_ran.assert_not_called()
+    assert not lock._aio_lock.locked()
+
+
+async def test_a_wedged_provider_setup_does_not_park_the_entry(hass: HomeAssistant):
+    """
+    `async_setup` is under the deadline as well as the capability probe.
+
+    It is device I/O on several providers -- akuvox and schlage run an
+    unmanaged-code tagging pass in it, zwave-js-ui subscribes -- and setup
+    runs while Home Assistant holds the entry's lock, so an unbounded call
+    here parks the entry in `setup_in_progress` and takes reload and remove
+    with it.
+    """
+    lock = _make_base_test_lock(hass, "wedged_provider_setup")
+    lock._min_operation_delay = 0
+
+    async def _never_returns(*_args, **_kwargs):
+        await asyncio.Event().wait()
+
+    with (
+        patch.object(
+            type(lock), "operation_timeout_seconds", property(lambda _s: 0.05)
+        ),
+        patch.object(lock, "async_setup", _never_returns),
+        patch.object(lock, "async_get_usercodes", AsyncMock(return_value={})),
+    ):
+        await asyncio.wait_for(
+            lock.async_setup_internal(lock.lock_config_entry), timeout=5
+        )
+
+    # Degraded, not parked: setup returned and the retry path is armed.
+    assert lock._setup_succeeded is False
+    assert lock._setup_complete.is_set()
+    assert lock._setup_deferred is True
+
+
 async def test_a_wedged_operation_stops_blocking_every_other_slot(
     hass: HomeAssistant,
 ):

--- a/tests/providers/test_base.py
+++ b/tests/providers/test_base.py
@@ -2824,6 +2824,11 @@ async def test_setup_does_not_hang_on_a_capability_probe_that_never_answers(
     # Degraded, not dropped: setup finished and the retry path is armed.
     assert lock._setup_succeeded is False
     assert lock._setup_complete.is_set()
+    # The flag IS the retry path. `_handle_connection_transition` checks
+    # nothing else, and the LOADED transition the state listener waits for
+    # never arrives for an integration that was already loaded and then went
+    # quiet -- so without this the lock never gets set up again.
+    assert lock._setup_deferred is True
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Proposed change

Follow-up to #1525. Stacked on #1526 — review the second commit; this PR's own diff shrinks once that merges.

5.5.2 put the deadline around `func` inside `_execute_rate_limited` and left the calls around it unbounded, so the #1523 park is still reachable two ways.

**The availability probes run before the deadline is armed.** `async_is_integration_connected()` and `async_is_device_available()` are device I/O on some providers — Schlage's is a `get_codes` cloud round trip — so a wedge there pins the slot in `SYNCING` with the deadline never reached. Waiting on `_aio_lock` behind another caller was unbounded for the same reason. The deadline now wraps the whole body.

**`async_setup` has no bound at all.** akuvox and schlage run an unmanaged-code tagging pass in it, zwave-js-ui subscribes, and setup runs while HA holds the entry's lock — so a wedge parks the entry in `setup_in_progress` and takes reload and remove with it. The capability probe had its own deadline; one now covers both, which is also the only bound a non-native-user provider gets in that method.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue: #1523
- Not fixed here: the per-slot budget scales with `managed_slots` rather than the operation's actual scope, so a throwaway allocation provider (empty `managed_slots`) gets the flat ten minutes for an occupancy scan that can walk up to `MAX_SEARCHED_SLOT` indices — under-budget, and it fails the scan that blocks user adds. Filed separately; it needs the budget to become scope-aware across three providers rather than a bare property.
- Mutation-verified: reverting either bound fails a test that names the behaviour.
- Full suite green at 100% coverage (2345); `prek` clean.