### PR TITLE
fix: a Matter user deleted outside LCM empties its slot at once (#1538)

### DIFF
--- a/custom_components/lock_code_manager/providers/matter.py
+++ b/custom_components/lock_code_manager/providers/matter.py
@@ -28,6 +28,7 @@ from homeassistant.components.matter.lock_helpers import (
     SetCredentialFailedError,
     clear_lock_credential,
     clear_lock_user,
+    get_lock_credential_status,
     get_lock_info,
     get_lock_users,
     set_lock_credential,
@@ -493,7 +494,7 @@ class MatterLock(BaseLock):
         # credential index are narrowed by explicit guards before use: the
         # Matter helper types both as ``int | None``.
         users: list[User] = []
-        slot_by_user_index: dict[int, int] = {}
+        anchors: dict[int, int | None] = {}
         for raw_user in await self._raw_lock_users():
             user_index = raw_user.get("user_index")
             if user_index is None:
@@ -502,8 +503,7 @@ class MatterLock(BaseLock):
             lcm_slot_from_tag: int | None = None
             if user_name:
                 lcm_slot_from_tag, _ = parse_tag(user_name)
-            if lcm_slot_from_tag is not None:
-                slot_by_user_index[user_index] = lcm_slot_from_tag
+            anchors[user_index] = lcm_slot_from_tag
             pin_credentials: list[Credential] = []
             for cred in raw_user.get("credentials") or []:
                 credential_index = cred.get("index")
@@ -529,7 +529,14 @@ class MatterLock(BaseLock):
                     credentials=pin_credentials,
                 )
             )
-        self._slot_by_user_index = slot_by_user_index
+        # Merge, never replace: a user that has vanished keeps its entry, so
+        # the CLEAR event that follows can still say which slot emptied. A
+        # user still present overwrites its entry -- or, untagged, removes it.
+        for index, anchored in anchors.items():
+            if anchored is None:
+                self._slot_by_user_index.pop(index, None)
+            else:
+                self._slot_by_user_index[index] = anchored
         return users
 
     async def async_get_capabilities(self) -> LockCapabilities:
@@ -1083,57 +1090,99 @@ class MatterLock(BaseLock):
                     reason=str(retry_err),
                 ) from retry_err
 
-        await self._verify_credential_landed(slot, user_id, result)
+        await self._verify_credential_landed(client, node, slot, user_id, result)
         self._push_credential_update(slot, SlotCredential.unreadable())
         return WriteResult.CONFIRMED
 
     async def _verify_credential_landed(
-        self, slot: int, user_id: int, result: dict[str, Any]
+        self,
+        client: Any,
+        node: Any,
+        slot: int,
+        user_id: int,
+        result: dict[str, Any],
     ) -> None:
         """
-        Check the lock filed the PIN under the user it was written for.
+        Check the lock associated the PIN with the user it was written for.
 
-        PINs are write-only, so this is the only pairing check there is: the
-        lock's answer names the credential index it allocated, and a re-read
-        shows which user holds that index. A PIN filed under another user
-        opens the door as somebody else while every slot still reads
-        occupied, so it is raised as a failed write -- the slot breaker
-        sees it and the slot suspends with the real reason -- rather than
-        pushed as a success.
+        PINs are write-only, so this is the only pairing check there is. The
+        helper's answer names the credential index it wrote to; the lock's
+        own GetCredentialStatus for that index names the user it associated
+        the credential with. A PIN filed under another user opens the door
+        as somebody else while every slot still reads occupied, so it is
+        cleared again and raised as a failed write -- the slot breaker sees
+        it and the slot suspends with the real reason -- rather than pushed
+        as a success.
+
+        A status read that fails proves nothing either way. The write has
+        landed; undoing it over an unanswered question (the seam rolls a
+        just-created user back on any error) would be worse than leaving
+        it unverified, so the failure is logged and the write stands.
         """
         credential_index = result.get("credential_index")
-        reported_user = result.get("user_index")
         LOGGER.debug(
-            "Lock %s: PIN for slot %s written to user_index %s; the lock reports "
-            "user_index %s, credential_index %s",
+            "Lock %s: PIN for slot %s written to user_index %s at credential_index %s",
             self.lock.entity_id,
             slot,
             user_id,
-            reported_user,
             credential_index,
         )
-        if reported_user is not None and reported_user != user_id:
-            raise LockOperationFailed(
-                f"{self.lock.entity_id}: the lock associated the PIN for slot "
-                f"{slot} with user {reported_user}, not user {user_id}"
-            )
         if credential_index is None:
             return
-        owner = next(
-            (
-                raw_user.get("user_index")
-                for raw_user in await self._raw_lock_users()
-                for cred in raw_user.get("credentials") or []
-                if cred.get("type") == "pin" and cred.get("index") == credential_index
-            ),
-            None,
-        )
-        if owner is not None and owner != user_id:
-            raise LockOperationFailed(
-                f"{self.lock.entity_id}: the lock filed the PIN for slot {slot} "
-                f"(credential {credential_index}) under user {owner}, not user "
-                f"{user_id}"
+        try:
+            status = await self._invoke_sdk(
+                "get_lock_credential_status",
+                get_lock_credential_status(
+                    client,
+                    node,
+                    credential_type="pin",
+                    credential_index=credential_index,
+                ),
             )
+        except (LockDisconnected, LockOperationFailed) as err:
+            LOGGER.debug(
+                "Lock %s: could not verify which user holds credential %s "
+                "written for slot %s: %s",
+                self.lock.entity_id,
+                credential_index,
+                slot,
+                err,
+            )
+            return
+        owner = status.get("user_index")
+        if owner is None or owner == user_id:
+            return
+        LOGGER.warning(
+            "Lock %s: the lock filed the PIN for slot %s (credential %s) under "
+            "user %s, not user %s; clearing it so it cannot open the door as "
+            "somebody else",
+            self.lock.entity_id,
+            slot,
+            credential_index,
+            owner,
+            user_id,
+        )
+        try:
+            await self._invoke_sdk(
+                "clear_lock_credential",
+                clear_lock_credential(
+                    client,
+                    node,
+                    credential_type="pin",
+                    credential_index=credential_index,
+                ),
+            )
+        except (LockDisconnected, LockOperationFailed) as err:
+            LOGGER.warning(
+                "Lock %s: could not clear misfiled credential %s: %s",
+                self.lock.entity_id,
+                credential_index,
+                err,
+            )
+        raise LockOperationFailed(
+            f"{self.lock.entity_id}: the lock filed the PIN for slot {slot} "
+            f"(credential {credential_index}) under user {owner}, not user {user_id}"
+        )
 
     async def async_delete_credential(self, ref: CredentialRef) -> bool:
         """

--- a/custom_components/lock_code_manager/providers/matter.py
+++ b/custom_components/lock_code_manager/providers/matter.py
@@ -11,7 +11,7 @@ and occupancy updates (LockUserChange).
 from __future__ import annotations
 
 from collections.abc import Collection
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import timedelta
 from typing import Any, Literal
 
@@ -75,7 +75,11 @@ _THREAD_TX_ACKED_COUNT = 26
 _LOCK_OPERATION_EVENT_ID = 2
 _LOCK_USER_CHANGE_EVENT_ID = 4
 
-# LockUserChange LockDataType values
+# LockUserChange LockDataType values. A user-record change is handled too:
+# ClearUser (what Home Assistant's Manage access deletion sends) removes the
+# user together with its credentials, and the user-level CLEAR is the event
+# that says so.
+_LOCK_DATA_TYPE_USER_INDEX = 2
 _LOCK_DATA_TYPE_PIN = 6
 
 # LockUserChange DataOperationType values
@@ -173,6 +177,12 @@ def _lcm_slot_from_raw_users_by_credential_index(
 @dataclass(repr=False, eq=False)
 class MatterLock(BaseLock):
     """Class to represent a Matter lock."""
+
+    # The LCM slot each lock-side user index anchored at the last read or
+    # write. A LockUserChange for a user that no longer exists cannot be
+    # resolved by reading the lock -- ClearUser takes the user and its
+    # credentials away together -- so this is what says which slot emptied.
+    _slot_by_user_index: dict[int, int] = field(default_factory=dict, init=False)
 
     @property
     def domain(self) -> str:
@@ -483,6 +493,7 @@ class MatterLock(BaseLock):
         # credential index are narrowed by explicit guards before use: the
         # Matter helper types both as ``int | None``.
         users: list[User] = []
+        slot_by_user_index: dict[int, int] = {}
         for raw_user in await self._raw_lock_users():
             user_index = raw_user.get("user_index")
             if user_index is None:
@@ -491,6 +502,8 @@ class MatterLock(BaseLock):
             lcm_slot_from_tag: int | None = None
             if user_name:
                 lcm_slot_from_tag, _ = parse_tag(user_name)
+            if lcm_slot_from_tag is not None:
+                slot_by_user_index[user_index] = lcm_slot_from_tag
             pin_credentials: list[Credential] = []
             for cred in raw_user.get("credentials") or []:
                 credential_index = cred.get("index")
@@ -516,6 +529,7 @@ class MatterLock(BaseLock):
                     credentials=pin_credentials,
                 )
             )
+        self._slot_by_user_index = slot_by_user_index
         return users
 
     async def async_get_capabilities(self) -> LockCapabilities:
@@ -633,6 +647,7 @@ class MatterLock(BaseLock):
                         ", ".join(f"{name!r}: {err}" for name, err in prior_failures),
                         name_used,
                     )
+            self._slot_by_user_index[existing_user_index] = slot
             return SetUserResult(user_id=existing_user_index, created=False)
 
         # CREATE: no LCM-tagged user exists for this slot yet — let
@@ -668,6 +683,7 @@ class MatterLock(BaseLock):
                 ", ".join(f"{name!r}: {err}" for name, err in prior_failures),
                 name_used,
             )
+        self._slot_by_user_index[result["user_index"]] = slot
         return SetUserResult(user_id=result["user_index"], created=True)
 
     @staticmethod
@@ -839,6 +855,7 @@ class MatterLock(BaseLock):
         await self._invoke_sdk(
             "clear_lock_user", clear_lock_user(client, node, user_id)
         )
+        self._slot_by_user_index.pop(user_id, None)
 
     async def async_release_managed_slot(self, slot: int) -> None:
         """
@@ -876,9 +893,12 @@ class MatterLock(BaseLock):
         pin: str,
         user_id: int,
         credential_index: int | None,
-    ) -> None:
+    ) -> dict[str, Any]:
         """
         Send set_lock_credential to the lock for the given user and PIN.
+
+        Returns the lock's answer: the credential index it filed the PIN
+        under and the user it associated it with.
 
         ``credential_index=None`` auto-allocates the next free credential slot
         (CREATE). Passing an existing index addresses the user's current PIN
@@ -890,13 +910,15 @@ class MatterLock(BaseLock):
         LockDisconnected on communication failure.
         """
         try:
-            await set_lock_credential(
-                client,
-                node,
-                credential_type="pin",
-                credential_data=pin,
-                credential_index=credential_index,
-                user_index=user_id,
+            return dict(
+                await set_lock_credential(
+                    client,
+                    node,
+                    credential_type="pin",
+                    credential_data=pin,
+                    credential_index=credential_index,
+                    user_index=user_id,
+                )
             )
         except SetCredentialFailedError:
             raise
@@ -971,7 +993,7 @@ class MatterLock(BaseLock):
         )
 
         try:
-            await self._send_set_credential(
+            result = await self._send_set_credential(
                 client, node, slot, pin, user_id, existing_credential_index
             )
         except SetCredentialFailedError as err:
@@ -1039,7 +1061,9 @@ class MatterLock(BaseLock):
             try:
                 # Retry with credential_index=None so Matter auto-allocates a
                 # fresh slot; we cleared the old one above.
-                await self._send_set_credential(client, node, slot, pin, user_id, None)
+                result = await self._send_set_credential(
+                    client, node, slot, pin, user_id, None
+                )
             except SetCredentialFailedError as retry_err:
                 retry_status = (retry_err.translation_placeholders or {}).get(
                     "status", ""
@@ -1059,8 +1083,57 @@ class MatterLock(BaseLock):
                     reason=str(retry_err),
                 ) from retry_err
 
+        await self._verify_credential_landed(slot, user_id, result)
         self._push_credential_update(slot, SlotCredential.unreadable())
         return WriteResult.CONFIRMED
+
+    async def _verify_credential_landed(
+        self, slot: int, user_id: int, result: dict[str, Any]
+    ) -> None:
+        """
+        Check the lock filed the PIN under the user it was written for.
+
+        PINs are write-only, so this is the only pairing check there is: the
+        lock's answer names the credential index it allocated, and a re-read
+        shows which user holds that index. A PIN filed under another user
+        opens the door as somebody else while every slot still reads
+        occupied, so it is raised as a failed write -- the slot breaker
+        sees it and the slot suspends with the real reason -- rather than
+        pushed as a success.
+        """
+        credential_index = result.get("credential_index")
+        reported_user = result.get("user_index")
+        LOGGER.debug(
+            "Lock %s: PIN for slot %s written to user_index %s; the lock reports "
+            "user_index %s, credential_index %s",
+            self.lock.entity_id,
+            slot,
+            user_id,
+            reported_user,
+            credential_index,
+        )
+        if reported_user is not None and reported_user != user_id:
+            raise LockOperationFailed(
+                f"{self.lock.entity_id}: the lock associated the PIN for slot "
+                f"{slot} with user {reported_user}, not user {user_id}"
+            )
+        if credential_index is None:
+            return
+        owner = next(
+            (
+                raw_user.get("user_index")
+                for raw_user in await self._raw_lock_users()
+                for cred in raw_user.get("credentials") or []
+                if cred.get("type") == "pin" and cred.get("index") == credential_index
+            ),
+            None,
+        )
+        if owner is not None and owner != user_id:
+            raise LockOperationFailed(
+                f"{self.lock.entity_id}: the lock filed the PIN for slot {slot} "
+                f"(credential {credential_index}) under user {owner}, not user "
+                f"{user_id}"
+            )
 
     async def async_delete_credential(self, ref: CredentialRef) -> bool:
         """
@@ -1379,7 +1452,10 @@ class MatterLock(BaseLock):
         added, modified, or cleared. Real-time change detection without
         waiting for the next poll cycle.
 
-        Only PIN credentials (LockDataType=6) are handled.
+        PIN credential changes (LockDataType=6) are handled, and so is a
+        user record being cleared (LockDataType=2): ClearUser removes the
+        user with its credentials, and for a deletion made outside LCM that
+        event is the only word the lock gives.
 
         The LCM slot is resolved by walking the event's ``userIndex`` to
         the owning user's name and parsing its ``lcm:<slot>:`` tag --
@@ -1394,7 +1470,8 @@ class MatterLock(BaseLock):
         """
         data: dict[str, Any] = getattr(node_event, "data", None) or {}
 
-        if data.get("lockDataType") != _LOCK_DATA_TYPE_PIN:
+        data_type = data.get("lockDataType")
+        if data_type not in (_LOCK_DATA_TYPE_PIN, _LOCK_DATA_TYPE_USER_INDEX):
             return
 
         user_index = parse_slot_num(data.get("userIndex"))
@@ -1413,6 +1490,10 @@ class MatterLock(BaseLock):
         operation = data.get("dataOperationType")
         if operation == _DATA_OP_CLEAR:
             resolved = SlotCredential.empty()
+        elif data_type == _LOCK_DATA_TYPE_USER_INDEX:
+            # A user record added or renamed says nothing about its PIN;
+            # the paired PIN event does.
+            return
         elif operation in (_DATA_OP_ADD, _DATA_OP_MODIFY):
             resolved = SlotCredential.unreadable()
         else:
@@ -1441,23 +1522,28 @@ class MatterLock(BaseLock):
         Resolve the LCM slot for a LockUserChange and push the update.
 
         Fetches the lock's current user list, finds the owner by
-        ``user_index``, parses its ``lcm:<slot>:`` tag, and pushes the
-        update. Events whose owning user isn't LCM-tagged are ignored so
-        out-of-band credential changes on non-LCM users don't drive
-        spurious coordinator updates.
+        ``user_index``, parses its ``lcm:<slot>:`` tag, and hands the
+        observation to the coordinator. A cleared user is no longer in
+        that list, so a CLEAR falls back to the slot the index anchored at
+        the last read or write. Events whose owning user isn't LCM-tagged
+        are ignored so out-of-band credential changes on non-LCM users
+        don't drive spurious coordinator updates.
         """
+        code_slot: int | None = None
         try:
             raw_users = await self._raw_lock_users()
         except (LockDisconnected, LockOperationFailed) as err:
             LOGGER.debug(
-                "Lock %s: could not resolve LockUserChange userIndex %s: %s",
+                "Lock %s: could not read users to resolve LockUserChange "
+                "userIndex %s: %s",
                 self.lock.entity_id,
                 user_index,
                 err,
             )
-            return
-
-        code_slot = _lcm_slot_from_raw_users_by_user_index(raw_users, user_index)
+        else:
+            code_slot = _lcm_slot_from_raw_users_by_user_index(raw_users, user_index)
+        if code_slot is None and resolved.is_empty:
+            code_slot = self._slot_by_user_index.pop(user_index, None)
         if code_slot is None:
             LOGGER.debug(
                 "Lock %s: LockUserChange userIndex %s did not resolve to an "
@@ -1474,7 +1560,7 @@ class MatterLock(BaseLock):
             operation,
             resolved,
         )
-        self._push_credential_update(code_slot, resolved)
+        self._confirm_slot(code_slot, resolved)
 
     async def async_hard_refresh_codes(self) -> dict[int, SlotCredential]:
         """

--- a/custom_components/lock_code_manager/providers/matter.py
+++ b/custom_components/lock_code_manager/providers/matter.py
@@ -1150,6 +1150,15 @@ class MatterLock(BaseLock):
             )
             return
         owner = status.get("user_index")
+        LOGGER.debug(
+            "Lock %s: the lock reports credential %s for slot %s exists=%s under "
+            "user_index %s",
+            self.lock.entity_id,
+            credential_index,
+            slot,
+            status.get("credential_exists"),
+            owner,
+        )
         if owner is None or owner == user_id:
             return
         LOGGER.warning(
@@ -1591,6 +1600,12 @@ class MatterLock(BaseLock):
             )
         else:
             code_slot = _lcm_slot_from_raw_users_by_user_index(raw_users, user_index)
+            if code_slot is None and any(
+                raw_user.get("user_index") == user_index for raw_user in raw_users
+            ):
+                # Present but untagged: somebody else's user now, whatever
+                # this index anchored before.
+                self._slot_by_user_index.pop(user_index, None)
         if code_slot is None and resolved.is_empty:
             code_slot = self._slot_by_user_index.pop(user_index, None)
         if code_slot is None:

--- a/tests/providers/matter/conftest.py
+++ b/tests/providers/matter/conftest.py
@@ -221,6 +221,12 @@ def matter_mock_helpers() -> dict[str, AsyncMock]:
         return_value={"credential_index": 1, "user_index": 1},
     )
 
+    # get_lock_credential_status: the pairing check after a set asks which user
+    # holds the written credential; user 1 matches set_lock_credential above.
+    helpers["get_lock_credential_status"] = AsyncMock(
+        return_value={"credential_exists": True, "user_index": 1},
+    )
+
     # set_lock_user: called by async_set_user
     helpers["set_lock_user"] = AsyncMock(return_value={"user_index": 1})
 
@@ -267,6 +273,10 @@ async def lcm_config_entry(
         patch(
             f"{_PROVIDER_MODULE}.set_lock_credential",
             matter_mock_helpers["set_lock_credential"],
+        ),
+        patch(
+            f"{_PROVIDER_MODULE}.get_lock_credential_status",
+            matter_mock_helpers["get_lock_credential_status"],
         ),
         patch(
             f"{_PROVIDER_MODULE}.set_lock_user",

--- a/tests/providers/matter/conftest.py
+++ b/tests/providers/matter/conftest.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import AsyncGenerator
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from matter_server.client.models.node import MatterNode
@@ -216,15 +217,30 @@ def matter_mock_helpers() -> dict[str, AsyncMock]:
         }
     )
 
-    # set_lock_credential: called by async_set_credential
-    helpers["set_lock_credential"] = AsyncMock(
-        return_value={"credential_index": 1, "user_index": 1},
-    )
+    # set_lock_credential: called by async_set_credential. Echoes the request,
+    # as the real helper does, so a write for any slot is answered for its
+    # own user.
+    last_write: dict[str, Any] = {}
+
+    async def _set_lock_credential(*_args: Any, **kwargs: Any) -> dict[str, Any]:
+        last_write.update(kwargs)
+        return {
+            "credential_index": kwargs.get("credential_index") or 1,
+            "user_index": kwargs.get("user_index"),
+        }
+
+    helpers["set_lock_credential"] = AsyncMock(side_effect=_set_lock_credential)
 
     # get_lock_credential_status: the pairing check after a set asks which user
-    # holds the written credential; user 1 matches set_lock_credential above.
+    # holds the written credential; the lock answers with the user it was
+    # written for, so no honest write is judged misfiled.
+    async def _get_lock_credential_status(
+        *_args: Any, **_kwargs: Any
+    ) -> dict[str, Any]:
+        return {"credential_exists": True, "user_index": last_write.get("user_index")}
+
     helpers["get_lock_credential_status"] = AsyncMock(
-        return_value={"credential_exists": True, "user_index": 1},
+        side_effect=_get_lock_credential_status
     )
 
     # set_lock_user: called by async_set_user

--- a/tests/providers/matter/test_e2e.py
+++ b/tests/providers/matter/test_e2e.py
@@ -2,13 +2,18 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
+from matter_server.client.models.node import MatterNode
+from matter_server.common.models import EventType, MatterNodeEvent
+import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
+from custom_components.lock_code_manager.const import TICK_INTERVAL
 from custom_components.lock_code_manager.domain.credentials import (
     WriteResult,
     pin_address,
@@ -17,6 +22,9 @@ from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers.matter import MatterLock
 
 # Module path where lock_helpers functions are imported in the provider
+from tests.common import in_sync_entity_id
+from tests.conftest import async_advance_time, async_initial_tick
+
 _PROVIDER_MODULE = "custom_components.lock_code_manager.providers.matter"
 
 
@@ -205,3 +213,111 @@ class TestGetUsercodes:
 
         assert codes[1] is SlotCredential.unreadable()
         assert codes[2] is SlotCredential.empty()
+
+
+# =============================================================================
+# The #1538 symptom, end to end on a real coordinator
+# =============================================================================
+
+_TAGGED_USERS = {
+    "max_users": 10,
+    "users": [
+        {
+            "user_index": 1,
+            "user_name": "lcm:1:slot1",
+            "credentials": [{"type": "pin", "index": 1}],
+        },
+        {
+            "user_index": 2,
+            "user_name": "lcm:2:slot2",
+            "credentials": [{"type": "pin", "index": 2}],
+        },
+    ],
+}
+_AFTER_USER_ONE_DELETED = {"max_users": 10, "users": _TAGGED_USERS["users"][1:]}
+
+
+def _user_cleared_event(node_id: int, user_index: int) -> MatterNodeEvent:
+    """The LockUserChange a lock emits for ClearUser (a user record, cleared)."""
+    return MatterNodeEvent(
+        node_id=node_id,
+        endpoint_id=1,
+        cluster_id=257,
+        event_id=4,
+        event_number=0,
+        priority=1,
+        timestamp=0,
+        timestamp_type=0,
+        data={
+            "lockDataType": 2,
+            "dataOperationType": 1,
+            "dataIndex": user_index,
+            "userIndex": user_index,
+        },
+    )
+
+
+class TestOutOfBandDeletion:
+    """A credential deleted through Manage access is noticed and put back."""
+
+    @pytest.fixture
+    def matter_mock_helpers(
+        self, matter_mock_helpers: dict[str, AsyncMock]
+    ) -> dict[str, AsyncMock]:
+        """LCM-tagged users, as the provider itself would have written them."""
+        matter_mock_helpers["get_lock_users"].return_value = _TAGGED_USERS
+        return matter_mock_helpers
+
+    async def test_clear_user_flips_in_sync_off_and_sync_recreates_the_pin(
+        self,
+        hass: HomeAssistant,
+        matter_client: MagicMock,
+        matter_node: MatterNode,
+        lock_entity: er.RegistryEntry,
+        lcm_config_entry: MockConfigEntry,
+        matter_mock_helpers: dict[str, AsyncMock],
+    ) -> None:
+        """Issue #1538 on a Matter lock: the deletion is seen at once, not hourly.
+
+        Manage access sends ClearUser, so the lock no longer lists the user
+        when the event arrives; the slot it anchored is resolved from the
+        provider's last read. The in-sync sensor goes off on the event, the
+        next tick writes the PIN back for the same user, and the sensor
+        returns to on once the lock lists the user again.
+        """
+        in_sync = in_sync_entity_id(hass, lcm_config_entry, 1, lock_entity.entity_id)
+        await async_initial_tick(hass, in_sync)
+        for _ in range(3):
+            if hass.states.get(in_sync).state == STATE_ON:
+                break
+            await async_advance_time(hass, TICK_INTERVAL)
+        assert hass.states.get(in_sync).state == STATE_ON
+
+        lock = lcm_config_entry.runtime_data.locks[lock_entity.entity_id]
+        # Home Assistant's own Matter lock entity subscribes to the same node
+        # events; take the provider's subscription, not the platform's.
+        deliver = next(
+            call.kwargs["callback"]
+            for call in matter_client.subscribe_events.call_args_list
+            if call.kwargs.get("event_filter") == EventType.NODE_EVENT
+            and call.kwargs.get("node_filter") == matter_node.node_id
+            and getattr(call.kwargs["callback"], "__self__", None) is lock
+        )
+
+        matter_mock_helpers["get_lock_users"].return_value = _AFTER_USER_ONE_DELETED
+        matter_mock_helpers["set_lock_credential"].reset_mock()
+        deliver(EventType.NODE_EVENT, _user_cleared_event(matter_node.node_id, 1))
+        await hass.async_block_till_done()
+        assert hass.states.get(in_sync).state == STATE_OFF
+
+        await async_advance_time(hass, TICK_INTERVAL * 2)
+        writes = matter_mock_helpers["set_lock_credential"].await_args_list
+        assert any(
+            call.kwargs.get("credential_data") == "1234"
+            and call.kwargs.get("user_index") == 1
+            for call in writes
+        ), [call.kwargs for call in writes]
+
+        matter_mock_helpers["get_lock_users"].return_value = _TAGGED_USERS
+        await async_advance_time(hass, TICK_INTERVAL * 3)
+        assert hass.states.get(in_sync).state == STATE_ON

--- a/tests/providers/matter/test_provider.py
+++ b/tests/providers/matter/test_provider.py
@@ -1498,8 +1498,8 @@ class TestLockUserChangeEvent:
             )
             await hass.async_block_till_done()
 
-        mock_coordinator.push_update.assert_called_once_with(
-            {3: SlotCredential.unreadable()}
+        mock_coordinator.observe_push.assert_called_once_with(
+            pin_address(3), SlotCredential.unreadable()
         )
 
     async def test_pin_modified_pushes_unknown(
@@ -1533,8 +1533,8 @@ class TestLockUserChangeEvent:
             )
             await hass.async_block_till_done()
 
-        mock_coordinator.push_update.assert_called_once_with(
-            {5: SlotCredential.unreadable()}
+        mock_coordinator.observe_push.assert_called_once_with(
+            pin_address(5), SlotCredential.unreadable()
         )
 
     async def test_pin_cleared_pushes_empty(
@@ -1568,8 +1568,8 @@ class TestLockUserChangeEvent:
             )
             await hass.async_block_till_done()
 
-        mock_coordinator.push_update.assert_called_once_with(
-            {2: SlotCredential.empty()}
+        mock_coordinator.observe_push.assert_called_once_with(
+            pin_address(2), SlotCredential.empty()
         )
 
     async def test_pin_event_for_untagged_user_ignored(
@@ -1607,7 +1607,7 @@ class TestLockUserChangeEvent:
             )
             await hass.async_block_till_done()
 
-        mock_coordinator.push_update.assert_not_called()
+        mock_coordinator.observe_push.assert_not_called()
 
     async def test_pin_event_with_unknown_operation_ignored(
         self, hass: HomeAssistant, matter_lock: MatterLock
@@ -1635,7 +1635,7 @@ class TestLockUserChangeEvent:
         )
         await hass.async_block_till_done()
 
-        mock_coordinator.push_update.assert_not_called()
+        mock_coordinator.observe_push.assert_not_called()
 
     async def test_pin_event_with_missing_data_index_still_fires(
         self, hass: HomeAssistant, matter_lock: MatterLock
@@ -1675,8 +1675,8 @@ class TestLockUserChangeEvent:
             )
             await hass.async_block_till_done()
 
-        mock_coordinator.push_update.assert_called_once_with(
-            {3: SlotCredential.unreadable()}
+        mock_coordinator.observe_push.assert_called_once_with(
+            pin_address(3), SlotCredential.unreadable()
         )
 
     async def test_pin_event_dispatch_swallows_lock_disconnected(
@@ -1710,7 +1710,7 @@ class TestLockUserChangeEvent:
             )
             await hass.async_block_till_done()
 
-        mock_coordinator.push_update.assert_not_called()
+        mock_coordinator.observe_push.assert_not_called()
 
     async def test_pin_event_for_user_with_no_name_ignored(
         self, hass: HomeAssistant, matter_lock: MatterLock
@@ -1747,7 +1747,7 @@ class TestLockUserChangeEvent:
             )
             await hass.async_block_till_done()
 
-        mock_coordinator.push_update.assert_not_called()
+        mock_coordinator.observe_push.assert_not_called()
 
     def test_non_pin_data_type_ignored(self, matter_lock: MatterLock) -> None:
         """Non-PIN LockDataType (e.g. RFID=7) is ignored."""
@@ -1766,7 +1766,7 @@ class TestLockUserChangeEvent:
             ),
         )
 
-        mock_coordinator.push_update.assert_not_called()
+        mock_coordinator.observe_push.assert_not_called()
 
     def test_missing_data_index_ignored(self, matter_lock: MatterLock) -> None:
         """Event with no dataIndex is ignored."""
@@ -1785,7 +1785,7 @@ class TestLockUserChangeEvent:
             ),
         )
 
-        mock_coordinator.push_update.assert_not_called()
+        mock_coordinator.observe_push.assert_not_called()
 
     def test_non_integer_data_index_ignored(self, matter_lock: MatterLock) -> None:
         """Non-integer dataIndex logs warning and is ignored."""
@@ -1804,7 +1804,7 @@ class TestLockUserChangeEvent:
             ),
         )
 
-        mock_coordinator.push_update.assert_not_called()
+        mock_coordinator.observe_push.assert_not_called()
 
     def test_unknown_operation_type_ignored(self, matter_lock: MatterLock) -> None:
         """Unknown DataOperationType is ignored."""
@@ -1823,7 +1823,7 @@ class TestLockUserChangeEvent:
             ),
         )
 
-        mock_coordinator.push_update.assert_not_called()
+        mock_coordinator.observe_push.assert_not_called()
 
     def test_no_coordinator_does_not_crash(self, matter_lock: MatterLock) -> None:
         """LockUserChange with no coordinator attached does not crash."""
@@ -1860,7 +1860,200 @@ class TestLockUserChangeEvent:
             ),
         )
 
-        mock_coordinator.push_update.assert_not_called()
+        mock_coordinator.observe_push.assert_not_called()
+
+    async def test_user_cleared_resolves_through_the_last_read(
+        self, hass: HomeAssistant, matter_lock: MatterLock
+    ) -> None:
+        """Deleting the user empties the slot it anchored (issue #1538).
+
+        Home Assistant's Manage access deletion sends ClearUser, which removes
+        the user with its credentials, so the event cannot be resolved by
+        reading the lock: the user is gone. The slot comes from what the last
+        read said that user index anchored.
+        """
+        mock_coordinator = MagicMock()
+        matter_lock.coordinator = mock_coordinator
+        with self._patch_users(
+            [
+                {
+                    "user_index": 42,
+                    "user_name": "lcm:3:Carol",
+                    "credentials": [{"type": "pin", "index": 7}],
+                }
+            ]
+        ):
+            await matter_lock.async_get_users()
+
+        with self._patch_users([]):
+            matter_lock._on_node_event(
+                None,
+                _make_node_event(
+                    event_id=4,
+                    data={
+                        "lockDataType": 2,  # a user record
+                        "dataOperationType": 1,  # Clear
+                        "dataIndex": 42,
+                        "userIndex": 42,
+                    },
+                ),
+            )
+            await hass.async_block_till_done()
+
+        mock_coordinator.observe_push.assert_called_once_with(
+            pin_address(3), SlotCredential.empty()
+        )
+        # Forgotten once used: a later event for a reused index is not ours.
+        assert 42 not in matter_lock._slot_by_user_index
+
+    async def test_pin_cleared_for_a_vanished_user_resolves_through_the_last_read(
+        self, hass: HomeAssistant, matter_lock: MatterLock
+    ) -> None:
+        """The PIN-level CLEAR that follows a ClearUser resolves the same way."""
+        mock_coordinator = MagicMock()
+        matter_lock.coordinator = mock_coordinator
+        with self._patch_users(
+            [
+                {
+                    "user_index": 8,
+                    "user_name": "lcm:2:Alice",
+                    "credentials": [{"type": "pin", "index": 11}],
+                }
+            ]
+        ):
+            await matter_lock.async_get_users()
+
+        with self._patch_users([]):
+            matter_lock._on_node_event(
+                None,
+                _make_node_event(
+                    event_id=4,
+                    data={
+                        "lockDataType": 6,  # PIN
+                        "dataOperationType": 1,  # Clear
+                        "dataIndex": 11,
+                        "userIndex": 8,
+                    },
+                ),
+            )
+            await hass.async_block_till_done()
+
+        mock_coordinator.observe_push.assert_called_once_with(
+            pin_address(2), SlotCredential.empty()
+        )
+
+    @pytest.mark.parametrize("operation", [0, 2], ids=["add", "modify"])
+    async def test_user_record_added_or_renamed_is_ignored(
+        self, hass: HomeAssistant, matter_lock: MatterLock, operation: int
+    ) -> None:
+        """A user record appearing or changing says nothing about its PIN."""
+        mock_coordinator = MagicMock()
+        matter_lock.coordinator = mock_coordinator
+        with self._patch_users(
+            [
+                {
+                    "user_index": 42,
+                    "user_name": "lcm:3:Carol",
+                    "credentials": [{"type": "pin", "index": 7}],
+                }
+            ]
+        ):
+            matter_lock._on_node_event(
+                None,
+                _make_node_event(
+                    event_id=4,
+                    data={
+                        "lockDataType": 2,
+                        "dataOperationType": operation,
+                        "dataIndex": 42,
+                        "userIndex": 42,
+                    },
+                ),
+            )
+            await hass.async_block_till_done()
+
+        mock_coordinator.observe_push.assert_not_called()
+
+    async def test_pin_added_to_a_vanished_user_is_not_resolved_from_the_map(
+        self, hass: HomeAssistant, matter_lock: MatterLock
+    ) -> None:
+        """Only a CLEAR may resolve through the last read.
+
+        An add or modify for a user the lock no longer lists cannot be
+        believed: resolving it through the map would show a deleted user's
+        slot as occupied.
+        """
+        mock_coordinator = MagicMock()
+        matter_lock.coordinator = mock_coordinator
+        with self._patch_users(
+            [
+                {
+                    "user_index": 42,
+                    "user_name": "lcm:3:Carol",
+                    "credentials": [{"type": "pin", "index": 7}],
+                }
+            ]
+        ):
+            await matter_lock.async_get_users()
+
+        with self._patch_users([]):
+            matter_lock._on_node_event(
+                None,
+                _make_node_event(
+                    event_id=4,
+                    data={
+                        "lockDataType": 6,
+                        "dataOperationType": 0,  # Add
+                        "dataIndex": 7,
+                        "userIndex": 42,
+                    },
+                ),
+            )
+            await hass.async_block_till_done()
+
+        mock_coordinator.observe_push.assert_not_called()
+        assert matter_lock._slot_by_user_index[42] == 3
+
+    async def test_clear_for_a_user_index_never_read_is_ignored(
+        self, hass: HomeAssistant, matter_lock: MatterLock
+    ) -> None:
+        """A cleared user LCM never saw anchors no slot of ours."""
+        mock_coordinator = MagicMock()
+        matter_lock.coordinator = mock_coordinator
+        with self._patch_users([]):
+            matter_lock._on_node_event(
+                None,
+                _make_node_event(
+                    event_id=4,
+                    data={
+                        "lockDataType": 2,
+                        "dataOperationType": 1,
+                        "dataIndex": 77,
+                        "userIndex": 77,
+                    },
+                ),
+            )
+            await hass.async_block_till_done()
+
+        mock_coordinator.observe_push.assert_not_called()
+
+    async def test_writes_and_deletes_keep_the_anchor_map_current(
+        self, hass: HomeAssistant, matter_lock: MatterLock
+    ) -> None:
+        """A user LCM creates is known before any read; a user it deletes is forgotten."""
+        with (
+            self._patch_users([]),
+            patch(
+                f"{_PROVIDER_MODULE}.set_lock_user",
+                AsyncMock(return_value={"user_index": 9}),
+            ),
+        ):
+            await matter_lock.async_set_user(User(user_id=3, name="lcm:3:Carol"))
+        assert matter_lock._slot_by_user_index[9] == 3
+
+        with patch(f"{_PROVIDER_MODULE}.clear_lock_user", AsyncMock(return_value=None)):
+            await matter_lock.async_delete_user(9)
+        assert 9 not in matter_lock._slot_by_user_index
 
 
 # =============================================================================
@@ -3443,10 +3636,113 @@ class TestSetCredential:
         assert call_kwargs["credential_index"] == 11
         assert call_kwargs["user_index"] == 3
 
+    # =============================================================================
+    # async_delete_credential tests
+    # =============================================================================
 
-# =============================================================================
-# async_delete_credential tests
-# =============================================================================
+    async def test_set_credential_filed_under_another_user_is_a_failed_write(
+        self, hass: HomeAssistant, matter_lock: MatterLock
+    ) -> None:
+        """A PIN the lock filed under another user opens the door as somebody else.
+
+        The lock's answer names the credential index; the re-read shows user
+        7 holding it although the write was for user 1. That is a failed
+        write for the slot breaker, not a success to push (issue #1538).
+        """
+        mock_coordinator = MagicMock()
+        matter_lock.coordinator = mock_coordinator
+        mock_set_credential = AsyncMock(
+            return_value={"credential_index": 4, "user_index": 1}
+        )
+        users = {
+            "max_users": 10,
+            "users": [
+                {"user_index": 1, "user_name": "lcm:1:Alice", "credentials": []},
+                {
+                    "user_index": 7,
+                    "user_name": "lcm:7:Grace",
+                    "credentials": [{"type": "pin", "index": 4}],
+                },
+            ],
+        }
+        with (
+            patch(f"{_PROVIDER_MODULE}.get_lock_users", AsyncMock(return_value=users)),
+            patch(f"{_PROVIDER_MODULE}.set_lock_credential", mock_set_credential),
+            pytest.raises(LockOperationFailed, match="under user 7"),
+        ):
+            await matter_lock.async_set_credential(
+                1, self._make_credential(slot=1), "1234", name=None, source="sync"
+            )
+
+        mock_coordinator.push_update.assert_not_called()
+
+    async def test_set_credential_answer_naming_another_user_is_a_failed_write(
+        self, hass: HomeAssistant, matter_lock: MatterLock
+    ) -> None:
+        """The lock's own answer associating the PIN with another user fails the write."""
+        mock_coordinator = MagicMock()
+        matter_lock.coordinator = mock_coordinator
+        mock_set_credential = AsyncMock(
+            return_value={"credential_index": 1, "user_index": 5}
+        )
+        with (
+            patch(f"{_PROVIDER_MODULE}.set_lock_credential", mock_set_credential),
+            pytest.raises(LockOperationFailed, match="with user 5"),
+        ):
+            await matter_lock.async_set_credential(
+                1, self._make_credential(slot=1), "1234", name=None, source="direct"
+            )
+
+        mock_coordinator.push_update.assert_not_called()
+
+    async def test_set_credential_answer_without_an_index_skips_the_owner_check(
+        self, hass: HomeAssistant, matter_lock: MatterLock
+    ) -> None:
+        """With no credential index in the answer there is nothing to look up."""
+        mock_set_credential = AsyncMock(return_value={"user_index": 1})
+        with (
+            patch(
+                f"{_PROVIDER_MODULE}.get_lock_users",
+                AsyncMock(return_value={"max_users": 10, "users": []}),
+            ) as reads,
+            patch(f"{_PROVIDER_MODULE}.set_lock_credential", mock_set_credential),
+        ):
+            result = await matter_lock.async_set_credential(
+                1, self._make_credential(slot=1), "1234", name=None, source="sync"
+            )
+        assert result is WriteResult.CONFIRMED
+        assert reads.await_count == 1  # the MODIFY-or-CREATE lookup only
+
+    async def test_set_credential_filed_under_the_right_user_is_confirmed(
+        self, hass: HomeAssistant, matter_lock: MatterLock
+    ) -> None:
+        """The re-read showing the PIN under the intended user confirms the write."""
+        mock_set_credential = AsyncMock(
+            return_value={"credential_index": 4, "user_index": 1}
+        )
+        users = {
+            "max_users": 10,
+            "users": [
+                {
+                    "user_index": 1,
+                    "user_name": "lcm:1:Alice",
+                    "credentials": [{"type": "pin", "index": 4}],
+                },
+            ],
+        }
+        # The first read decides MODIFY vs CREATE (empty: CREATE); the second
+        # is the pairing check.
+        with (
+            patch(
+                f"{_PROVIDER_MODULE}.get_lock_users",
+                AsyncMock(side_effect=[{"max_users": 10, "users": []}, users]),
+            ),
+            patch(f"{_PROVIDER_MODULE}.set_lock_credential", mock_set_credential),
+        ):
+            result = await matter_lock.async_set_credential(
+                1, self._make_credential(slot=1), "1234", name=None, source="sync"
+            )
+        assert result is WriteResult.CONFIRMED
 
 
 class TestDeleteCredential:

--- a/tests/providers/matter/test_provider.py
+++ b/tests/providers/matter/test_provider.py
@@ -2014,6 +2014,89 @@ class TestLockUserChangeEvent:
         mock_coordinator.observe_push.assert_not_called()
         assert matter_lock._slot_by_user_index[42] == 3
 
+    async def test_a_read_without_the_user_keeps_its_anchor_for_the_clear_that_follows(
+        self, hass: HomeAssistant, matter_lock: MatterLock
+    ) -> None:
+        """A read that no longer lists the user must not swallow its deletion event.
+
+        Reads run for every write on any slot; one landing between the
+        out-of-band deletion and its event must leave the anchor in place.
+        """
+        mock_coordinator = MagicMock()
+        matter_lock.coordinator = mock_coordinator
+        with self._patch_users(
+            [
+                {
+                    "user_index": 42,
+                    "user_name": "lcm:3:Carol",
+                    "credentials": [{"type": "pin", "index": 7}],
+                }
+            ]
+        ):
+            await matter_lock.async_get_users()
+        with self._patch_users([]):
+            await matter_lock.async_get_users()  # the user is already gone
+            matter_lock._on_node_event(
+                None,
+                _make_node_event(
+                    event_id=4,
+                    data={
+                        "lockDataType": 2,
+                        "dataOperationType": 1,
+                        "dataIndex": 42,
+                        "userIndex": 42,
+                    },
+                ),
+            )
+            await hass.async_block_till_done()
+
+        mock_coordinator.observe_push.assert_called_once_with(
+            pin_address(3), SlotCredential.empty()
+        )
+
+    async def test_a_read_showing_the_user_renamed_off_lcm_drops_its_anchor(
+        self, hass: HomeAssistant, matter_lock: MatterLock
+    ) -> None:
+        """A user someone renamed to an untagged name is no longer ours to empty."""
+        mock_coordinator = MagicMock()
+        matter_lock.coordinator = mock_coordinator
+        with self._patch_users(
+            [
+                {
+                    "user_index": 42,
+                    "user_name": "lcm:3:Carol",
+                    "credentials": [{"type": "pin", "index": 7}],
+                }
+            ]
+        ):
+            await matter_lock.async_get_users()
+        with self._patch_users(
+            [
+                {
+                    "user_index": 42,
+                    "user_name": "Carol at the vendor app",
+                    "credentials": [{"type": "pin", "index": 7}],
+                }
+            ]
+        ):
+            await matter_lock.async_get_users()
+        with self._patch_users([]):
+            matter_lock._on_node_event(
+                None,
+                _make_node_event(
+                    event_id=4,
+                    data={
+                        "lockDataType": 2,
+                        "dataOperationType": 1,
+                        "dataIndex": 42,
+                        "userIndex": 42,
+                    },
+                ),
+            )
+            await hass.async_block_till_done()
+
+        mock_coordinator.observe_push.assert_not_called()
+
     async def test_clear_for_a_user_index_never_read_is_ignored(
         self, hass: HomeAssistant, matter_lock: MatterLock
     ) -> None:
@@ -3176,10 +3259,18 @@ class TestSetCredential:
         Tests that want to exercise the MODIFY path can override this patch
         in their own context manager.
         """
-        with patch(
-            f"{_PROVIDER_MODULE}.get_lock_users",
-            AsyncMock(return_value={"max_users": 10, "users": []}),
-        ) as mock:
+        with (
+            patch(
+                f"{_PROVIDER_MODULE}.get_lock_users",
+                AsyncMock(return_value={"max_users": 10, "users": []}),
+            ) as mock,
+            # The pairing check asks the lock who holds the written credential;
+            # an unknown owner is not a mismatch.
+            patch(
+                f"{_PROVIDER_MODULE}.get_lock_credential_status",
+                AsyncMock(return_value={"credential_exists": True, "user_index": None}),
+            ),
+        ):
             yield mock
 
     def _make_credential(self, slot: int = 1, pin: str = "1234") -> Credential:
@@ -3640,109 +3731,130 @@ class TestSetCredential:
     # async_delete_credential tests
     # =============================================================================
 
-    async def test_set_credential_filed_under_another_user_is_a_failed_write(
+    @staticmethod
+    def _patch_status(**status: Any) -> Any:
+        """Answer the pairing check's GetCredentialStatus."""
+        return patch(
+            f"{_PROVIDER_MODULE}.get_lock_credential_status",
+            AsyncMock(return_value={"credential_exists": True, **status}),
+        )
+
+    async def test_set_credential_filed_under_another_user_is_cleared_and_failed(
         self, hass: HomeAssistant, matter_lock: MatterLock
     ) -> None:
         """A PIN the lock filed under another user opens the door as somebody else.
 
-        The lock's answer names the credential index; the re-read shows user
-        7 holding it although the write was for user 1. That is a failed
-        write for the slot breaker, not a success to push (issue #1538).
+        The lock's own credential status names user 7 for the index the write
+        went to, although the write was for user 1. The credential is cleared
+        again and the write fails for the slot breaker; nothing is pushed as
+        a success (issue #1538).
         """
         mock_coordinator = MagicMock()
         matter_lock.coordinator = mock_coordinator
-        mock_set_credential = AsyncMock(
-            return_value={"credential_index": 4, "user_index": 1}
-        )
-        users = {
-            "max_users": 10,
-            "users": [
-                {"user_index": 1, "user_name": "lcm:1:Alice", "credentials": []},
-                {
-                    "user_index": 7,
-                    "user_name": "lcm:7:Grace",
-                    "credentials": [{"type": "pin", "index": 4}],
-                },
-            ],
-        }
+        mock_clear = AsyncMock(return_value={})
         with (
-            patch(f"{_PROVIDER_MODULE}.get_lock_users", AsyncMock(return_value=users)),
-            patch(f"{_PROVIDER_MODULE}.set_lock_credential", mock_set_credential),
+            patch(
+                f"{_PROVIDER_MODULE}.set_lock_credential",
+                AsyncMock(return_value={"credential_index": 4, "user_index": 1}),
+            ),
+            self._patch_status(user_index=7),
+            patch(f"{_PROVIDER_MODULE}.clear_lock_credential", mock_clear),
+            pytest.raises(LockOperationFailed, match="under user 7, not user 1"),
+        ):
+            await matter_lock.async_set_credential(
+                1, self._make_credential(slot=1), "1234", name=None, source="sync"
+            )
+
+        mock_clear.assert_awaited_once()
+        assert mock_clear.await_args.kwargs["credential_index"] == 4
+        mock_coordinator.push_update.assert_not_called()
+
+    async def test_set_credential_misfiled_pin_that_cannot_be_cleared_still_fails(
+        self, hass: HomeAssistant, matter_lock: MatterLock
+    ) -> None:
+        """Failing to clear the misfiled credential does not turn it into a success."""
+        with (
+            patch(
+                f"{_PROVIDER_MODULE}.set_lock_credential",
+                AsyncMock(return_value={"credential_index": 4, "user_index": 1}),
+            ),
+            self._patch_status(user_index=7),
+            patch(
+                f"{_PROVIDER_MODULE}.clear_lock_credential",
+                AsyncMock(side_effect=HomeAssistantError("offline")),
+            ),
             pytest.raises(LockOperationFailed, match="under user 7"),
         ):
             await matter_lock.async_set_credential(
                 1, self._make_credential(slot=1), "1234", name=None, source="sync"
             )
 
-        mock_coordinator.push_update.assert_not_called()
-
-    async def test_set_credential_answer_naming_another_user_is_a_failed_write(
-        self, hass: HomeAssistant, matter_lock: MatterLock
-    ) -> None:
-        """The lock's own answer associating the PIN with another user fails the write."""
-        mock_coordinator = MagicMock()
-        matter_lock.coordinator = mock_coordinator
-        mock_set_credential = AsyncMock(
-            return_value={"credential_index": 1, "user_index": 5}
-        )
-        with (
-            patch(f"{_PROVIDER_MODULE}.set_lock_credential", mock_set_credential),
-            pytest.raises(LockOperationFailed, match="with user 5"),
-        ):
-            await matter_lock.async_set_credential(
-                1, self._make_credential(slot=1), "1234", name=None, source="direct"
-            )
-
-        mock_coordinator.push_update.assert_not_called()
-
-    async def test_set_credential_answer_without_an_index_skips_the_owner_check(
-        self, hass: HomeAssistant, matter_lock: MatterLock
-    ) -> None:
-        """With no credential index in the answer there is nothing to look up."""
-        mock_set_credential = AsyncMock(return_value={"user_index": 1})
-        with (
-            patch(
-                f"{_PROVIDER_MODULE}.get_lock_users",
-                AsyncMock(return_value={"max_users": 10, "users": []}),
-            ) as reads,
-            patch(f"{_PROVIDER_MODULE}.set_lock_credential", mock_set_credential),
-        ):
-            result = await matter_lock.async_set_credential(
-                1, self._make_credential(slot=1), "1234", name=None, source="sync"
-            )
-        assert result is WriteResult.CONFIRMED
-        assert reads.await_count == 1  # the MODIFY-or-CREATE lookup only
-
     async def test_set_credential_filed_under_the_right_user_is_confirmed(
         self, hass: HomeAssistant, matter_lock: MatterLock
     ) -> None:
-        """The re-read showing the PIN under the intended user confirms the write."""
-        mock_set_credential = AsyncMock(
-            return_value={"credential_index": 4, "user_index": 1}
-        )
-        users = {
-            "max_users": 10,
-            "users": [
-                {
-                    "user_index": 1,
-                    "user_name": "lcm:1:Alice",
-                    "credentials": [{"type": "pin", "index": 4}],
-                },
-            ],
-        }
-        # The first read decides MODIFY vs CREATE (empty: CREATE); the second
-        # is the pairing check.
+        """The lock naming the intended user confirms the write."""
+        mock_coordinator = MagicMock()
+        matter_lock.coordinator = mock_coordinator
         with (
             patch(
-                f"{_PROVIDER_MODULE}.get_lock_users",
-                AsyncMock(side_effect=[{"max_users": 10, "users": []}, users]),
+                f"{_PROVIDER_MODULE}.set_lock_credential",
+                AsyncMock(return_value={"credential_index": 4, "user_index": 1}),
             ),
-            patch(f"{_PROVIDER_MODULE}.set_lock_credential", mock_set_credential),
+            self._patch_status(user_index=1),
         ):
             result = await matter_lock.async_set_credential(
                 1, self._make_credential(slot=1), "1234", name=None, source="sync"
             )
         assert result is WriteResult.CONFIRMED
+        mock_coordinator.push_update.assert_called_once_with(
+            {1: SlotCredential.unreadable()}
+        )
+
+    async def test_set_credential_unanswered_status_leaves_the_write_standing(
+        self, hass: HomeAssistant, matter_lock: MatterLock
+    ) -> None:
+        """A status read that fails proves nothing; the landed write is not undone.
+
+        Raising here would make the seam roll a just-created user back,
+        deleting the PIN that just landed and charging the lock breaker for a
+        write that succeeded.
+        """
+        mock_coordinator = MagicMock()
+        matter_lock.coordinator = mock_coordinator
+        with (
+            patch(
+                f"{_PROVIDER_MODULE}.set_lock_credential",
+                AsyncMock(return_value={"credential_index": 4, "user_index": 1}),
+            ),
+            patch(
+                f"{_PROVIDER_MODULE}.get_lock_credential_status",
+                AsyncMock(side_effect=HomeAssistantError("offline")),
+            ),
+        ):
+            result = await matter_lock.async_set_credential(
+                1, self._make_credential(slot=1), "1234", name=None, source="sync"
+            )
+        assert result is WriteResult.CONFIRMED
+        mock_coordinator.push_update.assert_called_once_with(
+            {1: SlotCredential.unreadable()}
+        )
+
+    async def test_set_credential_answer_without_an_index_asks_nothing(
+        self, hass: HomeAssistant, matter_lock: MatterLock
+    ) -> None:
+        """With no credential index in the answer there is nothing to look up."""
+        with (
+            patch(
+                f"{_PROVIDER_MODULE}.set_lock_credential",
+                AsyncMock(return_value={"user_index": 1}),
+            ),
+            self._patch_status(user_index=7) as status,
+        ):
+            result = await matter_lock.async_set_credential(
+                1, self._make_credential(slot=1), "1234", name=None, source="sync"
+            )
+        assert result is WriteResult.CONFIRMED
+        status.assert_not_awaited()
 
 
 class TestDeleteCredential:

--- a/tests/providers/matter/test_provider.py
+++ b/tests/providers/matter/test_provider.py
@@ -1447,6 +1447,19 @@ class TestEventSubscription:
 # =============================================================================
 
 
+def _cleared_event(user_index: int, data_type: int = 2) -> MatterNodeEvent:
+    """A LockUserChange CLEAR for ``user_index`` (a user record by default)."""
+    return _make_node_event(
+        event_id=4,
+        data={
+            "lockDataType": data_type,
+            "dataOperationType": 1,
+            "dataIndex": user_index,
+            "userIndex": user_index,
+        },
+    )
+
+
 class TestLockUserChangeEvent:
     """Test _handle_lock_user_change callback and coordinator push updates.
 
@@ -1904,7 +1917,10 @@ class TestLockUserChangeEvent:
             pin_address(3), SlotCredential.empty()
         )
         # Forgotten once used: a later event for a reused index is not ours.
-        assert 42 not in matter_lock._slot_by_user_index
+        with self._patch_users([]):
+            matter_lock._on_node_event(None, _cleared_event(42))
+            await hass.async_block_till_done()
+        mock_coordinator.observe_push.assert_called_once()
 
     async def test_pin_cleared_for_a_vanished_user_resolves_through_the_last_read(
         self, hass: HomeAssistant, matter_lock: MatterLock
@@ -2012,7 +2028,13 @@ class TestLockUserChangeEvent:
             await hass.async_block_till_done()
 
         mock_coordinator.observe_push.assert_not_called()
-        assert matter_lock._slot_by_user_index[42] == 3
+        # ...and the anchor is still there for the deletion that follows.
+        with self._patch_users([]):
+            matter_lock._on_node_event(None, _cleared_event(42))
+            await hass.async_block_till_done()
+        mock_coordinator.observe_push.assert_called_once_with(
+            pin_address(3), SlotCredential.empty()
+        )
 
     async def test_a_read_without_the_user_keeps_its_anchor_for_the_clear_that_follows(
         self, hass: HomeAssistant, matter_lock: MatterLock
@@ -2124,6 +2146,8 @@ class TestLockUserChangeEvent:
         self, hass: HomeAssistant, matter_lock: MatterLock
     ) -> None:
         """A user LCM creates is known before any read; a user it deletes is forgotten."""
+        mock_coordinator = MagicMock()
+        matter_lock.coordinator = mock_coordinator
         with (
             self._patch_users([]),
             patch(
@@ -2132,11 +2156,104 @@ class TestLockUserChangeEvent:
             ),
         ):
             await matter_lock.async_set_user(User(user_id=3, name="lcm:3:Carol"))
-        assert matter_lock._slot_by_user_index[9] == 3
+            matter_lock._on_node_event(None, _cleared_event(9))
+            await hass.async_block_till_done()
+        mock_coordinator.observe_push.assert_called_once_with(
+            pin_address(3), SlotCredential.empty()
+        )
 
-        with patch(f"{_PROVIDER_MODULE}.clear_lock_user", AsyncMock(return_value=None)):
+        with (
+            self._patch_users([]),
+            patch(
+                f"{_PROVIDER_MODULE}.set_lock_user",
+                AsyncMock(return_value={"user_index": 9}),
+            ),
+            patch(f"{_PROVIDER_MODULE}.clear_lock_user", AsyncMock(return_value=None)),
+        ):
+            await matter_lock.async_set_user(User(user_id=3, name="lcm:3:Carol"))
             await matter_lock.async_delete_user(9)
-        assert 9 not in matter_lock._slot_by_user_index
+            matter_lock._on_node_event(None, _cleared_event(9))
+            await hass.async_block_till_done()
+        mock_coordinator.observe_push.assert_called_once()  # no second resolution
+
+    async def test_adopting_an_untagged_user_records_the_index_it_anchors(
+        self, hass: HomeAssistant, matter_lock: MatterLock
+    ) -> None:
+        """Legacy adoption is a write, not a read: the map learns the index from it."""
+        mock_coordinator = MagicMock()
+        matter_lock.coordinator = mock_coordinator
+        untagged_holder = [
+            {
+                "user_index": 5,
+                "user_name": "Legacy Carol",
+                "credentials": [{"type": "pin", "index": 3}],
+            }
+        ]
+        with (
+            self._patch_users(untagged_holder),
+            patch(
+                f"{_PROVIDER_MODULE}.set_lock_user",
+                AsyncMock(return_value={"user_index": 5}),
+            ),
+        ):
+            await matter_lock.async_set_user(User(user_id=3, name="lcm:3:Carol"))
+        with self._patch_users([]):
+            matter_lock._on_node_event(None, _cleared_event(5))
+            await hass.async_block_till_done()
+        mock_coordinator.observe_push.assert_called_once_with(
+            pin_address(3), SlotCredential.empty()
+        )
+
+    async def test_a_read_that_fails_during_a_clear_still_resolves_from_the_map(
+        self, hass: HomeAssistant, matter_lock: MatterLock
+    ) -> None:
+        """A flaky read at the moment of deletion must not lose the deletion."""
+        mock_coordinator = MagicMock()
+        matter_lock.coordinator = mock_coordinator
+        with self._patch_users(
+            [
+                {
+                    "user_index": 42,
+                    "user_name": "lcm:3:Carol",
+                    "credentials": [{"type": "pin", "index": 7}],
+                }
+            ]
+        ):
+            await matter_lock.async_get_users()
+        with patch(
+            f"{_PROVIDER_MODULE}.get_lock_users",
+            AsyncMock(side_effect=HomeAssistantError("offline")),
+        ):
+            matter_lock._on_node_event(None, _cleared_event(42))
+            await hass.async_block_till_done()
+        mock_coordinator.observe_push.assert_called_once_with(
+            pin_address(3), SlotCredential.empty()
+        )
+
+    async def test_the_lock_as_read_now_beats_what_the_map_remembers(
+        self, hass: HomeAssistant, matter_lock: MatterLock
+    ) -> None:
+        """A user re-tagged to another slot since the last read empties that slot."""
+        mock_coordinator = MagicMock()
+        matter_lock.coordinator = mock_coordinator
+        with self._patch_users(
+            [
+                {
+                    "user_index": 42,
+                    "user_name": "lcm:3:Carol",
+                    "credentials": [{"type": "pin", "index": 7}],
+                }
+            ]
+        ):
+            await matter_lock.async_get_users()
+        with self._patch_users(
+            [{"user_index": 42, "user_name": "lcm:4:Carol", "credentials": []}]
+        ):
+            matter_lock._on_node_event(None, _cleared_event(42, data_type=6))
+            await hass.async_block_till_done()
+        mock_coordinator.observe_push.assert_called_once_with(
+            pin_address(4), SlotCredential.empty()
+        )
 
 
 # =============================================================================
@@ -3855,6 +3972,35 @@ class TestSetCredential:
             )
         assert result is WriteResult.CONFIRMED
         status.assert_not_awaited()
+
+    async def test_set_credential_duplicate_retry_answer_is_verified_too(
+        self, hass: HomeAssistant, matter_lock: MatterLock
+    ) -> None:
+        """The write that lands after a duplicate clear is checked like any other."""
+        mock_coordinator = MagicMock()
+        matter_lock.coordinator = mock_coordinator
+        mock_set_credential = AsyncMock(
+            side_effect=[
+                _make_set_credential_failed_error("duplicate"),
+                {"credential_index": 4, "user_index": 1},
+            ]
+        )
+        mock_clear = AsyncMock(return_value={})
+        with (
+            self._patch_user_with_pin(user_id=1, credential_index=10),
+            patch(f"{_PROVIDER_MODULE}.set_lock_credential", mock_set_credential),
+            patch(f"{_PROVIDER_MODULE}.clear_lock_credential", mock_clear),
+            self._patch_status(user_index=7),
+            pytest.raises(LockOperationFailed, match="under user 7"),
+        ):
+            await matter_lock.async_set_credential(
+                1, self._make_credential(slot=1), "1234", name=None, source="sync"
+            )
+        cleared = [
+            call.kwargs["credential_index"] for call in mock_clear.await_args_list
+        ]
+        assert cleared == [10, 4]  # the duplicate, then the misfiled retry
+        mock_coordinator.push_update.assert_not_called()
 
 
 class TestDeleteCredential:

--- a/tests/providers/matter/test_provider.py
+++ b/tests/providers/matter/test_provider.py
@@ -2230,6 +2230,39 @@ class TestLockUserChangeEvent:
             pin_address(3), SlotCredential.empty()
         )
 
+    async def test_a_user_now_untagged_on_the_lock_is_not_ours_to_empty(
+        self, hass: HomeAssistant, matter_lock: MatterLock
+    ) -> None:
+        """The lock reusing an index for a vendor-app user drops the old anchor.
+
+        Without this the vendor user's own later deletion would empty the
+        slot the index anchored for LCM long ago.
+        """
+        mock_coordinator = MagicMock()
+        matter_lock.coordinator = mock_coordinator
+        with self._patch_users(
+            [
+                {
+                    "user_index": 42,
+                    "user_name": "lcm:3:Carol",
+                    "credentials": [{"type": "pin", "index": 7}],
+                }
+            ]
+        ):
+            await matter_lock.async_get_users()
+        vendor_user = [
+            {"user_index": 42, "user_name": "Vendor app user", "credentials": []}
+        ]
+        with self._patch_users(vendor_user):
+            matter_lock._on_node_event(None, _cleared_event(42, data_type=6))
+            await hass.async_block_till_done()
+        mock_coordinator.observe_push.assert_not_called()
+        # And the anchor is gone: the vendor user's own deletion resolves nothing.
+        with self._patch_users([]):
+            matter_lock._on_node_event(None, _cleared_event(42))
+            await hass.async_block_till_done()
+        mock_coordinator.observe_push.assert_not_called()
+
     async def test_the_lock_as_read_now_beats_what_the_map_remembers(
         self, hass: HomeAssistant, matter_lock: MatterLock
     ) -> None:

--- a/tests/providers/matter/test_sdk_exception_translation.py
+++ b/tests/providers/matter/test_sdk_exception_translation.py
@@ -29,6 +29,7 @@ _SDK_FUNCTION_NAMES = frozenset(
         "clear_lock_user",
         "set_lock_credential",
         "clear_lock_credential",
+        "get_lock_credential_status",
     }
 )
 


### PR DESCRIPTION
## Proposed change

jprasm retested #1538 on 5.5.4: a credential deleted through Matter's **Manage access** left the In Sync sensor `on` for over a minute with no repair. The in-sync fix in #1545 is sound but acts only on what the coordinator *observes*, and on Matter it observed nothing.

### Why the coordinator never saw the deletion

Manage access sends `ClearUser`, which removes the user together with its credentials. LCM's `LockUserChange` handler ignored user-level events, and it resolved PIN-level ones by re-reading the lock's user list and finding the event's `userIndex`. That user no longer exists, so the event was dropped as "not LCM-tagged". The only other observation is the hourly drift hard refresh, so the sensor would have flipped within an hour, not within the minute the reporter waited.

### The fix

- The provider remembers which LCM slot each lock-side user index anchored, merged from every read (a vanished user keeps its entry until its deletion event consumes it; a user renamed off LCM loses it) and from every write it makes itself, and forgotten when it deletes the user. A CLEAR for a user the lock no longer lists resolves through that map, and the entry is consumed so a later event for a reused index is not misattributed.
- User-level CLEAR events are handled; user-level add and modify events carry no PIN information and are ignored, as are add and modify events for a user the lock no longer lists (resolving those through the map would show a deleted user's slot as occupied).
- Every event observation goes through the seam's `_confirm_slot`, so pending-write resolution applies as it does for every other push provider. This was the one event path that pushed straight to the coordinator.

### The attribution symptom

The same PIN has been attributed to different users across rewrites, which points at the PIN landing under the wrong user at write time. PINs are write-only, so the one pairing check available is to ask the lock: the set helper's answer names the credential index it wrote to, and the lock's own `GetCredentialStatus` for that index (one round trip) names the user it associated the credential with. The set path now performs that check. A PIN filed under another user opens the door as somebody else while every slot still reads occupied, so the misfiled credential is cleared again, a warning names both users, and the write is raised as failed for the slot breaker rather than pushed as a success. A status read that fails proves nothing either way and leaves the landed write standing (raising there would make the seam roll a just-created user back, deleting the PIN that just landed). The pairing is logged at debug, both the request and the lock's answer, so the reporter's logs can show it.

One risk to read the reporter's next logs with in mind: this check trusts the lock's `GetCredentialStatus` over its `SetCredential=success`. If the U200 is instead *mis-reporting* ownership (the attribution symptom fits both), every write on that lock would now be cleared, warned about, and suspended after three ticks, and the warning would say so on every attempt. That is the visible failure this PR prefers over a PIN silently opening the door as someone else, but it is a bet on which of the two the lock is doing.

### Verification

- Full suite green at 100% line coverage.
- An end-to-end test on a real coordinator now covers the reporter's scenario: an out-of-band `ClearUser` flips the In Sync sensor off on the event, the next tick writes the PIN back for the same user, and the sensor returns to on once the lock lists the user again.
- Twenty-three mutants, each killed by the test written for it, across: the event filter, the anchor map (refresh, merge rather than replace, untagged users dropped, reused indexes pruned, creation and deletion, consumption on use, fallback only for a CLEAR, live read beating the map, a failing read still resolving), the seam handoff, and the pairing check (owner check, unknown owner, a failed status read leaving the write standing, the misfiled credential cleared, the duplicate retry's answer verified).
- Two review rounds: the first found nothing HIGH and two MEDIUMs (a failed verification re-read undoing a landed write; a detected misfile left live so the retry disabled the slot for the wrong reason), both fixed; the second found nothing above LOW, and its LOW items are in the last commit.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: the Matter out-of-band deletion path of #1538
- This PR is related to issue: #1538, #1545

🤖 Generated with [Claude Code](https://claude.com/claude-code)
