### PR TITLE
fix: waiting for the lock's turn is not the lock failing to answer (#1535)

### DIFF
--- a/custom_components/lock_code_manager/__init__.py
+++ b/custom_components/lock_code_manager/__init__.py
@@ -115,11 +115,7 @@ from .domain.config import (
     parse_slot_unique_id,
 )
 from .domain.credentials import CredentialType
-from .domain.exceptions import (
-    LockDisconnected,
-    LockOperationFailed,
-    UnclaimedLockError,
-)
+from .domain.exceptions import LockCodeManagerProviderError, UnclaimedLockError
 from .domain.locks import async_create_lock_instance, get_locks_from_targets
 from .domain.models import (
     LockCodeManagerConfigEntry,
@@ -2000,9 +1996,10 @@ async def _async_apply_entry_update(
             continue
         try:
             await release_lock.async_release_managed_slot(slot_num)
-        except (LockDisconnected, LockOperationFailed) as err:
+        except LockCodeManagerProviderError as err:
             # The slot is gone from LCM config either way; lock-side cleanup
-            # is best-effort and must not block the teardown.
+            # is best-effort and must not block the teardown -- whatever the
+            # provider had to say about it (unreachable, refused, or busy).
             _LOGGER.warning(
                 "%s (%s): could not release slot %s on lock %s: %s",
                 entry_id,

--- a/custom_components/lock_code_manager/domain/coordinator.py
+++ b/custom_components/lock_code_manager/domain/coordinator.py
@@ -711,10 +711,11 @@ class LockUsercodeUpdateCoordinator(
             data = await self._lock.async_internal_get_usercodes()
         except LockBusy as err:
             # Another operation had the lock's turn for the whole wait. Not the
-            # lock's word: no backoff. Keep what we have; before anything has
-            # been read there is nothing to keep, and a false success would
-            # hide that (#1268).
-            if self.data:
+            # lock's word: no backoff either way. Keep what we have, unless
+            # nothing has ever been read (a false first success would hide
+            # that, #1268) or the lock is in backoff (a returned value would
+            # read as "recovered" while the breaker still says otherwise).
+            if self._reached_once and not self._lock_breaker.tripped:
                 return self.data
             raise UpdateFailed from err
         except LockCodeManagerError as err:

--- a/custom_components/lock_code_manager/domain/coordinator.py
+++ b/custom_components/lock_code_manager/domain/coordinator.py
@@ -449,6 +449,14 @@ class LockUsercodeUpdateCoordinator(
         fails once a pending write is past its deadline gives that write up
         all the same: the lock has had the time to live to be seen holding it,
         and was not.
+
+        Not getting a turn at the lock is the one exception. That is time
+        spent behind somebody else's operation rather than evidence about the
+        lock, and giving a write up for it would charge a slot for a lock
+        that was merely busy doing legitimate work -- the fault this
+        integration invented ``LockBusy`` to stop inventing. Turns are handed
+        out in the order they were asked for, so a look that keeps asking
+        gets one.
         """
         if not self._pending:
             return
@@ -712,10 +720,16 @@ class LockUsercodeUpdateCoordinator(
         except LockBusy as err:
             # Another operation had the lock's turn for the whole wait. Not the
             # lock's word: no backoff either way. Keep what we have, unless
-            # nothing has ever been read (a false first success would hide
-            # that, #1268) or the lock is in backoff (a returned value would
-            # read as "recovered" while the breaker still says otherwise).
-            if self._reached_once and not self._lock_breaker.tripped:
+            # there is nothing to keep or keeping it would be read as news.
+            # Nothing has ever been read: a false first success would hide
+            # that (#1268). The last poll failed, or the breaker has the lock
+            # in backoff: returning data would report a recovery this read did
+            # nothing to earn.
+            if (
+                self.last_update_success
+                and self._reached_once
+                and not self._lock_breaker.tripped
+            ):
                 return self.data
             raise UpdateFailed from err
         except LockCodeManagerError as err:

--- a/custom_components/lock_code_manager/domain/coordinator.py
+++ b/custom_components/lock_code_manager/domain/coordinator.py
@@ -33,7 +33,7 @@ from ..const import (
     POLL_FAILURE_ALERT_THRESHOLD,
 )
 from .credentials import CredentialAddress, CredentialType, pin_address
-from .exceptions import LockCodeManagerError
+from .exceptions import LockBusy, LockCodeManagerError
 from .models import SlotCredential
 from .queries import get_entry_config
 from .resilience import CircuitBreaker
@@ -478,6 +478,14 @@ class LockUsercodeUpdateCoordinator(
             self._fail_overdue(
                 [address for address in self._pending if address not in new_data]
             )
+        except LockBusy as err:
+            # Never reached the lock; the next look asks again.
+            _LOGGER.debug(
+                "Confirmation read for %s waits for its turn: %s",
+                self._lock.lock.entity_id,
+                err,
+            )
+            return
         except LockCodeManagerError as err:
             self._give_up_overdue(err)
             return
@@ -701,6 +709,14 @@ class LockUsercodeUpdateCoordinator(
         """Fetch usercodes from the provider, normalize slot keys, and apply backoff handling."""
         try:
             data = await self._lock.async_internal_get_usercodes()
+        except LockBusy as err:
+            # Another operation had the lock's turn for the whole wait. Not the
+            # lock's word: no backoff. Keep what we have; before anything has
+            # been read there is nothing to keep, and a false success would
+            # hide that (#1268).
+            if self.data:
+                return self.data
+            raise UpdateFailed from err
         except LockCodeManagerError as err:
             self._apply_backoff()
             # Don't swallow into {}: DataUpdateCoordinator records any return as
@@ -734,6 +750,13 @@ class LockUsercodeUpdateCoordinator(
                     await self._lock.async_internal_hard_refresh_codes()
                 )
             )
+        except LockBusy as err:
+            _LOGGER.debug(
+                "Drift detection for %s waits for its turn: %s",
+                self._lock.lock.entity_id,
+                err,
+            )
+            return
         except LockCodeManagerError as err:
             self._apply_backoff()
             _LOGGER.warning(

--- a/custom_components/lock_code_manager/domain/exceptions.py
+++ b/custom_components/lock_code_manager/domain/exceptions.py
@@ -88,6 +88,18 @@ class LockDisconnected(LockCodeManagerProviderError):
     """Raised when lock can't be communicated with."""
 
 
+class LockBusy(LockCodeManagerProviderError):
+    """
+    Raised when a caller's turn at the lock did not come within its wait budget.
+
+    Another operation on the same lock held the mutex for the whole wait.
+    That says nothing about the lock -- the caller never reached it -- so
+    this charges no breaker: the sync tick tries again on its own cadence,
+    the poll keeps its last data, and a direct action tells the user the
+    lock is busy.
+    """
+
+
 class LockOperationFailed(LockCodeManagerProviderError):
     """
     Raised when the lock is reachable but the operation failed.

--- a/custom_components/lock_code_manager/domain/sync.py
+++ b/custom_components/lock_code_manager/domain/sync.py
@@ -793,8 +793,9 @@ class SlotSyncManager:
         # pending check so an outage right after an accepted write suspends
         # as the outage it is while it lasts. If the lock is still unreadable
         # at that write's deadline the coordinator gives the write up all the
-        # same, and the re-sync after recovery costs the one strike that
-        # trade accepts: a landed write re-syncs as no change.
+        # same -- unless its looks never got a turn at the lock, which says
+        # nothing about the lock -- and the re-sync after recovery costs the
+        # one strike that trade accepts: a landed write re-syncs as no change.
         if self._coordinator.unreachable or not self._lock.provider_setup_succeeded:
             self._state = SyncState.SUSPENDED
             self._write_state()

--- a/custom_components/lock_code_manager/domain/sync.py
+++ b/custom_components/lock_code_manager/domain/sync.py
@@ -57,6 +57,7 @@ from .config import build_slot_unique_id
 from .credentials import CredentialAddress, CredentialType
 from .exceptions import (
     CodeRejectedError,
+    LockBusy,
     LockDisconnected,
     LockOperationFailed,
     LockOperationUnsupported,
@@ -892,6 +893,13 @@ class SlotSyncManager:
             # request_sync_check will see the slot as in-sync (no code
             # desired, no code on lock). Set to OUT_OF_SYNC so the next
             # tick resolves to IN_SYNC.
+            self._state = SyncState.OUT_OF_SYNC
+            return
+        except LockBusy as err:
+            # Another operation on this lock had the turn for the whole wait.
+            # Not the lock's word about anything, so nothing is charged; the
+            # next tick asks again.
+            _LOGGER.debug("%s: %s. Will retry on next tick.", self._log_prefix, err)
             self._state = SyncState.OUT_OF_SYNC
             return
         except LockDisconnected as err:

--- a/custom_components/lock_code_manager/providers/_base.py
+++ b/custom_components/lock_code_manager/providers/_base.py
@@ -63,6 +63,7 @@ from ..domain.events import CredentialOperation, async_fire_credential_used
 from ..domain.exceptions import (
     CodeRejectedError,
     DuplicateCodeError,
+    LockBusy,
     LockCodeManagerError,
     LockCodeManagerProviderError,
     LockDisconnected,
@@ -296,51 +297,71 @@ class BaseLock:
         """
         Execute operation with connection check, serialization, and delay.
 
+        Three bounds, one per question, because one number cannot answer
+        "how long may my call take" and "how long will I queue behind
+        someone else's" at once (issue #1535):
+
+        - The availability probes are device I/O on some providers --
+          Schlage's is a cloud round trip -- and get the operation budget.
+          A probe that never answers is ``LockDisconnected``.
+        - The wait for ``_aio_lock`` gets one holder's worth. A wait that
+          runs out is ``LockBusy``: the caller never reached the lock, so it
+          is not the lock's word about anything and charges no breaker.
+        - The operation gets the operation budget, starting at acquire, so a
+          caller that waited its turn still has its whole budget for real
+          I/O. A call that answers nothing in that long is ``LockDisconnected``:
+          a disconnection, not an operation failure, and the distinction
+          decides what happens. A failure charges the SLOT breaker, which is
+          windowed -- three strikes inside five minutes -- so at a budget
+          longer than that window it could never trip. A disconnection
+          charges the LOCK breaker, which counts consecutively: three trips
+          ``unreachable``, the tick gates on it, backoff stops the hammering,
+          and it self-heals on the next successful poll.
+
         pre_execute runs inside the lock before the operation, for checks
         that must be atomic with the operation (e.g., duplicate detection).
         """
+        budget = self.operation_timeout_seconds
+        what = f"{_OPERATION_MESSAGES[operation_type]} {self.lock.entity_id}"
+        try:
+            async with asyncio.timeout(budget):
+                await self._check_reachable(operation_type)
+        except TimeoutError as err:
+            raise LockDisconnected(
+                f"Cannot {what} - availability check gave no answer within "
+                f"{budget:.0f}s"
+            ) from err
+
+        try:
+            async with asyncio.timeout(budget):
+                await self._aio_lock.acquire()
+        except TimeoutError as err:
+            raise LockBusy(
+                f"Cannot {what} - another operation on this lock has held it for "
+                f"{budget:.0f}s"
+            ) from err
+
+        try:
+            async with asyncio.timeout(budget):
+                return await self._execute_locked(
+                    operation_type, func, *args, pre_execute=pre_execute, **kwargs
+                )
+        except TimeoutError as err:
+            raise LockDisconnected(
+                f"Cannot {what} - no answer within {budget:.0f}s"
+            ) from err
+        finally:
+            self._aio_lock.release()
+
+    @final
+    async def _check_reachable(
+        self, operation_type: Literal["get", "set", "clear", "refresh"]
+    ) -> None:
+        """Run both availability probes; raise LockDisconnected if either fails."""
         # Evaluate both layers, feed the combined reachability to the
         # transition handler, then raise the layer-specific message. The two
         # checks are kept distinct for diagnostics; the transition only cares
         # whether the lock is reachable end-to-end.
-        # Inside the deadline, not before it. These are device I/O on some
-        # providers -- Schlage's availability check is a `get_codes` cloud
-        # round trip -- and waiting on `_aio_lock` behind another caller is
-        # the #1523 park itself. Bounding only `func` left both unbounded.
-        try:
-            async with asyncio.timeout(self.operation_timeout_seconds):
-                return await self._execute_bounded(
-                    operation_type, func, *args, pre_execute=pre_execute, **kwargs
-                )
-        except TimeoutError as err:
-            # A disconnection, not an operation failure, and the distinction
-            # decides whether anything happens at all. A failure charges the
-            # SLOT breaker, which is windowed -- three strikes inside five
-            # minutes -- so at a budget longer than that window the count
-            # resets on every retry and it can never trip. A disconnection
-            # charges the LOCK breaker, which counts consecutively: three
-            # trips `unreachable`, the tick gates on it, and backoff stops the
-            # hammering. It self-heals on the next successful poll too, where
-            # a suspended slot would wait for someone to edit the PIN.
-            #
-            # It is the honest word besides: a lock that has answered nothing
-            # in this long is not reachable.
-            raise LockDisconnected(
-                f"Cannot {_OPERATION_MESSAGES[operation_type]} "
-                f"{self.lock.entity_id} - no answer within "
-                f"{self.operation_timeout_seconds:.0f}s"
-            ) from err
-
-    @final
-    async def _execute_bounded(
-        self,
-        operation_type: Literal["get", "set", "clear", "refresh"],
-        func: Callable[..., Any],
-        *args: Any,
-        pre_execute: Callable[[], None] | None = None,
-        **kwargs: Any,
-    ) -> Any:
-        """Run one operation, with the caller holding the deadline."""
         integration_up = await self.async_is_integration_connected()
         device_up = await self.async_is_device_available()
         self._note_reachability(integration_up and device_up)
@@ -353,30 +374,39 @@ class BaseLock:
                 f"Cannot {_OPERATION_MESSAGES[operation_type]} {self.lock.entity_id} - device not available"
             )
 
-        async with self._aio_lock:
-            if pre_execute:
-                pre_execute()
+    @final
+    async def _execute_locked(
+        self,
+        operation_type: Literal["get", "set", "clear", "refresh"],
+        func: Callable[..., Any],
+        *args: Any,
+        pre_execute: Callable[[], None] | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Run one operation with ``_aio_lock`` held by the caller."""
+        if pre_execute:
+            pre_execute()
 
-            elapsed = time.monotonic() - self._last_operation_time
-            if elapsed < self._min_operation_delay:
-                delay = self._min_operation_delay - elapsed
-                LOGGER.debug(
-                    "Rate limiting %s operation on %s, waiting %.1f seconds",
-                    operation_type,
-                    self.lock.entity_id,
-                    delay,
-                )
-                await asyncio.sleep(delay)
-
+        elapsed = time.monotonic() - self._last_operation_time
+        if elapsed < self._min_operation_delay:
+            delay = self._min_operation_delay - elapsed
             LOGGER.debug(
-                "Executing %s operation on %s",
+                "Rate limiting %s operation on %s, waiting %.1f seconds",
                 operation_type,
                 self.lock.entity_id,
+                delay,
             )
+            await asyncio.sleep(delay)
 
-            result = await func(*args, **kwargs)
-            self._last_operation_time = time.monotonic()
-            return result
+        LOGGER.debug(
+            "Executing %s operation on %s",
+            operation_type,
+            self.lock.entity_id,
+        )
+
+        result = await func(*args, **kwargs)
+        self._last_operation_time = time.monotonic()
+        return result
 
     @final
     def _serialize_sequence(self) -> contextlib.AbstractAsyncContextManager[None]:

--- a/tests/providers/test_base.py
+++ b/tests/providers/test_base.py
@@ -55,6 +55,7 @@ from custom_components.lock_code_manager.domain.credentials import (
 from custom_components.lock_code_manager.domain.events import CredentialOperation
 from custom_components.lock_code_manager.domain.exceptions import (
     DuplicateCodeError,
+    LockBusy,
     LockCodeManagerProviderError,
     LockDisconnected,
     LockOperationFailed,
@@ -2945,3 +2946,72 @@ async def test_setup_does_not_hang_on_a_lock_that_never_answers(
     # a bare CancelledError that formats as the empty string -- which would
     # make the log line report the failure without naming it.
     assert "no answer within" in str(lock.coordinator.last_exception)
+
+
+async def test_a_waiter_whose_turn_never_comes_is_busy_not_disconnected(
+    hass: HomeAssistant,
+):
+    """
+    Queueing behind a long holder is not the lock failing to answer (issue #1535).
+
+    The waiter never reached the lock, so what it raises must not be the
+    disconnect that charges the lock breaker: three queued slots used to
+    mark a working lock unreachable with no device evidence at all.
+    """
+    lock = _make_base_test_lock(hass, "busy_not_disconnected")
+    lock._min_operation_delay = 0
+    lock._budget = 10.0
+
+    async def _never_returns(*_args, **_kwargs):
+        await asyncio.Event().wait()
+
+    with patch.object(
+        type(lock), "operation_timeout_seconds", property(lambda s: s._budget)
+    ):
+        holder = asyncio.create_task(lock._execute_rate_limited("set", _never_returns))
+        for _ in range(5):
+            await asyncio.sleep(0)
+        assert lock._aio_lock.locked()
+
+        lock._budget = 0.05
+        with pytest.raises(LockBusy) as excinfo:
+            await asyncio.wait_for(
+                lock._execute_rate_limited("get", AsyncMock(return_value="x")),
+                timeout=5,
+            )
+        assert not isinstance(excinfo.value, LockDisconnected)
+        assert not holder.done()  # the holder is still the one being waited for
+        holder.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await holder
+
+
+async def test_the_operation_deadline_starts_when_the_turn_comes(
+    hass: HomeAssistant,
+):
+    """
+    Waiting one's turn does not eat into the budget for the call itself.
+
+    Holder takes 0.2 s, the waiter's call takes 0.2 s, the budget is 0.3 s:
+    one deadline over both would cut the waiter off; a deadline that starts
+    at acquire lets it finish.
+    """
+    lock = _make_base_test_lock(hass, "deadline_at_acquire")
+    lock._min_operation_delay = 0
+
+    async def _slow(*_args, **_kwargs):
+        await asyncio.sleep(0.2)
+        return "done"
+
+    with patch.object(
+        type(lock), "operation_timeout_seconds", property(lambda _s: 0.3)
+    ):
+        holder = asyncio.create_task(lock._execute_rate_limited("set", _slow))
+        for _ in range(5):
+            await asyncio.sleep(0)
+        result = await asyncio.wait_for(
+            lock._execute_rate_limited("get", _slow), timeout=5
+        )
+        await holder
+
+    assert result == "done"

--- a/tests/providers/test_base.py
+++ b/tests/providers/test_base.py
@@ -3025,3 +3025,35 @@ async def test_the_operation_deadline_starts_when_the_turn_comes(
         result = await asyncio.wait_for(waiter, timeout=5)
 
     assert result == "done"
+
+
+async def test_a_probe_that_never_answers_is_cut_off_before_the_queue(
+    hass: HomeAssistant,
+):
+    """The availability probes get their own bound, ahead of the wait for a turn.
+
+    They are device I/O on some providers -- Schlage's is a cloud round trip
+    -- so they are bounded; and they run before the mutex, so a lock that
+    cannot even be probed is reported as unreachable without first queueing
+    behind somebody else's operation. Collapsing the two bounds into one
+    would let a slow probe eat the budget meant for the call, holding the
+    mutex while it did.
+    """
+    lock = _make_base_test_lock(hass, "probe_before_queue")
+    lock._min_operation_delay = 0
+
+    async def _never_answers():
+        await asyncio.Event().wait()
+
+    with (
+        patch.object(
+            type(lock), "operation_timeout_seconds", property(lambda _s: 0.05)
+        ),
+        patch.object(lock, "async_is_integration_connected", _never_answers),
+        pytest.raises(LockDisconnected, match="availability check gave no answer"),
+    ):
+        await asyncio.wait_for(
+            lock._execute_rate_limited("get", AsyncMock(return_value="x")), timeout=5
+        )
+
+    assert not lock._aio_lock.locked()

--- a/tests/providers/test_base.py
+++ b/tests/providers/test_base.py
@@ -2992,26 +2992,36 @@ async def test_the_operation_deadline_starts_when_the_turn_comes(
     """
     Waiting one's turn does not eat into the budget for the call itself.
 
-    Holder takes 0.2 s, the waiter's call takes 0.2 s, the budget is 0.3 s:
-    one deadline over both would cut the waiter off; a deadline that starts
-    at acquire lets it finish.
+    The holder is released by the test after 0.6 s and the waiter's own call
+    takes 0.6 s, against a budget of 1.0 s: one deadline over both legs would
+    cut the waiter off at 1.2 s; a deadline that starts at acquire lets it
+    finish, and each leg sits 0.4 s inside the budget so loop jitter cannot
+    decide the outcome.
     """
     lock = _make_base_test_lock(hass, "deadline_at_acquire")
     lock._min_operation_delay = 0
+    let_go = asyncio.Event()
+
+    async def _holds_until_released(*_args, **_kwargs):
+        await let_go.wait()
+        return "held"
 
     async def _slow(*_args, **_kwargs):
-        await asyncio.sleep(0.2)
+        await asyncio.sleep(0.6)
         return "done"
 
     with patch.object(
-        type(lock), "operation_timeout_seconds", property(lambda _s: 0.3)
+        type(lock), "operation_timeout_seconds", property(lambda _s: 1.0)
     ):
-        holder = asyncio.create_task(lock._execute_rate_limited("set", _slow))
+        holder = asyncio.create_task(
+            lock._execute_rate_limited("set", _holds_until_released)
+        )
         for _ in range(5):
             await asyncio.sleep(0)
-        result = await asyncio.wait_for(
-            lock._execute_rate_limited("get", _slow), timeout=5
-        )
-        await holder
+        waiter = asyncio.create_task(lock._execute_rate_limited("get", _slow))
+        await asyncio.sleep(0.6)
+        let_go.set()
+        assert await asyncio.wait_for(holder, timeout=5) == "held"
+        result = await asyncio.wait_for(waiter, timeout=5)
 
     assert result == "done"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -37,7 +37,10 @@ from custom_components.lock_code_manager.domain.credentials import (
     CredentialType,
     pin_address,
 )
-from custom_components.lock_code_manager.domain.exceptions import LockDisconnected
+from custom_components.lock_code_manager.domain.exceptions import (
+    LockBusy,
+    LockDisconnected,
+)
 from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers.virtual import VirtualLock
 
@@ -1942,3 +1945,60 @@ async def test_apply_read_keeps_showing_a_believed_write_while_waiting(
     out = push_coordinator._apply_read({pin_address(1): SlotCredential.empty()})
     assert out[pin_address(1)] == SlotCredential.known("9999")
     assert push_coordinator.is_verified(pin_address(1)) is False
+
+
+async def test_poll_finding_the_lock_busy_keeps_its_data_without_backoff(
+    poll_lock: MockLCMLock, poll_coordinator: LockUsercodeUpdateCoordinator
+) -> None:
+    """A poll that never got its turn is not a failed poll (issue #1535)."""
+    await poll_coordinator.async_refresh()
+    before = dict(poll_coordinator.data)
+    with patch.object(
+        poll_lock, "async_get_usercodes", AsyncMock(side_effect=LockBusy("busy"))
+    ):
+        data = await poll_coordinator.async_get_usercodes()
+    assert data == before
+    assert poll_coordinator._lock_breaker.failure_count == 0
+
+
+async def test_first_poll_finding_the_lock_busy_fails_without_backoff(
+    poll_lock: MockLCMLock, poll_coordinator: LockUsercodeUpdateCoordinator
+) -> None:
+    """Before anything was ever read there is nothing to keep, and no false success."""
+    with (
+        patch.object(
+            poll_lock, "async_get_usercodes", AsyncMock(side_effect=LockBusy("busy"))
+        ),
+        pytest.raises(UpdateFailed),
+    ):
+        await poll_coordinator.async_get_usercodes()
+    assert poll_coordinator._lock_breaker.failure_count == 0
+
+
+async def test_confirmation_look_finding_the_lock_busy_keeps_waiting(
+    push_lock: MockLCMPushLock,
+    push_coordinator: LockUsercodeUpdateCoordinator,
+    freezer,
+) -> None:
+    """A look that never reached the lock gives nothing up, even past the deadline."""
+    push_coordinator.record_write(pin_address(1), "9999", believed=True)
+    freezer.tick(timedelta(seconds=PENDING_WRITE_TTL + 1))
+    with patch.object(
+        push_lock, "async_hard_refresh_codes", AsyncMock(side_effect=LockBusy("busy"))
+    ):
+        await push_coordinator.async_confirm_pending_writes()
+    assert push_coordinator.has_pending_write(pin_address(1)) is True
+    assert push_coordinator.take_failed_write(pin_address(1)) is False
+
+
+async def test_drift_check_finding_the_lock_busy_applies_no_backoff(
+    push_lock: MockLCMPushLock, push_coordinator: LockUsercodeUpdateCoordinator
+) -> None:
+    """Drift detection that never got its turn is not a failed refresh."""
+    await push_coordinator.async_refresh()
+    with patch.object(
+        push_lock, "async_hard_refresh_codes", AsyncMock(side_effect=LockBusy("busy"))
+    ):
+        await push_coordinator._async_drift_check(dt_util.utcnow())
+    assert push_coordinator._lock_breaker.failure_count == 0
+    assert push_coordinator.unreachable is False

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2002,3 +2002,27 @@ async def test_drift_check_finding_the_lock_busy_applies_no_backoff(
         await push_coordinator._async_drift_check(dt_util.utcnow())
     assert push_coordinator._lock_breaker.failure_count == 0
     assert push_coordinator.unreachable is False
+
+
+async def test_poll_finding_the_lock_busy_during_backoff_is_not_a_recovery(
+    poll_lock: MockLCMLock, poll_coordinator: LockUsercodeUpdateCoordinator
+) -> None:
+    """While the breaker says the lock is in backoff, a busy poll changes nothing.
+
+    Returning data would flip the coordinator to "recovered" with the
+    breaker still tripped; failing without backoff keeps both honest.
+    """
+    await poll_coordinator.async_refresh()
+    for _ in range(BACKOFF_FAILURE_THRESHOLD):
+        poll_coordinator._apply_backoff()
+    assert poll_coordinator._lock_breaker.tripped
+    failures = poll_coordinator._lock_breaker.failure_count
+
+    with (
+        patch.object(
+            poll_lock, "async_get_usercodes", AsyncMock(side_effect=LockBusy("busy"))
+        ),
+        pytest.raises(UpdateFailed),
+    ):
+        await poll_coordinator.async_get_usercodes()
+    assert poll_coordinator._lock_breaker.failure_count == failures

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1980,7 +1980,14 @@ async def test_confirmation_look_finding_the_lock_busy_keeps_waiting(
     push_coordinator: LockUsercodeUpdateCoordinator,
     freezer,
 ) -> None:
-    """A look that never reached the lock gives nothing up, even past the deadline."""
+    """A look that never reached the lock gives nothing up, even past the deadline.
+
+    A read that fails past the deadline does give the write up, because the
+    lock has had its time to be seen holding it. Waiting for a turn is not
+    that: it is time spent behind somebody else's operation, and charging a
+    slot for it would blame a lock that was merely busy working. Turns are
+    handed out in order, so a look that keeps asking gets one.
+    """
     push_coordinator.record_write(pin_address(1), "9999", believed=True)
     freezer.tick(timedelta(seconds=PENDING_WRITE_TTL + 1))
     with patch.object(
@@ -2026,3 +2033,31 @@ async def test_poll_finding_the_lock_busy_during_backoff_is_not_a_recovery(
     ):
         await poll_coordinator.async_get_usercodes()
     assert poll_coordinator._lock_breaker.failure_count == failures
+
+
+async def test_a_busy_poll_after_a_failed_one_does_not_report_a_recovery(
+    poll_lock: MockLCMLock, poll_coordinator: LockUsercodeUpdateCoordinator
+) -> None:
+    """Keeping the last data is only safe while the last poll actually succeeded.
+
+    One failed poll does not trip the breaker, so a busy poll behind it would
+    otherwise return data and be recorded as the lock recovering -- with
+    nothing read.
+    """
+    await poll_coordinator.async_refresh()
+    with patch.object(
+        poll_lock,
+        "async_get_usercodes",
+        AsyncMock(side_effect=LockDisconnected("gone")),
+    ):
+        await poll_coordinator.async_refresh()
+    assert poll_coordinator.last_update_success is False
+    assert not poll_coordinator._lock_breaker.tripped
+
+    with (
+        patch.object(
+            poll_lock, "async_get_usercodes", AsyncMock(side_effect=LockBusy("busy"))
+        ),
+        pytest.raises(UpdateFailed),
+    ):
+        await poll_coordinator.async_get_usercodes()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -67,6 +67,7 @@ from custom_components.lock_code_manager.domain.config import (
     build_slot_device_identifier,
 )
 from custom_components.lock_code_manager.domain.exceptions import (
+    LockBusy,
     LockDisconnected,
 )
 from custom_components.lock_code_manager.domain.models import SlotCredential, SyncState
@@ -2082,19 +2083,26 @@ async def test_update_listener_slot_removal_handles_missing_and_failing_coordina
     assert "slot 2 coordinator stop raised" in caplog.text
 
 
+@pytest.mark.parametrize(
+    "release_error",
+    [LockDisconnected("simulated disconnect"), LockBusy("simulated busy")],
+    ids=["disconnected", "busy"],
+)
 async def test_pairs_removed_skips_untracked_lock_and_logs_release_failure(
     hass: HomeAssistant,
     mock_lock_config_entry,
     caplog: pytest.LogCaptureFixture,
+    release_error: Exception,
 ):
     """Slot removal releases lock-side state per (lock, slot) pair, tolerating failures.
 
     Covers two edge cases in the ``pairs_removed`` loop of
     ``async_update_listener``: a lock still listed in config but absent
     from ``runtime_data.locks`` (e.g. it failed setup) is skipped rather
-    than raising, and a ``LockDisconnected``/``LockOperationFailed`` from a
-    present lock's ``async_release_managed_slot`` is logged as a warning
-    without blocking the rest of the teardown.
+    than raising, and any provider error from a present lock's
+    ``async_release_managed_slot`` -- unreachable, or merely busy behind
+    another operation -- is logged as a warning without blocking the rest of
+    the teardown.
     """
     config = copy.deepcopy(BASE_CONFIG)
     entry = MockConfigEntry(
@@ -2121,7 +2129,7 @@ async def test_pairs_removed_skips_untracked_lock_and_logs_release_failure(
     with patch.object(
         lock_1,
         "async_release_managed_slot",
-        AsyncMock(side_effect=LockDisconnected("simulated disconnect")),
+        AsyncMock(side_effect=release_error),
     ):
         new_config = copy.deepcopy(config)
         new_config[CONF_SLOTS].pop(1)

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -30,6 +30,7 @@ from custom_components.lock_code_manager.domain.credentials import (
 )
 from custom_components.lock_code_manager.domain.exceptions import (
     CodeRejectedError,
+    LockBusy,
     LockDisconnected,
     LockOperationFailed,
     LockOperationUnsupported,
@@ -2203,3 +2204,33 @@ class TestPendingWritesOwnedByCoordinator:
 
         await manager.async_start()
         assert manager._coordinator.take_failed_write(pin_address(1)) is False
+
+
+class TestLockBusy:
+    """A tick that did not get its turn at the lock learned nothing about it."""
+
+    async def test_busy_lock_is_retried_without_charging_any_breaker(
+        self,
+        hass: HomeAssistant,
+        mock_lock_config_entry,
+        lock_code_manager_config_entry,
+    ) -> None:
+        """LockBusy returns the slot to OUT_OF_SYNC and charges neither breaker."""
+        manager = get_in_sync_entity_obj(hass, SLOT_1_IN_SYNC_ENTITY)._sync_manager
+        manager._state = SyncState.OUT_OF_SYNC
+        manager._coordinator.data[pin_address(1)] = SlotCredential.empty()
+        lock_failures = manager._coordinator._lock_breaker.failure_count
+        slot_failures = manager._slot_breaker.failure_count
+
+        with patch.object(
+            manager,
+            "_perform_sync",
+            new_callable=AsyncMock,
+            side_effect=LockBusy("another operation has the lock"),
+        ):
+            await manager._async_tick()
+            await hass.async_block_till_done()
+
+        assert manager._state is SyncState.OUT_OF_SYNC
+        assert manager._coordinator._lock_breaker.failure_count == lock_failures
+        assert manager._slot_breaker.failure_count == slot_failures


### PR DESCRIPTION
## Proposed change

Fixes #1535.

### The bug

Since #1527 one deadline covered the availability probes, the wait for the lock's mutex, and the operation itself. Every slot on an entry ticks on its own interval and they all queue on one mutex, so a caller behind a long holder expired without ever reaching the lock, and it expired as `LockDisconnected`. The sync tick charges that to the consecutive lock breaker, so three queued slots marked a working lock unreachable with no device evidence at all; a caller that acquired late ran its real I/O on whatever budget the wait had left, sometimes seconds.

#1529 tried a guard that refused queued callers whenever the breaker already said unreachable, and was reverted for the reasons in the issue: it threw away fresher evidence than it used, fed its own refusals back into the breaker, and refused the very recovery poll meant to notice the lock was back.

### The fix

Three bounds, one per question:

- The availability probes keep the operation budget (they are device I/O on some providers). A probe that never answers is still `LockDisconnected`.
- The wait for the mutex gets one holder's worth of budget. A wait that runs out raises a new `LockBusy`, a provider error that is neither `LockDisconnected` nor `LockOperationFailed`. The caller never reached the lock, so it is not the lock's word about anything and charges nothing: the tick returns the slot to `OUT_OF_SYNC` and asks again on its own two-second cadence; the poll keeps its last data, unless there is nothing to keep or keeping it would be read as news (nothing ever read, the last poll failed, or the breaker has the lock in backoff -- then it fails, still without backoff); the confirmation look and the drift check wait for their next look; a direct action surfaces "another operation on this lock has held it" to the user.
- The operation budget starts at acquire, so a caller that waited its turn has the whole of it for the device.

The refusal is keyed on the mutex being held right now, which is local, fresh and free, never on the breaker flag, so none of #1529's failure modes can recur and the recovery poll is not guarded.

### The one case a busy read does not settle

A read that fails once a pending write is past its deadline gives that write up: the lock has had its time to be seen holding it. A read that never got a turn is deliberately not that. Waiting behind somebody else's operation is not evidence about the lock, and giving a write up for it would charge a slot for a lock that was merely busy doing legitimate work -- the fault this PR exists to stop inventing. Turns are handed out in the order they were asked for, so a look that keeps asking gets one. Both comments that used to promise otherwise now say this, and the test that pins it says why.

### What this does not change

- N wedged slots still cost one honest attempt each, sequentially; the breaker trips after three genuine ones and suspends the rest. A single per-lock sync driver is the right long-term shape but not proportionate here.
- The worst case for one queued caller is now the sum of the three bounds rather than one: probe budget plus wait budget plus operation budget, each `operation_timeout_seconds` (600 s flat, 900 s on a ten-slot ZHA lock), so up to 30 or 45 minutes with everything wedged, where before it was one budget. A slot in `SYNCING` and an `async_stop` awaiting it are bounded by that sum (#1552). The trade is deliberate: one shared number is what produced the false disconnects; #1528 sizes the wait to a full walk and the operation to what it actually does.
- `async_stop` still awaits in-flight ticks with an unbounded gather (bounded only by the operation deadline); filed as #1552, which carries the three-bound arithmetic above.

### Verification

- Full suite green at 100% line coverage.
- Ten mutants, each killed by the test written for it: the wait timeout raised as a disconnect; one deadline over wait and operation; the probes collapsed into the operation deadline behind the queue; the tick charging the lock breaker on busy; the poll applying backoff on busy; the poll returning data after a failed poll; the confirmation look giving up a write on busy; the drift check applying backoff on busy; the release handler narrowed back to its old tuple; the deadline not starting at acquire.
- Two review rounds. Round one found two MEDIUMs (a busy release aborted the entry-update pass; the three-bound worst case was understated), both fixed. Round two found no HIGH; its MEDIUM was the two comments above, and its LOWs are the poll gate and the missing probe test, all fixed.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #1535
- This PR is related to issue: #1523, #1528, #1529, #1536

🤖 Generated with [Claude Code](https://claude.com/claude-code)
