### PR TITLE
feat!: require Home Assistant 2026.9 and validate with probatio directly

### DIFF
--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -8,7 +8,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
-import voluptuous as vol
+import probatio as vol
 
 from homeassistant.components.event import DOMAIN as EVENT_DOMAIN
 from homeassistant.components.http import StaticPathConfig
@@ -1349,7 +1349,9 @@ def _async_remove_slot_devices(
     dev_reg = dr.async_get(hass)
     for slot_num in slot_nums:
         identifier = build_slot_device_identifier(config_entry.entry_id, slot_num)
-        if device := dev_reg.async_get_device(identifiers={(DOMAIN, identifier)}):
+        if device := dev_reg.async_get_device_by_identifier(
+            (DOMAIN, identifier), config_entry.entry_id
+        ):
             _LOGGER.debug(
                 "%s (%s): Removing device for slot %s",
                 config_entry.entry_id,
@@ -1442,7 +1444,9 @@ def _async_remove_hub_device(
     break, so leaving it behind would log on every registration.
     """
     dev_reg = dr.async_get(hass)
-    device = dev_reg.async_get_device(identifiers={(DOMAIN, config_entry.entry_id)})
+    device = dev_reg.async_get_device_by_identifier(
+        (DOMAIN, config_entry.entry_id), config_entry.entry_id
+    )
     if device is None:
         return
     _LOGGER.debug(
@@ -1517,10 +1521,13 @@ def _async_purge_dropped_slots(
             ent_reg.async_remove(entity.entity_id)
     dev_reg = dr.async_get(hass)
     for slot_num in slots:
-        identifiers = {
-            (DOMAIN, build_slot_device_identifier(config_entry.entry_id, slot_num))
-        }
-        if device := dev_reg.async_get_device(identifiers):
+        identifier = (
+            DOMAIN,
+            build_slot_device_identifier(config_entry.entry_id, slot_num),
+        )
+        if device := dev_reg.async_get_device_by_identifier(
+            identifier, config_entry.entry_id
+        ):
             dev_reg.async_remove_device(device.id)
 
 
@@ -1617,7 +1624,7 @@ def _async_rename_slot_devices(
     config = get_entry_config(config_entry)
     for slot_num, name in ((num, config.name_for(num)) for num in config.slot_numbers):
         identifier = build_slot_device_identifier(entry_id, slot_num)
-        device = dev_reg.async_get_device(identifiers={(DOMAIN, identifier)})
+        device = dev_reg.async_get_device_by_identifier((DOMAIN, identifier), entry_id)
         # Same shape build_slot_device_info uses, entry title included: a
         # rename that dropped the prefix would leave the device disagreeing
         # with the entity IDs derived from it.

--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -6,7 +6,7 @@ from collections.abc import Container, Iterable, Mapping, Sequence
 import logging
 from typing import Any
 
-import voluptuous as vol
+import probatio as vol
 
 from homeassistant import config_entries
 from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN

--- a/custom_components/lock_code_manager/diagnostics.py
+++ b/custom_components/lock_code_manager/diagnostics.py
@@ -170,7 +170,9 @@ def _slot_diagnostic(
         DOMAIN,
         build_slot_device_identifier(config_entry.entry_id, slot_num),
     )
-    device = dev_reg.async_get_device(identifiers={slot_identifier})
+    device = dev_reg.async_get_device_by_identifier(
+        slot_identifier, config_entry.entry_id
+    )
     if device:
         result["entities"] = _entity_states_for_device(hass, ent_reg, device.id)
 

--- a/custom_components/lock_code_manager/websocket.py
+++ b/custom_components/lock_code_manager/websocket.py
@@ -9,7 +9,7 @@ from functools import wraps
 import logging
 from typing import Any
 
-import voluptuous as vol
+import probatio as vol
 
 from homeassistant.components import websocket_api
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN

--- a/hacs.json
+++ b/hacs.json
@@ -2,6 +2,6 @@
   "name": "Lock Code Manager",
   "zip_release": true,
   "filename": "lock_code_manager.zip",
-  "homeassistant": "2026.7.0b0",
+  "homeassistant": "2026.9.0",
   "render_readme": true
 }

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,6 @@
 -r requirements_lint.txt
 -r requirements_test.txt
-aioesphomeapi==46.2.0
+aioesphomeapi==46.2.1
 aiofiles==25.1.0
 aiousbwatcher==1.1.2
 colorlog==6.12.0
@@ -13,8 +13,8 @@ pyudev==0.24.4
 universal-silabs-flasher==1.1.0
 usb-devices>=0.5.1
 uv
-zeroconf==0.150.0
-zha==2.1.0
-zha-quirks==2.2.0
+zeroconf==0.151.1
+zha==2.2.0
+zha-quirks==2.2.1
 zigpy>=2.1.0
 zwave-js-server-python==0.73.1

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,7 +1,7 @@
 hypothesis>=6.165.10
 pylint-strict-informational>=0.1
 pytest>=9.0.3
-pytest-homeassistant-custom-component==0.13.357
+pytest-homeassistant-custom-component==0.13.361
 # Declared directly rather than leaned on transitively: `timeout` in
 # pyproject.toml degrades to a warning if this goes missing, so the
 # protection would vanish silently.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 from hypothesis import settings as hypothesis_settings
+from probatio import to_field_list
 import pytest
 from pytest_homeassistant_custom_component.common import (
     MockConfigEntry,
@@ -28,10 +29,7 @@ from homeassistant.config_entries import ConfigEntry, ConfigFlow
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowHandler
-from homeassistant.helpers import (
-    config_validation as cv,
-    data_entry_flow as hass_data_entry_flow,
-)
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
@@ -98,32 +96,6 @@ def _flow_classes() -> list[type[FlowHandler]]:
     ]
 
 
-def _serialize_flow_schema(schema: Any) -> Any:
-    """
-    Serialize a form schema the way Home Assistant serializes it.
-
-    Resolved off Home Assistant's own module rather than imported from a
-    validation library, because which library that is has changed under
-    this test. Both versions call it from the same place --
-    ``_BaseFlowManagerView._prepare_result_json`` -- with the same
-    ``custom_serializer``; 2026.9 swapped ``voluptuous_serialize.convert``
-    for probatio's ``to_field_list`` and dropped the old package, which is
-    also why importing it by name stopped working at all.
-
-    Naming either library here would let this guard go on passing against
-    a serializer Home Assistant had stopped using, and a form that renders
-    in the test but not in a browser is the exact failure it exists to
-    catch (issue #1495).
-    """
-    if (
-        to_field_list := getattr(hass_data_entry_flow, "to_field_list", None)
-    ) is not None:
-        return to_field_list(schema, custom_serializer=cv.custom_serializer)
-    return hass_data_entry_flow.voluptuous_serialize.convert(
-        schema, custom_serializer=cv.custom_serializer
-    )
-
-
 @pytest.fixture(autouse=True)
 def assert_flow_forms_serialize() -> Generator[None]:
     """
@@ -133,6 +105,12 @@ def assert_flow_forms_serialize() -> Generator[None]:
     untouched, so a validator the frontend has no representation for reaches
     a real browser as an unknown error and never a failing test. Converting
     here makes every test that shows a form the test that catches it.
+
+    ``to_field_list`` with ``cv.custom_serializer`` is the exact call
+    ``_BaseFlowManagerView._prepare_result_json`` makes, so what passes here
+    is what renders. Converting with anything else -- a serializer the
+    frontend does not use -- would let a form pass the test and fail the
+    browser, which is issue #1495 with the suite still green.
     """
 
     def checked(cls: type[FlowHandler]) -> Any:
@@ -148,7 +126,7 @@ def assert_flow_forms_serialize() -> Generator[None]:
         def _converted(self, **kwargs: Any):
             result = original(self, **kwargs)
             if schema := result.get("data_schema"):
-                _serialize_flow_schema(schema)
+                to_field_list(schema, custom_serializer=cv.custom_serializer)
             return result
 
         return patch.object(cls, "async_show_form", _converted)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,6 @@ from pytest_homeassistant_custom_component.common import (
     mock_integration,
     mock_platform,
 )
-import voluptuous_serialize
 
 from homeassistant.components.calendar import DOMAIN as CALENDAR_DOMAIN
 from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
@@ -29,7 +28,10 @@ from homeassistant.config_entries import ConfigEntry, ConfigFlow
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowHandler
-from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import (
+    config_validation as cv,
+    data_entry_flow as hass_data_entry_flow,
+)
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
@@ -96,6 +98,32 @@ def _flow_classes() -> list[type[FlowHandler]]:
     ]
 
 
+def _serialize_flow_schema(schema: Any) -> Any:
+    """
+    Serialize a form schema the way Home Assistant serializes it.
+
+    Resolved off Home Assistant's own module rather than imported from a
+    validation library, because which library that is has changed under
+    this test. Both versions call it from the same place --
+    ``_BaseFlowManagerView._prepare_result_json`` -- with the same
+    ``custom_serializer``; 2026.9 swapped ``voluptuous_serialize.convert``
+    for probatio's ``to_field_list`` and dropped the old package, which is
+    also why importing it by name stopped working at all.
+
+    Naming either library here would let this guard go on passing against
+    a serializer Home Assistant had stopped using, and a form that renders
+    in the test but not in a browser is the exact failure it exists to
+    catch (issue #1495).
+    """
+    if (
+        to_field_list := getattr(hass_data_entry_flow, "to_field_list", None)
+    ) is not None:
+        return to_field_list(schema, custom_serializer=cv.custom_serializer)
+    return hass_data_entry_flow.voluptuous_serialize.convert(
+        schema, custom_serializer=cv.custom_serializer
+    )
+
+
 @pytest.fixture(autouse=True)
 def assert_flow_forms_serialize() -> Generator[None]:
     """
@@ -120,9 +148,7 @@ def assert_flow_forms_serialize() -> Generator[None]:
         def _converted(self, **kwargs: Any):
             result = original(self, **kwargs)
             if schema := result.get("data_schema"):
-                voluptuous_serialize.convert(
-                    schema, custom_serializer=cv.custom_serializer
-                )
+                _serialize_flow_schema(schema)
             return result
 
         return patch.object(cls, "async_show_form", _converted)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -98,7 +98,7 @@ def test_diff_no_changes() -> None:
 
 def test_diff_str_keys_match_int_keys() -> None:
     """
-    Stored data has str slot keys; voluptuous output has int.
+    Stored data has str slot keys; probatio output has int.
 
     EntryConfig.from_mapping normalizes keys to int up front, so by the
     time the diff is computed both sides are int-keyed and ``"1"`` /
@@ -302,7 +302,7 @@ def test_entry_config_accessors_absorb_str_or_int_slot_num() -> None:
 
 
 def test_entry_config_from_mapping_preserves_int_slot_keys() -> None:
-    """Int keys (voluptuous output) pass through unchanged."""
+    """Int keys (probatio output) pass through unchanged."""
     config = EntryConfig.from_mapping(
         {CONF_LOCKS: ["lock.a"], CONF_SLOTS: {1: _slot()}}
     )

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -70,7 +70,9 @@ async def test_device_diagnostics_slot_device(
     dev_reg = dr.async_get(hass)
     entry_id = lock_code_manager_config_entry.entry_id
 
-    slot_device = dev_reg.async_get_device(identifiers={(DOMAIN, f"{entry_id}|1")})
+    slot_device = dev_reg.async_get_device_by_identifier(
+        (DOMAIN, f"{entry_id}|1"), entry_id
+    )
     assert slot_device is not None
 
     result = await async_get_device_diagnostics(
@@ -107,7 +109,7 @@ async def test_device_diagnostics_lock_device(
         # No device entry — device diagnostics falls through to config entry
         dev_reg = dr.async_get(hass)
         entry_id = lock_code_manager_config_entry.entry_id
-        ce_device = dev_reg.async_get_device(identifiers={(DOMAIN, entry_id)})
+        ce_device = dev_reg.async_get_device_by_identifier((DOMAIN, entry_id), entry_id)
         assert ce_device is not None
         result = await async_get_device_diagnostics(
             hass, lock_code_manager_config_entry, ce_device

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -129,7 +129,9 @@ async def test_entry_setup_and_unload(
     ent_reg = er.async_get(hass)
 
     for entity_id in (LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID):
-        device = dev_reg.async_get_device({(LOCK_DEVICE_DOMAIN, entity_id)})
+        device = dev_reg.async_get_device_by_identifier(
+            (LOCK_DEVICE_DOMAIN, entity_id), mock_lock_entry_id
+        )
         assert device
         assert device.config_entries == {mock_lock_entry_id}
         # Nothing of ours sits on the lock's own device. A device belongs to
@@ -143,8 +145,9 @@ async def test_entry_setup_and_unload(
 
     # The per-lock entities live on the slot device beside the shared ones.
     for slot in range(1, 3):
-        slot_device = dev_reg.async_get_device(
-            {(DOMAIN, build_slot_device_identifier(lcm_entry_id, slot))}
+        slot_device = dev_reg.async_get_device_by_identifier(
+            (DOMAIN, build_slot_device_identifier(lcm_entry_id, slot)),
+            lcm_entry_id,
         )
         assert slot_device
         assert slot_device.config_entries == {lcm_entry_id}
@@ -269,7 +272,9 @@ async def test_entry_setup_and_unload(
 
     # LOCK_2 was removed from the LCM config entry; its device keeps its own
     # config entry and no longer has any LCM entities linked to it.
-    device = dev_reg.async_get_device({(LOCK_DEVICE_DOMAIN, LOCK_2_ENTITY_ID)})
+    device = dev_reg.async_get_device_by_identifier(
+        (LOCK_DEVICE_DOMAIN, LOCK_2_ENTITY_ID), mock_lock_entry_id
+    )
     assert device
     assert device.config_entries == {mock_lock_entry_id}
     assert not [
@@ -1754,8 +1759,10 @@ async def test_removing_slot_removes_its_device(
     """
     entry_id = lock_code_manager_config_entry.entry_id
     dev_reg = dr.async_get(hass)
-    slot_2_identifiers = {(DOMAIN, f"{entry_id}|2")}
-    assert dev_reg.async_get_device(slot_2_identifiers) is not None
+    slot_2_identifier = (DOMAIN, f"{entry_id}|2")
+    assert (
+        dev_reg.async_get_device_by_identifier(slot_2_identifier, entry_id) is not None
+    )
 
     # Removing a user is removing them from `users`; the slot they occupied is
     # freed with them.
@@ -1768,11 +1775,14 @@ async def test_removing_slot_removes_its_device(
     )
     await hass.async_block_till_done()
 
-    assert dev_reg.async_get_device(slot_2_identifiers) is None
+    assert dev_reg.async_get_device_by_identifier(slot_2_identifier, entry_id) is None
     # The surviving slot and the entry's own device are untouched.
-    assert dev_reg.async_get_device({(DOMAIN, f"{entry_id}|1")}) is not None
+    assert (
+        dev_reg.async_get_device_by_identifier((DOMAIN, f"{entry_id}|1"), entry_id)
+        is not None
+    )
     # And there is no entry-level device left behind either.
-    assert dev_reg.async_get_device({(DOMAIN, entry_id)}) is None
+    assert dev_reg.async_get_device_by_identifier((DOMAIN, entry_id), entry_id) is None
 
 
 @pytest.mark.parametrize("stale_slot", [99, 0, -1])
@@ -1806,8 +1816,16 @@ async def test_setup_prunes_devices_for_unconfigured_slots(
     await hass.config_entries.async_reload(entry_id)
     await hass.async_block_till_done()
 
-    assert dev_reg.async_get_device({(DOMAIN, f"{entry_id}|{stale_slot}")}) is None
-    assert dev_reg.async_get_device({(DOMAIN, f"{entry_id}|1")}) is not None
+    assert (
+        dev_reg.async_get_device_by_identifier(
+            (DOMAIN, f"{entry_id}|{stale_slot}"), entry_id
+        )
+        is None
+    )
+    assert (
+        dev_reg.async_get_device_by_identifier((DOMAIN, f"{entry_id}|1"), entry_id)
+        is not None
+    )
 
 
 async def test_remove_config_entry_device_allows_only_unconfigured_slots(
@@ -1824,7 +1842,9 @@ async def test_remove_config_entry_device_allows_only_unconfigured_slots(
     entry_id = lock_code_manager_config_entry.entry_id
     dev_reg = dr.async_get(hass)
 
-    configured = dev_reg.async_get_device({(DOMAIN, f"{entry_id}|1")})
+    configured = dev_reg.async_get_device_by_identifier(
+        (DOMAIN, f"{entry_id}|1"), entry_id
+    )
     assert configured is not None
     assert (
         await async_remove_config_entry_device(
@@ -2238,8 +2258,9 @@ async def test_setup_reclaims_entities_left_on_a_split_device(
     await hass.config_entries.async_setup(entry_id)
     await hass.async_block_till_done()
 
-    slot_device = dev_reg.async_get_device(
-        {(DOMAIN, build_slot_device_identifier(entry_id, 1))}
+    slot_device = dev_reg.async_get_device_by_identifier(
+        (DOMAIN, build_slot_device_identifier(entry_id, 1)),
+        entry_id,
     )
     assert slot_device
     reclaimed = ent_reg.async_get_entity_id(stranded.domain, DOMAIN, stranded.unique_id)
@@ -2261,7 +2282,9 @@ async def test_setup_leaves_devices_of_other_integrations_alone(
     dev_reg = dr.async_get(hass)
     ent_reg = er.async_get(hass)
 
-    lock_device = dev_reg.async_get_device({(LOCK_DEVICE_DOMAIN, LOCK_1_ENTITY_ID)})
+    lock_device = dev_reg.async_get_device_by_identifier(
+        (LOCK_DEVICE_DOMAIN, LOCK_1_ENTITY_ID), mock_lock_config_entry.entry_id
+    )
     assert lock_device
     before = {
         entry.entity_id
@@ -2383,7 +2406,10 @@ async def test_reclaim_leaves_our_own_empty_devices_alone(
     # away itself, which would prove nothing about this pass.
     _async_reclaim_entities_from_foreign_devices(hass, config_entry)
 
-    assert dev_reg.async_get_device({(DOMAIN, f"{entry_id}|404")}) is not None
+    assert (
+        dev_reg.async_get_device_by_identifier((DOMAIN, f"{entry_id}|404"), entry_id)
+        is not None
+    )
 
     await hass.config_entries.async_unload(entry_id)
 
@@ -2427,8 +2453,9 @@ async def test_reclaim_moves_a_disabled_entity_rather_than_deleting_it(
     )
     assert survivor is not None
     assert survivor.disabled_by is er.RegistryEntryDisabler.USER
-    slot_device = dev_reg.async_get_device(
-        {(DOMAIN, build_slot_device_identifier(entry_id, 1))}
+    slot_device = dev_reg.async_get_device_by_identifier(
+        (DOMAIN, build_slot_device_identifier(entry_id, 1)),
+        entry_id,
     )
     assert slot_device and survivor.device_id == slot_device.id
     assert dev_reg.async_get(split.id) is None
@@ -2471,7 +2498,9 @@ async def test_reclaim_does_not_resurrect_a_device_for_an_unconfigured_slot(
 
     # Slot 9 is not configured, so neither device may survive.
     assert (
-        dev_reg.async_get_device({(DOMAIN, build_slot_device_identifier(entry_id, 9))})
+        dev_reg.async_get_device_by_identifier(
+            (DOMAIN, build_slot_device_identifier(entry_id, 9)), entry_id
+        )
         is None
     )
     assert dev_reg.async_get(split.id) is None
@@ -2492,7 +2521,9 @@ async def test_reclaim_moves_an_entity_off_the_lock_integrations_device(
     dev_reg = dr.async_get(hass)
     ent_reg = er.async_get(hass)
 
-    lock_device = dev_reg.async_get_device({(LOCK_DEVICE_DOMAIN, LOCK_1_ENTITY_ID)})
+    lock_device = dev_reg.async_get_device_by_identifier(
+        (LOCK_DEVICE_DOMAIN, LOCK_1_ENTITY_ID), mock_lock_config_entry.entry_id
+    )
     assert lock_device
     assert lock_device.config_entries != {DOMAIN}
 
@@ -2515,8 +2546,9 @@ async def test_reclaim_moves_an_entity_off_the_lock_integrations_device(
     await hass.config_entries.async_setup(entry_id)
     await hass.async_block_till_done()
 
-    slot_device = dev_reg.async_get_device(
-        {(DOMAIN, build_slot_device_identifier(entry_id, 1))}
+    slot_device = dev_reg.async_get_device_by_identifier(
+        (DOMAIN, build_slot_device_identifier(entry_id, 1)),
+        entry_id,
     )
     assert slot_device
     reclaimed = ent_reg.async_get_entity_id(stranded.domain, DOMAIN, stranded.unique_id)
@@ -2608,8 +2640,9 @@ async def test_migration_of_a_real_world_entry_shape(
             # lingering under a name for a user who does not exist.
             assert moved is None
             assert (
-                dev_reg.async_get_device(
-                    {(DOMAIN, build_slot_device_identifier(entry.entry_id, slot))}
+                dev_reg.async_get_device_by_identifier(
+                    (DOMAIN, build_slot_device_identifier(entry.entry_id, slot)),
+                    entry.entry_id,
                 )
                 is None
             )
@@ -2631,7 +2664,9 @@ async def test_a_slot_device_is_named_for_the_user_who_holds_it(
     config = get_entry_config(lock_code_manager_config_entry)
 
     for slot_num in config.slot_numbers:
-        device = dev_reg.async_get_device({(DOMAIN, f"{entry_id}|{slot_num}")})
+        device = dev_reg.async_get_device_by_identifier(
+            (DOMAIN, f"{entry_id}|{slot_num}"), entry_id
+        )
         assert device is not None
         # Prefixed with the entry title, which is what makes the entity IDs
         # derived from it unique across entries.
@@ -2655,9 +2690,12 @@ async def test_renaming_a_user_renames_their_device(
     """
     entry_id = lock_code_manager_config_entry.entry_id
     dev_reg = dr.async_get(hass)
-    identifiers = {(DOMAIN, f"{entry_id}|1")}
+    identifier = (DOMAIN, f"{entry_id}|1")
     before = get_entry_config(lock_code_manager_config_entry).name_for(1)
-    assert dev_reg.async_get_device(identifiers).name == f"Mock Title {before}"
+    assert (
+        dev_reg.async_get_device_by_identifier(identifier, entry_id).name
+        == f"Mock Title {before}"
+    )
 
     await hass.services.async_call(
         TEXT_DOMAIN,
@@ -2669,7 +2707,10 @@ async def test_renaming_a_user_renames_their_device(
     await hass.async_block_till_done()
 
     assert get_entry_config(lock_code_manager_config_entry).name_for(1) == "Sherene"
-    assert dev_reg.async_get_device(identifiers).name == "Mock Title Sherene"
+    assert (
+        dev_reg.async_get_device_by_identifier(identifier, entry_id).name
+        == "Mock Title Sherene"
+    )
 
 
 async def test_migration_reslugs_entity_ids_onto_the_user_name(
@@ -2804,14 +2845,22 @@ async def test_migration_takes_away_the_config_entrys_own_device(
         manufacturer="Lock Code Manager",
         name="All Locks",
     )
-    assert dev_reg.async_get_device({(DOMAIN, entry.entry_id)}) is not None
+    assert (
+        dev_reg.async_get_device_by_identifier((DOMAIN, entry.entry_id), entry.entry_id)
+        is not None
+    )
 
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert dev_reg.async_get_device({(DOMAIN, entry.entry_id)}) is None
+    assert (
+        dev_reg.async_get_device_by_identifier((DOMAIN, entry.entry_id), entry.entry_id)
+        is None
+    )
 
-    user_device = dev_reg.async_get_device({(DOMAIN, f"{entry.entry_id}|1")})
+    user_device = dev_reg.async_get_device_by_identifier(
+        (DOMAIN, f"{entry.entry_id}|1"), entry.entry_id
+    )
     assert user_device is not None
     assert user_device.via_device_id is None
     assert user_device.id != hub.id

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -7,12 +7,12 @@ import json
 import logging
 from unittest.mock import AsyncMock, patch
 
+import probatio as vol
 import pytest
 from pytest_homeassistant_custom_component.common import (
     MockConfigEntry,
     async_capture_events,
 )
-import voluptuous as vol
 
 from homeassistant.components.event import (
     ATTR_EVENT_TYPE,


### PR DESCRIPTION
# Breaking change

Lock Code Manager now requires **Home Assistant 2026.9.0** or newer. HACS will not offer this release to installations on an older core. Nothing changes in how you configure or use the integration; this is the version floor moving to match Home Assistant's validation stack.

## Proposed change

This started as unblocking #1537 and grew into the version bump it was always going to need. Three things, in the order they were found.

### 1. `voluptuous_serialize` is gone in 2026.9

#1537 failed before it got as far as a version conflict:

```
E   ModuleNotFoundError: No module named 'voluptuous_serialize'
```

`tests/conftest.py` imported it directly and nothing declared it — it arrived transitively through `homeassistant`. 2026.9 moves Home Assistant's validation stack to [probatio](https://probatio.frenck.dev), frenck's clean-room reimplementation of voluptuous, and drops the old package.

Both versions serialize a flow form at the same call site, `_BaseFlowManagerView._prepare_result_json`, with the same `custom_serializer`:

| | |
|---|---|
| 2026.8 | `voluptuous_serialize.convert(schema, custom_serializer=cv.custom_serializer)` |
| 2026.9 | `to_field_list(schema, custom_serializer=cv.custom_serializer)` |

The guard in `conftest.py` exists so a form that renders in a test also renders in a browser (#1495). It now makes exactly the call Home Assistant makes. Declaring `voluptuous-serialize` instead would have kept the suite green while converting through a serializer the frontend no longer uses — the one outcome the guard is for.

### 2. Rather than shim, raise the floor

The first commit on this branch resolved the serializer off Home Assistant's module with a fallback for 2026.8. @raman325 pointed out that with 2026.9 final due 2026-09-02, we can just require it and use probatio directly. So:

- `hacs.json` floor → `2026.9.0`
- `import voluptuous as vol` → `import probatio as vol` in the three integration modules and one test module that use it

Two things I verified rather than assumed, because "drop-in replacement" is about source compatibility, not runtime interop:

- **Keeping `import voluptuous` would also have worked on 2026.9** — probatio ships `install_as_voluptuous()`, and `homeassistant/__init__.py` calls it before anything imports. Importing probatio by name says what we depend on instead of relying on who set up the alias.
- **Mixing them does not work.** `probatio.Schema is not voluptuous.Schema`, and 2026.8's `voluptuous_serialize.convert()` rejects a probatio schema outright (`ValueError: Unable to convert schema`). So using probatio on a 2026.8 core would have broken every config flow form. The floor bump is what makes this safe, not the API similarity.

### 3. The floor bump surfaced a second 2026.9 change

Running the suite against 2026.9.0b4 produced seventeen `RuntimeError`s, all the same:

```
Detected code that calls `device_registry.async_get_device`, which is deprecated
because device identifiers and connections are no longer unique across config
entries; use `async_get_device_by_identifier`, ...
```

In production a custom integration only **logs** for this (removal is 2027.8). Under test, calls made from test code have no integration frame, so the core behaviour applies and they raise — that is what the seventeen were. Every call site, five in the integration and twenty-six in tests, now uses `async_get_device_by_identifier(identifier, config_entry_id)`. All of them already had the owning entry in scope; the lookups were always meant to be that specific.

### Dependencies

`pytest-homeassistant-custom-component` → `0.13.361` (`homeassistant==2026.9.0b4`), plus the four `requirements_dev.txt` pins that track it. This is what #1537 was bringing in, so #1537 can be closed as superseded once this merges.

## Testing

Suite run against 2026.9.0b4 in a clean venv built from `requirements_dev.txt`:

```
2345 passed, 3 skipped
```

Coverage gate held. The #1495 guard was re-verified to still catch its defect: putting `str.strip` back into a rendered schema fails 57 tests.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: supersedes #1537
- This PR is related to issue: #1495

🤖 Generated with [Claude Code](https://claude.com/claude-code)