### PR TITLE
fix: the coordinator owns a write from sent to seen (#1538)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -446,44 +446,55 @@ with a comment citing the contract. Never silence one by rerunning.
 
 If `supports_push` returns `True`, implement:
 
-- `subscribe_push_updates()`: Subscribe to real-time updates, call `coordinator.push_update({slot: value})`
+- `subscribe_push_updates()`: Subscribe to real-time updates and hand each slot
+  observation to `self._confirm_slot(slot, SlotCredential)`. That routes it
+  through `coordinator.observe_push`, which resolves any write still pending on
+  the slot before updating the data. Do not call `coordinator.push_update`
+  from an event handler: it bypasses that resolution.
 - `unsubscribe_push_updates()`: Clean up subscriptions
 
-### Optimistic Updates
+### Writes, and how they are confirmed
 
-For providers where the underlying integration's value cache updates asynchronously (e.g., Z-Wave JS
-push notifications), implement optimistic updates to prevent sync loops:
+The coordinator owns a write from the moment it is sent until a read or a push
+shows it on the lock (`record_write` / `observe_push` / `take_failed_write` in
+`domain/coordinator.py`). A provider never tracks pending writes itself; it
+only chooses what to return from `async_set_credential`:
 
 ```python
 async def async_set_credential(self, ref: CredentialRef, value: str, ...) -> WriteResult:
     # ... perform the set operation ...
     await self._call_service_to_set_code(ref.slot, value)
 
-    # Optimistic update: the command succeeded, so tell the coordinator now
-    # rather than waiting for a cache that updates later.
-    self._push_credential_update(
-        ref.slot, SlotCredential.known(value), optimistic=True
-    )
-    return WriteResult(changed=True)
-
-async def async_delete_credential(self, ref: CredentialRef) -> bool:
-    # ... perform the clear operation ...
-    await self._call_service_to_clear_code(ref.slot)
-
-    self._push_credential_update(ref.slot, SlotCredential.empty(), optimistic=True)
-    return True
+    # A push provider pushes the value it wrote before returning CONFIRMED:
+    # its own push is the lock's word, and the seam records nothing pending.
+    self._push_credential_update(ref.slot, SlotCredential.known(value))
+    return WriteResult.CONFIRMED
 ```
+
+- `CONFIRMED` from a **push** provider: the lock accepted the write and the
+  provider (or the driver's event) has pushed the value. Nothing is pending.
+- `CONFIRMED` from a **polled** provider: the service accepted the write, but
+  only a later read can vouch for it. The seam records it pending, unbelieved;
+  the coordinator reads the lock back on its own schedule and the slot is in
+  sync once the read shows it.
+- `OPTIMISTIC`: the write most likely landed but the provider cannot say (for
+  example an ambiguous driver result). The seam records it pending with the
+  value believed, so the entity shows it at once, and the coordinator reads it
+  back. A write the lock never shows is given up after `PENDING_WRITE_TTL` and
+  charged to the slot breaker once.
+- `NO_CHANGE`: nothing was written; nothing is recorded.
 
 Push `SlotCredential` values, never raw strings — every consumer calls
 `.is_present` / `.matches` on them. `_push_credential_update` is the helper that
 wraps `coordinator.push_update` correctly.
 
-**When needed:** The Z-Wave command is acknowledged by the lock (via Supervision CC), but the JS value
-cache updates later via push notification. Without optimistic updates, the coordinator refresh reads
-stale cache data, sees a mismatch, and triggers repeated sync attempts.
+**Why the push before CONFIRMED matters:** for Z-Wave the command is acknowledged
+by the lock (via Supervision CC) but the JS value cache updates later. Without
+the push, the coordinator would hold the stale pre-write value, the write would
+be judged against it, and the slot would re-sync for nothing.
 
-**When NOT needed:** Providers with synchronous caches (like Virtual) don't need this - their next
-read returns the updated value immediately after set/clear.
+**Polled providers with synchronous caches** (like Virtual) need nothing special:
+the coordinator's read straight after the write finds the new value.
 
 ## Important Constraints
 

--- a/custom_components/lock_code_manager/const.py
+++ b/custom_components/lock_code_manager/const.py
@@ -205,11 +205,13 @@ BACKOFF_MAX_SECONDS: int = 1800  # 30 minutes
 # Poll failure alerting
 POLL_FAILURE_ALERT_THRESHOLD: int = 12
 
-# How long a write waits to be seen on the lock before it is given up on: the
-# coordinator drops the pending record on the first read past this that still
-# does not show the write, and the sync tick charges the slot breaker once for
-# it. Three of these must fit inside SYNC_ATTEMPT_WINDOW, or a write the lock
-# never keeps could never trip the breaker.
+# How long a write waits to be seen on the lock before it is given up and
+# re-synced. The coordinator reads the lock back on its own schedule while it
+# waits, so this does not have to span a polled lock's scan interval -- and
+# must not be long: a write the lock never keeps is given up by the first
+# look at or after the deadline, so one failed cycle is this plus up to
+# CONFIRM_READ_INTERVAL plus the read and the re-set, and the breaker only
+# trips when three such failures land inside SYNC_ATTEMPT_WINDOW.
 PENDING_WRITE_TTL: float = 60.0
 # How often the coordinator reads the lock back while a write is pending: four
 # looks inside one time to live, so a write that landed late is seen well

--- a/custom_components/lock_code_manager/const.py
+++ b/custom_components/lock_code_manager/const.py
@@ -205,6 +205,17 @@ BACKOFF_MAX_SECONDS: int = 1800  # 30 minutes
 # Poll failure alerting
 POLL_FAILURE_ALERT_THRESHOLD: int = 12
 
+# How long a write waits to be seen on the lock before it is given up on: the
+# coordinator drops the pending record on the first read past this that still
+# does not show the write, and the sync tick charges the slot breaker once for
+# it. Three of these must fit inside SYNC_ATTEMPT_WINDOW, or a write the lock
+# never keeps could never trip the breaker.
+PENDING_WRITE_TTL: float = 60.0
+# How often the coordinator reads the lock back while a write is pending: four
+# looks inside one time to live, so a write that landed late is seen well
+# before the deadline and a lock that never keeps it is asked, not hammered.
+CONFIRM_READ_INTERVAL: float = PENDING_WRITE_TTL / 4
+
 # Sync timing
 TICK_INTERVAL = timedelta(seconds=2)
 MAX_SYNC_ATTEMPTS = 3

--- a/custom_components/lock_code_manager/domain/coordinator.py
+++ b/custom_components/lock_code_manager/domain/coordinator.py
@@ -237,6 +237,10 @@ class LockUsercodeUpdateCoordinator(
                 del self._pending[address]
                 self._failed_writes.add(address)
                 out[address] = cred
+            elif pending.believed:
+                # Still waiting, and the write was believed: keep showing it
+                # rather than flickering to the read and back on confirmation.
+                out[address] = SlotCredential.known(pending.pin)
             else:
                 out[address] = cred
         return out

--- a/custom_components/lock_code_manager/domain/coordinator.py
+++ b/custom_components/lock_code_manager/domain/coordinator.py
@@ -7,7 +7,7 @@ Stores ALL slots (managed and unmanaged). See ARCHITECTURE.md for the full data 
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from datetime import datetime, timedelta
 import logging
 import time
@@ -357,9 +357,17 @@ class LockUsercodeUpdateCoordinator(
 
     @callback
     def _start_look(self) -> None:
-        """Start the one confirmation look for this lock, unless one is under way."""
-        if self._confirm_task is not None or self._confirm_unsub is not None:
+        """
+        Start the confirmation look now, unless one is already in flight.
+
+        A timer waiting for the next look is pulled forward instead: the write
+        that just returned gets its immediate look, and the chain stays one.
+        """
+        if self._confirm_task is not None:
             return
+        if self._confirm_unsub is not None:
+            self._confirm_unsub()
+            self._confirm_unsub = None
         # Not eager: record_write is called from inside the provider's own
         # write path, and an eagerly started read would reenter the provider
         # before that write has returned.
@@ -453,6 +461,14 @@ class LockUsercodeUpdateCoordinator(
             # slot it no longer reports is one the lock no longer has.
             failed_before = len(self._failed_writes)
             new_data = self._apply_read(self._normalize_keys(raw))
+            # A completed read that does not name a pending address is the
+            # lock not holding it -- a poller's read is scoped to name every
+            # pending slot, and a push provider's refresh reads the whole
+            # device -- so it is judged like an absent slot: waited for
+            # until the deadline, then given up.
+            self._fail_overdue(
+                [address for address in self._pending if address not in new_data]
+            )
         except LockCodeManagerError as err:
             self._give_up_overdue(err)
             return
@@ -472,6 +488,20 @@ class LockUsercodeUpdateCoordinator(
             self.async_update_listeners()
 
     @callback
+    def _fail_overdue(
+        self, addresses: Iterable[CredentialAddress]
+    ) -> list[CredentialAddress]:
+        """Fail every given pending write that is past its deadline; return them."""
+        now = time.monotonic()
+        overdue = [
+            address for address in addresses if now >= self._pending[address].deadline
+        ]
+        for address in overdue:
+            del self._pending[address]
+            self._failed_writes.add(address)
+        return overdue
+
+    @callback
     def _give_up_overdue(self, err: BaseException) -> None:
         """
         After a failed read, give up every pending write past its deadline.
@@ -480,15 +510,7 @@ class LockUsercodeUpdateCoordinator(
         tick's later warning about an unconfirmed write has a reason on
         record; a failure that leaves everything still waiting is routine.
         """
-        now = time.monotonic()
-        overdue = [
-            address
-            for address, pending in self._pending.items()
-            if now >= pending.deadline
-        ]
-        for address in overdue:
-            del self._pending[address]
-            self._failed_writes.add(address)
+        overdue = self._fail_overdue(list(self._pending))
         if overdue:
             self.async_update_listeners()
             _LOGGER.info(

--- a/custom_components/lock_code_manager/domain/coordinator.py
+++ b/custom_components/lock_code_manager/domain/coordinator.py
@@ -287,15 +287,7 @@ class LockUsercodeUpdateCoordinator(
             new_data = {**self.data, checked: SlotCredential.known(pin)}
             if new_data != self.data:
                 self.async_set_updated_data(new_data)
-        if self._confirm_task is None and self._confirm_unsub is None:
-            # Not eager: this is called from inside the provider's own write
-            # path, and an eagerly started read would reenter the provider
-            # before that write has returned.
-            self._confirm_task = self.hass.async_create_task(
-                self._async_confirmation_look(),
-                f"{DOMAIN} confirmation read for {self._lock.lock.entity_id}",
-                eager_start=False,
-            )
+        self._start_look()
 
     @callback
     def drop_pending(self, address: CredentialAddress) -> None:
@@ -351,10 +343,28 @@ class LockUsercodeUpdateCoordinator(
         else:
             self._failed_writes.add(checked)
             value = observed
+        before = self.data
         self.push_update({checked.user_ref: value})
+        if self.data is before and checked in self._failed_writes:
+            # Same data, failed write: let the sync layer judge it now.
+            self.async_update_listeners()
+
+    @callback
+    def _start_look(self) -> None:
+        """Start the one confirmation look for this lock, unless one is under way."""
+        if self._confirm_task is not None or self._confirm_unsub is not None:
+            return
+        # Not eager: record_write is called from inside the provider's own
+        # write path, and an eagerly started read would reenter the provider
+        # before that write has returned.
+        self._confirm_task = self.hass.async_create_task(
+            self._async_confirmation_look(),
+            f"{DOMAIN} confirmation read for {self._lock.lock.entity_id}",
+            eager_start=False,
+        )
 
     async def _async_confirmation_look(self) -> None:
-        """Look once right after a write; hand off to the timer while anything is pending."""
+        """Look once; hand off to the timer while anything is still pending."""
         try:
             await self.async_confirm_pending_writes()
         finally:
@@ -364,14 +374,11 @@ class LockUsercodeUpdateCoordinator(
                 self.hass, CONFIRM_READ_INTERVAL, self._async_confirmation_timer
             )
 
-    async def _async_confirmation_timer(self, _now: datetime) -> None:
-        """Timer callback: read the lock back, and re-arm while anything is pending."""
+    @callback
+    def _async_confirmation_timer(self, _now: datetime) -> None:
+        """Run the next look as the tracked task, so shutdown can cancel it too."""
         self._confirm_unsub = None
-        await self.async_confirm_pending_writes()
-        if self._pending:
-            self._confirm_unsub = async_call_later(
-                self.hass, CONFIRM_READ_INTERVAL, self._async_confirmation_timer
-            )
+        self._start_look()
 
     def credential(self, address: CredentialAddress) -> SlotCredential | None:
         """
@@ -419,10 +426,11 @@ class LockUsercodeUpdateCoordinator(
         provider is hard-refreshed, since its ordinary path is the cache the
         write may not have reached.
 
-        A failed read is non-fatal and does not touch the lock breaker --
-        connectivity is the scheduled poll's to judge. A read that fails once a
-        pending write is past its deadline gives that write up all the same:
-        the lock has had the time to live to be seen holding it, and was not.
+        A failed read is not the lock's word: it is non-fatal, touches no
+        breaker, and the write stays pending for the next look. A read that
+        fails once a pending write is past its deadline gives that write up
+        all the same: the lock has had the time to live to be seen holding it,
+        and was not.
         """
         if not self._pending:
             return
@@ -434,33 +442,61 @@ class LockUsercodeUpdateCoordinator(
                     self._lock.managed_slots
                     | {address.user_ref for address in self._pending}
                 )
+            # Replace, as the poll and drift paths do: the read names every
+            # managed and pending slot plus whatever else the lock holds, so a
+            # slot it no longer reports is one the lock no longer has.
+            new_data = self._apply_read(self._normalize_keys(raw))
         except LockCodeManagerError as err:
-            _LOGGER.debug(
-                "Confirmation read failed for %s: %s",
-                self._lock.lock.entity_id,
-                err,
-            )
-            self._expire_overdue()
+            self._give_up_overdue(err)
             return
-        except Exception:
+        except Exception as err:
             _LOGGER.exception(
                 "Unexpected error during confirmation read for %s",
                 self._lock.lock.entity_id,
             )
-            self._expire_overdue()
+            self._give_up_overdue(err)
             return
-        new_data = {**self.data, **self._apply_read(self._normalize_keys(raw))}
         if new_data != self.data:
             self.async_set_updated_data(new_data)
+        elif self._failed_writes:
+            # The data did not move, but a write failed against it: a slot
+            # left in sync must judge that now, not be charged for it by some
+            # later, unrelated sync.
+            self.async_update_listeners()
 
     @callback
-    def _expire_overdue(self) -> None:
-        """Give up every pending write whose deadline has passed unread."""
+    def _give_up_overdue(self, err: BaseException) -> None:
+        """
+        After a failed read, give up every pending write past its deadline.
+
+        Said at info with the cause when anything is given up, so the sync
+        tick's later warning about an unconfirmed write has a reason on
+        record; a failure that leaves everything still waiting is routine.
+        """
         now = time.monotonic()
-        for address, pending in list(self._pending.items()):
-            if now >= pending.deadline:
-                del self._pending[address]
-                self._failed_writes.add(address)
+        overdue = [
+            address
+            for address, pending in self._pending.items()
+            if now >= pending.deadline
+        ]
+        for address in overdue:
+            del self._pending[address]
+            self._failed_writes.add(address)
+        if overdue:
+            self.async_update_listeners()
+            _LOGGER.info(
+                "%s could not be read back before the deadline (%s); giving up "
+                "on the writes to slots %s",
+                self._lock.lock.entity_id,
+                err,
+                [address.user_ref for address in overdue],
+            )
+        else:
+            _LOGGER.debug(
+                "Confirmation read failed for %s, will retry: %s",
+                self._lock.lock.entity_id,
+                err,
+            )
 
     @callback
     def push_update(self, updates: dict[int, SlotCredential]) -> None:
@@ -695,6 +731,10 @@ class LockUsercodeUpdateCoordinator(
 
     async def async_shutdown(self) -> None:
         """Shut down the coordinator and clean up resources."""
+        # Nothing may be looked at again: a look already in flight is
+        # cancelled, and an empty pending set arms no timer after it.
+        self._pending.clear()
+        self._failed_writes.clear()
         if self._confirm_task is not None:
             self._confirm_task.cancel()
             self._confirm_task = None

--- a/custom_components/lock_code_manager/domain/coordinator.py
+++ b/custom_components/lock_code_manager/domain/coordinator.py
@@ -6,14 +6,16 @@ Stores ALL slots (managed and unmanaged). See ARCHITECTURE.md for the full data 
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Callable
 from datetime import datetime, timedelta
 import logging
-from typing import TYPE_CHECKING, Any
+import time
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from homeassistant.const import CONF_ENABLED, CONF_PIN
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.helpers.event import async_call_later, async_track_time_interval
 from homeassistant.helpers.issue_registry import (
     IssueSeverity,
     async_create_issue,
@@ -25,7 +27,9 @@ from ..const import (
     BACKOFF_FAILURE_THRESHOLD,
     BACKOFF_INITIAL_SECONDS,
     BACKOFF_MAX_SECONDS,
+    CONFIRM_READ_INTERVAL,
     DOMAIN,
+    PENDING_WRITE_TTL,
     POLL_FAILURE_ALERT_THRESHOLD,
 )
 from .credentials import CredentialAddress, CredentialType, pin_address
@@ -39,6 +43,26 @@ if TYPE_CHECKING:
     from ..providers import BaseLock
 
 _LOGGER = logging.getLogger(__name__)
+
+
+class PendingWrite(NamedTuple):
+    """
+    A write the lock has not yet been seen to hold.
+
+    ``believed`` says whether ``data`` carries the written PIN on the strength
+    of the write alone (an optimistic write pushes its value before anything
+    confirms it). Either way the address is unverified until a read or push
+    shows the slot present, and given up on at ``deadline``.
+    """
+
+    pin: str
+    written_at: float
+    believed: bool
+
+    @property
+    def deadline(self) -> float:
+        """Monotonic time after which an absent read means the write did not land."""
+        return self.written_at + PENDING_WRITE_TTL
 
 
 def _checked(address: CredentialAddress) -> CredentialAddress:
@@ -91,17 +115,26 @@ class LockUsercodeUpdateCoordinator(
             config_entry=config_entry,
         )
         self.data: dict[CredentialAddress, SlotCredential] = {}
-        # Slots awaiting confirmation, kept in lockstep with ``data``. A slot is
-        # unverified only while an optimistic (ambiguous-but-treated-as-completed)
-        # write awaits confirmation; every other source -- genuine push events,
-        # polls, hard refreshes, and authoritative writes -- is verified.
-        #
-        # A set rather than a per-slot flag, because "verified" has no
-        # representation of its own: membership is the whole state. Storing it as
-        # ``dict[int, bool]`` admitted a third, redundant value -- an explicit
-        # ``True`` that read identically to absence -- and every writer had to
-        # remember which of the two to use. See the Phase 2 push-as-commit spec.
-        self._unverified: set[CredentialAddress] = set()
+        # Writes the lock has not yet been seen to hold, by address. This is the
+        # whole of "unverified": an address is verified exactly when nothing is
+        # pending against it. Confirmed by a read or push showing the slot
+        # present; given up on by the first read past the deadline that still
+        # does not -- which is also the only way a pending write ends without
+        # confirmation, so nothing outside a completed read ever has to guess.
+        # Keyed by CredentialAddress, NOT by device slot: one slot can hold a
+        # credential of each type, and a slot-keyed map would let two addresses
+        # sharing a slot consume each other's entry.
+        self._pending: dict[CredentialAddress, PendingWrite] = {}
+        # Addresses whose pending write failed -- not seen by the deadline, or
+        # displaced by a different code -- awaiting the sync tick's one charge
+        # to the slot breaker. Consumed by ``take_failed_write``.
+        self._failed_writes: set[CredentialAddress] = set()
+        # The single confirmation look for this lock: a task for the immediate
+        # first look, then a timer while anything stays pending. One per
+        # coordinator, not per write: N pending slots on one lock are one read
+        # apart, not N.
+        self._confirm_task: asyncio.Task[None] | None = None
+        self._confirm_unsub: Callable[[], None] | None = None
         self._config_entry = config_entry
         self._lock_breaker = CircuitBreaker(
             BACKOFF_FAILURE_THRESHOLD,
@@ -174,59 +207,171 @@ class LockUsercodeUpdateCoordinator(
         """
         Resolve a genuine read (poll or hard refresh) against pending writes.
 
-        A read is the dropped-push backstop for the verified-credential
-        lifecycle: for a slot with an outstanding optimistic write, observing
-        the slot present confirms our write -- keep the believed value and mark
-        it verified. The one exception (mirroring ``BaseLock._confirm_slot``) is
-        a *readable* observation of a different code: that is an external change
-        racing our write, so take the observation rather than masking it with
-        the believed value -- otherwise a drift refresh, whose whole purpose is
-        to surface out-of-band changes, would silently overwrite one. Observing
-        the slot still absent means the write has not landed yet, so keep waiting
-        (stay unverified, pending intact). Slots with no pending write are
-        genuine observations and are marked verified. See the Phase 2
-        push-as-commit spec.
+        For an address with a write pending, observing the slot present
+        confirms the write: keep the written value, verified. The one
+        exception (mirroring ``observe_push``) is a *readable* observation of
+        a different code: the slot holds something else, so the write did not
+        take -- take the observation, otherwise a drift refresh, whose whole
+        purpose is to surface out-of-band changes, would silently overwrite
+        one, and count the write as failed. Observing the slot still absent
+        before the deadline means the write has not landed yet: keep waiting.
+        Absent at or past the deadline means it is not going to: give the
+        write up, take the observation, and count it failed. Either failure
+        leaves the address for the sync tick to charge once. Addresses with
+        nothing pending are the lock's word as read.
         """
+        now = time.monotonic()
         out: dict[CredentialAddress, SlotCredential] = {}
         for address, cred in observed.items():
-            pending = self._lock._pending_writes.get(address)
-            if pending is not None and cred.is_present:
-                pin, _deadline = pending
-                del self._lock._pending_writes[address]
-                if cred.is_readable and cred.readable_pin != pin:
+            pending = self._pending.get(address)
+            if pending is None:
+                out[address] = cred
+            elif cred.is_present:
+                del self._pending[address]
+                if cred.is_readable and cred.readable_pin != pending.pin:
+                    self._failed_writes.add(address)
                     out[address] = cred
                 else:
-                    out[address] = SlotCredential.known(pin)
-                self._unverified.discard(address)
-            elif pending is not None:
+                    out[address] = SlotCredential.known(pending.pin)
+            elif now >= pending.deadline:
+                del self._pending[address]
+                self._failed_writes.add(address)
                 out[address] = cred
-                self._unverified.add(address)
             else:
                 out[address] = cred
-                self._unverified.discard(address)
-        # Keep the unverified set in lockstep with the read.
-        self._unverified &= out.keys()
         return out
 
     def is_verified(self, address: CredentialAddress) -> bool:
         """
-        Return whether the address's credential is a confirmed observation.
+        Return whether the address's credential is the lock's word.
 
-        Unlisted addresses are verified: an address is only unverified while
-        an optimistic write awaits confirmation (push event or hard refresh).
+        False exactly while a write is pending against the address: an
+        optimistic write anywhere, or a confirmed write on a polled lock,
+        until a read or push shows the slot present -- or the deadline passes
+        and the write is given up on.
         """
-        return _checked(address) not in self._unverified
+        return _checked(address) not in self._pending
+
+    def pending_write(self, address: CredentialAddress) -> PendingWrite | None:
+        """Return the write pending against ``address``, if any."""
+        return self._pending.get(_checked(address))
+
+    def has_pending_write(self, address: CredentialAddress) -> bool:
+        """Return whether a write is pending against ``address``."""
+        return _checked(address) in self._pending
 
     @callback
-    def mark_verified(self, address: CredentialAddress) -> None:
+    def record_write(
+        self, address: CredentialAddress, pin: str, *, believed: bool
+    ) -> None:
         """
-        Drop an address from the unverified set.
+        Record a write the lock has not yet been seen to hold, and go look.
 
-        Called when a write is confirmed by the lock (an authoritative
-        ``WriteResult.CONFIRMED``), so an address left unverified by a prior
-        optimistic write on the same address cannot strand it.
+        ``believed`` pushes the written value into ``data`` on the strength of
+        the write alone -- what an optimistic write does, so the code sensor
+        shows the PIN the driver most likely stored. A polled lock's confirmed
+        write is recorded without it: the cloud accepting the write is not
+        the lock reporting it, and the read that follows is what will say.
+
+        Starts the confirmation look if one is not already under way. The
+        first look is an immediate task, so a lock that already reports the
+        write settles on the next sync tick; later looks are a timer,
+        CONFIRM_READ_INTERVAL apart, until nothing is pending. A newer write
+        to the same address replaces the record, so the read confirms the PIN
+        actually sent last.
         """
-        self._unverified.discard(_checked(address))
+        checked = _checked(address)
+        self._pending[checked] = PendingWrite(pin, time.monotonic(), believed)
+        self._failed_writes.discard(checked)
+        if believed:
+            new_data = {**self.data, checked: SlotCredential.known(pin)}
+            if new_data != self.data:
+                self.async_set_updated_data(new_data)
+        if self._confirm_task is None and self._confirm_unsub is None:
+            # Not eager: this is called from inside the provider's own write
+            # path, and an eagerly started read would reenter the provider
+            # before that write has returned.
+            self._confirm_task = self.hass.async_create_task(
+                self._async_confirmation_look(),
+                f"{DOMAIN} confirmation read for {self._lock.lock.entity_id}",
+                eager_start=False,
+            )
+
+    @callback
+    def drop_pending(self, address: CredentialAddress) -> None:
+        """
+        Forget a pending write without judging it.
+
+        For a write that is no longer wanted -- the slot was cleared, or the
+        desired PIN changed while it was outstanding. Not a failure, so it
+        leaves nothing for the tick to charge.
+        """
+        checked = _checked(address)
+        self._pending.pop(checked, None)
+        self._failed_writes.discard(checked)
+
+    @callback
+    def take_failed_write(self, address: CredentialAddress) -> bool:
+        """
+        Return, once, whether a pending write to ``address`` failed.
+
+        Set when a read past the deadline still did not show the write, or
+        when a read showed the slot holding a different code instead; cleared
+        by this call. The sync tick charges the slot breaker exactly once per
+        write the lock did not keep.
+        """
+        checked = _checked(address)
+        if checked in self._failed_writes:
+            self._failed_writes.discard(checked)
+            return True
+        return False
+
+    @callback
+    def observe_push(
+        self, address: CredentialAddress, observed: SlotCredential
+    ) -> None:
+        """
+        Resolve a push event for one address against any pending write.
+
+        The push-side twin of ``_apply_read``, with one deliberate difference:
+        a push is the lock speaking now, so an absent push ends the pending
+        write and is taken as the lock's word rather than waited out -- and
+        counts the write failed. A present push confirms the write (keeping
+        the written value), unless a readable different code shows the slot
+        holds something else, which counts it failed as well.
+        """
+        checked = _checked(address)
+        pending = self._pending.pop(checked, None)
+        if pending is None:
+            value = observed
+        elif observed.is_present and not (
+            observed.is_readable and observed.readable_pin != pending.pin
+        ):
+            value = SlotCredential.known(pending.pin)
+        else:
+            self._failed_writes.add(checked)
+            value = observed
+        self.push_update({checked.user_ref: value})
+
+    async def _async_confirmation_look(self) -> None:
+        """Look once right after a write; hand off to the timer while anything is pending."""
+        try:
+            await self.async_confirm_pending_writes()
+        finally:
+            self._confirm_task = None
+        if self._pending:
+            self._confirm_unsub = async_call_later(
+                self.hass, CONFIRM_READ_INTERVAL, self._async_confirmation_timer
+            )
+
+    async def _async_confirmation_timer(self, _now: datetime) -> None:
+        """Timer callback: read the lock back, and re-arm while anything is pending."""
+        self._confirm_unsub = None
+        await self.async_confirm_pending_writes()
+        if self._pending:
+            self._confirm_unsub = async_call_later(
+                self.hass, CONFIRM_READ_INTERVAL, self._async_confirmation_timer
+            )
 
     def credential(self, address: CredentialAddress) -> SlotCredential | None:
         """
@@ -264,90 +409,73 @@ class LockUsercodeUpdateCoordinator(
 
     async def async_confirm_pending_writes(self) -> None:
         """
-        Actively read the lock back to confirm outstanding optimistic writes.
+        Read the lock back to settle the writes pending against it.
 
-        An ambiguous write (``WriteResult.OPTIMISTIC``) gets no confirming push
-        on some stacks: node-zwave-js, for one, emits no ``credential
-        added/modified`` event when its own post-write verification fails on a
-        lock that reports codes back masked -- the event and the ``ERROR_UNKNOWN``
-        result are mutually exclusive. Waiting for the hourly drift refresh would
-        let the breaker suspend a slot whose code actually landed (~3 attempts in
-        the 5-minute window, long before the hourly backstop). So the seam calls
-        this immediately after recording an optimistic write.
+        The order-independent confirmation path: it does not depend on a push
+        arriving, which some stacks never send for an ambiguous write and a
+        polled lock never sends at all. A polled lock is read through its
+        ordinary read, scoped to the managed slots plus every pending address,
+        so a write to a slot nothing manages is still asked about; a push
+        provider is hard-refreshed, since its ordinary path is the cache the
+        write may not have reached.
 
-        This is the order-independent confirmation path: it does not depend on
-        receiving any event. A hard read observes the slot present-but-masked
-        (LCM projects masked codes to ``unreadable`` rather than repeating the
-        driver's ``userCode == codeData`` check) and ``_apply_read`` confirms it;
-        a genuinely-absent slot stays pending and re-syncs on the next tick.
-
-        A failed read is non-fatal and does not apply backoff: the slot stays
-        pending and the sync tick reconciles it within the TTL.
+        A failed read is non-fatal and does not touch the lock breaker --
+        connectivity is the scheduled poll's to judge. A read that fails once a
+        pending write is past its deadline gives that write up all the same:
+        the lock has had the time to live to be seen holding it, and was not.
         """
-        if not self._lock._pending_writes:
+        if not self._pending:
             return
         try:
-            new_data = self._apply_read(
-                self._normalize_keys(
-                    await self._lock.async_internal_hard_refresh_codes()
+            if self._is_push:
+                raw = await self._lock.async_internal_hard_refresh_codes()
+            else:
+                raw = await self._lock.async_internal_get_usercodes(
+                    self._lock.managed_slots
+                    | {address.user_ref for address in self._pending}
                 )
-            )
         except LockCodeManagerError as err:
             _LOGGER.debug(
-                "On-demand confirmation read failed for %s: %s; leaving pending "
-                "writes for the sync tick to reconcile",
+                "Confirmation read failed for %s: %s",
                 self._lock.lock.entity_id,
                 err,
             )
+            self._expire_overdue()
             return
         except Exception:
-            # The confirmation read is a best-effort backstop, never fatal: it
-            # must not escape into the set seam and suspend the slot. The pending
-            # write stays recorded and the sync tick reconciles it via the TTL.
             _LOGGER.exception(
-                "Unexpected error during on-demand confirmation read for %s; "
-                "leaving pending writes for the sync tick to reconcile",
+                "Unexpected error during confirmation read for %s",
                 self._lock.lock.entity_id,
             )
+            self._expire_overdue()
             return
-        # _apply_read already cleared pending + updated the unverified set in
-        # place, so the confirmation takes effect even when the data is
-        # unchanged; only the listener notification is gated on a real delta.
+        new_data = {**self.data, **self._apply_read(self._normalize_keys(raw))}
         if new_data != self.data:
             self.async_set_updated_data(new_data)
 
     @callback
-    def push_update(
-        self, updates: dict[int, SlotCredential], *, optimistic: bool = False
-    ) -> None:
-        """
-        Push one or more slot updates and notify listening entities.
+    def _expire_overdue(self) -> None:
+        """Give up every pending write whose deadline has passed unread."""
+        now = time.monotonic()
+        for address, pending in list(self._pending.items()):
+            if now >= pending.deadline:
+                del self._pending[address]
+                self._failed_writes.add(address)
 
-        ``optimistic=True`` marks the pushed slots unverified (an ambiguous
-        write we are treating as completed but have not yet confirmed). The
-        default, ``False``, marks them verified -- every existing caller keeps
-        today's behavior.
+    @callback
+    def push_update(self, updates: dict[int, SlotCredential]) -> None:
+        """
+        Push one or more slot updates, as the lock's word, and notify entities.
+
+        Whether an address is verified is not a property of the value pushed
+        but of whether a write is pending against it; see ``record_write`` and
+        ``observe_push`` for the paths that touch that.
         """
         if not updates:
             return
 
-        normalized = self._normalize_keys(updates)
-        new_data = {**self.data, **normalized}
-
-        # Record the pushed slots regardless of whether the value changed: an
-        # optimistic re-push of the same value still flips the slot to
-        # unverified.
-        if optimistic:
-            self._unverified |= normalized.keys()
-        else:
-            self._unverified -= normalized.keys()
-        # Keep the unverified set in lockstep with data.
-        self._unverified &= new_data.keys()
-
+        new_data = {**self.data, **self._normalize_keys(updates)}
         if new_data == self.data:
-            # Verification-only change: the sync layer reads ``is_verified``
-            # directly on its next tick, and entities don't render the flag, so
-            # there's nothing to notify and no reachability proof (no new data).
             return
 
         # A successful push update proves the lock is reachable, so reset
@@ -567,6 +695,12 @@ class LockUsercodeUpdateCoordinator(
 
     async def async_shutdown(self) -> None:
         """Shut down the coordinator and clean up resources."""
+        if self._confirm_task is not None:
+            self._confirm_task.cancel()
+            self._confirm_task = None
+        if self._confirm_unsub:
+            self._confirm_unsub()
+            self._confirm_unsub = None
         if self._drift_unsub:
             self._drift_unsub()
             self._drift_unsub = None

--- a/custom_components/lock_code_manager/domain/coordinator.py
+++ b/custom_components/lock_code_manager/domain/coordinator.py
@@ -280,6 +280,10 @@ class LockUsercodeUpdateCoordinator(
         to the same address replaces the record, so the read confirms the PIN
         actually sent last.
         """
+        if self._shutdown_requested:
+            # A write returning after unload has no one left to confirm it
+            # for; recording it would start a look against a torn-down lock.
+            return
         checked = _checked(address)
         self._pending[checked] = PendingWrite(pin, time.monotonic(), believed)
         self._failed_writes.discard(checked)
@@ -334,6 +338,7 @@ class LockUsercodeUpdateCoordinator(
         """
         checked = _checked(address)
         pending = self._pending.pop(checked, None)
+        failed = False
         if pending is None:
             value = observed
         elif observed.is_present and not (
@@ -342,10 +347,11 @@ class LockUsercodeUpdateCoordinator(
             value = SlotCredential.known(pending.pin)
         else:
             self._failed_writes.add(checked)
+            failed = True
             value = observed
         before = self.data
         self.push_update({checked.user_ref: value})
-        if self.data is before and checked in self._failed_writes:
+        if failed and self.data is before:
             # Same data, failed write: let the sync layer judge it now.
             self.async_update_listeners()
 
@@ -445,6 +451,7 @@ class LockUsercodeUpdateCoordinator(
             # Replace, as the poll and drift paths do: the read names every
             # managed and pending slot plus whatever else the lock holds, so a
             # slot it no longer reports is one the lock no longer has.
+            failed_before = len(self._failed_writes)
             new_data = self._apply_read(self._normalize_keys(raw))
         except LockCodeManagerError as err:
             self._give_up_overdue(err)
@@ -458,10 +465,10 @@ class LockUsercodeUpdateCoordinator(
             return
         if new_data != self.data:
             self.async_set_updated_data(new_data)
-        elif self._failed_writes:
-            # The data did not move, but a write failed against it: a slot
-            # left in sync must judge that now, not be charged for it by some
-            # later, unrelated sync.
+        elif len(self._failed_writes) > failed_before:
+            # The data did not move, but a write just failed against it: a
+            # slot left in sync must judge that now, not be charged for it by
+            # some later, unrelated sync.
             self.async_update_listeners()
 
     @callback

--- a/custom_components/lock_code_manager/domain/credentials.py
+++ b/custom_components/lock_code_manager/domain/credentials.py
@@ -236,14 +236,15 @@ class WriteResult(StrEnum):
 
     - ``NO_CHANGE`` -- the value was already set; nothing was written. The
       coordinator is not refreshed.
-    - ``CONFIRMED`` -- the lock acknowledged the write. The slot is marked
-      verified; non-push providers refresh to read it back.
+    - ``CONFIRMED`` -- the write was accepted. On a push provider that is the
+      lock's word: the provider pushes the value (or the driver's event does)
+      and nothing is left pending. On a polled lock it is the cloud service's
+      word only, so the coordinator records the write pending -- unverified
+      until a read shows the slot hold it, given up on if none does in time.
     - ``OPTIMISTIC`` -- the write returned an ambiguous result we treat as
       completed but have NOT confirmed (e.g. a Z-Wave driver
-      ``ERROR_UNKNOWN`` from a masked read-back). The slot is marked
-      unverified and awaits confirmation via a push event or hard refresh;
-      if none arrives, it re-syncs rather than silently reporting success.
-      See the Phase 2 push-as-commit spec.
+      ``ERROR_UNKNOWN`` from a masked read-back). Recorded pending with the
+      value believed, and settled the same way.
     """
 
     NO_CHANGE = "no_change"

--- a/custom_components/lock_code_manager/domain/sync.py
+++ b/custom_components/lock_code_manager/domain/sync.py
@@ -645,6 +645,12 @@ class SlotSyncManager:
                 self._state = SyncState.OUT_OF_SYNC
                 self._breaker_reset_requested = True
                 self._write_state()
+            elif snapshot is not None:
+                # A write that failed but left the slot in sync -- a direct
+                # write of some other PIN the lock did not keep -- is not this
+                # sync's strike. Discard it here, or the next sync to run
+                # would be charged and warned for a write it never made.
+                self._coordinator.take_failed_write(self._address)
         elif self._state is SyncState.SUSPENDED:
             if self._code_suspend_target is not None:
                 # Suspended for a non-converging code or an unexpected error.

--- a/custom_components/lock_code_manager/domain/sync.py
+++ b/custom_components/lock_code_manager/domain/sync.py
@@ -290,6 +290,9 @@ class SlotSyncManager:
         if self._started:
             return
         self._started = True
+        # A write that failed before this manager existed -- a direct write to
+        # a slot nobody managed yet -- is not this manager's strike.
+        self._coordinator.take_failed_write(self._address)
         self._setup_state_tracking()
         self._setup_coordinator_listener()
         self._tick_unsub = async_track_time_interval(
@@ -786,8 +789,11 @@ class SlotSyncManager:
         # the capability probe, landing in the generic error handler with a
         # misleading "report this bug" suspension — and, for Z-Wave, re-fire
         # the slot-count recovery device query on every attempt. Ahead of the
-        # pending check so an outage right after an accepted write reads as
-        # the outage it is, not as a write the lock declined.
+        # pending check so an outage right after an accepted write suspends
+        # as the outage it is while it lasts. If the lock is still unreadable
+        # at that write's deadline the coordinator gives the write up all the
+        # same, and the re-sync after recovery costs the one strike that
+        # trade accepts: a landed write re-syncs as no change.
         if self._coordinator.unreachable or not self._lock.provider_setup_succeeded:
             self._state = SyncState.SUSPENDED
             self._write_state()

--- a/custom_components/lock_code_manager/domain/sync.py
+++ b/custom_components/lock_code_manager/domain/sync.py
@@ -17,7 +17,6 @@ from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from datetime import datetime
 import logging
-import time
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any
 
@@ -456,12 +455,11 @@ class SlotSyncManager:
         unreadable, and that taking over a slot with an existing masked code
         triggers a set.
 
-        An unverified slot (an optimistic write still awaiting confirmation,
-        or one whose confirmation never arrived) is never in sync: the
-        coordinator holds the believed value but the lock has not confirmed it,
-        so the tick must keep watching (PENDING_CONFIRMATION) or re-sync rather
-        than declare success. Slots with no recorded flag read as verified, so
-        this is a no-op for providers that never write optimistically.
+        An unverified slot -- one with a write pending against it that no
+        read or push has yet shown -- is never in sync: the coordinator may
+        hold the believed value, but the lock has not said so, and the tick
+        must keep watching (PENDING_CONFIRMATION) rather than declare success.
+        A slot with nothing pending is verified, whatever it holds.
         """
         if not self._coordinator.is_verified(self._address):
             return False
@@ -469,15 +467,15 @@ class SlotSyncManager:
         if snapshot.active_state == STATE_ON:
             if credential is not None:
                 if credential.is_empty:
-                    # If we recently set a PIN on this slot and it matches the
-                    # configured PIN, trust the set — the provider may not
-                    # have caught up yet (eventual consistency, e.g. Schlage
-                    # cloud API).
-                    return (
-                        self._last_set_pin is not None
-                        and snapshot.credential_state == self._last_set_pin
-                    )
+                    # The lock's answer, not a lagging read: while a write of
+                    # ours could still be ahead of the read, the address is
+                    # unverified and the guard above refuses it. An active slot
+                    # the lock says is empty is out of sync.
+                    return False
                 if not credential.is_readable:
+                    # No read will ever say what a write-only lock holds, so
+                    # the last PIN written is the only thing to compare the
+                    # configured one against.
                     return snapshot.credential_state == self._last_set_pin
                 return credential.matches(snapshot.credential_state)
             # No coordinator data — fall back to the code sensor entity state.
@@ -776,56 +774,55 @@ class SlotSyncManager:
             self._write_state()
             return
 
-        # -- PENDING_CONFIRMATION: an optimistic write is awaiting confirmation.
-        # Don't re-write while waiting; a push event / hard refresh resolves it
-        # (clearing the pending entry). On timeout, count a breaker failure and
-        # fall through to re-sync -- so a write the lock never committed ends in
-        # a visible suspend, never a silent in-sync.
-        pending = self._lock._pending_writes.get(self._address)
-        if pending is not None:
-            believed_pin, deadline = pending
-            # A pending write only gates reconciliation while it still reflects
-            # the desired state. If the user changed the PIN or disabled the slot
-            # while the write was outstanding, the entry is stale: drop it and
-            # reconcile the new target instead of holding PENDING_CONFIRMATION
-            # (and re-syncing the old value) until the deadline.
-            still_wanted = (
-                snapshot.active_state == STATE_ON
-                and snapshot.credential_state == believed_pin
-            )
-            if still_wanted and time.monotonic() < deadline:
-                if self._state is not SyncState.PENDING_CONFIRMATION:
-                    self._state = SyncState.PENDING_CONFIRMATION
-                    self._write_state()
-                return
-            # Drop the entry and re-sync on the NEXT tick. Returning here (rather
-            # than falling through to _perform_sync this tick) lets a confirming
-            # push that lands between ticks resolve the slot first, and avoids
-            # double-charging the breaker when the re-sync itself also fails.
-            del self._lock._pending_writes[self._address]
-            if still_wanted:
-                # Genuine timeout: the write we still want never confirmed.
-                self._slot_breaker.record_failure()
-                _LOGGER.warning(
-                    "%s: optimistic write not confirmed within the timeout; "
-                    "re-syncing (attempt %s)",
-                    self._log_prefix,
-                    self._slot_breaker.failure_count,
-                )
-            # A stale entry (desired state changed) is not a sync failure, so it
-            # does not charge the breaker.
-            self._state = SyncState.OUT_OF_SYNC
-            self._write_state()
-            return
-
-        # -- OUT_OF_SYNC: check lock readiness, then attempt sync --
+        # -- Lock readiness, before anything about pending writes --
         # An unvalidated provider setup (deferred or structurally failed)
         # suspends alongside unreachability: any write would only fail on
         # the capability probe, landing in the generic error handler with a
         # misleading "report this bug" suspension — and, for Z-Wave, re-fire
-        # the slot-count recovery device query on every attempt.
+        # the slot-count recovery device query on every attempt. Ahead of the
+        # pending check so an outage right after an accepted write reads as
+        # the outage it is, not as a write the lock declined.
         if self._coordinator.unreachable or not self._lock.provider_setup_succeeded:
             self._state = SyncState.SUSPENDED
+            self._write_state()
+            return
+
+        # -- PENDING_CONFIRMATION: a write is awaiting the lock's word --
+        # The coordinator owns the write from here: it reads the lock back on
+        # its own schedule, confirms the write when a read or push shows the
+        # slot present, and gives it up when a read past the deadline still
+        # does not. This tick only watches. Don't re-write while waiting.
+        pending = self._coordinator.pending_write(self._address)
+        if pending is not None:
+            # A pending write only gates reconciliation while it still reflects
+            # the desired state. If the user changed the PIN or disabled the slot
+            # while the write was outstanding, it is stale: forget it and
+            # reconcile the new target instead of waiting on the old one.
+            if (
+                snapshot.active_state == STATE_ON
+                and snapshot.credential_state == pending.pin
+            ):
+                if self._state is not SyncState.PENDING_CONFIRMATION:
+                    self._state = SyncState.PENDING_CONFIRMATION
+                    self._write_state()
+                return
+            self._coordinator.drop_pending(self._address)
+            self._state = SyncState.OUT_OF_SYNC
+            self._write_state()
+            return
+
+        # A write the lock did not keep -- never seen, or displaced by another
+        # code: charged once, then re-synced on the NEXT tick, so a confirming
+        # push that lands between ticks can still settle the slot first and the
+        # re-sync's own outcome is judged apart.
+        if self._coordinator.take_failed_write(self._address):
+            self._slot_breaker.record_failure()
+            _LOGGER.warning(
+                "%s: write not confirmed within the timeout; re-syncing (attempt %s)",
+                self._log_prefix,
+                self._slot_breaker.failure_count,
+            )
+            self._state = SyncState.OUT_OF_SYNC
             self._write_state()
             return
 
@@ -950,6 +947,13 @@ class SlotSyncManager:
             )
             return
         else:
+            # A write the coordinator recorded pending is its to confirm: it
+            # has already gone to read the lock back, and this tick's own read
+            # would only find the same answer two seconds later.
+            if self._coordinator.has_pending_write(self._address):
+                self._state = SyncState.PENDING_CONFIRMATION
+                self._write_state()
+                return
             # Sync succeeded — refresh coordinator to verify.
             # Skip for push providers — they update coordinator optimistically
             # via push_update() and refreshing from cache could read stale data.
@@ -971,16 +975,6 @@ class SlotSyncManager:
                         self._slot_breaker.record_failure()
                     self._state = SyncState.OUT_OF_SYNC
                     return
-
-        # An optimistic (ambiguous) set records a pending write: don't judge it
-        # now -- wait for the lock to confirm it (a push event or hard refresh)
-        # in PENDING_CONFIRMATION. The breaker is only charged when that wait
-        # times out (handled at the top of the tick), so a masked-but-accepted
-        # write is not penalised before its confirming event arrives.
-        if self._address in self._lock._pending_writes:
-            self._state = SyncState.PENDING_CONFIRMATION
-            self._write_state()
-            return
 
         # Check if sync actually worked.
         snapshot = self._resolve_credential_snapshot()

--- a/custom_components/lock_code_manager/domain/sync.py
+++ b/custom_components/lock_code_manager/domain/sync.py
@@ -830,7 +830,8 @@ class SlotSyncManager:
         if self._coordinator.take_failed_write(self._address):
             self._slot_breaker.record_failure()
             _LOGGER.warning(
-                "%s: write not confirmed within the timeout; re-syncing (attempt %s)",
+                "%s: the lock did not keep the write (not seen by the deadline, "
+                "or holding a different code); re-syncing (attempt %s)",
                 self._log_prefix,
                 self._slot_breaker.failure_count,
             )

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -1482,14 +1482,17 @@ class BaseLock:
             code_slot,
             source,
         )
-        # A clear supersedes any write pending on this slot.
-        if self.coordinator is not None:
-            self.coordinator.drop_pending(pin_address(code_slot))
         changed = await self._execute_rate_limited(
             "clear",
             partial(self.async_clear_usercode, adopt_untagged=adopt_untagged),
             code_slot,
         )
+        # A clear that ran supersedes any write pending on this slot. One that
+        # raised superseded nothing: the write stays pending, so a believed
+        # value it pushed is not taken as verified on the strength of a clear
+        # that never reached the lock.
+        if self.coordinator is not None:
+            self.coordinator.drop_pending(pin_address(code_slot))
         # Only a clear that changed something is evidence about the slot. A
         # provider that found nothing to clear has said nothing about what is
         # there.

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -49,7 +49,6 @@ from ..domain.config import build_slot_unique_id
 from ..domain.coordinator import LockUsercodeUpdateCoordinator
 from ..domain.credentials import (
     Credential,
-    CredentialAddress,
     CredentialRef,
     CredentialType,
     LockCapabilities,
@@ -116,11 +115,6 @@ MIN_OPERATION_DELAY = 2.0
 # this constant exists to avoid.
 OPERATION_TIMEOUT = 600.0
 
-
-# How long an optimistic write waits for confirmation (push event or hard-refresh
-# presence) before the sync layer gives up waiting and re-syncs. See the Phase 2
-# push-as-commit spec.
-PENDING_WRITE_TTL = 60.0
 _OPERATION_MESSAGES: dict[Literal["get", "set", "clear", "refresh"], str] = {
     "get": "get from",
     "set": "set on",
@@ -277,15 +271,6 @@ class BaseLock:
     # A confirmation -- a push event or a hard-refresh read observing the slot
     # present -- clears the entry and re-pushes the believed value as verified;
     # if none arrives before the deadline, the sync layer re-syncs. See the
-    # Phase 2 push-as-commit spec.
-    # Keyed by CredentialAddress, NOT by device slot. One slot can hold a
-    # credential of each type, so a slot-keyed map would let two addresses
-    # sharing a slot collide: the first read processed would consume the
-    # other's pending entry, apply its believed value to the wrong
-    # credential, and leave the second silently marked verified.
-    _pending_writes: dict[CredentialAddress, tuple[str, float]] = field(
-        default_factory=dict, init=False
-    )
     # Reconnect task spawned by the config-entry state listener when the lock
     # integration transitions to LOADED. Tracked so async_unload can cancel it
     # before teardown -- otherwise a late reconnect can call
@@ -504,66 +489,25 @@ class BaseLock:
     @final
     @callback
     def _push_credential_update(
-        self, code_slot: int, credential: SlotCredential, *, optimistic: bool = False
+        self, code_slot: int, credential: SlotCredential
     ) -> None:
-        """
-        Push a coordinator credential update; no-op when no coordinator is attached.
-
-        ``optimistic=True`` marks the slot unverified (an ambiguous write we are
-        treating as completed but have not confirmed). The default keeps the
-        slot verified.
-        """
+        """Push a coordinator credential update; no-op when no coordinator is attached."""
         if self.coordinator is None:
             return
-        # Only pass the kwarg when optimistic, so the common verified push keeps
-        # its plain call shape (and existing call-shape assertions hold).
-        if optimistic:
-            self.coordinator.push_update({code_slot: credential}, optimistic=True)
-        else:
-            self.coordinator.push_update({code_slot: credential})
-
-    @callback
-    def _record_optimistic_write(self, code_slot: int, pin: str) -> None:
-        """
-        Record an outstanding optimistic write and push its believed value.
-
-        Called by the seam when ``async_set_credential`` returns OPTIMISTIC.
-        The slot is pushed as ``known(pin)`` but marked unverified; it awaits
-        a confirmation (push event or hard-refresh presence) via
-        ``_confirm_slot``, or re-syncs once the deadline passes.
-        """
-        self._pending_writes[pin_address(code_slot)] = (
-            pin,
-            time.monotonic() + PENDING_WRITE_TTL,
-        )
-        self._push_credential_update(
-            code_slot, SlotCredential.known(pin), optimistic=True
-        )
+        self.coordinator.push_update({code_slot: credential})
 
     @callback
     def _confirm_slot(self, code_slot: int, observed: SlotCredential) -> None:
         """
-        Resolve an observation (push event or hard-refresh read) for a slot.
+        Resolve a push event for a slot against any write pending on it.
 
-        When an optimistic write for the slot is outstanding and the observed
-        state shows a code present, the observation confirms our write: keep
-        the believed value (even if the observation itself is masked/unreadable)
-        and mark it verified. The one exception is a *readable* observation of a
-        different code -- that is an external change racing our write, so we take
-        the observation rather than masking it with our believed value.
-        Otherwise -- no pending write, or the slot is now empty -- take the
-        observation as the verified state. Either way the pending entry is
-        cleared.
+        The coordinator owns pending writes and their resolution; this is the
+        provider-facing name for handing it an observation. No-op without a
+        coordinator, when there is nothing to resolve against or update.
         """
-        pending = self._pending_writes.pop(pin_address(code_slot), None)
-        if pending is not None and observed.is_present:
-            pin, _deadline = pending
-            if observed.is_readable and observed.readable_pin != pin:
-                self._push_credential_update(code_slot, observed)
-            else:
-                self._push_credential_update(code_slot, SlotCredential.known(pin))
+        if self.coordinator is None:
             return
-        self._push_credential_update(code_slot, observed)
+        self.coordinator.observe_push(pin_address(code_slot), observed)
 
     @final
     def is_slot_managed(self, code_slot: int) -> bool:
@@ -1411,30 +1355,27 @@ class BaseLock:
             name=name,
             source=source,
         )
+        if self.coordinator is None or not result.changed:
+            return
+        address = pin_address(code_slot)
         if result is WriteResult.OPTIMISTIC:
-            # Ambiguous write: record it pending and push the believed value as
-            # unverified, then actively read the lock back to confirm it. Some
-            # stacks send no confirming push for an ambiguous write (node-zwave-js
-            # emits no credential event when its post-write verify fails on a
-            # masked lock), so waiting passively would let the breaker suspend a
-            # slot whose code actually landed. The active read confirms a
-            # present-but-masked slot; a genuinely-absent slot stays pending and
-            # the sync tick re-syncs after the TTL.
-            self._record_optimistic_write(code_slot, str(usercode))
-            if self.coordinator is not None:
-                await self.coordinator.async_confirm_pending_writes()
-        elif result is WriteResult.CONFIRMED:
-            # The lock acknowledged the write: supersede any pending optimistic
-            # state and drop the slot from the unverified set left by a prior
-            # optimistic write, so it can converge instead of churning to a suspend.
-            self._pending_writes.pop(pin_address(code_slot), None)
-            if self.coordinator is not None:
-                self.coordinator.mark_verified(pin_address(code_slot))
-        # Skip coordinator refresh for push providers — they update optimistically
-        # via push_update(), and refreshing from cache could overwrite with stale
-        # data when the driver defers cache updates until device confirmation.
-        if result.changed and self.coordinator and not self.supports_push:
-            await self.coordinator.async_request_refresh()
+            # Ambiguous: the driver most likely stored it but could not say.
+            # Record it pending with the value believed, and let the
+            # coordinator read the lock back -- some stacks send no confirming
+            # push for an ambiguous write, so waiting passively would let the
+            # breaker suspend a slot whose code actually landed.
+            self.coordinator.record_write(address, str(usercode), believed=True)
+        elif self.supports_push:
+            # The provider's own push (or the driver's event) is the lock's
+            # word for the write. Any older pending write to the slot is
+            # superseded by it.
+            self.coordinator.drop_pending(address)
+        else:
+            # A polled lock has nothing to vouch for the write but a later
+            # read: "confirmed" here is the cloud service accepting it, not
+            # the lock reporting it. Record it pending; the coordinator reads
+            # the lock back and settles it -- for any slot, managed or not.
+            self.coordinator.record_write(address, str(usercode), believed=False)
 
     async def async_clear_usercode(
         self, code_slot: int, *, adopt_untagged: bool = True
@@ -1541,10 +1482,9 @@ class BaseLock:
             code_slot,
             source,
         )
-        # A clear supersedes any outstanding optimistic set on this slot, so the
-        # stale pending entry must not keep gating reconciliation (the sync tick
-        # keys PENDING_CONFIRMATION on this dict).
-        self._pending_writes.pop(pin_address(code_slot), None)
+        # A clear supersedes any write pending on this slot.
+        if self.coordinator is not None:
+            self.coordinator.drop_pending(pin_address(code_slot))
         changed = await self._execute_rate_limited(
             "clear",
             partial(self.async_clear_usercode, adopt_untagged=adopt_untagged),
@@ -2119,9 +2059,20 @@ class BaseLock:
         )
 
     @final
-    async def async_internal_get_usercodes(self) -> dict[int, SlotCredential]:
-        """Rate-limited wrapper around async_get_usercodes()."""
-        return await self._execute_rate_limited("get", self.async_get_usercodes)
+    async def async_internal_get_usercodes(
+        self, slots: Collection[int] | None = None
+    ) -> dict[int, SlotCredential]:
+        """
+        Rate-limited wrapper around async_get_usercodes().
+
+        ``slots`` widens or narrows the read's scope; left unset, the provider
+        reads its managed slots. The coordinator's confirmation read names the
+        pending addresses too, so a write to a slot nothing manages is still
+        asked about.
+        """
+        if slots is None:
+            return await self._execute_rate_limited("get", self.async_get_usercodes)
+        return await self._execute_rate_limited("get", self.async_get_usercodes, slots)
 
     @final
     async def async_internal_get_occupied_indices(

--- a/custom_components/lock_code_manager/providers/zwave_js.py
+++ b/custom_components/lock_code_manager/providers/zwave_js.py
@@ -913,7 +913,15 @@ class ZWaveJSLock(BaseLock):
     def _handle_uc_code_update(self, code_slot: int, new_value: Any) -> None:
         """Handle a userCode value update for a code slot."""
         if not new_value:
-            resolved = SlotCredential.empty()
+            # No value from a slot the status says is occupied is the lock
+            # withholding the code, not a cleared slot -- the same rule the
+            # read path's occupancy overlay applies. Taken as empty, it
+            # would fail a pending write the lock in fact kept.
+            resolved = (
+                SlotCredential.unreadable()
+                if self._uc_slot_in_use(code_slot) is True
+                else SlotCredential.empty()
+            )
         else:
             value = str(new_value)
             slot_in_use = self._uc_slot_in_use(code_slot)

--- a/custom_components/lock_code_manager/providers/zwave_js.py
+++ b/custom_components/lock_code_manager/providers/zwave_js.py
@@ -693,6 +693,12 @@ class ZWaveJSLock(BaseLock):
         # Pre-15.25.2 drivers never persist a supervised success to the
         # value database (see _async_uc_reconcile_value_db).
         await self._async_uc_reconcile_value_db(credential.slot)
+        # Push what the driver just confirmed, as every push provider does
+        # before returning CONFIRMED: the seam records nothing pending for a
+        # push provider on the strength of the value being on the coordinator
+        # when this returns. A driver event may follow and refine it; none is
+        # guaranteed to, so this cannot wait for one.
+        self._push_credential_update(credential.slot, SlotCredential.known(pin))
         return WriteResult.CONFIRMED
 
     async def async_delete_credential(self, ref: CredentialRef) -> bool:

--- a/tests/common.py
+++ b/tests/common.py
@@ -8,7 +8,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 import json
-from typing import Literal
+from typing import Any, Literal
 from unittest.mock import patch
 
 from pytest_homeassistant_custom_component.common import async_fire_mqtt_message
@@ -306,19 +306,29 @@ class MockLCMLock(BaseLock):
         self.service_calls["get_usercodes"].append(snapshot)
         codes = {slot: SlotCredential.known(pin) for slot, pin in snapshot.items()}
         codes.update({slot: SlotCredential.unreadable() for slot in self.write_only})
-        if slots is None:
-            return codes
         # Mirrors the base projection, including the part that matters: a slot
-        # in the scope that holds nothing is empty, and a slot the lock holds
-        # OUTSIDE the scope is still reported. Answering with exactly the
-        # scope would model the one shape where a caller's own bounds check
-        # is a no-op.
-        return {**dict.fromkeys(slots, SlotCredential.empty()), **codes}
+        # in the scope -- the managed slots, when the caller names none -- that
+        # holds nothing is empty, and a slot the lock holds OUTSIDE the scope
+        # is still reported. Answering with exactly the scope would model the
+        # one shape where a caller's own bounds check is a no-op; omitting an
+        # empty managed slot would hide the read the pending-write machinery
+        # waits on.
+        scope = self.managed_slots if slots is None else slots
+        return {**dict.fromkeys(scope, SlotCredential.empty()), **codes}
 
 
 @dataclass(repr=False, eq=False)
 class MockLCMPushLock(MockLCMLock):
     """Mock lock that supports push-based updates."""
+
+    async def async_set_usercode(
+        self, code_slot: int, usercode: str, *args: Any, **kwargs: Any
+    ) -> WriteResult:
+        """Set a code and push it, as every push provider does before CONFIRMED."""
+        result = await super().async_set_usercode(code_slot, usercode, *args, **kwargs)
+        if result is WriteResult.CONFIRMED:
+            self._push_credential_update(code_slot, SlotCredential.known(usercode))
+        return result
 
     def __init__(self, *args, **kwargs):
         """Initialize mock push lock."""

--- a/tests/properties/test_in_sync.py
+++ b/tests/properties/test_in_sync.py
@@ -68,16 +68,25 @@ def test_active_readable_credential_syncs_iff_pin_matches(
     assert manager.calculate_in_sync(state) is (pin == credential_pin)
 
 
-@given(pin=PINS, last_set_pin=LAST_SET)
-def test_active_empty_credential_trusts_recent_set_only(
-    pin: str, last_set_pin: str | None
+@given(pin=PINS, other=LAST_SET, same_as_last_set=st.booleans())
+def test_active_verified_empty_credential_is_never_in_sync(
+    pin: str, other: str | None, same_as_last_set: bool
 ) -> None:
-    """Active + lock reports empty: in sync only if we just set this exact PIN."""
+    """Active + a verified read that the slot is empty: never in sync.
+
+    The coordinator only reports an address verified when no write is pending
+    against it, so by the time this branch sees EMPTY the lock has had its say
+    and nothing we wrote is still in flight. Trusting our own write over that
+    is what let a deleted credential report as synchronized (issue #1538).
+
+    ``same_as_last_set`` is an explicit axis because two independent draws
+    almost never collide, and the case that matters is exactly the one where
+    the configured PIN equals the one last written.
+    """
+    last_set_pin = pin if same_as_last_set else other
     manager = _manager(verified=True, last_set_pin=last_set_pin)
     state = CredentialSyncState(STATE_ON, pin, None, "", SlotCredential.empty())
-    assert manager.calculate_in_sync(state) is (
-        last_set_pin is not None and pin == last_set_pin
-    )
+    assert manager.calculate_in_sync(state) is False
 
 
 @given(pin=PINS, last_set_pin=LAST_SET)

--- a/tests/providers/test_base.py
+++ b/tests/providers/test_base.py
@@ -785,32 +785,37 @@ async def test_async_call_service_wraps_os_error_as_lock_disconnected(
     hass.services.async_remove("test_domain", "timeout_service")
 
 
-async def test_set_usercode_refreshes_coordinator_on_change(
+async def test_set_usercode_records_a_pending_write_on_change(
     hass: HomeAssistant,
     mock_lock_config_entry,
     lock_code_manager_config_entry,
 ):
-    """Test that async_internal_set_usercode refreshes coordinator when value changes."""
+    """A changed set on a polled lock is pending until the coordinator's read sees it.
+
+    The seam does not ask for a refresh; the coordinator owns the follow-up
+    read. Setting the same value again changes nothing and records nothing.
+    """
     lock_provider = lock_code_manager_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
     coordinator = lock_provider.coordinator
     assert coordinator is not None
 
-    # Track coordinator refreshes
-    refresh_count = [0]
-    original_refresh = coordinator.async_request_refresh
-
-    async def track_refresh():
-        refresh_count[0] += 1
-        return await original_refresh()
-
-    with patch.object(coordinator, "async_request_refresh", track_refresh):
-        # Setting a new usercode should trigger a coordinator refresh
+    with (
+        patch.object(coordinator, "async_request_refresh", AsyncMock()) as refresh,
+        patch.object(
+            coordinator, "record_write", wraps=coordinator.record_write
+        ) as record,
+    ):
         await lock_provider.async_internal_set_usercode(3, "3333", "Test 3")
-        assert refresh_count[0] == 1
+        record.assert_called_once_with(pin_address(3), "3333", believed=False)
+        assert coordinator.has_pending_write(pin_address(3))
+        refresh.assert_not_awaited()
 
-        # Setting the same usercode should NOT trigger refresh (no change)
+        # The coordinator's own read confirms it; the same value again is no change.
+        await hass.async_block_till_done()
+        assert coordinator.is_verified(pin_address(3))
         await lock_provider.async_internal_set_usercode(3, "3333", "Test 3")
-        assert refresh_count[0] == 1  # Still 1, no new refresh
+        record.assert_called_once()
+        assert coordinator.is_verified(pin_address(3))
 
 
 async def test_clear_usercode_refreshes_coordinator_on_change(

--- a/tests/providers/test_seam.py
+++ b/tests/providers/test_seam.py
@@ -1221,15 +1221,39 @@ async def test_no_change_records_nothing(hass: HomeAssistant) -> None:
     lock.coordinator.drop_pending.assert_not_called()
 
 
-async def test_clear_drops_any_pending_write_before_it_is_sent(
+async def test_clear_drops_any_pending_write_once_it_has_run(
     hass: HomeAssistant,
 ) -> None:
-    """A clear supersedes whatever write was pending on the slot."""
+    """A clear that ran supersedes whatever write was pending on the slot."""
     lock, _pushed = _slot_only_lock_with_coordinator(hass)
     lock._min_operation_delay = 0.0
     with patch.object(BaseLock, "async_is_integration_connected", return_value=True):
         await lock.async_internal_clear_usercode(4)
     lock.coordinator.drop_pending.assert_called_once_with(pin_address(4))
+
+
+async def test_clear_that_raises_leaves_the_pending_write_standing(
+    hass: HomeAssistant,
+) -> None:
+    """A clear that never reached the lock supersedes nothing.
+
+    Otherwise a believed optimistic write would lose its pending record here,
+    read as verified, and put the slot falsely in sync on a value the lock
+    was never seen holding.
+    """
+    lock, _pushed = _slot_only_lock_with_coordinator(hass)
+    lock._min_operation_delay = 0.0
+    with (
+        patch.object(BaseLock, "async_is_integration_connected", return_value=True),
+        patch.object(
+            lock,
+            "async_clear_usercode",
+            AsyncMock(side_effect=LockDisconnected("offline")),
+        ),
+        pytest.raises(LockDisconnected),
+    ):
+        await lock.async_internal_clear_usercode(4)
+    lock.coordinator.drop_pending.assert_not_called()
 
 
 async def test_confirm_slot_hands_the_observation_to_the_coordinator(

--- a/tests/providers/test_seam.py
+++ b/tests/providers/test_seam.py
@@ -1047,141 +1047,25 @@ async def test_set_usercode_logs_warning_when_rollback_user_delete_fails(
 
 
 def _slot_only_lock_with_coordinator(hass: HomeAssistant):
-    """Build a _DegenerateStubLock with a mock coordinator that records pushes."""
+    """Build a _DegenerateStubLock with a mock coordinator that records pushes.
+
+    The coordinator owns pending writes, so what the seam is tested for here
+    is what it tells the coordinator: ``record_write``, ``drop_pending`` and
+    ``observe_push`` are plain mocks the assertions read.
+    """
     lock = _make_lock(hass, _DegenerateStubLock, "seam_optimistic")
     coord = MagicMock()
     coord.data = {}
-    pushed: list[tuple[dict, bool]] = []
+    pushed: list[dict] = []
 
-    def _push(updates, *, optimistic=False):
+    def _push(updates):
         coord.data = {**coord.data, **updates}
-        pushed.append((dict(updates), optimistic))
+        pushed.append(dict(updates))
 
     coord.push_update.side_effect = _push
-    coord.async_confirm_pending_writes = AsyncMock()
     coord.async_request_refresh = AsyncMock()
     lock.coordinator = coord
     return lock, pushed
-
-
-async def test_record_optimistic_write_pushes_unverified_and_tracks_pending(
-    hass: HomeAssistant,
-) -> None:
-    """An optimistic write pushes the believed value unverified and records pending."""
-    lock, pushed = _slot_only_lock_with_coordinator(hass)
-    lock._record_optimistic_write(4, "1234")
-
-    assert pushed == [({4: SlotCredential.known("1234")}, True)]
-    assert pin_address(4) in lock._pending_writes
-    assert lock._pending_writes[pin_address(4)][0] == "1234"
-
-
-async def test_clear_usercode_drops_stale_pending_write(
-    hass: HomeAssistant,
-) -> None:
-    """Clearing a slot supersedes and drops any outstanding optimistic set."""
-    lock, _pushed = _slot_only_lock_with_coordinator(hass)
-    lock._min_operation_delay = 0.0
-    lock._record_optimistic_write(4, "1234")
-    assert pin_address(4) in lock._pending_writes
-
-    with patch.object(BaseLock, "async_is_integration_connected", return_value=True):
-        await lock.async_internal_clear_usercode(4)
-
-    assert pin_address(4) not in lock._pending_writes
-
-
-async def test_optimistic_set_actively_confirms_instead_of_waiting(
-    hass: HomeAssistant,
-) -> None:
-    """An OPTIMISTIC write records pending AND drives an on-demand confirm read.
-
-    The confirm read is the durable, order-independent backstop: some stacks
-    send no push for an ambiguous write, so the seam must read the slot back
-    rather than wait passively (which would let the breaker suspend a slot whose
-    code actually landed).
-    """
-    lock, _pushed = _slot_only_lock_with_coordinator(hass)
-    lock._min_operation_delay = 0.0
-    with (
-        patch.object(BaseLock, "async_is_integration_connected", return_value=True),
-        patch.object(
-            lock, "async_set_usercode", AsyncMock(return_value=WriteResult.OPTIMISTIC)
-        ),
-    ):
-        await lock.async_internal_set_usercode(4, "1234", "carol")
-
-    assert pin_address(4) in lock._pending_writes
-    lock.coordinator.async_confirm_pending_writes.assert_awaited_once()
-
-
-async def test_confirm_slot_keeps_believed_value_on_present_observation(
-    hass: HomeAssistant,
-) -> None:
-    """A present (even masked) observation confirms a pending write as verified."""
-    lock, pushed = _slot_only_lock_with_coordinator(hass)
-    lock._record_optimistic_write(4, "1234")
-    pushed.clear()
-
-    # The lock reports the slot present but unreadable (masked) -- still confirms.
-    lock._confirm_slot(4, SlotCredential.unreadable())
-
-    assert pushed == [({4: SlotCredential.known("1234")}, False)]
-    assert pin_address(4) not in lock._pending_writes
-
-
-async def test_confirm_slot_takes_observation_when_no_pending(
-    hass: HomeAssistant,
-) -> None:
-    """With no pending write, the observation is taken verbatim as verified."""
-    lock, pushed = _slot_only_lock_with_coordinator(hass)
-    lock._confirm_slot(2, SlotCredential.unreadable())
-
-    assert pushed == [({2: SlotCredential.unreadable()}, False)]
-
-
-async def test_confirm_slot_empty_observation_clears_pending(
-    hass: HomeAssistant,
-) -> None:
-    """An empty observation (slot cleared) overrides a pending write."""
-    lock, pushed = _slot_only_lock_with_coordinator(hass)
-    lock._record_optimistic_write(4, "1234")
-    pushed.clear()
-
-    lock._confirm_slot(4, SlotCredential.empty())
-
-    assert pushed == [({4: SlotCredential.empty()}, False)]
-    assert pin_address(4) not in lock._pending_writes
-
-
-async def test_confirm_slot_takes_differing_readable_external_change(
-    hass: HomeAssistant,
-) -> None:
-    """A readable observation of a *different* code is an external change: take it."""
-    lock, pushed = _slot_only_lock_with_coordinator(hass)
-    lock._record_optimistic_write(4, "1234")
-    pushed.clear()
-
-    # The lock reports a readable code that differs from what we wrote -- someone
-    # changed it out from under us; surface the observation, not our belief.
-    lock._confirm_slot(4, SlotCredential.known("9999"))
-
-    assert pushed == [({4: SlotCredential.known("9999")}, False)]
-    assert pin_address(4) not in lock._pending_writes
-
-
-async def test_confirm_slot_keeps_belief_when_readable_matches(
-    hass: HomeAssistant,
-) -> None:
-    """A readable observation matching the believed PIN confirms it verbatim."""
-    lock, pushed = _slot_only_lock_with_coordinator(hass)
-    lock._record_optimistic_write(4, "1234")
-    pushed.clear()
-
-    lock._confirm_slot(4, SlotCredential.known("1234"))
-
-    assert pushed == [({4: SlotCredential.known("1234")}, False)]
-    assert pin_address(4) not in lock._pending_writes
 
 
 # Slot capacity pre-flight (issue #1398)
@@ -1273,3 +1157,96 @@ async def test_set_usercode_skips_capacity_check_when_capabilities_unavailable(
     with patch.object(BaseLock, "async_is_integration_connected", return_value=True):
         await lock.async_internal_set_usercode(50, "4321", "guest")
     assert ("set_credential", 50, 50) in lock.calls
+
+
+# =============================================================================
+# The seam hands writes and observations to the coordinator
+# =============================================================================
+
+
+async def _set_through_seam(lock, result: WriteResult, *, push: bool = False) -> None:
+    """Drive one set through the seam with the provider answering ``result``."""
+    lock._min_operation_delay = 0.0
+    with (
+        patch.object(BaseLock, "async_is_integration_connected", return_value=True),
+        patch.object(type(lock), "supports_push", property(lambda _self: push)),
+        patch.object(lock, "async_set_usercode", AsyncMock(return_value=result)),
+    ):
+        await lock.async_internal_set_usercode(4, "1234", "carol")
+
+
+async def test_optimistic_set_is_recorded_pending_with_the_value_believed(
+    hass: HomeAssistant,
+) -> None:
+    """An ambiguous write is recorded believed; the coordinator reads it back."""
+    lock, _pushed = _slot_only_lock_with_coordinator(hass)
+    await _set_through_seam(lock, WriteResult.OPTIMISTIC)
+    lock.coordinator.record_write.assert_called_once_with(
+        pin_address(4), "1234", believed=True
+    )
+
+
+async def test_confirmed_set_on_a_poller_is_recorded_pending_without_a_value(
+    hass: HomeAssistant,
+) -> None:
+    """The cloud accepting a write is not the lock reporting it: pending, not believed.
+
+    For any slot -- the coordinator's read names every pending address, so a
+    slot nothing manages is asked about too.
+    """
+    lock, pushed = _slot_only_lock_with_coordinator(hass)
+    await _set_through_seam(lock, WriteResult.CONFIRMED)
+    lock.coordinator.record_write.assert_called_once_with(
+        pin_address(4), "1234", believed=False
+    )
+    lock.coordinator.async_request_refresh.assert_not_awaited()
+    assert pushed == []
+
+
+async def test_confirmed_set_on_a_push_provider_records_nothing_pending(
+    hass: HomeAssistant,
+) -> None:
+    """The provider's own push is the lock's word; any older pending write is superseded."""
+    lock, _pushed = _slot_only_lock_with_coordinator(hass)
+    await _set_through_seam(lock, WriteResult.CONFIRMED, push=True)
+    lock.coordinator.record_write.assert_not_called()
+    lock.coordinator.drop_pending.assert_called_once_with(pin_address(4))
+
+
+async def test_no_change_records_nothing(hass: HomeAssistant) -> None:
+    """Nothing was written, so there is nothing to confirm."""
+    lock, _pushed = _slot_only_lock_with_coordinator(hass)
+    await _set_through_seam(lock, WriteResult.NO_CHANGE)
+    lock.coordinator.record_write.assert_not_called()
+    lock.coordinator.drop_pending.assert_not_called()
+
+
+async def test_clear_drops_any_pending_write_before_it_is_sent(
+    hass: HomeAssistant,
+) -> None:
+    """A clear supersedes whatever write was pending on the slot."""
+    lock, _pushed = _slot_only_lock_with_coordinator(hass)
+    lock._min_operation_delay = 0.0
+    with patch.object(BaseLock, "async_is_integration_connected", return_value=True):
+        await lock.async_internal_clear_usercode(4)
+    lock.coordinator.drop_pending.assert_called_once_with(pin_address(4))
+
+
+async def test_confirm_slot_hands_the_observation_to_the_coordinator(
+    hass: HomeAssistant,
+) -> None:
+    """The provider-facing name for ``observe_push``; resolution lives on the coordinator."""
+    lock, _pushed = _slot_only_lock_with_coordinator(hass)
+    lock._confirm_slot(2, SlotCredential.unreadable())
+    lock.coordinator.observe_push.assert_called_once_with(
+        pin_address(2), SlotCredential.unreadable()
+    )
+
+
+async def test_confirm_slot_without_a_coordinator_is_a_no_op(
+    hass: HomeAssistant,
+) -> None:
+    """Before setup attaches a coordinator there is nothing to resolve against."""
+    lock = _make_lock(hass, _DegenerateStubLock, "seam_no_coord")
+    lock.coordinator = None
+    lock._confirm_slot(2, SlotCredential.empty())  # must not raise

--- a/tests/providers/zigbee2mqtt/test_payload.py
+++ b/tests/providers/zigbee2mqtt/test_payload.py
@@ -10,6 +10,7 @@ from pytest_homeassistant_custom_component.common import async_fire_mqtt_message
 
 from homeassistant.core import HomeAssistant
 
+from custom_components.lock_code_manager.domain.credentials import pin_address
 from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers.zigbee2mqtt import (
     Zigbee2MQTTLock,
@@ -30,8 +31,8 @@ def test_users_enabled_without_pin_key_pushes_unreadable() -> None:
     lock = _minimal_lock()
     lock.coordinator = MagicMock()
     lock._process_z2m_device_payload({"users": {"5": {"status": "enabled"}}})
-    lock.coordinator.push_update.assert_called_once_with(
-        {5: SlotCredential.unreadable()}
+    lock.coordinator.observe_push.assert_called_once_with(
+        pin_address(5), SlotCredential.unreadable()
     )
 
 
@@ -40,8 +41,8 @@ def test_users_not_supported_status_pushes_unreadable() -> None:
     lock = _minimal_lock()
     lock.coordinator = MagicMock()
     lock._process_z2m_device_payload({"users": {"3": {"status": "not_supported_5"}}})
-    lock.coordinator.push_update.assert_called_once_with(
-        {3: SlotCredential.unreadable()}
+    lock.coordinator.observe_push.assert_called_once_with(
+        pin_address(3), SlotCredential.unreadable()
     )
 
 
@@ -57,17 +58,19 @@ def test_users_republication_of_unchanged_state_not_repushed() -> None:
     payload = {"users": {"2": {"status": "enabled", "pin_code": "1234"}}}
 
     lock._process_z2m_device_payload(payload)
-    lock.coordinator.push_update.assert_called_once_with(
-        {2: SlotCredential.known("1234")}
+    lock.coordinator.observe_push.assert_called_once_with(
+        pin_address(2), SlotCredential.known("1234")
     )
 
-    lock.coordinator.push_update.reset_mock()
+    lock.coordinator.observe_push.reset_mock()
     lock._process_z2m_device_payload(payload)
-    lock.coordinator.push_update.assert_not_called()
+    lock.coordinator.observe_push.assert_not_called()
 
     # A genuine change still gets through.
     lock._process_z2m_device_payload({"users": {"2": {"status": "available"}}})
-    lock.coordinator.push_update.assert_called_once_with({2: SlotCredential.empty()})
+    lock.coordinator.observe_push.assert_called_once_with(
+        pin_address(2), SlotCredential.empty()
+    )
 
 
 async def test_users_payload_resolves_pending_read() -> None:
@@ -107,7 +110,9 @@ def test_users_enabled_with_numeric_zero_pin_updates() -> None:
     lock._process_z2m_device_payload(
         {"users": {"2": {"status": "enabled", "pin_code": 0}}}
     )
-    lock.coordinator.push_update.assert_called_once_with({2: SlotCredential.known("0")})
+    lock.coordinator.observe_push.assert_called_once_with(
+        pin_address(2), SlotCredential.known("0")
+    )
 
 
 def test_users_enabled_pin_null_clears_slot() -> None:
@@ -117,7 +122,9 @@ def test_users_enabled_pin_null_clears_slot() -> None:
     lock._process_z2m_device_payload(
         {"users": {"5": {"status": "enabled", "pin_code": None}}}
     )
-    lock.coordinator.push_update.assert_called_once_with({5: SlotCredential.empty()})
+    lock.coordinator.observe_push.assert_called_once_with(
+        pin_address(5), SlotCredential.empty()
+    )
 
 
 @pytest.mark.parametrize(
@@ -145,7 +152,7 @@ def test_users_masked_code_is_unreadable_not_known(
     lock._process_z2m_device_payload(
         {"users": {"6": {"status": "enabled", "pin_code": pin_code}}}
     )
-    lock.coordinator.push_update.assert_called_once_with({6: expected})
+    lock.coordinator.observe_push.assert_called_once_with(pin_address(6), expected)
 
 
 def test_users_non_numeric_slot_key_skipped() -> None:
@@ -155,7 +162,7 @@ def test_users_non_numeric_slot_key_skipped() -> None:
     lock._process_z2m_device_payload(
         {"users": {"bad": {"status": "enabled", "pin_code": "1"}}}
     )
-    lock.coordinator.push_update.assert_not_called()
+    lock.coordinator.observe_push.assert_not_called()
 
 
 async def test_pin_code_get_disabled_or_empty_pin_sets_future_empty() -> None:
@@ -230,7 +237,7 @@ async def test_mqtt_payload_invalid_json_ignored(
     async_fire_mqtt_message(hass, Z2M_FULL_TOPIC, "not json {{{")
     await hass.async_block_till_done()
 
-    lock.coordinator.push_update.assert_not_called()
+    lock.coordinator.observe_push.assert_not_called()
 
 
 def test_keypad_unlock_action_fires_code_slot_event() -> None:
@@ -376,8 +383,8 @@ def test_users_payload_before_coordinator_does_not_poison_delta_gate() -> None:
 
     lock.coordinator = MagicMock()
     lock._process_z2m_device_payload(payload)
-    lock.coordinator.push_update.assert_called_once_with(
-        {2: SlotCredential.known("1234")}
+    lock.coordinator.observe_push.assert_called_once_with(
+        pin_address(2), SlotCredential.known("1234")
     )
 
 
@@ -397,8 +404,8 @@ def test_users_non_dict_user_info_skipped() -> None:
             }
         }
     )
-    lock.coordinator.push_update.assert_called_once_with(
-        {3: SlotCredential.known("1234")}
+    lock.coordinator.observe_push.assert_called_once_with(
+        pin_address(3), SlotCredential.known("1234")
     )
 
 

--- a/tests/providers/zwave_js/test_events.py
+++ b/tests/providers/zwave_js/test_events.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import time
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -488,8 +487,8 @@ async def test_credential_added_pin_pushes_unreadable(
     )
     await hass.async_block_till_done()
 
-    mock_coordinator.push_update.assert_called_once_with(
-        {2: SlotCredential.unreadable()}
+    mock_coordinator.observe_push.assert_called_once_with(
+        pin_address(2), SlotCredential.unreadable()
     )
 
     zwave_js_lock.unsubscribe_push_updates()
@@ -516,8 +515,8 @@ async def test_credential_added_pin_with_data_pushes_known(
     )
     await hass.async_block_till_done()
 
-    mock_coordinator.push_update.assert_called_once_with(
-        {2: SlotCredential.known("1234")}
+    mock_coordinator.observe_push.assert_called_once_with(
+        pin_address(2), SlotCredential.known("1234")
     )
 
     zwave_js_lock.unsubscribe_push_updates()
@@ -542,8 +541,8 @@ async def test_credential_modified_pin_pushes_unreadable(
     )
     await hass.async_block_till_done()
 
-    mock_coordinator.push_update.assert_called_once_with(
-        {3: SlotCredential.unreadable()}
+    mock_coordinator.observe_push.assert_called_once_with(
+        pin_address(3), SlotCredential.unreadable()
     )
 
     zwave_js_lock.unsubscribe_push_updates()
@@ -568,7 +567,9 @@ async def test_credential_deleted_pin_pushes_empty(
     )
     await hass.async_block_till_done()
 
-    mock_coordinator.push_update.assert_called_once_with({5: SlotCredential.empty()})
+    mock_coordinator.observe_push.assert_called_once_with(
+        pin_address(5), SlotCredential.empty()
+    )
 
     zwave_js_lock.unsubscribe_push_updates()
 
@@ -596,7 +597,7 @@ async def test_credential_added_non_pin_ignored(
     )
     await hass.async_block_till_done()
 
-    mock_coordinator.push_update.assert_not_called()
+    mock_coordinator.observe_push.assert_not_called()
 
     zwave_js_lock.unsubscribe_push_updates()
 
@@ -624,7 +625,7 @@ async def test_credential_deleted_non_pin_ignored(
     )
     await hass.async_block_till_done()
 
-    mock_coordinator.push_update.assert_not_called()
+    mock_coordinator.observe_push.assert_not_called()
 
     zwave_js_lock.unsubscribe_push_updates()
 
@@ -673,8 +674,8 @@ async def test_uc_shim_plain_code_pushes_known(
     )
     await hass.async_block_till_done()
 
-    mock_coordinator.push_update.assert_called_once_with(
-        {2: SlotCredential.known("8642")}
+    mock_coordinator.observe_push.assert_called_once_with(
+        pin_address(2), SlotCredential.known("8642")
     )
 
     zwave_js_lock.unsubscribe_push_updates()
@@ -700,8 +701,8 @@ async def test_uc_shim_masked_code_pushes_unreadable(
     )
     await hass.async_block_till_done()
 
-    mock_coordinator.push_update.assert_called_once_with(
-        {2: SlotCredential.unreadable()}
+    mock_coordinator.observe_push.assert_called_once_with(
+        pin_address(2), SlotCredential.unreadable()
     )
 
     zwave_js_lock.unsubscribe_push_updates()
@@ -727,7 +728,9 @@ async def test_uc_shim_zeros_on_available_slot_pushes_empty(
     )
     await hass.async_block_till_done()
 
-    mock_coordinator.push_update.assert_called_once_with({3: SlotCredential.empty()})
+    mock_coordinator.observe_push.assert_called_once_with(
+        pin_address(3), SlotCredential.empty()
+    )
 
     zwave_js_lock.unsubscribe_push_updates()
 
@@ -762,8 +765,8 @@ async def test_uc_shim_zeros_on_unknown_slot_pushes_known(
     )
     await hass.async_block_till_done()
 
-    mock_coordinator.push_update.assert_called_once_with(
-        {99: SlotCredential.known("0000")}
+    mock_coordinator.observe_push.assert_called_once_with(
+        pin_address(99), SlotCredential.known("0000")
     )
 
     zwave_js_lock.unsubscribe_push_updates()
@@ -788,7 +791,9 @@ async def test_uc_shim_empty_code_pushes_empty(
     )
     await hass.async_block_till_done()
 
-    mock_coordinator.push_update.assert_called_once_with({2: SlotCredential.empty()})
+    mock_coordinator.observe_push.assert_called_once_with(
+        pin_address(2), SlotCredential.empty()
+    )
 
     zwave_js_lock.unsubscribe_push_updates()
 
@@ -815,7 +820,9 @@ async def test_uc_shim_status_available_pushes_empty(
     )
     await hass.async_block_till_done()
 
-    mock_coordinator.push_update.assert_called_once_with({2: SlotCredential.empty()})
+    mock_coordinator.observe_push.assert_called_once_with(
+        pin_address(2), SlotCredential.empty()
+    )
 
     zwave_js_lock.unsubscribe_push_updates()
 
@@ -846,7 +853,7 @@ async def test_uc_shim_status_available_ignored_when_pin_expected(
     )
     await hass.async_block_till_done()
 
-    mock_coordinator.push_update.assert_not_called()
+    mock_coordinator.observe_push.assert_not_called()
 
     zwave_js_lock.unsubscribe_push_updates()
 
@@ -872,7 +879,7 @@ async def test_uc_shim_status_occupied_ignored(
     )
     await hass.async_block_till_done()
 
-    mock_coordinator.push_update.assert_not_called()
+    mock_coordinator.observe_push.assert_not_called()
 
     zwave_js_lock.unsubscribe_push_updates()
 
@@ -918,7 +925,7 @@ async def test_uc_shim_ignores_unrelated_value_events(
     )
     await hass.async_block_till_done()
 
-    mock_coordinator.push_update.assert_not_called()
+    mock_coordinator.observe_push.assert_not_called()
 
     zwave_js_lock.unsubscribe_push_updates()
 
@@ -930,28 +937,26 @@ async def test_uc_shim_confirms_pending_optimistic_write(
     mock_access_control: MagicMock,
     mock_lock_helpers: dict,
 ) -> None:
-    """A masked verification report confirms a pending optimistic write.
+    """A masked verification report reaches the coordinator as an observation.
 
     The driver's post-write verification GET produces a report (and thus a
     value event) but no unified credential event on released drivers; the
-    shim must route it through _confirm_slot so the believed value is kept
-    and marked verified.
+    shim must route it through _confirm_slot so the coordinator can settle
+    the pending write against it.
     """
     mock_coordinator = MagicMock()
     mock_coordinator.data = {}
     zwave_js_lock.coordinator = mock_coordinator
 
     zwave_js_lock.subscribe_push_updates()
-    zwave_js_lock._pending_writes[pin_address(2)] = ("8642", time.monotonic() + 60)
 
     lock_schlage_be469.receive_event(
         _make_uc_value_event(lock_schlage_be469.node_id, "userCode", 2, "****")
     )
     await hass.async_block_till_done()
 
-    mock_coordinator.push_update.assert_called_once_with(
-        {2: SlotCredential.known("8642")}
+    mock_coordinator.observe_push.assert_called_once_with(
+        pin_address(2), SlotCredential.unreadable()
     )
-    assert pin_address(2) not in zwave_js_lock._pending_writes
 
     zwave_js_lock.unsubscribe_push_updates()

--- a/tests/providers/zwave_js/test_events.py
+++ b/tests/providers/zwave_js/test_events.py
@@ -772,28 +772,43 @@ async def test_uc_shim_zeros_on_unknown_slot_pushes_known(
     zwave_js_lock.unsubscribe_push_updates()
 
 
-async def test_uc_shim_empty_code_pushes_empty(
+@pytest.mark.parametrize(
+    ("in_use", "expected"),
+    [
+        (False, SlotCredential.empty()),
+        (None, SlotCredential.empty()),
+        (True, SlotCredential.unreadable()),
+    ],
+    ids=["free", "unknown", "occupied"],
+)
+async def test_uc_shim_empty_code_follows_occupancy(
     hass: HomeAssistant,
     zwave_js_lock: ZWaveJSLock,
     lock_schlage_be469: Node,
     mock_access_control: MagicMock,
     mock_lock_helpers: dict,
+    in_use: bool | None,
+    expected: SlotCredential,
 ) -> None:
-    """An empty userCode value update pushes SlotCredential.empty()."""
+    """An empty userCode value is a cleared slot -- unless the status says occupied.
+
+    A lock withholding the code reports the slot in use with no value; that
+    is the same occupied-but-masked case the read path's overlay resolves to
+    unreadable, and taking it as empty would fail a write the lock kept.
+    """
     mock_coordinator = MagicMock()
     mock_coordinator.data = {pin_address(2): SlotCredential.known("1234")}
     zwave_js_lock.coordinator = mock_coordinator
 
     zwave_js_lock.subscribe_push_updates()
 
-    lock_schlage_be469.receive_event(
-        _make_uc_value_event(lock_schlage_be469.node_id, "userCode", 2, "")
-    )
-    await hass.async_block_till_done()
+    with patch.object(zwave_js_lock, "_uc_slot_in_use", return_value=in_use):
+        lock_schlage_be469.receive_event(
+            _make_uc_value_event(lock_schlage_be469.node_id, "userCode", 2, "")
+        )
+        await hass.async_block_till_done()
 
-    mock_coordinator.observe_push.assert_called_once_with(
-        pin_address(2), SlotCredential.empty()
-    )
+    mock_coordinator.observe_push.assert_called_once_with(pin_address(2), expected)
 
     zwave_js_lock.unsubscribe_push_updates()
 

--- a/tests/providers/zwave_js/test_events.py
+++ b/tests/providers/zwave_js/test_events.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -809,6 +809,51 @@ async def test_uc_shim_empty_code_follows_occupancy(
         await hass.async_block_till_done()
 
     mock_coordinator.observe_push.assert_called_once_with(pin_address(2), expected)
+
+    zwave_js_lock.unsubscribe_push_updates()
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [
+        (CodeSlotStatus.ENABLED, SlotCredential.unreadable()),
+        (CodeSlotStatus.AVAILABLE, SlotCredential.empty()),
+    ],
+    ids=["occupied-withheld", "cleared"],
+)
+async def test_uc_shim_status_then_empty_code_reads_the_fresh_status(
+    hass: HomeAssistant,
+    zwave_js_lock: ZWaveJSLock,
+    lock_schlage_be469: Node,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
+    status: CodeSlotStatus,
+    expected: SlotCredential,
+) -> None:
+    """The driver reports status before code; the code handler reads that status.
+
+    A report of an occupied slot with the code withheld arrives as ENABLED
+    then an empty userCode, and resolves to unreadable. A real clear arrives
+    as AVAILABLE then an empty userCode, and resolves to empty both times.
+    """
+    mock_coordinator = MagicMock()
+    mock_coordinator.data = {pin_address(2): SlotCredential.known("1234")}
+    mock_coordinator.desired_credential.return_value = SlotCredential.empty()
+    zwave_js_lock.coordinator = mock_coordinator
+
+    zwave_js_lock.subscribe_push_updates()
+
+    lock_schlage_be469.receive_event(
+        _make_uc_value_event(lock_schlage_be469.node_id, "userIdStatus", 2, status)
+    )
+    lock_schlage_be469.receive_event(
+        _make_uc_value_event(lock_schlage_be469.node_id, "userCode", 2, "")
+    )
+    await hass.async_block_till_done()
+
+    assert mock_coordinator.observe_push.call_args_list[-1] == call(
+        pin_address(2), expected
+    )
 
     zwave_js_lock.unsubscribe_push_updates()
 

--- a/tests/providers/zwave_js/test_provider.py
+++ b/tests/providers/zwave_js/test_provider.py
@@ -1386,6 +1386,37 @@ async def test_async_set_credential_raises_duplicate_code_error(
     assert exc_info.value.lock_entity_id == zwave_js_lock.lock.entity_id
 
 
+async def test_set_credential_confirmed_pushes_the_value_like_every_push_provider(
+    hass: HomeAssistant,
+    zwave_js_lock: ZWaveJSLock,
+    mock_lock_helpers: dict,
+) -> None:
+    """A confirmed set leaves the value on the coordinator before it returns.
+
+    Every push provider pushes what it just wrote before returning CONFIRMED,
+    and the seam records nothing pending for a push provider on exactly that
+    strength; a driver event may follow, but none is guaranteed to.
+    """
+    mock_coordinator = MagicMock()
+    zwave_js_lock.coordinator = mock_coordinator
+    mock_lock_helpers["async_set_credential"].return_value = {
+        "credential_slot": 2,
+        "user_id": 1,
+    }
+    credential = Credential(
+        type=CredentialType.PIN, slot=2, state=SlotCredential.known("5678")
+    )
+
+    result = await zwave_js_lock.async_set_credential(
+        user_id=1, credential=credential, pin="5678", name="alice", source="sync"
+    )
+
+    assert result is WriteResult.CONFIRMED
+    mock_coordinator.push_update.assert_called_once_with(
+        {2: SlotCredential.known("5678")}
+    )
+
+
 async def test_async_set_credential_raises_code_rejected_error_on_other_ha_error(
     zwave_js_lock: ZWaveJSLock,
     mock_access_control: MagicMock,

--- a/tests/providers/zwave_js_ui/test_push.py
+++ b/tests/providers/zwave_js_ui/test_push.py
@@ -21,6 +21,7 @@ from custom_components.lock_code_manager.const import (
     ATTR_TO,
     EVENT_LOCK_STATE_CHANGED,
 )
+from custom_components.lock_code_manager.domain.credentials import pin_address
 from custom_components.lock_code_manager.domain.exceptions import LockDisconnected
 from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers.zwave_js_ui import ZWaveJSUILock
@@ -135,8 +136,8 @@ class TestUserCodeValues:
         fire_node_value(hass, f"{property_path}/3", payload)
         await hass.async_block_till_done()
 
-        lock.coordinator.push_update.assert_called_once_with(
-            {3: SlotCredential.known("1234")}
+        lock.coordinator.observe_push.assert_called_once_with(
+            pin_address(3), SlotCredential.known("1234")
         )
 
     @pytest.mark.parametrize(
@@ -171,8 +172,8 @@ class TestUserCodeValues:
         fire_node_value(hass, f"{USER_CODE_VALUEID}/3", payload)
         await hass.async_block_till_done()
 
-        lock.coordinator.push_update.assert_called_once_with(
-            {3: SlotCredential.known(expected_code)}
+        lock.coordinator.observe_push.assert_called_once_with(
+            pin_address(3), SlotCredential.known(expected_code)
         )
 
     @pytest.mark.parametrize(
@@ -194,8 +195,8 @@ class TestUserCodeValues:
         fire_node_value(hass, f"{property_path}/4", payload)
         await hass.async_block_till_done()
 
-        lock.coordinator.push_update.assert_called_once_with(
-            {4: SlotCredential.empty()}
+        lock.coordinator.observe_push.assert_called_once_with(
+            pin_address(4), SlotCredential.empty()
         )
 
     @pytest.mark.parametrize(
@@ -227,7 +228,7 @@ class TestUserCodeValues:
         fire_node_value(hass, f"{USER_ID_STATUS_VALUEID}/5", payload)
         await hass.async_block_till_done()
 
-        lock.coordinator.push_update.assert_not_called()
+        lock.coordinator.observe_push.assert_not_called()
 
     @pytest.mark.parametrize(
         "payload",
@@ -265,7 +266,7 @@ class TestUserCodeValues:
         fire_node_value(hass, f"{USER_CODE_VALUEID}/6", payload)
         await hass.async_block_till_done()
 
-        lock.coordinator.push_update.assert_not_called()
+        lock.coordinator.observe_push.assert_not_called()
 
 
 class TestStaleAvailable:
@@ -288,7 +289,7 @@ class TestStaleAvailable:
         fire_node_value(hass, f"{USER_ID_STATUS_VALUEID}/4", wrapped(0))
         await hass.async_block_till_done()
 
-        lock.coordinator.push_update.assert_not_called()
+        lock.coordinator.observe_push.assert_not_called()
 
     async def test_available_confirms_empty_when_no_pin_is_expected(
         self, hass: HomeAssistant, zui_lock_subscribed: ZWaveJSUILock
@@ -300,8 +301,8 @@ class TestStaleAvailable:
         fire_node_value(hass, f"{USER_ID_STATUS_VALUEID}/4", wrapped(0))
         await hass.async_block_till_done()
 
-        lock.coordinator.push_update.assert_called_once_with(
-            {4: SlotCredential.empty()}
+        lock.coordinator.observe_push.assert_called_once_with(
+            pin_address(4), SlotCredential.empty()
         )
 
     async def test_available_confirms_empty_without_a_coordinator(
@@ -345,7 +346,7 @@ class TestStatusGatedCodes:
         fire_node_value(hass, f"{USER_CODE_VALUEID}/3", wrapped("1234"))
         await hass.async_block_till_done()
 
-        lock.coordinator.push_update.assert_not_called()
+        lock.coordinator.observe_push.assert_not_called()
 
     async def test_a_code_before_any_status_confirms_the_slot(
         self, hass: HomeAssistant, zui_lock_subscribed: ZWaveJSUILock
@@ -362,8 +363,8 @@ class TestStatusGatedCodes:
         fire_node_value(hass, f"{USER_CODE_VALUEID}/3", wrapped("1234"))
         await hass.async_block_till_done()
 
-        lock.coordinator.push_update.assert_called_once_with(
-            {3: SlotCredential.known("1234")}
+        lock.coordinator.observe_push.assert_called_once_with(
+            pin_address(3), SlotCredential.known("1234")
         )
 
     async def test_a_disabled_slot_does_not_gate_another_slot(
@@ -376,8 +377,8 @@ class TestStatusGatedCodes:
         fire_node_value(hass, f"{USER_CODE_VALUEID}/4", wrapped("5678"))
         await hass.async_block_till_done()
 
-        lock.coordinator.push_update.assert_called_once_with(
-            {4: SlotCredential.known("5678")}
+        lock.coordinator.observe_push.assert_called_once_with(
+            pin_address(4), SlotCredential.known("5678")
         )
 
     async def test_re_enabling_a_slot_re_admits_its_code(
@@ -391,8 +392,8 @@ class TestStatusGatedCodes:
         fire_node_value(hass, f"{USER_CODE_VALUEID}/3", wrapped("1234"))
         await hass.async_block_till_done()
 
-        lock.coordinator.push_update.assert_called_once_with(
-            {3: SlotCredential.known("1234")}
+        lock.coordinator.observe_push.assert_called_once_with(
+            pin_address(3), SlotCredential.known("1234")
         )
 
     async def test_an_uninterpretable_status_does_not_gate(
@@ -411,8 +412,8 @@ class TestStatusGatedCodes:
         fire_node_value(hass, f"{USER_CODE_VALUEID}/3", wrapped("1234"))
         await hass.async_block_till_done()
 
-        lock.coordinator.push_update.assert_called_once_with(
-            {3: SlotCredential.known("1234")}
+        lock.coordinator.observe_push.assert_called_once_with(
+            pin_address(3), SlotCredential.known("1234")
         )
 
     async def test_teardown_forgets_the_tracked_statuses(
@@ -435,8 +436,8 @@ class TestStatusGatedCodes:
         fire_node_value(hass, f"{USER_CODE_VALUEID}/3", wrapped("1234"))
         await hass.async_block_till_done()
 
-        lock.coordinator.push_update.assert_called_once_with(
-            {3: SlotCredential.known("1234")}
+        lock.coordinator.observe_push.assert_called_once_with(
+            pin_address(3), SlotCredential.known("1234")
         )
 
 
@@ -591,7 +592,7 @@ class TestForeignNodeTraffic:
         fire_node_value(hass, suffix, keypad_payload(3))
         await hass.async_block_till_done()
 
-        lock.coordinator.push_update.assert_not_called()
+        lock.coordinator.observe_push.assert_not_called()
         assert events == []
         assert [record for record in caplog.records if record.levelno >= ERROR] == []
 
@@ -618,7 +619,7 @@ class TestForeignNodeTraffic:
         lock._process_node_message("zwave/nodeID_200/99/0/userCode/3", b"1234")
         await hass.async_block_till_done()
 
-        lock.coordinator.push_update.assert_not_called()
+        lock.coordinator.observe_push.assert_not_called()
 
     async def test_nothing_is_classified_before_the_subscription_exists(
         self,
@@ -631,7 +632,7 @@ class TestForeignNodeTraffic:
 
         lock._process_node_message(f"{ZUI_NODE_TOPIC}/99/0/userCode/3", b"1234")
 
-        lock.coordinator.push_update.assert_not_called()
+        lock.coordinator.observe_push.assert_not_called()
 
 
 class TestNodeSubscriptionLifecycle:
@@ -694,8 +695,8 @@ class TestNodeSubscriptionLifecycle:
 
         async_fire_mqtt_message(hass, f"{renamed_node_topic}/99/0/userCode/3", "1234")
         await hass.async_block_till_done()
-        lock.coordinator.push_update.assert_called_once_with(
-            {3: SlotCredential.known("1234")}
+        lock.coordinator.observe_push.assert_called_once_with(
+            pin_address(3), SlotCredential.known("1234")
         )
 
     async def test_a_transiently_unresolvable_topic_keeps_the_subscription(
@@ -849,7 +850,7 @@ class TestNodeSubscriptionLifecycle:
         # Nothing arrives after teardown, and a second call is a no-op.
         fire_node_value(hass, f"{USER_CODE_VALUEID}/3", "1234")
         await hass.async_block_till_done()
-        lock.coordinator.push_update.assert_not_called()
+        lock.coordinator.observe_push.assert_not_called()
         lock.teardown_push_subscription()
 
     async def test_unload_releases_the_node_subscription_once(
@@ -951,7 +952,7 @@ async def test_a_second_lock_on_the_same_node_is_addressed_separately(
     fire_node_value(hass, f"{USER_CODE_VALUEID}/3", "1234")
     await hass.async_block_till_done()
 
-    zui_lock_subscribed.coordinator.push_update.assert_called_once_with(
-        {3: SlotCredential.known("1234")}
+    zui_lock_subscribed.coordinator.observe_push.assert_called_once_with(
+        pin_address(3), SlotCredential.known("1234")
     )
-    other_lock.coordinator.push_update.assert_not_called()
+    other_lock.coordinator.observe_push.assert_not_called()

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -7,7 +7,10 @@ import logging
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from pytest_homeassistant_custom_component.common import MockConfigEntry
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+    async_fire_time_changed,
+)
 
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
@@ -30,7 +33,6 @@ from homeassistant.const import (
 )
 from homeassistant.core import Event, HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
-from homeassistant.helpers.update_coordinator import UpdateFailed
 from homeassistant.util import dt as dt_util
 
 from custom_components.lock_code_manager.const import (
@@ -40,6 +42,7 @@ from custom_components.lock_code_manager.const import (
     ATTR_USERCODE,
     CONF_LOCKS,
     CONF_SLOTS,
+    CONFIRM_READ_INTERVAL,
     DOMAIN,
     MAX_SYNC_ATTEMPTS,
     SERVICE_SET_USERCODE,
@@ -53,6 +56,7 @@ from custom_components.lock_code_manager.domain.credentials import pin_address
 from custom_components.lock_code_manager.domain.exceptions import (
     DuplicateCodeError,
     LockCodeManagerError,
+    LockDisconnected,
     LockOperationFailed,
 )
 from custom_components.lock_code_manager.domain.locks import async_create_lock_instance
@@ -615,54 +619,6 @@ async def test_handles_disconnected_lock_on_clear(
     assert lock_provider.codes.get(1) is None
 
 
-async def test_coordinator_refresh_failure_schedules_retry(
-    hass: HomeAssistant,
-    mock_lock_config_entry,
-    lock_code_manager_config_entry,
-):
-    """Test that coordinator refresh failure after sync sets dirty flag."""
-    await async_initial_tick(hass, SLOT_1_IN_SYNC_ENTITY)
-
-    # Verify initial state - slot should be active and in sync
-    synced_state = hass.states.get(SLOT_1_IN_SYNC_ENTITY)
-    assert synced_state.state == STATE_ON
-
-    lock_provider = lock_code_manager_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
-    coordinator = lock_provider.coordinator
-    assert coordinator is not None
-
-    in_sync_entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
-
-    # Ensure manager is in a tickable state
-    in_sync_entity_obj._sync_manager._state = SyncState.OUT_OF_SYNC
-
-    # Patch coordinator refresh to fail BEFORE changing PIN
-    # This way the failure happens during the sync triggered by the PIN change
-    with patch.object(
-        coordinator,
-        "async_refresh",
-        new=AsyncMock(side_effect=UpdateFailed("Connection failed")),
-    ):
-        # Change PIN to trigger sync - coordinator refresh will fail
-        await hass.services.async_call(
-            TEXT_DOMAIN,
-            TEXT_SERVICE_SET_VALUE,
-            service_data={ATTR_VALUE: "9999"},
-            target={ATTR_ENTITY_ID: SLOT_1_PIN_ENTITY},
-            blocking=True,
-        )
-        await hass.async_block_till_done()
-
-        # Trigger tick to attempt sync - coordinator refresh will fail
-        await in_sync_entity_obj._sync_manager._async_tick()
-        await hass.async_block_till_done()
-
-    # State should be OUT_OF_SYNC due to coordinator refresh failure
-    assert in_sync_entity_obj._sync_manager._state is SyncState.OUT_OF_SYNC, (
-        "State should be OUT_OF_SYNC when coordinator refresh fails after sync"
-    )
-
-
 async def test_coordinator_update_triggers_sync_on_external_change(
     hass: HomeAssistant,
     mock_lock_config_entry,
@@ -1026,13 +982,15 @@ async def test_sync_tracker_does_not_fire_breaker_with_expired_window(
     # _request_sync_check transitions IN_SYNC -> OUT_OF_SYNC
     assert sync_mgr._state is SyncState.OUT_OF_SYNC
 
-    # Tick fires — expired window causes record_failure to reset the
-    # counter, so the breaker does not fire. Sync succeeds and resets the
-    # breaker.
+    # Tick fires -- the stale count is outside the window, so the breaker does
+    # not fire and the write goes out. On a polled lock it is pending until
+    # the coordinator's own read sees it; the tick after that settles it.
     await sync_mgr._async_tick()
+    assert sync_mgr._state is SyncState.PENDING_CONFIRMATION
     await hass.async_block_till_done()
+    await sync_mgr._async_tick()
 
-    # Sync succeeded — lock should be IN_SYNC, not SUSPENDED
+    # Sync succeeded -- lock should be IN_SYNC, not SUSPENDED
     assert sync_mgr._state is SyncState.IN_SYNC
     # Breaker reset after successful sync
     assert sync_mgr._slot_breaker.failure_count == 0
@@ -1626,8 +1584,12 @@ async def test_push_update_during_sync_operation_does_not_corrupt_state(
         await tick_task
         await hass.async_block_till_done()
 
-    # After sync completes, the manager should be in a valid state
-    assert mgr._state in (SyncState.IN_SYNC, SyncState.OUT_OF_SYNC)
+    # The set went out, so on a polled lock it is pending until the
+    # coordinator's own read sees it; block_till_done ran that read, and the
+    # next tick finds the slot settled. The mid-sync push corrupted nothing.
+    assert mgr._state is SyncState.PENDING_CONFIRMATION
+    await mgr._async_tick()
+    assert mgr._state is SyncState.IN_SYNC
 
 
 async def test_sync_manager_stop_during_active_sync_does_not_raise(
@@ -1786,67 +1748,6 @@ async def test_pin_change_during_sync_uses_snapshot(
     set_calls = lock_provider.service_calls.get("set_usercode", [])
     assert len(set_calls) == 1
     assert set_calls[0][1] == "4321"
-
-
-async def test_coordinator_refresh_failure_after_sync_retries_on_next_tick(
-    hass: HomeAssistant,
-    mock_lock_config_entry,
-    lock_code_manager_config_entry,
-):
-    """
-    If coordinator refresh fails after a successful sync, retry on next tick.
-
-    This exercises the try/except around coordinator.async_refresh() in
-    _async_tick_impl. The sync succeeded but we cannot verify it.
-    """
-    await async_initial_tick(hass, SLOT_1_IN_SYNC_ENTITY)
-
-    lock_provider = lock_code_manager_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
-    coordinator = lock_provider.coordinator
-    assert coordinator is not None
-    in_sync_entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
-    mgr = in_sync_entity_obj._sync_manager
-
-    # Change PIN to create a mismatch
-    await hass.services.async_call(
-        TEXT_DOMAIN,
-        TEXT_SERVICE_SET_VALUE,
-        service_data={ATTR_VALUE: "9999"},
-        target={ATTR_ENTITY_ID: SLOT_1_PIN_ENTITY},
-        blocking=True,
-    )
-    await hass.async_block_till_done()
-
-    # Force out of sync
-    mgr._state = SyncState.OUT_OF_SYNC
-
-    # Patch coordinator.async_refresh to raise on first call
-    refresh_call_count = {"count": 0}
-    original_refresh = coordinator.async_refresh
-
-    async def failing_refresh(*args, **kwargs):
-        refresh_call_count["count"] += 1
-        if refresh_call_count["count"] == 1:
-            raise UpdateFailed("Connection lost")
-        return await original_refresh(*args, **kwargs)
-
-    with patch.object(coordinator, "async_refresh", failing_refresh):
-        # Fire tick -- sync succeeds but refresh fails
-        await mgr._async_tick()
-        await hass.async_block_till_done()
-
-    # The code was set on the lock even though refresh failed
-    assert lock_provider.codes[1] == "9999"
-
-    # State should be OUT_OF_SYNC because we could not verify
-    assert mgr._state is SyncState.OUT_OF_SYNC
-
-    # Fire another tick -- refresh succeeds this time, state resolves
-    await mgr._async_tick()
-    await hass.async_block_till_done()
-
-    assert mgr._state is SyncState.IN_SYNC
-    assert hass.states.get(SLOT_1_IN_SYNC_ENTITY).state == STATE_ON
 
 
 # Full LCM setup briefly holds the coordinator's debounced refresh lock while
@@ -2438,3 +2339,98 @@ async def test_a_code_written_by_service_invalidates_the_clear(
     await hass.async_block_till_done()
 
     assert lock_provider.last_write_was_clear(1) is False
+
+
+async def test_confirmation_read_failure_leaves_the_write_pending_and_uncharged(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """
+    A read that fails after a confirmed write leaves the write pending, not settled.
+
+    On a polled lock a confirmed write is trusted only once a read has seen
+    it. The coordinator's read straight after the write fails here, so
+    nothing has vouched for it: the slot waits, pending, the breaker is not
+    charged for a connection problem, and the coordinator will ask again.
+    """
+    await async_initial_tick(hass, SLOT_1_IN_SYNC_ENTITY)
+    lock_provider = lock_code_manager_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
+    coordinator = lock_provider.coordinator
+    mgr = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)._sync_manager
+
+    await hass.services.async_call(
+        TEXT_DOMAIN,
+        TEXT_SERVICE_SET_VALUE,
+        service_data={ATTR_VALUE: "9999"},
+        target={ATTR_ENTITY_ID: SLOT_1_PIN_ENTITY},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    mgr._state = SyncState.OUT_OF_SYNC
+    failures_before = mgr._slot_breaker.failure_count
+
+    with patch.object(
+        lock_provider,
+        "async_get_usercodes",
+        AsyncMock(side_effect=LockDisconnected("Connection lost")),
+    ):
+        await mgr._async_tick()
+        await hass.async_block_till_done()  # the coordinator's immediate look fails
+
+    assert lock_provider.codes[1] == "9999"
+    assert mgr._state is SyncState.PENDING_CONFIRMATION
+    assert coordinator.has_pending_write(pin_address(1))
+    assert mgr._slot_breaker.failure_count == failures_before
+    assert hass.states.get(SLOT_1_IN_SYNC_ENTITY).state == STATE_OFF
+
+
+async def test_the_next_confirmation_read_settles_a_pending_write_without_a_second_set(
+    hass: HomeAssistant,
+    mock_lock_config_entry,
+    lock_code_manager_config_entry,
+):
+    """
+    After a failed read, the coordinator's next look confirms the write.
+
+    No second set is issued along the way, and the tick after the confirming
+    read finds the slot in sync.
+    """
+    await async_initial_tick(hass, SLOT_1_IN_SYNC_ENTITY)
+    lock_provider = lock_code_manager_config_entry.runtime_data.locks[LOCK_1_ENTITY_ID]
+    coordinator = lock_provider.coordinator
+    mgr = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)._sync_manager
+
+    await hass.services.async_call(
+        TEXT_DOMAIN,
+        TEXT_SERVICE_SET_VALUE,
+        service_data={ATTR_VALUE: "9999"},
+        target={ATTR_ENTITY_ID: SLOT_1_PIN_ENTITY},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    mgr._state = SyncState.OUT_OF_SYNC
+
+    with patch.object(
+        lock_provider,
+        "async_get_usercodes",
+        AsyncMock(side_effect=LockDisconnected("Connection lost")),
+    ):
+        await mgr._async_tick()
+        await hass.async_block_till_done()
+    assert mgr._state is SyncState.PENDING_CONFIRMATION
+
+    with patch.object(
+        lock_provider, "async_set_usercode", wraps=lock_provider.async_set_usercode
+    ) as second_set:
+        async_fire_time_changed(
+            hass, dt_util.utcnow() + timedelta(seconds=CONFIRM_READ_INTERVAL + 1)
+        )
+        await hass.async_block_till_done()
+        assert coordinator.is_verified(pin_address(1)) is True
+        await mgr._async_tick()
+        await hass.async_block_till_done()
+    second_set.assert_not_called()
+
+    assert mgr._state is SyncState.IN_SYNC
+    assert hass.states.get(SLOT_1_IN_SYNC_ENTITY).state == STATE_ON

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1909,3 +1909,17 @@ async def test_unchanged_push_on_a_slot_with_an_old_failed_write_does_not_wake_l
 
     push_coordinator.observe_push(pin_address(9), SlotCredential.empty())  # restated
     assert len(wakes) == woken
+
+
+async def test_apply_read_keeps_showing_a_believed_write_while_waiting(
+    push_coordinator: LockUsercodeUpdateCoordinator,
+) -> None:
+    """A believed write absent before the deadline stays shown, still pending.
+
+    Flipping to the read and back on confirmation would be flicker for the
+    code sensor; the address is unverified either way.
+    """
+    push_coordinator.record_write(pin_address(1), "9999", believed=True)
+    out = push_coordinator._apply_read({pin_address(1): SlotCredential.empty()})
+    assert out[pin_address(1)] == SlotCredential.known("9999")
+    assert push_coordinator.is_verified(pin_address(1)) is False

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,11 +1,14 @@
 """Test the coordinator module."""
 
+from collections.abc import AsyncGenerator
 from datetime import timedelta
-import time
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from pytest_homeassistant_custom_component.common import MockConfigEntry
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+    async_fire_time_changed,
+)
 
 from homeassistant.const import CONF_ENABLED, CONF_NAME, CONF_PIN
 from homeassistant.core import HomeAssistant, callback
@@ -20,7 +23,9 @@ from custom_components.lock_code_manager.const import (
     BACKOFF_MAX_SECONDS,
     CONF_LOCKS,
     CONF_SLOTS,
+    CONFIRM_READ_INTERVAL,
     DOMAIN,
+    PENDING_WRITE_TTL,
     POLL_FAILURE_ALERT_THRESHOLD,
 )
 from custom_components.lock_code_manager.domain.coordinator import (
@@ -92,11 +97,13 @@ def push_lock(
 
 
 @pytest.fixture
-def poll_coordinator(
+async def poll_coordinator(
     hass: HomeAssistant, poll_lock: MockLCMLock, lcm_config_entry: MockConfigEntry
-) -> LockUsercodeUpdateCoordinator:
+) -> AsyncGenerator[LockUsercodeUpdateCoordinator]:
     """Return a coordinator with a poll-based lock."""
-    return _make_coordinator(hass, poll_lock, lcm_config_entry)
+    coordinator = _make_coordinator(hass, poll_lock, lcm_config_entry)
+    yield coordinator
+    await coordinator.async_shutdown()
 
 
 @pytest.fixture
@@ -225,46 +232,6 @@ async def test_push_update_default_marks_verified(
     """The default (optimistic=False) push marks the slot verified."""
     push_coordinator.push_update({1: SlotCredential.known("9999")})
     assert push_coordinator.is_verified(pin_address(1)) is True
-
-
-async def test_push_update_optimistic_marks_unverified(
-    push_coordinator: LockUsercodeUpdateCoordinator,
-):
-    """An optimistic push marks the slot unverified."""
-    push_coordinator.push_update({1: SlotCredential.known("9999")}, optimistic=True)
-    assert push_coordinator.data[pin_address(1)] == SlotCredential.known("9999")
-    assert push_coordinator.is_verified(pin_address(1)) is False
-
-
-async def test_push_update_verified_push_clears_unverified(
-    push_coordinator: LockUsercodeUpdateCoordinator,
-):
-    """A later verified push of a new value re-verifies the slot."""
-    push_coordinator.push_update({1: SlotCredential.known("9999")}, optimistic=True)
-    assert push_coordinator.is_verified(pin_address(1)) is False
-
-    push_coordinator.push_update({1: SlotCredential.unreadable()})
-    assert push_coordinator.is_verified(pin_address(1)) is True
-
-
-async def test_push_update_optimistic_same_value_flips_flag_without_notifying(
-    push_coordinator: LockUsercodeUpdateCoordinator,
-):
-    """An optimistic re-push of the same value flips the flag but doesn't notify."""
-    push_coordinator.data = {pin_address(1): SlotCredential.known("9999")}
-    with patch.object(push_coordinator, "async_set_updated_data") as mock_set_updated:
-        push_coordinator.push_update({1: SlotCredential.known("9999")}, optimistic=True)
-        mock_set_updated.assert_not_called()
-    assert push_coordinator.is_verified(pin_address(1)) is False
-
-
-async def test_verified_map_pruned_with_data(
-    push_coordinator: LockUsercodeUpdateCoordinator,
-):
-    """The verified map drops slots no longer present in data."""
-    push_coordinator.push_update({1: SlotCredential.known("1111")}, optimistic=True)
-    # The internal map should only track slots still in data.
-    assert set(push_coordinator._unverified) <= set(push_coordinator.data)
 
 
 async def test_push_update_ignores_empty_updates(
@@ -1255,102 +1222,6 @@ async def test_unreachable_clears_on_recovery(
     )
 
 
-async def test_confirm_pending_writes_confirms_present_masked(
-    push_coordinator: LockUsercodeUpdateCoordinator,
-    push_lock: MockLCMPushLock,
-) -> None:
-    """An on-demand confirm read of a present-but-masked slot verifies it.
-
-    This is the order-independent confirmation that replaces waiting for a push
-    node-zwave-js never sends for a masked write: the slot reads back present
-    (unreadable), so the believed PIN is confirmed and pending is cleared.
-    """
-    push_lock._pending_writes[pin_address(1)] = ("9999", time.monotonic() + 60.0)
-    push_coordinator.push_update({1: SlotCredential.known("9999")}, optimistic=True)
-    assert push_coordinator.is_verified(pin_address(1)) is False
-
-    with patch.object(
-        push_lock,
-        "async_hard_refresh_codes",
-        AsyncMock(return_value={1: SlotCredential.unreadable()}),
-    ):
-        await push_coordinator.async_confirm_pending_writes()
-
-    assert pin_address(1) not in push_lock._pending_writes
-    assert push_coordinator.is_verified(pin_address(1)) is True
-    assert push_coordinator.data[pin_address(1)] == SlotCredential.known("9999")
-
-
-async def test_confirm_pending_writes_keeps_absent_slot_pending(
-    push_coordinator: LockUsercodeUpdateCoordinator,
-    push_lock: MockLCMPushLock,
-) -> None:
-    """A confirm read that finds the slot absent leaves it pending to re-sync."""
-    push_lock._pending_writes[pin_address(1)] = ("9999", time.monotonic() + 60.0)
-    push_coordinator.push_update({1: SlotCredential.known("9999")}, optimistic=True)
-
-    with patch.object(
-        push_lock,
-        "async_hard_refresh_codes",
-        AsyncMock(return_value={1: SlotCredential.empty()}),
-    ):
-        await push_coordinator.async_confirm_pending_writes()
-
-    assert pin_address(1) in push_lock._pending_writes
-    assert push_coordinator.is_verified(pin_address(1)) is False
-
-
-async def test_confirm_pending_writes_tolerates_read_failure(
-    push_coordinator: LockUsercodeUpdateCoordinator,
-    push_lock: MockLCMPushLock,
-) -> None:
-    """A failed confirm read is non-fatal and leaves pending state untouched."""
-    push_lock._pending_writes[pin_address(1)] = ("9999", time.monotonic() + 60.0)
-    push_coordinator.push_update({1: SlotCredential.known("9999")}, optimistic=True)
-
-    with patch.object(
-        push_lock,
-        "async_hard_refresh_codes",
-        AsyncMock(side_effect=LockDisconnected("offline")),
-    ):
-        await push_coordinator.async_confirm_pending_writes()
-
-    assert pin_address(1) in push_lock._pending_writes
-    assert push_coordinator.is_verified(pin_address(1)) is False
-
-
-async def test_confirm_pending_writes_noop_without_pending(
-    push_coordinator: LockUsercodeUpdateCoordinator,
-    push_lock: MockLCMPushLock,
-) -> None:
-    """With no pending writes the confirm path never touches the lock."""
-    mock_refresh = AsyncMock()
-    with patch.object(push_lock, "async_hard_refresh_codes", mock_refresh):
-        await push_coordinator.async_confirm_pending_writes()
-
-    mock_refresh.assert_not_called()
-
-
-async def test_confirm_pending_writes_swallows_unexpected_error(
-    push_coordinator: LockUsercodeUpdateCoordinator,
-    push_lock: MockLCMPushLock,
-) -> None:
-    """A non-LCM error from the confirm read must not escape (it would suspend the slot)."""
-    push_lock._pending_writes[pin_address(1)] = ("9999", time.monotonic() + 60.0)
-    push_coordinator.push_update({1: SlotCredential.known("9999")}, optimistic=True)
-
-    with patch.object(
-        push_lock,
-        "async_hard_refresh_codes",
-        AsyncMock(side_effect=RuntimeError("boom")),
-    ):
-        # Must not raise: the seam awaits this and a raise would suspend the slot.
-        await push_coordinator.async_confirm_pending_writes()
-
-    assert pin_address(1) in push_lock._pending_writes
-    assert push_coordinator.is_verified(pin_address(1)) is False
-
-
 async def test_desired_credential_disabled_slot_is_empty(
     hass: HomeAssistant,
     poll_coordinator: LockUsercodeUpdateCoordinator,
@@ -1415,36 +1286,9 @@ async def test_connection_check_swallows_lock_code_manager_error(
     mock_check.assert_called_once()
 
 
-async def test_apply_read_takes_differing_readable_external_change(
-    push_coordinator: LockUsercodeUpdateCoordinator,
-    push_lock: MockLCMPushLock,
-) -> None:
-    """A read observing a readable code different from a pending write takes the observation.
-
-    Mirrors BaseLock._confirm_slot: a drift/poll read of an externally-changed
-    readable code must not be masked by the believed value.
-    """
-    push_lock._pending_writes[pin_address(1)] = ("1234", time.monotonic() + 60.0)
-    push_coordinator.push_update({1: SlotCredential.known("1234")}, optimistic=True)
-
-    out = push_coordinator._apply_read({pin_address(1): SlotCredential.known("9999")})
-
-    assert out[pin_address(1)] == SlotCredential.known("9999")
-    assert pin_address(1) not in push_lock._pending_writes
-    assert push_coordinator.is_verified(pin_address(1)) is True
-
-
-async def test_accessors_are_addressed_not_slot_numbered(push_coordinator) -> None:
-    """The credential accessors round-trip through a CredentialAddress."""
-    address = pin_address(1)
-    push_coordinator.push_update({1: SlotCredential.known("1234")}, optimistic=True)
-    assert push_coordinator.is_verified(address) is False
-    push_coordinator.mark_verified(address)
-    assert push_coordinator.is_verified(address) is True
-
-
 @pytest.mark.parametrize(
-    "accessor", ["is_verified", "mark_verified", "desired_credential"]
+    "accessor",
+    ["is_verified", "has_pending_write", "pending_write", "desired_credential"],
 )
 async def test_non_pin_address_is_rejected(push_coordinator, accessor) -> None:
     """A non-PIN address is a programming error, not a missing entry.
@@ -1465,9 +1309,9 @@ async def test_string_slot_number_still_resolves(push_coordinator) -> None:
     is_verified would miss every int key and report True for a slot whose
     optimistic write is still unconfirmed.
     """
-    push_coordinator.push_update({1: SlotCredential.known("1234")}, optimistic=True)
+    push_coordinator.record_write(pin_address(1), "1234", believed=True)
     assert push_coordinator.is_verified(pin_address("1")) is False
-    push_coordinator.mark_verified(pin_address("1"))
+    push_coordinator.drop_pending(pin_address("1"))
     assert push_coordinator.is_verified(pin_address(1)) is True
 
 
@@ -1499,3 +1343,264 @@ async def test_credential_distinguishes_absent_from_empty(push_coordinator) -> N
     assert push_coordinator.credential(pin_address(9)) is None
     assert push_coordinator.has_credential(pin_address(1)) is True
     assert push_coordinator.has_credential(pin_address(9)) is False
+
+
+# =============================================================================
+# Pending writes: the coordinator owns them from "sent" to "seen"
+# =============================================================================
+
+
+async def test_record_write_believed_pushes_the_value_and_is_unverified(
+    push_coordinator: LockUsercodeUpdateCoordinator,
+) -> None:
+    """An optimistic write shows its PIN at once, and is not verified until seen."""
+    push_coordinator.record_write(pin_address(1), "9999", believed=True)
+    assert push_coordinator.data[pin_address(1)] == SlotCredential.known("9999")
+    assert push_coordinator.is_verified(pin_address(1)) is False
+    assert push_coordinator.pending_write(pin_address(1)).pin == "9999"
+
+
+async def test_record_write_not_believed_leaves_data_alone(
+    poll_coordinator: LockUsercodeUpdateCoordinator,
+) -> None:
+    """A polled lock's confirmed write is recorded without a value: the read will say."""
+    poll_coordinator.push_update({1: SlotCredential.empty()})
+    poll_coordinator.record_write(pin_address(1), "9999", believed=False)
+    assert poll_coordinator.data[pin_address(1)] == SlotCredential.empty()
+    assert poll_coordinator.is_verified(pin_address(1)) is False
+
+
+async def test_is_verified_is_exactly_not_pending(
+    poll_coordinator: LockUsercodeUpdateCoordinator,
+) -> None:
+    """Verified derives from the pending record; nothing is mirrored to drift."""
+    address = pin_address(1)
+    assert poll_coordinator.is_verified(address) is True
+    poll_coordinator.record_write(address, "1234", believed=False)
+    assert poll_coordinator.is_verified(address) is False
+    poll_coordinator.drop_pending(address)
+    assert poll_coordinator.is_verified(address) is True
+
+
+async def test_record_write_arms_one_timer_for_the_whole_lock(
+    poll_coordinator: LockUsercodeUpdateCoordinator,
+) -> None:
+    """N pending slots on one lock are one read apart, not N."""
+    assert poll_coordinator._confirm_task is None
+    poll_coordinator.record_write(pin_address(1), "1111", believed=False)
+    first = poll_coordinator._confirm_task
+    assert first is not None
+    poll_coordinator.record_write(pin_address(2), "2222", believed=False)
+    assert poll_coordinator._confirm_task is first
+
+
+async def test_apply_read_confirms_a_present_slot_with_the_written_value(
+    push_coordinator: LockUsercodeUpdateCoordinator,
+) -> None:
+    """Present -- even masked -- confirms the write; the written PIN is kept."""
+    push_coordinator.record_write(pin_address(1), "9999", believed=True)
+    out = push_coordinator._apply_read({pin_address(1): SlotCredential.unreadable()})
+    assert out[pin_address(1)] == SlotCredential.known("9999")
+    assert push_coordinator.is_verified(pin_address(1)) is True
+
+
+async def test_apply_read_takes_differing_readable_external_change(
+    push_coordinator: LockUsercodeUpdateCoordinator,
+) -> None:
+    """A readable read of a DIFFERENT code is an external change, and wins."""
+    push_coordinator.record_write(pin_address(1), "1234", believed=True)
+    out = push_coordinator._apply_read({pin_address(1): SlotCredential.known("9999")})
+    assert out[pin_address(1)] == SlotCredential.known("9999")
+    assert push_coordinator.is_verified(pin_address(1)) is True
+    # The slot holds something else: our write did not take.
+    assert push_coordinator.take_failed_write(pin_address(1)) is True
+
+
+async def test_apply_read_keeps_an_absent_slot_pending_before_the_deadline(
+    poll_coordinator: LockUsercodeUpdateCoordinator,
+) -> None:
+    """Absent before the deadline: the write may not have landed yet. Keep waiting."""
+    poll_coordinator.record_write(pin_address(1), "9999", believed=False)
+    out = poll_coordinator._apply_read({pin_address(1): SlotCredential.empty()})
+    assert out[pin_address(1)] == SlotCredential.empty()
+    assert poll_coordinator.is_verified(pin_address(1)) is False
+    assert poll_coordinator.take_failed_write(pin_address(1)) is False
+
+
+async def test_apply_read_fails_an_absent_slot_past_the_deadline_once(
+    poll_coordinator: LockUsercodeUpdateCoordinator, freezer
+) -> None:
+    """Absent at the deadline: give the write up, take the observation, charge once.
+
+    Expiry happens only inside a completed read, so nothing outside a read
+    ever has to guess whether the lock was asked. ``take_failed_write`` hands the
+    sync tick exactly one charge.
+    """
+    poll_coordinator.record_write(pin_address(1), "9999", believed=False)
+    freezer.tick(timedelta(seconds=PENDING_WRITE_TTL + 1))
+    out = poll_coordinator._apply_read({pin_address(1): SlotCredential.empty()})
+    assert out[pin_address(1)] == SlotCredential.empty()
+    assert poll_coordinator.is_verified(pin_address(1)) is True
+    assert poll_coordinator.take_failed_write(pin_address(1)) is True
+    assert poll_coordinator.take_failed_write(pin_address(1)) is False
+
+
+async def test_drop_pending_leaves_nothing_to_charge(
+    poll_coordinator: LockUsercodeUpdateCoordinator, freezer
+) -> None:
+    """A write no longer wanted is forgotten, not judged."""
+    poll_coordinator.record_write(pin_address(1), "9999", believed=False)
+    freezer.tick(timedelta(seconds=PENDING_WRITE_TTL + 1))
+    poll_coordinator.drop_pending(pin_address(1))
+    assert poll_coordinator.is_verified(pin_address(1)) is True
+    assert poll_coordinator.take_failed_write(pin_address(1)) is False
+
+
+async def test_observe_push_present_confirms_absent_ends(
+    push_coordinator: LockUsercodeUpdateCoordinator,
+) -> None:
+    """A push is the lock speaking now: present confirms, absent is taken as its word."""
+    push_coordinator.record_write(pin_address(1), "1234", believed=True)
+    push_coordinator.observe_push(pin_address(1), SlotCredential.unreadable())
+    assert push_coordinator.data[pin_address(1)] == SlotCredential.known("1234")
+    assert push_coordinator.is_verified(pin_address(1)) is True
+
+    push_coordinator.record_write(pin_address(2), "5678", believed=True)
+    push_coordinator.observe_push(pin_address(2), SlotCredential.empty())
+    assert push_coordinator.data[pin_address(2)] == SlotCredential.empty()
+    assert push_coordinator.is_verified(pin_address(2)) is True
+
+    push_coordinator.record_write(pin_address(3), "1111", believed=True)
+    push_coordinator.observe_push(pin_address(3), SlotCredential.known("2222"))
+    assert push_coordinator.data[pin_address(3)] == SlotCredential.known("2222")
+    assert push_coordinator.take_failed_write(pin_address(3)) is True
+    # ...and an absent push after a write counts it failed as well.
+    assert push_coordinator.take_failed_write(pin_address(2)) is True
+    assert push_coordinator.take_failed_write(pin_address(1)) is False
+
+
+async def test_confirmation_read_on_a_poller_uses_the_ordinary_read_with_pending_scope(
+    poll_lock: MockLCMLock, poll_coordinator: LockUsercodeUpdateCoordinator
+) -> None:
+    """A polled lock is read through its poll path, asked about every pending slot.
+
+    Slot 9 is managed by nobody; a direct write there is still pending, so the
+    read names it and the write is confirmed or given up like any other.
+    """
+    poll_lock.codes[9] = "4321"
+    poll_coordinator.record_write(pin_address(9), "4321", believed=False)
+    hard = poll_lock.service_calls["hard_refresh_codes"]
+    reads = poll_lock.service_calls["get_usercodes"]
+    before = (len(hard), len(reads))
+
+    await poll_coordinator.async_confirm_pending_writes()
+
+    assert len(hard) == before[0]
+    assert len(reads) == before[1] + 1
+    assert poll_coordinator.is_verified(pin_address(9)) is True
+    assert poll_coordinator.data[pin_address(9)] == SlotCredential.known("4321")
+
+
+async def test_confirmation_read_on_a_push_provider_hard_refreshes(
+    push_lock: MockLCMPushLock, push_coordinator: LockUsercodeUpdateCoordinator
+) -> None:
+    """A push provider's ordinary read is a cache; confirmation goes to the device."""
+    push_coordinator.record_write(pin_address(1), "9999", believed=True)
+    with patch.object(
+        push_lock,
+        "async_hard_refresh_codes",
+        AsyncMock(return_value={1: SlotCredential.unreadable()}),
+    ) as hard:
+        await push_coordinator.async_confirm_pending_writes()
+    hard.assert_awaited_once()
+    assert push_coordinator.is_verified(pin_address(1)) is True
+    assert push_coordinator.data[pin_address(1)] == SlotCredential.known("9999")
+
+
+async def test_confirmation_read_noop_without_pending(
+    push_lock: MockLCMPushLock, push_coordinator: LockUsercodeUpdateCoordinator
+) -> None:
+    """Nothing pending, nothing read."""
+    with patch.object(push_lock, "async_hard_refresh_codes", AsyncMock()) as hard:
+        await push_coordinator.async_confirm_pending_writes()
+    hard.assert_not_called()
+
+
+@pytest.mark.parametrize("failure", [LockDisconnected("offline"), RuntimeError("boom")])
+async def test_confirmation_read_failure_is_non_fatal_and_keeps_waiting(
+    push_lock: MockLCMPushLock,
+    push_coordinator: LockUsercodeUpdateCoordinator,
+    failure: Exception,
+) -> None:
+    """A failed read is not the lock's word: stay pending, touch no breaker."""
+    push_coordinator.record_write(pin_address(1), "9999", believed=True)
+    with patch.object(
+        push_lock, "async_hard_refresh_codes", AsyncMock(side_effect=failure)
+    ):
+        await push_coordinator.async_confirm_pending_writes()
+    assert push_coordinator.is_verified(pin_address(1)) is False
+    assert push_coordinator.unreachable is False
+    assert push_coordinator.take_failed_write(pin_address(1)) is False
+
+
+async def test_confirmation_read_failure_past_the_deadline_gives_the_write_up(
+    push_lock: MockLCMPushLock, push_coordinator: LockUsercodeUpdateCoordinator, freezer
+) -> None:
+    """Reads that keep failing do not keep a write alive forever.
+
+    The lock has had the time to live to be seen holding the write and has not
+    been; a lock whose writes land but whose reads never return still ends in
+    a charged re-sync and a visible suspend, not a silent pending state.
+    """
+    push_coordinator.record_write(pin_address(1), "9999", believed=True)
+    freezer.tick(timedelta(seconds=PENDING_WRITE_TTL + 1))
+    with patch.object(
+        push_lock,
+        "async_hard_refresh_codes",
+        AsyncMock(side_effect=LockDisconnected("offline")),
+    ):
+        await push_coordinator.async_confirm_pending_writes()
+    assert push_coordinator.is_verified(pin_address(1)) is True
+    assert push_coordinator.take_failed_write(pin_address(1)) is True
+
+
+async def test_confirmation_timer_fires_reads_and_rearms_while_pending(
+    hass: HomeAssistant,
+    poll_lock: MockLCMLock,
+    poll_coordinator: LockUsercodeUpdateCoordinator,
+) -> None:
+    """The coordinator schedules its own looks: now, then every interval, until settled."""
+    poll_lock.codes.pop(1, None)  # every read comes back absent
+    reads = poll_lock.service_calls["get_usercodes"]
+    before = len(reads)
+
+    poll_coordinator.record_write(pin_address(1), "9999", believed=False)
+    await hass.async_block_till_done()  # the immediate first look
+    assert len(reads) == before + 1
+    assert poll_coordinator._confirm_unsub is not None  # re-armed: still pending
+
+    async_fire_time_changed(
+        hass, dt_util.utcnow() + timedelta(seconds=CONFIRM_READ_INTERVAL + 1)
+    )
+    await hass.async_block_till_done()
+    assert len(reads) == before + 2
+
+    # The lock now holds it: the next look confirms and the timer stands down.
+    poll_lock.codes[1] = "9999"
+    async_fire_time_changed(
+        hass, dt_util.utcnow() + timedelta(seconds=2 * CONFIRM_READ_INTERVAL + 2)
+    )
+    await hass.async_block_till_done()
+    assert poll_coordinator.is_verified(pin_address(1)) is True
+    assert poll_coordinator._confirm_unsub is None
+
+
+async def test_shutdown_cancels_the_confirmation_timer(
+    poll_coordinator: LockUsercodeUpdateCoordinator,
+) -> None:
+    """No read fires after the coordinator is gone."""
+    poll_coordinator.record_write(pin_address(1), "9999", believed=False)
+    assert poll_coordinator._confirm_task is not None
+    await poll_coordinator.async_shutdown()
+    assert poll_coordinator._confirm_task is None
+    assert poll_coordinator._confirm_unsub is None

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,5 +1,6 @@
 """Test the coordinator module."""
 
+import asyncio
 from collections.abc import AsyncGenerator
 from datetime import timedelta
 from unittest.mock import AsyncMock, patch
@@ -107,12 +108,14 @@ async def poll_coordinator(
 
 
 @pytest.fixture
-def push_coordinator(
+async def push_coordinator(
     hass: HomeAssistant, push_lock: MockLCMPushLock, lcm_config_entry: MockConfigEntry
-) -> LockUsercodeUpdateCoordinator:
+) -> AsyncGenerator[LockUsercodeUpdateCoordinator]:
     """Return a coordinator with a push-based lock (with hard refresh enabled)."""
     push_lock._hard_refresh_interval = timedelta(hours=1)
-    return _make_coordinator(hass, push_lock, lcm_config_entry)
+    coordinator = _make_coordinator(hass, push_lock, lcm_config_entry)
+    yield coordinator
+    await coordinator.async_shutdown()
 
 
 async def test_drift_timer_not_created_without_hard_refresh_interval(
@@ -1595,12 +1598,228 @@ async def test_confirmation_timer_fires_reads_and_rearms_while_pending(
     assert poll_coordinator._confirm_unsub is None
 
 
-async def test_shutdown_cancels_the_confirmation_timer(
+async def test_shutdown_cancels_the_armed_timer_and_forgets_pending(
+    hass: HomeAssistant,
+    poll_lock: MockLCMLock,
     poll_coordinator: LockUsercodeUpdateCoordinator,
 ) -> None:
-    """No read fires after the coordinator is gone."""
+    """No read fires after the coordinator is gone, and nothing stays pending."""
+    poll_lock.codes.pop(1, None)
+    reads = poll_lock.service_calls["get_usercodes"]
     poll_coordinator.record_write(pin_address(1), "9999", believed=False)
-    assert poll_coordinator._confirm_task is not None
+    await hass.async_block_till_done()  # first look ran, found it absent, armed
+    assert poll_coordinator._confirm_unsub is not None
+    before = len(reads)
+
     await poll_coordinator.async_shutdown()
-    assert poll_coordinator._confirm_task is None
     assert poll_coordinator._confirm_unsub is None
+    assert poll_coordinator.has_pending_write(pin_address(1)) is False
+
+    async_fire_time_changed(
+        hass, dt_util.utcnow() + timedelta(seconds=CONFIRM_READ_INTERVAL + 1)
+    )
+    await hass.async_block_till_done()
+    assert len(reads) == before
+
+
+async def test_shutdown_cancels_a_timer_fired_read_in_flight(
+    hass: HomeAssistant,
+    poll_lock: MockLCMLock,
+    poll_coordinator: LockUsercodeUpdateCoordinator,
+) -> None:
+    """A read the timer started is the tracked look: shutdown cancels it mid-flight."""
+    poll_lock.codes.pop(1, None)
+    poll_coordinator.record_write(pin_address(1), "9999", believed=False)
+    await hass.async_block_till_done()  # timer armed
+
+    gate = asyncio.Event()
+    completed: list[int] = []
+
+    async def slow_read(*_args, **_kwargs):
+        await gate.wait()
+        completed.append(1)
+        return {1: SlotCredential.empty()}
+
+    with patch.object(poll_lock, "async_get_usercodes", slow_read):
+        async_fire_time_changed(
+            hass, dt_util.utcnow() + timedelta(seconds=CONFIRM_READ_INTERVAL + 1)
+        )
+        for _ in range(3):
+            await asyncio.sleep(0)  # let the timer start the look and enter the read
+        assert poll_coordinator._confirm_task is not None
+
+        await poll_coordinator.async_shutdown()
+        gate.set()
+        await hass.async_block_till_done()
+
+    assert completed == []
+    assert poll_coordinator._confirm_unsub is None
+
+
+async def test_record_write_while_the_timer_is_armed_starts_no_second_look(
+    hass: HomeAssistant,
+    poll_lock: MockLCMLock,
+    poll_coordinator: LockUsercodeUpdateCoordinator,
+) -> None:
+    """One look per lock holds across the timer too, not only before the first look."""
+    poll_lock.codes.pop(1, None)
+    poll_coordinator.record_write(pin_address(1), "1111", believed=False)
+    await hass.async_block_till_done()
+    armed = poll_coordinator._confirm_unsub
+    assert armed is not None
+
+    poll_coordinator.record_write(pin_address(2), "2222", believed=False)
+    assert poll_coordinator._confirm_task is None
+    assert poll_coordinator._confirm_unsub is armed
+
+
+async def test_a_read_with_an_unusable_key_does_not_strand_the_look(
+    hass: HomeAssistant,
+    push_lock: MockLCMPushLock,
+    push_coordinator: LockUsercodeUpdateCoordinator,
+) -> None:
+    """Whatever the read returns, the look either settles the write or re-arms."""
+    push_coordinator.record_write(pin_address(1), "9999", believed=True)
+    with patch.object(
+        push_lock,
+        "async_hard_refresh_codes",
+        AsyncMock(return_value={"bogus": SlotCredential.empty()}),
+    ):
+        await hass.async_block_till_done()
+    assert push_coordinator.has_pending_write(pin_address(1)) is True
+    assert push_coordinator._confirm_task is None
+    assert push_coordinator._confirm_unsub is not None
+
+
+async def test_observe_push_with_nothing_pending_is_the_locks_word(
+    push_coordinator: LockUsercodeUpdateCoordinator,
+) -> None:
+    """An external change or deletion pushed with nothing pending lands as read.
+
+    Every push provider's event path ends here, so this is the path by which a
+    code changed or deleted at the keypad reaches the data at all.
+    """
+    push_coordinator.push_update({1: SlotCredential.known("1234")})
+    push_coordinator.observe_push(pin_address(1), SlotCredential.known("4321"))
+    assert push_coordinator.data[pin_address(1)] == SlotCredential.known("4321")
+    assert push_coordinator.is_verified(pin_address(1)) is True
+
+    push_coordinator.observe_push(pin_address(1), SlotCredential.empty())
+    assert push_coordinator.data[pin_address(1)] == SlotCredential.empty()
+    assert push_coordinator.is_verified(pin_address(1)) is True
+    assert push_coordinator.take_failed_write(pin_address(1)) is False
+
+
+async def test_newer_record_write_replaces_the_pending_pin(
+    push_coordinator: LockUsercodeUpdateCoordinator,
+) -> None:
+    """Two quick PIN changes: the read is judged against the PIN sent last."""
+    push_coordinator.record_write(pin_address(1), "1111", believed=True)
+    push_coordinator.record_write(pin_address(1), "2222", believed=True)
+    assert push_coordinator.pending_write(pin_address(1)).pin == "2222"
+    assert push_coordinator.data[pin_address(1)] == SlotCredential.known("2222")
+
+    out = push_coordinator._apply_read({pin_address(1): SlotCredential.known("2222")})
+    assert out[pin_address(1)] == SlotCredential.known("2222")
+    assert push_coordinator.is_verified(pin_address(1)) is True
+    assert push_coordinator.take_failed_write(pin_address(1)) is False
+
+
+async def test_record_write_forgets_an_earlier_failed_write(
+    poll_coordinator: LockUsercodeUpdateCoordinator, freezer
+) -> None:
+    """A new write to the address supersedes an uncharged failure of the old one.
+
+    Otherwise a direct set landing between the failure and the tick would be
+    charged for a write the lock then kept.
+    """
+    poll_coordinator.record_write(pin_address(1), "1111", believed=False)
+    freezer.tick(timedelta(seconds=PENDING_WRITE_TTL + 1))
+    poll_coordinator._apply_read({pin_address(1): SlotCredential.empty()})
+
+    poll_coordinator.record_write(pin_address(1), "2222", believed=False)
+    poll_coordinator._apply_read({pin_address(1): SlotCredential.known("2222")})
+    assert poll_coordinator.is_verified(pin_address(1)) is True
+    assert poll_coordinator.take_failed_write(pin_address(1)) is False
+
+
+async def test_push_provider_confirmed_set_is_present_and_settled_through_the_seam(
+    push_lock: MockLCMPushLock, push_coordinator: LockUsercodeUpdateCoordinator
+) -> None:
+    """The push-provider contract, end to end on a real coordinator.
+
+    A push provider pushes the value it wrote before returning CONFIRMED, so
+    after the seam returns the value is on the coordinator, nothing is
+    pending, and no confirmation look was started for it.
+    """
+    push_lock.coordinator = push_coordinator
+    push_lock._min_operation_delay = 0.0
+    await push_lock.async_internal_set_usercode(2, "8642", "dana")
+
+    assert push_coordinator.data[pin_address(2)] == SlotCredential.known("8642")
+    assert push_coordinator.is_verified(pin_address(2)) is True
+    assert push_coordinator._confirm_task is None
+    assert push_coordinator._confirm_unsub is None
+
+
+async def test_record_write_during_a_timer_fired_read_joins_that_look(
+    hass: HomeAssistant,
+    poll_lock: MockLCMLock,
+    poll_coordinator: LockUsercodeUpdateCoordinator,
+) -> None:
+    """A write landing while the timer's read is in flight starts no second chain.
+
+    The timer's read is the tracked look, so the write waits for it and the
+    re-arm after it covers both slots.
+    """
+    poll_lock.codes.pop(1, None)
+    poll_coordinator.record_write(pin_address(1), "1111", believed=False)
+    await hass.async_block_till_done()  # timer armed
+
+    gate = asyncio.Event()
+
+    async def slow_read(*_args, **_kwargs):
+        await gate.wait()
+        return {1: SlotCredential.empty(), 2: SlotCredential.empty()}
+
+    with patch.object(poll_lock, "async_get_usercodes", slow_read):
+        async_fire_time_changed(
+            hass, dt_util.utcnow() + timedelta(seconds=CONFIRM_READ_INTERVAL + 1)
+        )
+        for _ in range(3):
+            await asyncio.sleep(0)
+        in_flight = poll_coordinator._confirm_task
+        assert in_flight is not None
+
+        poll_coordinator.record_write(pin_address(2), "2222", believed=False)
+        assert poll_coordinator._confirm_task is in_flight
+        assert poll_coordinator._confirm_unsub is None
+
+        gate.set()
+        await hass.async_block_till_done()
+
+    assert poll_coordinator._confirm_task is None
+    assert poll_coordinator._confirm_unsub is not None  # one chain, re-armed once
+
+
+async def test_confirmation_read_drops_a_slot_the_lock_no_longer_reports(
+    hass: HomeAssistant,
+    poll_lock: MockLCMLock,
+    poll_coordinator: LockUsercodeUpdateCoordinator,
+) -> None:
+    """An unmanaged code deleted out of band disappears with the confirmation read.
+
+    The scoped read has the same shape as a poll -- every managed and pending
+    slot plus whatever else the lock holds -- so it replaces the data as a
+    poll would, rather than keeping a slot the lock has stopped reporting.
+    """
+    poll_lock.codes[9] = "4321"
+    await poll_coordinator.async_refresh()
+    assert poll_coordinator.data[pin_address(9)] == SlotCredential.known("4321")
+
+    del poll_lock.codes[9]
+    poll_coordinator.record_write(pin_address(1), "1234", believed=False)
+    await hass.async_block_till_done()
+
+    assert pin_address(9) not in poll_coordinator.data
+    assert poll_coordinator.is_verified(pin_address(1)) is True

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1656,21 +1656,53 @@ async def test_shutdown_cancels_a_timer_fired_read_in_flight(
     assert poll_coordinator._confirm_unsub is None
 
 
-async def test_record_write_while_the_timer_is_armed_starts_no_second_look(
+async def test_record_write_while_the_timer_is_armed_pulls_the_look_forward(
     hass: HomeAssistant,
     poll_lock: MockLCMLock,
     poll_coordinator: LockUsercodeUpdateCoordinator,
 ) -> None:
-    """One look per lock holds across the timer too, not only before the first look."""
+    """A write landing while the timer waits gets its look now, on the one chain."""
     poll_lock.codes.pop(1, None)
     poll_coordinator.record_write(pin_address(1), "1111", believed=False)
     await hass.async_block_till_done()
-    armed = poll_coordinator._confirm_unsub
-    assert armed is not None
+    assert poll_coordinator._confirm_unsub is not None
+    reads = poll_lock.service_calls["get_usercodes"]
+    before = len(reads)
 
     poll_coordinator.record_write(pin_address(2), "2222", believed=False)
+    assert poll_coordinator._confirm_task is not None
+    assert poll_coordinator._confirm_unsub is None  # the waiting timer was cancelled
+
+    await hass.async_block_till_done()
+    assert len(reads) == before + 1
     assert poll_coordinator._confirm_task is None
-    assert poll_coordinator._confirm_unsub is armed
+    assert poll_coordinator._confirm_unsub is not None  # one chain, re-armed once
+
+
+async def test_pending_slot_a_completed_read_never_names_is_given_up_at_the_deadline(
+    push_lock: MockLCMPushLock,
+    push_coordinator: LockUsercodeUpdateCoordinator,
+    freezer,
+) -> None:
+    """A whole-device read that omits a pending slot is the lock not holding it.
+
+    Waited for until the deadline like an absent slot, then failed -- never
+    left pending to hard-refresh the device every interval for good.
+    """
+    push_coordinator.record_write(pin_address(9), "4321", believed=True)
+    with patch.object(
+        push_lock,
+        "async_hard_refresh_codes",
+        AsyncMock(return_value={1: SlotCredential.known("1234")}),
+    ):
+        await push_coordinator.async_confirm_pending_writes()
+        assert push_coordinator.has_pending_write(pin_address(9)) is True
+        assert push_coordinator.take_failed_write(pin_address(9)) is False
+
+        freezer.tick(timedelta(seconds=PENDING_WRITE_TTL + 1))
+        await push_coordinator.async_confirm_pending_writes()
+    assert push_coordinator.has_pending_write(pin_address(9)) is False
+    assert push_coordinator.take_failed_write(pin_address(9)) is True
 
 
 async def test_a_read_with_an_unusable_key_does_not_strand_the_look(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1823,3 +1823,57 @@ async def test_confirmation_read_drops_a_slot_the_lock_no_longer_reports(
 
     assert pin_address(9) not in poll_coordinator.data
     assert poll_coordinator.is_verified(pin_address(1)) is True
+
+
+async def test_record_write_after_shutdown_records_nothing(
+    poll_coordinator: LockUsercodeUpdateCoordinator,
+) -> None:
+    """A write returning after unload starts no look against a torn-down lock."""
+    await poll_coordinator.async_shutdown()
+    poll_coordinator.record_write(pin_address(1), "9999", believed=False)
+    assert poll_coordinator.has_pending_write(pin_address(1)) is False
+    assert poll_coordinator._confirm_task is None
+    assert poll_coordinator._confirm_unsub is None
+
+
+async def test_quiet_read_with_an_old_failed_write_does_not_wake_listeners(
+    poll_lock: MockLCMLock, poll_coordinator: LockUsercodeUpdateCoordinator, freezer
+) -> None:
+    """Listeners are woken for a write that just failed, not for every read after.
+
+    A failed direct write to a slot nothing manages has no one to consume
+    it; it must not turn every later unchanged read into a full notify.
+    """
+    await poll_coordinator.async_refresh()
+    wakes: list[int] = []
+    poll_coordinator.async_add_listener(lambda: wakes.append(1))
+
+    poll_lock.codes.pop(9, None)
+    poll_coordinator.record_write(pin_address(9), "4321", believed=False)
+    freezer.tick(timedelta(seconds=PENDING_WRITE_TTL + 1))
+    await poll_coordinator.async_confirm_pending_writes()  # fails slot 9's write
+    assert poll_coordinator.is_verified(pin_address(9)) is True
+    await poll_coordinator.async_refresh()  # settle: slot 9 leaves the read scope
+    woken = len(wakes)
+
+    # A later write the lock does keep; the read changes nothing in the data.
+    poll_coordinator.record_write(pin_address(1), poll_lock.codes[1], believed=False)
+    await poll_coordinator.async_confirm_pending_writes()
+    assert poll_coordinator.is_verified(pin_address(1)) is True
+    assert len(wakes) == woken
+
+
+async def test_unchanged_push_on_a_slot_with_an_old_failed_write_does_not_wake_listeners(
+    push_coordinator: LockUsercodeUpdateCoordinator,
+) -> None:
+    """Only the push that fails a write wakes listeners on unchanged data."""
+    wakes: list[int] = []
+    push_coordinator.async_add_listener(lambda: wakes.append(1))
+
+    push_coordinator.record_write(pin_address(9), "4321", believed=True)
+    push_coordinator.observe_push(pin_address(9), SlotCredential.empty())  # fails it
+    assert push_coordinator.data[pin_address(9)] == SlotCredential.empty()
+    woken = len(wakes)
+
+    push_coordinator.observe_push(pin_address(9), SlotCredential.empty())  # restated
+    assert len(wakes) == woken

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -2185,3 +2185,21 @@ class TestPendingWritesOwnedByCoordinator:
 
         assert manager._state is SyncState.IN_SYNC
         assert manager._coordinator.take_failed_write(pin_address(1)) is False
+
+    async def test_manager_start_discards_a_failed_write_that_predates_it(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+        freezer,
+    ) -> None:
+        """A direct write that failed before the slot was managed is nobody's strike."""
+        manager = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)._sync_manager
+        await manager.async_stop()
+
+        manager._coordinator.record_write(pin_address(1), "0000", believed=False)
+        freezer.tick(timedelta(seconds=PENDING_WRITE_TTL + 1))
+        manager._coordinator._apply_read({pin_address(1): SlotCredential.empty()})
+
+        await manager.async_start()
+        assert manager._coordinator.take_failed_write(pin_address(1)) is False

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import timedelta
 import logging
-import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -21,6 +21,7 @@ from custom_components.lock_code_manager.const import (
     BACKOFF_FAILURE_THRESHOLD,
     DOMAIN,
     MAX_SYNC_ATTEMPTS,
+    PENDING_WRITE_TTL,
 )
 from custom_components.lock_code_manager.domain.credentials import (
     CredentialType,
@@ -156,7 +157,7 @@ class TestCalculateInSync:
                     "pin": "1234",
                     "coordinator_credential": SlotCredential.empty(),
                 },
-                True,
+                False,
                 id="active-empty-code-matching-last-set",
             ),
             pytest.param(
@@ -861,157 +862,6 @@ class TestSyncStateMachine:
 
         await async_trigger_sync_tick(hass, SLOT_1_IN_SYNC_ENTITY, set_dirty=False)
         assert manager._state is SyncState.IN_SYNC
-
-    async def test_pending_optimistic_write_holds_in_pending_confirmation(
-        self,
-        hass: HomeAssistant,
-        mock_lock_config_entry,
-        lock_code_manager_config_entry,
-    ) -> None:
-        """An unexpired pending write parks the slot in PENDING_CONFIRMATION.
-
-        The tick must not re-write while waiting for the lock to confirm.
-        """
-        entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
-        manager = entity_obj._sync_manager
-        await async_trigger_sync_tick(hass, SLOT_1_IN_SYNC_ENTITY, set_dirty=False)
-
-        # Arrange an outstanding (unexpired) optimistic write.
-        manager._lock._pending_writes[pin_address(1)] = (
-            "1234",
-            time.monotonic() + 100.0,
-        )
-        manager._coordinator.push_update(
-            {1: SlotCredential.known("1234")}, optimistic=True
-        )
-        manager.request_sync_check()
-
-        with patch.object(
-            manager, "_perform_sync", new_callable=AsyncMock
-        ) as mock_sync:
-            await manager._async_tick()
-
-        assert manager._state is SyncState.PENDING_CONFIRMATION
-        mock_sync.assert_not_called()
-
-    async def test_pending_optimistic_write_confirmed_reaches_in_sync(
-        self,
-        hass: HomeAssistant,
-        mock_lock_config_entry,
-        lock_code_manager_config_entry,
-    ) -> None:
-        """A confirmation (push/refresh) of a pending write reaches IN_SYNC.
-
-        End-to-end masked-accepted convergence: optimistic write parks in
-        PENDING_CONFIRMATION; a credential event confirming the slot present
-        (even masked) marks it verified and the next tick is IN_SYNC.
-        """
-        entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
-        manager = entity_obj._sync_manager
-        await async_trigger_sync_tick(hass, SLOT_1_IN_SYNC_ENTITY, set_dirty=False)
-
-        # Optimistic write outstanding (unexpired).
-        manager._lock._pending_writes[pin_address(1)] = (
-            "1234",
-            time.monotonic() + 100.0,
-        )
-        manager._coordinator.push_update(
-            {1: SlotCredential.known("1234")}, optimistic=True
-        )
-        manager.request_sync_check()
-        with patch.object(manager, "_perform_sync", new_callable=AsyncMock):
-            await manager._async_tick()
-        assert manager._state is SyncState.PENDING_CONFIRMATION
-
-        # The lock confirms the slot present but masked -> believed value kept,
-        # marked verified, pending cleared.
-        manager._lock._confirm_slot(1, SlotCredential.unreadable())
-        assert pin_address(1) not in manager._lock._pending_writes
-        assert manager._coordinator.is_verified(pin_address(1)) is True
-
-        manager.request_sync_check()
-        await async_trigger_sync_tick(hass, SLOT_1_IN_SYNC_ENTITY, set_dirty=False)
-        assert manager._state is SyncState.IN_SYNC
-
-    async def test_pending_optimistic_write_expiry_records_failure_and_resyncs(
-        self,
-        hass: HomeAssistant,
-        mock_lock_config_entry,
-        lock_code_manager_config_entry,
-    ) -> None:
-        """An expired pending write counts a breaker failure and re-syncs."""
-        entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
-        manager = entity_obj._sync_manager
-        await async_trigger_sync_tick(hass, SLOT_1_IN_SYNC_ENTITY, set_dirty=False)
-
-        # Genuine failure: the code never landed on the lock, so a re-read
-        # cannot confirm it. Arrange an already-expired optimistic write whose
-        # value is NOT present on the lock.
-        manager._lock.codes.pop(1, None)
-        manager._lock._pending_writes[pin_address(1)] = ("1234", time.monotonic() - 1.0)
-        manager._coordinator.push_update(
-            {1: SlotCredential.known("1234")}, optimistic=True
-        )
-        manager.request_sync_check()
-        before = manager._slot_breaker.failure_count
-
-        with patch.object(
-            manager, "_perform_sync", new_callable=AsyncMock, return_value=True
-        ) as mock_sync:
-            # Tick 1: the expired pending write is dropped and charged to the
-            # breaker, and the slot parks at OUT_OF_SYNC without re-syncing this
-            # tick (so a concurrent confirming push could still land, and so the
-            # breaker is not double-charged by a same-tick sync failure).
-            await manager._async_tick()
-            assert pin_address(1) not in manager._lock._pending_writes
-            assert manager._slot_breaker.failure_count > before
-            assert manager._state is SyncState.OUT_OF_SYNC
-            mock_sync.assert_not_called()
-
-            # Tick 2: the code is genuinely absent, so the slot re-syncs.
-            manager.request_sync_check()
-            await manager._async_tick()
-            mock_sync.assert_called()
-
-    async def test_pending_write_abandoned_when_desired_changes(
-        self,
-        hass: HomeAssistant,
-        mock_lock_config_entry,
-        lock_code_manager_config_entry,
-    ) -> None:
-        """A pending write no longer matching the desired state is dropped, no charge."""
-        entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
-        manager = entity_obj._sync_manager
-        await async_trigger_sync_tick(hass, SLOT_1_IN_SYNC_ENTITY, set_dirty=False)
-
-        # An optimistic write is still in its (un-expired) confirmation window,
-        # but its believed value no longer matches the desired PIN -- the user
-        # changed it while the write was outstanding. The stale entry must not
-        # hold the slot in PENDING_CONFIRMATION (re-syncing the old value) until
-        # the deadline; it is dropped and the new target re-syncs.
-        desired = manager._resolve_credential_snapshot().credential_state
-        stale_pin = f"{desired}9"
-        manager._lock._pending_writes[pin_address(1)] = (
-            stale_pin,
-            time.monotonic() + 60.0,
-        )
-        manager._coordinator.push_update(
-            {1: SlotCredential.known(stale_pin)}, optimistic=True
-        )
-        manager.request_sync_check()
-        before = manager._slot_breaker.failure_count
-
-        with patch.object(
-            manager, "_perform_sync", new_callable=AsyncMock, return_value=True
-        ) as mock_sync:
-            await manager._async_tick()
-
-        # Stale entry dropped; a desired-state change is not a sync failure, so
-        # the breaker is not charged; the slot leaves PENDING_CONFIRMATION.
-        assert pin_address(1) not in manager._lock._pending_writes
-        assert manager._slot_breaker.failure_count == before
-        assert manager._state is SyncState.OUT_OF_SYNC
-        mock_sync.assert_not_called()
 
     async def test_syncing_to_out_of_sync_on_lock_disconnected(
         self,
@@ -1926,31 +1776,31 @@ class TestBreakerTickSoleMutatorInvariant:
         mock_lock_config_entry,
         lock_code_manager_config_entry,
     ) -> None:
-        """A set that completes but whose readback still shows out-of-sync increments the breaker."""
+        """A set whose readback shows a different code costs one breaker failure.
+
+        The set is accepted but the lock goes on holding another code. The
+        coordinator's look after the write finds it -- a displaced write is a
+        failed write -- and the next tick takes the one charge and re-syncs.
+        """
         entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
         manager = entity_obj._sync_manager
-
-        manager._coordinator.data[pin_address(1)] = SlotCredential.known("9999")
-        manager._state = SyncState.OUT_OF_SYNC
-        starting_count = manager._slot_breaker.failure_count
         lock_provider = lock_code_manager_config_entry.runtime_data.locks[
             LOCK_1_ENTITY_ID
         ]
+        lock_provider.codes[1] = "9999"
+        manager._coordinator.data[pin_address(1)] = SlotCredential.known("9999")
+        manager._state = SyncState.OUT_OF_SYNC
+        starting_count = manager._slot_breaker.failure_count
 
-        # async_set_usercode succeeds (was_set=True) but we no-op the
-        # refresh so coordinator.data[pin_address(1)] still reports the stale value and
-        # calculate_in_sync returns False -- the post-verification miss
-        # branch must then record a failure.
-        with (
-            patch.object(
-                lock_provider,
-                "async_set_usercode",
-                AsyncMock(return_value=WriteResult.CONFIRMED),
-            ),
-            patch.object(
-                manager._coordinator, "async_refresh", AsyncMock(return_value=None)
-            ),
+        # The set "succeeds" without changing what the lock holds.
+        with patch.object(
+            lock_provider,
+            "async_set_usercode",
+            AsyncMock(return_value=WriteResult.CONFIRMED),
         ):
+            await manager._async_tick_impl()
+            assert manager._state is SyncState.PENDING_CONFIRMATION
+            await hass.async_block_till_done()  # the coordinator's look
             await manager._async_tick_impl()
 
         assert manager._state is SyncState.OUT_OF_SYNC
@@ -1989,56 +1839,6 @@ class TestBreakerTickSoleMutatorInvariant:
 
 class TestOptimisticSetPendingConfirmation:
     """Tests for the post-sync pending-write check in ``_async_tick_impl``."""
-
-    async def test_optimistic_set_transitions_to_pending_confirmation(
-        self,
-        hass: HomeAssistant,
-        mock_lock_config_entry,
-        lock_code_manager_config_entry,
-    ) -> None:
-        """A successful but ambiguous (OPTIMISTIC) set parks the slot in PENDING_CONFIRMATION.
-
-        Mirrors a masked lock whose post-write verification is ambiguous: the
-        provider returns ``WriteResult.OPTIMISTIC``, the seam records a
-        pending write, and when the immediate confirmation read can't observe
-        the slot (simulated here by removing it from the mock lock's
-        readable codes), the pending write survives into the tick's post-sync
-        check, which must not declare success or failure -- it waits.
-        """
-        entity_obj = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)
-        manager = entity_obj._sync_manager
-        await async_trigger_sync_tick(hass, SLOT_1_IN_SYNC_ENTITY, set_dirty=False)
-        assert manager._state is SyncState.IN_SYNC
-
-        manager._coordinator.data[pin_address(1)] = SlotCredential.empty()
-        manager.request_sync_check()
-        assert manager._state is SyncState.OUT_OF_SYNC
-
-        async def optimistic_set_usercode(
-            code_slot: int,
-            usercode: str,
-            name: str | None = None,
-            source: str = "direct",
-        ) -> WriteResult:
-            return WriteResult.OPTIMISTIC
-
-        async def absent_read() -> dict[int, SlotCredential]:
-            # Every read (the immediate confirmation read AND the tick's own
-            # post-sync poll refresh) observes slot 1 as still empty -- e.g.
-            # a masked lock whose write hasn't propagated to readback yet --
-            # so the pending write survives both.
-            return {1: SlotCredential.empty(), 2: SlotCredential.known("5678")}
-
-        with (
-            patch.object(manager._lock, "async_set_usercode", optimistic_set_usercode),
-            patch.object(manager._lock, "async_hard_refresh_codes", absent_read),
-            patch.object(manager._lock, "async_get_usercodes", absent_read),
-        ):
-            await manager._async_tick()
-
-        assert manager._state is SyncState.PENDING_CONFIRMATION
-        assert pin_address(1) in manager._lock._pending_writes
-        assert manager._coordinator.is_verified(pin_address(1)) is False
 
 
 class TestAsyncTickDefensiveGuards:
@@ -2169,3 +1969,148 @@ class TestValueEntityKey:
         """
         with pytest.raises(ValueError, match="has no value entity key"):
             value_entity_key(credential_type)
+
+
+class TestPendingWritesOwnedByCoordinator:
+    """The tick watches a pending write; the coordinator settles it."""
+
+    async def test_pending_write_holds_in_pending_confirmation_without_io(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """A wanted pending write parks the slot; the tick neither writes nor reads."""
+        manager = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)._sync_manager
+        await async_trigger_sync_tick(hass, SLOT_1_IN_SYNC_ENTITY, set_dirty=False)
+        manager._coordinator.record_write(pin_address(1), "1234", believed=True)
+        manager.request_sync_check()
+
+        with (
+            patch.object(manager, "_perform_sync", new_callable=AsyncMock) as sync,
+            patch.object(
+                manager._coordinator,
+                "async_confirm_pending_writes",
+                new_callable=AsyncMock,
+            ) as read,
+        ):
+            await manager._async_tick()
+
+        assert manager._state is SyncState.PENDING_CONFIRMATION
+        sync.assert_not_called()
+        read.assert_not_called()
+
+    async def test_confirmed_pending_write_reaches_in_sync(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """A push confirming the write settles the slot on the next tick."""
+        manager = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)._sync_manager
+        await async_trigger_sync_tick(hass, SLOT_1_IN_SYNC_ENTITY, set_dirty=False)
+        manager._coordinator.record_write(pin_address(1), "1234", believed=True)
+        manager.request_sync_check()
+        await manager._async_tick()
+        assert manager._state is SyncState.PENDING_CONFIRMATION
+
+        manager._lock._confirm_slot(1, SlotCredential.unreadable())
+        assert manager._coordinator.is_verified(pin_address(1)) is True
+
+        manager.request_sync_check()
+        await manager._async_tick()
+        assert manager._state is SyncState.IN_SYNC
+
+    async def test_expired_pending_write_is_charged_once_then_resynced(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+        freezer,
+    ) -> None:
+        """A write the lock never kept costs one breaker failure, then a re-sync.
+
+        Expiry is the coordinator's, inside a read past the deadline that still
+        did not show the write. The tick takes the one charge, re-syncs on the
+        NEXT tick so a confirming push landing in between still counts first,
+        and never charges the same write twice.
+        """
+        manager = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)._sync_manager
+        await async_trigger_sync_tick(hass, SLOT_1_IN_SYNC_ENTITY, set_dirty=False)
+        manager._lock.codes.pop(1, None)  # the lock never holds it
+        manager._coordinator.record_write(pin_address(1), "1234", believed=False)
+        manager.request_sync_check()
+        before = manager._slot_breaker.failure_count
+
+        freezer.tick(timedelta(seconds=PENDING_WRITE_TTL + 1))
+        await manager._coordinator.async_confirm_pending_writes()
+        assert manager._coordinator.is_verified(pin_address(1)) is True
+
+        with patch.object(
+            manager, "_perform_sync", AsyncMock(return_value=False)
+        ) as sync:
+            await manager._async_tick()
+            assert manager._slot_breaker.failure_count == before + 1
+            assert manager._state is SyncState.OUT_OF_SYNC
+            sync.assert_not_called()
+
+            manager.request_sync_check()
+            await manager._async_tick()
+            sync.assert_called()
+            assert manager._slot_breaker.failure_count == before + 1
+
+    async def test_pending_write_abandoned_when_desired_changes(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """A write for a PIN nobody wants any more is forgotten, not charged."""
+        manager = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)._sync_manager
+        await async_trigger_sync_tick(hass, SLOT_1_IN_SYNC_ENTITY, set_dirty=False)
+        manager._coordinator.record_write(pin_address(1), "0000", believed=True)
+        manager.request_sync_check()
+        before = manager._slot_breaker.failure_count
+
+        with patch.object(manager, "_perform_sync", new_callable=AsyncMock) as sync:
+            await manager._async_tick()
+
+        assert manager._coordinator.has_pending_write(pin_address(1)) is False
+        assert manager._slot_breaker.failure_count == before
+        assert manager._state is SyncState.OUT_OF_SYNC
+        sync.assert_not_called()
+
+    async def test_set_on_a_poller_parks_pending_and_the_coordinators_read_settles_it(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """End to end on a polled lock: set, pending, the coordinator's own read, in sync.
+
+        The tick issues no read of its own after the set; the coordinator's
+        immediate look confirms the write and the next tick finds it settled.
+        """
+        manager = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)._sync_manager
+        lock = manager._lock
+        assert lock.supports_push is False
+        await async_trigger_sync_tick(hass, SLOT_1_IN_SYNC_ENTITY, set_dirty=False)
+        # Someone changed the code on the lock; the coordinator saw it.
+        lock.codes[1] = "9999"
+        manager._coordinator.data[pin_address(1)] = SlotCredential.known("9999")
+        manager._state = SyncState.OUT_OF_SYNC
+
+        with patch.object(
+            manager._coordinator,
+            "async_refresh",
+            wraps=manager._coordinator.async_refresh,
+        ) as tick_refresh:
+            await manager._async_tick_impl()
+        tick_refresh.assert_not_awaited()
+        assert manager._state is SyncState.PENDING_CONFIRMATION
+        assert lock.codes[1] == "1234"
+
+        await hass.async_block_till_done()  # the coordinator's immediate look
+        assert manager._coordinator.is_verified(pin_address(1)) is True
+        await manager._async_tick_impl()
+        assert manager._state is SyncState.IN_SYNC

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -2114,3 +2114,74 @@ class TestPendingWritesOwnedByCoordinator:
         assert manager._coordinator.is_verified(pin_address(1)) is True
         await manager._async_tick_impl()
         assert manager._state is SyncState.IN_SYNC
+
+    async def test_external_deletion_pushed_with_nothing_pending_goes_out_of_sync(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """A code deleted at the lock and pushed as empty is out of sync (#1538).
+
+        Nothing is pending, so the observation is the lock's word, and an
+        active slot the lock says is empty must not stay in sync.
+        """
+        manager = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)._sync_manager
+        await async_trigger_sync_tick(hass, SLOT_1_IN_SYNC_ENTITY, set_dirty=False)
+        assert manager._state is SyncState.IN_SYNC
+
+        # Deleted at the lock, and the lock says so.
+        manager._lock.codes.pop(1)
+        manager._lock._confirm_slot(1, SlotCredential.empty())
+        await hass.async_block_till_done()
+        assert manager._coordinator.data[pin_address(1)] == SlotCredential.empty()
+        assert manager._state is SyncState.OUT_OF_SYNC
+
+        # The tick re-programs it and waits for the read to see it.
+        await manager._async_tick()
+        assert manager._lock.codes[1] == "1234"
+        assert manager._state is SyncState.PENDING_CONFIRMATION
+
+    async def test_failed_direct_write_on_an_in_sync_slot_is_not_charged_later(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """A direct write of another PIN that the lock did not keep is nobody's strike.
+
+        The slot stays in sync on the configured PIN, so the failed write is
+        judged and discarded now, rather than lingering to be charged to the
+        next sync that happens to run.
+        """
+        manager = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)._sync_manager
+        await async_trigger_sync_tick(hass, SLOT_1_IN_SYNC_ENTITY, set_dirty=False)
+        assert manager._state is SyncState.IN_SYNC
+        assert manager._lock.codes[1] == "1234"
+
+        # A direct service write of "0000" the lock did not keep; the
+        # coordinator's read shows the slot still holding the configured PIN.
+        manager._coordinator.record_write(pin_address(1), "0000", believed=False)
+        await manager._coordinator.async_confirm_pending_writes()
+        await hass.async_block_till_done()
+
+        assert manager._state is SyncState.IN_SYNC
+        assert manager._coordinator.take_failed_write(pin_address(1)) is False
+
+    async def test_failed_direct_write_seen_by_a_push_on_an_in_sync_slot_is_discarded(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """The push-path twin: a push showing the configured PIN fails the stray write."""
+        manager = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)._sync_manager
+        await async_trigger_sync_tick(hass, SLOT_1_IN_SYNC_ENTITY, set_dirty=False)
+        assert manager._state is SyncState.IN_SYNC
+
+        manager._coordinator.record_write(pin_address(1), "0000", believed=False)
+        manager._lock._confirm_slot(1, SlotCredential.known("1234"))
+        await hass.async_block_till_done()
+
+        assert manager._state is SyncState.IN_SYNC
+        assert manager._coordinator.take_failed_write(pin_address(1)) is False


### PR DESCRIPTION
## Proposed change

One of the four symptoms in #1538: LCM reported users as **in sync** while `matter.get_lock_users` showed the lock held no PIN credentials at all.

### The bug

`calculate_in_sync` overrode a lock that said the slot held nothing, on the strength of the last PIN it wrote there. Nothing made that write *recent*: `_last_set_pin` was set on every successful write and cleared only by a clear or a restart. A poll that read the slot empty marked the address verified, the override passed, and a credential deleted out of band read as synchronized forever, with no tick to put it back because a slot in sync has nothing to do.

### The fix

An active slot the lock verifiably reports empty is never in sync. Full stop, no clock.

That alone would make a polled lock re-sync every tick until its scan interval caught up with its own write, so a **confirmed write stays pending until a read or push has seen it on the lock**. #1539 built that on the provider and the sync tick and never converged: four review rounds each found a new hole in the same place, because the tick and the coordinator were two schedulers over one piece of state (a read the tick asked for that the coordinator throttled; a throttle keyed on the wrong read; a timeout that could charge without a read; a read failure charging the lock breaker at tick cadence). This PR gives the whole thing to the coordinator, which already owned the reads.

**The coordinator owns a write from sent to seen.**

- `record_write(address, pin, believed=)` is the seam's one call after a write. OPTIMISTIC is recorded *believed* (the value shows at once, and keeps showing while the coordinator waits for the lock); a poller's CONFIRMED is recorded *not believed* (the cloud accepted it, the lock has not said); a push provider's CONFIRMED records nothing, because its own push is the lock's word. `is_verified(address)` is exactly "nothing pending here". The `_unverified` set, `mark_verified`, and the provider's `_pending_writes` dict are gone.
- **One confirmation look per lock**, however many slots are pending: a task straight after the write (non-eager, so it cannot reenter the provider before the provider's own write has returned), then a timer every `CONFIRM_READ_INTERVAL` (a quarter of `PENDING_WRITE_TTL`) while anything is pending. A write that lands while the timer is waiting pulls the look forward onto the same chain; the timer's own read is that same tracked task, so shutdown cancels whatever is in flight and a coordinator that has shut down records nothing. Pollers are read through their poll path, scoped to managed and pending slots so a direct write to an unmanaged slot is asked about too; push providers hard-refresh. The look never charges the lock breaker: a failed read is not the lock's word.
- **A write fails** when a read past the deadline still does not show it (including a completed read that simply does not name the slot, which for a whole-device refresh is the lock not holding it), or when a read (or push) shows the slot holding a *different* code. Both are the lock not keeping what we wrote, and both leave one charge for the tick to take via `take_failed_write`, once. A read that keeps failing past the deadline gives the write up too (logged at info with the cause), so a lock whose writes land but whose reads never return ends in a visible re-sync rather than a silent pending state. On a write-only lock, whose slots read as unreadable, that re-sync settles on the last PIN written, since that is the only evidence such a lock ever offers; this PR keeps that trade deliberately.
- **A failed write that leaves the slot in sync is discarded, not banked.** A direct service write of some other PIN that the lock did not keep fails against a slot still holding the configured PIN. The coordinator wakes the sync layer even though the data did not move, and the in-sync check discards the failure, so no later, unrelated sync is charged and warned for a write it never made.
- **The tick only watches.** With a write pending it parks in `PENDING_CONFIRMATION` and issues no read of its own; a pending write the user no longer wants (PIN changed, slot disabled) is dropped without a charge; a failed write is charged and re-synced on the *next* tick, so a confirming push landing in between still counts first. The post-set refresh is skipped when the coordinator has already gone to read the lock back.
- **zwave_js pushes the value it wrote before returning CONFIRMED**, like every other push provider. It was the one that did not, which left a stale `empty()` on the coordinator to be judged against.
- **zwave_js treats an empty `userCode` event on an occupied slot as withheld, not cleared**, the rule its read path's occupancy overlay already applied. An absent push now fails a pending write, so a User Code lock that reports the slot in use but withholds the code must not read as empty, or a working PIN would be re-set and suspended.

### What it does not carry from #1539

- `_last_set_pin` stays on the sync manager. Moving it to the provider is right (direct writes bypass the sync manager) but is its own change, and Matter's `async_release_managed_slot` would need to forget it too.
- The pre-existing AVAILABLE guard in zwave_js has the same deletion-hiding shape as the guard reverted in #1539, and the three "expects a PIN" guards across zwave_js/zwave_js_ui should be one predicate or none. Both noted, neither touched here.

### The breaker bound, stated honestly

A write the lock never keeps is given up by the first look at or after `PENDING_WRITE_TTL`, so one failed cycle is the TTL plus up to `CONFIRM_READ_INTERVAL` plus the read and the re-set, and the slot breaker trips only when three such failures land inside `SYNC_ATTEMPT_WINDOW`. With the defaults that leaves roughly a minute of read-plus-write latency per cycle before the third failure falls outside the window. The pre-PR tick charged at the TTL regardless of reads and had a bound of the same shape (two cycles of TTL plus the re-set); the constants' comment now states the real one instead of "three TTLs fit".

### Known limit, not this PR

zwave-js-ui in API-only mode (no push) maps a per-slot read that times out to `unreadable`, and an unreadable read confirms a pending write like any other present observation. So on a lossy mesh a write can be confirmed by silence. The mapping predates this PR (the same slot reached in-sync via `_last_set_pin` before), and separating "occupied but masked" from "did not answer" is the credential-state question already on file.

### Verification

- Full suite green at 100% line coverage under HA 2026.9.0b4.
- Sixteen mutants, one per invariant, each killed by the test written for it: verified-empty active slot never in sync; unverified slot never in sync; poller CONFIRMED pending until seen; push CONFIRMED records nothing; zwave_js pushes before returning; absent read before the deadline keeps waiting; absent read at the deadline fails the write once; displaced readable read fails the write (read and push paths); one look per lock; the look does not start eagerly; a stale drop does not charge; the tick charges a failed write; the tick does not read while a write is pending.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: the false in-sync symptom of #1538 (the other three symptoms are tracked there and are not closed by this PR)
- This PR is related to issue: #1538
- Supersedes #1539, which is closed in favour of this redesign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
