### PR TITLE
fix: confirm a write by re-reading its slot, not by walking the lock (#1549)

### DIFF
--- a/custom_components/lock_code_manager/domain/coordinator.py
+++ b/custom_components/lock_code_manager/domain/coordinator.py
@@ -470,10 +470,11 @@ class LockUsercodeUpdateCoordinator(
             failed_before = len(self._failed_writes)
             new_data = self._apply_read(self._normalize_keys(raw))
             # A completed read that does not name a pending address is the
-            # lock not holding it -- a poller's read is scoped to name every
-            # pending slot, and a push provider's refresh reads the whole
-            # device -- so it is judged like an absent slot: waited for
-            # until the deadline, then given up.
+            # lock not holding it: a poller's read is scoped to name every
+            # pending slot, and a push provider's refresh re-reads the pending
+            # slots from the device and then projects everything the lock
+            # holds. So it is judged like an absent slot: waited for until
+            # the deadline, then given up.
             self._fail_overdue(
                 [address for address in self._pending if address not in new_data]
             )

--- a/custom_components/lock_code_manager/domain/coordinator.py
+++ b/custom_components/lock_code_manager/domain/coordinator.py
@@ -454,7 +454,11 @@ class LockUsercodeUpdateCoordinator(
             return
         try:
             if self._is_push:
-                raw = await self._lock.async_internal_hard_refresh_codes()
+                # Only the slots with a write pending need re-reading from the
+                # device; on a lossy link that is what lets the read complete.
+                raw = await self._lock.async_internal_hard_refresh_codes(
+                    {address.user_ref for address in self._pending}
+                )
             else:
                 raw = await self._lock.async_internal_get_usercodes(
                     self._lock.managed_slots

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -1291,10 +1291,6 @@ class BaseLock:
         self, slots: Collection[int] | None = None
     ) -> dict[int, SlotCredential]:
         """Rate-limited wrapper around async_hard_refresh_codes()."""
-        if slots is None:
-            return await self._execute_rate_limited(
-                "refresh", self.async_hard_refresh_codes
-            )
         return await self._execute_rate_limited(
             "refresh", self.async_hard_refresh_codes, slots
         )

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -1264,18 +1264,39 @@ class BaseLock:
         elif self._last_connection_up is True and not is_up:
             self.unsubscribe_push_updates()
 
-    async def async_hard_refresh_codes(self) -> dict[int, SlotCredential]:
-        """Re-fetch all codes from the lock and return them in the same shape as async_get_usercodes()."""
+    async def async_hard_refresh_codes(
+        self, slots: Collection[int] | None = None
+    ) -> dict[int, SlotCredential]:
+        """
+        Re-read from the lock device and return the same shape as async_get_usercodes().
+
+        ``slots`` names the slots whose device state must be re-read; ``None``
+        means everything. The returned projection is never narrowed by it:
+        the coordinator replaces its data with what comes back, so a read
+        must still name every managed slot. A provider that reads the whole
+        device in one call may ignore ``slots``; one that walks the lock a
+        slot at a time should re-read only those, because the coordinator's
+        confirmation read asks about the one or two slots with a write
+        pending, and on a marginal radio link the difference between one
+        command and a walk of the lock is the difference between confirming
+        the write and never confirming it.
+        """
         self._raise_not_implemented(
             "async_hard_refresh_codes",
             "Override this method to re-fetch codes from the lock device.",
         )
 
     @final
-    async def async_internal_hard_refresh_codes(self) -> dict[int, SlotCredential]:
+    async def async_internal_hard_refresh_codes(
+        self, slots: Collection[int] | None = None
+    ) -> dict[int, SlotCredential]:
         """Rate-limited wrapper around async_hard_refresh_codes()."""
+        if slots is None:
+            return await self._execute_rate_limited(
+                "refresh", self.async_hard_refresh_codes
+            )
         return await self._execute_rate_limited(
-            "refresh", self.async_hard_refresh_codes
+            "refresh", self.async_hard_refresh_codes, slots
         )
 
     async def async_set_usercode(

--- a/custom_components/lock_code_manager/providers/_mqtt.py
+++ b/custom_components/lock_code_manager/providers/_mqtt.py
@@ -103,7 +103,9 @@ class BaseMqttLock(BaseLock):
         """
         return timedelta(hours=1)
 
-    async def async_hard_refresh_codes(self) -> dict[int, SlotCredential]:
+    async def async_hard_refresh_codes(
+        self, slots: Collection[int] | None = None
+    ) -> dict[int, SlotCredential]:
         """
         Perform hard refresh and return all codes.
 

--- a/custom_components/lock_code_manager/providers/akuvox.py
+++ b/custom_components/lock_code_manager/providers/akuvox.py
@@ -199,7 +199,9 @@ class AkuvoxLock(BaseLock):
         await self._async_tag_unmanaged_users()
         self._tagged_once = True
 
-    async def async_hard_refresh_codes(self) -> dict[int, SlotCredential]:
+    async def async_hard_refresh_codes(
+        self, slots: Collection[int] | None = None
+    ) -> dict[int, SlotCredential]:
         """
         Re-tag unmanaged users, then return all codes.
 

--- a/custom_components/lock_code_manager/providers/matter.py
+++ b/custom_components/lock_code_manager/providers/matter.py
@@ -1626,7 +1626,9 @@ class MatterLock(BaseLock):
         )
         self._confirm_slot(code_slot, resolved)
 
-    async def async_hard_refresh_codes(self) -> dict[int, SlotCredential]:
+    async def async_hard_refresh_codes(
+        self, slots: Collection[int] | None = None
+    ) -> dict[int, SlotCredential]:
         """
         Perform a hard refresh and return all slot credentials.
 

--- a/custom_components/lock_code_manager/providers/schlage.py
+++ b/custom_components/lock_code_manager/providers/schlage.py
@@ -466,7 +466,9 @@ class SchlageLock(BaseLock):
         )
         return True
 
-    async def async_hard_refresh_codes(self) -> dict[int, SlotCredential]:
+    async def async_hard_refresh_codes(
+        self, slots: Collection[int] | None = None
+    ) -> dict[int, SlotCredential]:
         """
         Perform hard refresh and return all codes.
 

--- a/custom_components/lock_code_manager/providers/virtual.py
+++ b/custom_components/lock_code_manager/providers/virtual.py
@@ -111,7 +111,9 @@ class VirtualLock(BaseLock):
         else:
             await self._store.async_save(self._data)
 
-    async def async_hard_refresh_codes(self) -> dict[int, SlotCredential]:
+    async def async_hard_refresh_codes(
+        self, slots: Collection[int] | None = None
+    ) -> dict[int, SlotCredential]:
         """Reload from store and return all codes."""
         self._data = data if (data := await self._store.async_load()) else {}
         return await self.async_get_usercodes()

--- a/custom_components/lock_code_manager/providers/zha.py
+++ b/custom_components/lock_code_manager/providers/zha.py
@@ -471,7 +471,9 @@ class ZHALock(BaseLock):
             return None
         return min(int(supported), MAX_SEARCHED_SLOT)
 
-    async def async_hard_refresh_codes(self) -> dict[int, SlotCredential]:
+    async def async_hard_refresh_codes(
+        self, slots: Collection[int] | None = None
+    ) -> dict[int, SlotCredential]:
         """Re-read all codes from the lock (no cache to invalidate)."""
         return await self.async_get_usercodes()
 

--- a/custom_components/lock_code_manager/providers/zwave_js.py
+++ b/custom_components/lock_code_manager/providers/zwave_js.py
@@ -1142,11 +1142,30 @@ class ZWaveJSLock(BaseLock):
             f"refusing the code."
         )
 
-    async def async_hard_refresh_codes(self) -> dict[int, SlotCredential]:
-        """Re-read users AND credentials fresh from the device, then project to slots."""
+    async def async_hard_refresh_codes(
+        self, slots: Collection[int] | None = None
+    ) -> dict[int, SlotCredential]:
+        """
+        Re-read from the device, then project to slots.
+
+        Unscoped, this re-reads every user and credential: a walk of the
+        whole lock, one command per slot on a User Code CC lock. Given
+        ``slots`` it re-reads only those, one command each. That is what the
+        coordinator's confirmation read needs, and on a lock dropping half
+        its responses it is the difference between a read that completes
+        about half the time and one that essentially never does (issues
+        #1397 and #1307). The projection is unscoped either way, so the
+        answer still names every managed slot.
+        """
         try:
-            await self.node.access_control.get_users()
-            await self.node.access_control.get_all_credentials()
+            if slots is None:
+                await self.node.access_control.get_users()
+                await self.node.access_control.get_all_credentials()
+            else:
+                for slot in slots:
+                    await self.node.access_control.get_credential(
+                        UserCredentialType.PIN_CODE, slot
+                    )
         except BaseZwaveJSServerError as err:
             raise _mapped_zwave_error(err, "hard refresh failed") from err
         except HomeAssistantError as err:

--- a/tests/common.py
+++ b/tests/common.py
@@ -257,9 +257,11 @@ class MockLCMLock(BaseLock):
         self.service_calls["unload"].append((remove_permanently,))
         await super().async_unload(remove_permanently)
 
-    async def async_hard_refresh_codes(self) -> dict[int, SlotCredential]:
-        """Perform hard refresh of all codes."""
-        self.service_calls["hard_refresh_codes"].append(())
+    async def async_hard_refresh_codes(
+        self, slots: Collection[int] | None = None
+    ) -> dict[int, SlotCredential]:
+        """Perform hard refresh; records the scope it was asked for."""
+        self.service_calls["hard_refresh_codes"].append((slots,))
         return await self.async_get_usercodes()
 
     async def async_set_usercode(

--- a/tests/providers/zwave_js/test_provider.py
+++ b/tests/providers/zwave_js/test_provider.py
@@ -357,6 +357,53 @@ async def test_hard_refresh_codes_calls_access_control(
     assert 2 in codes
 
 
+async def test_hard_refresh_codes_scoped_reads_only_those_slots(
+    hass: HomeAssistant,
+    zwave_js_lock: ZWaveJSLock,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
+) -> None:
+    """Given slots, the refresh re-reads one credential per slot and nothing else.
+
+    The projection stays unscoped: every managed slot is still in the
+    answer, so the coordinator can replace its data with it (issue #1549).
+    Slot 99 is managed but the fixture device knows nothing about it, so
+    only the unscoped projection can put it there.
+    """
+    lcm_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_LOCKS: [zwave_js_lock.lock.entity_id],
+            CONF_SLOTS: {"1": {CONF_NAME: "User 1"}, "99": {CONF_NAME: "User 99"}},
+        },
+    )
+    lcm_entry.add_to_hass(hass)
+
+    codes = await zwave_js_lock.async_hard_refresh_codes({3, 5})
+
+    mock_access_control.get_users.assert_not_called()
+    mock_access_control.get_all_credentials.assert_not_called()
+    assert {
+        call.args for call in mock_access_control.get_credential.await_args_list
+    } == {(UserCredentialType.PIN_CODE, 3), (UserCredentialType.PIN_CODE, 5)}
+    assert 1 in codes
+    assert codes[99] == SlotCredential.empty()
+
+
+async def test_hard_refresh_codes_scoped_maps_transport_error_to_lock_disconnected(
+    zwave_js_lock: ZWaveJSLock,
+    mock_access_control: MagicMock,
+    mock_lock_helpers: dict,
+) -> None:
+    """A single-slot re-read that fails surfaces the same way as the walk."""
+    mock_access_control.get_credential.side_effect = FailedZWaveCommand(
+        "cmd", 1, "node gone"
+    )
+
+    with pytest.raises(LockDisconnected, match="hard refresh failed"):
+        await zwave_js_lock.async_hard_refresh_codes({3})
+
+
 async def test_hard_refresh_codes_maps_transport_error_to_lock_disconnected(
     zwave_js_lock: ZWaveJSLock,
     mock_access_control: MagicMock,

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1520,6 +1520,25 @@ async def test_confirmation_read_on_a_push_provider_hard_refreshes(
     assert push_coordinator.data[pin_address(1)] == SlotCredential.known("9999")
 
 
+async def test_confirmation_read_on_a_push_provider_asks_only_about_the_pending_slots(
+    push_lock: MockLCMPushLock, push_coordinator: LockUsercodeUpdateCoordinator
+) -> None:
+    """The confirmation read is scoped to the pending slots; the drift read is not.
+
+    On a lock that drops half its responses, re-reading one slot completes
+    about half the time and a walk of the whole lock essentially never; the
+    scope is what lets a write on such a lock ever confirm (issue #1549).
+    """
+    reads = push_lock.service_calls["hard_refresh_codes"]
+    push_coordinator.record_write(pin_address(1), "9999", believed=True)
+    push_coordinator.record_write(pin_address(3), "3333", believed=True)
+    await push_coordinator.async_confirm_pending_writes()
+    assert reads[-1] == ({1, 3},)
+
+    await push_coordinator._async_drift_check(dt_util.utcnow())
+    assert reads[-1] == (None,)
+
+
 async def test_confirmation_read_noop_without_pending(
     push_lock: MockLCMPushLock, push_coordinator: LockUsercodeUpdateCoordinator
 ) -> None:


### PR DESCRIPTION
## Proposed change

Fixes #1549, found on #1307 (same reporter and locks as #1397).

### The bug

The coordinator's confirmation read for a push provider was an unscoped hard refresh. For zwave_js that is `get_users()` plus `get_all_credentials()`: a fresh walk of the whole lock, one command per slot on a User Code CC lock (250 slots on a Kwikset HC620). The reporter's two locks sit behind one weak repeater hop and time out on about half of every command sent (94 of ~190 each, round trips of 1.5–1.8 s). A walk that long essentially never completes, so every confirmation read failed; since 5.5.4 the write was then given up at `PENDING_WRITE_TTL`, charged, re-set, and suspended after three attempts, although the PIN works on the keypad. The in-sync rule from #1545 is right; the read it depended on was the wrong size for this lock.

### The fix

- `async_hard_refresh_codes(slots=None)`: `slots` names the slots whose device state must be re-read; `None` means everything. The returned projection is never narrowed by it, so the coordinator's replace semantics are unchanged.
- zwave_js re-reads only those slots, one command each, through the single-slot read it already uses to reconcile the value database after a write (`access_control.get_credential`). Unscoped it still walks the lock, as the drift check and the `hard_refresh_usercodes` action want.
- The six providers that read the whole device in one call (Matter, ZHA, the MQTT bridges, Schlage, Akuvox, virtual) accept and ignore the scope.
- The coordinator passes the pending slots for the confirmation read; the drift check stays unscoped.

One command at roughly 51% success, retried every `CONFIRM_READ_INTERVAL` inside the TTL, confirms about 94% of the time on that link; the walk confirmed about never.

### Verification

- Full suite green at 100% line coverage.
- Three mutants, each killed by the test written for it: the coordinator confirming with an unscoped walk; zwave_js ignoring the scope; zwave_js narrowing the projection to the scope (caught through a managed slot the device knows nothing about, since occupied slots reappear through the User Code CC overlay either way).

- One clean-room review round: nothing above LOW. It verified against node-zwave-js that the single-slot read is a fresh device query whose report is persisted to the value database before the call returns, that an empty slot answers `None` rather than an error, and that the User Code CC report shim resolving the pending write mid-read is idempotent with the read's own confirmation. Its one nit (a dead branch in the wrapper) is fixed. A pre-existing LOW it noted, not changed here: ZHA's hard refresh walks managed slots only, so a direct write to an unmanaged ZHA slot is never named by its confirmation read and is given up at the deadline.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #1549
- This PR is related to issue: #1307, #1397, #1545

🤖 Generated with [Claude Code](https://claude.com/claude-code)
