### PR TITLE
fix: a long lock read shows progress, and numbers held by tenure are not read (#1536)

### DIFF
--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Container, Iterable, Mapping, Sequence
+import asyncio
+from collections.abc import Callable, Collection, Container, Iterable, Mapping, Sequence
 import logging
 from typing import Any
 
@@ -243,12 +244,18 @@ async def _async_validate_users_yaml(
     return parsed_users, {}, {}
 
 
+_AllocationOutcome = tuple[frozenset[int] | None, dict[str, str], dict[str, Any]]
+
+
 async def _allocate_for(
     hass: HomeAssistant,
     config_entry: ConfigEntry | None,
     locks: Sequence[str],
     num_users: int,
-) -> tuple[frozenset[int] | None, dict[str, str], dict[str, Any]]:
+    *,
+    held: Collection[int] = (),
+    progress: Callable[[float], None] | None = None,
+) -> _AllocationOutcome:
     """
     Find numbers for ``num_users``, or say why it could not.
 
@@ -261,13 +268,91 @@ async def _allocate_for(
     ``None``, which by the same rule holds nothing.
     """
     try:
-        unavailable = await async_allocate_for(hass, config_entry, locks, num_users)
+        unavailable = await async_allocate_for(
+            hass, config_entry, locks, num_users, held=held, progress=progress
+        )
     except SlotAllocationError as err:
         return None, {"base": err.translation_key}, err.placeholders
+    except Exception:
+        # Runs as a flow progress task: an exception escaping here would
+        # reach the user as "Unknown error" with nothing in the form.
+        _LOGGER.exception("Allocating slot numbers on %s failed", ", ".join(locks))
+        return None, {"base": "allocation_failed"}, {}
     return unavailable, {}, {}
 
 
-class LockCodeManagerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
+class _AllocatesInProgress:
+    """
+    Run allocation as a progress task, so a long lock read is visible.
+
+    A lock that answers one index per round trip can take a minute or more
+    per lock, and both flows that allocate are interactive (issue #1536). The
+    step that takes the submission starts the task and shows progress; Home
+    Assistant re-enters the step when the task finishes, the step hands off
+    to its ``<step>_allocated`` sibling, and that one either proceeds or
+    re-shows the same form with the refusal.
+    """
+
+    # Provided by the FlowHandler this is mixed into.
+    hass: HomeAssistant
+    async_show_progress: Callable[..., Any]
+    async_show_progress_done: Callable[..., Any]
+    async_update_progress: Callable[[float], None]
+
+    _allocation_task: asyncio.Task[_AllocationOutcome] | None = None
+    _allocation_submission: dict[str, Any] | None = None
+
+    def _start_allocation(
+        self,
+        step_id: str,
+        config_entry: ConfigEntry | None,
+        locks: Sequence[str],
+        num_users: int,
+        submission: dict[str, Any],
+        *,
+        held: Collection[int] = (),
+    ) -> Any:
+        """Start allocating for ``submission`` and show progress for it."""
+        self._allocation_submission = submission
+        self._allocation_task = self.hass.async_create_task(
+            _allocate_for(
+                self.hass,
+                config_entry,
+                locks,
+                num_users,
+                held=held,
+                progress=self.async_update_progress,
+            )
+        )
+        return self.async_show_progress(
+            step_id=step_id,
+            progress_action="allocating",
+            progress_task=self._allocation_task,
+        )
+
+    def _allocation_progress(self, step_id: str) -> Any | None:
+        """Return the progress result while allocating; None when nothing is."""
+        task = self._allocation_task
+        if task is None:
+            return None
+        if not task.done():
+            return self.async_show_progress(
+                step_id=step_id, progress_action="allocating", progress_task=task
+            )
+        return self.async_show_progress_done(next_step_id=f"{step_id}_allocated")
+
+    def _take_allocation(self) -> tuple[dict[str, Any], _AllocationOutcome]:
+        """Return the submission and the finished allocation's outcome, once."""
+        task, submission = self._allocation_task, self._allocation_submission
+        assert task is not None and submission is not None
+        self._allocation_task = None
+        self._allocation_submission = None
+        return submission, task.result()
+
+
+class LockCodeManagerFlowHandler(
+    _AllocatesInProgress, config_entries.ConfigFlow, domain=DOMAIN
+):
     """Config flow for Lock Code Manager."""
 
     VERSION = 4
@@ -335,25 +420,41 @@ class LockCodeManagerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> dict[str, Any]:
         """Ask how many users to configure."""
-        errors: dict[str, str] = {}
-        description_placeholders: dict[str, Any] = {}
+        if (progress := self._allocation_progress("ui")) is not None:
+            return progress
         if user_input is not None:
-            num_users = user_input[CONF_NUM_USERS]
             # Settled before a single name is collected. Which users get
             # configured does not change which numbers allocation issues, so
             # the count alone decides whether they fit -- and a refusal here
             # is one the user can still act on. The ``None`` is the entry the
             # lock reads are made for: this flow is what creates it.
-            (
-                unavailable,
-                errors,
-                description_placeholders,
-            ) = await _allocate_for(self.hass, None, self.data[CONF_LOCKS], num_users)
-            if unavailable is not None:
-                self._users_to_configure = num_users
-                self._unavailable = unavailable
-                return await self.async_step_code_slot()
+            return self._start_allocation(
+                "ui",
+                None,
+                self.data[CONF_LOCKS],
+                user_input[CONF_NUM_USERS],
+                user_input,
+            )
+        return self._show_ui_form(None, {}, {})
 
+    async def async_step_ui_allocated(
+        self, user_input: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        """Take the finished allocation: on to the users, or back to the count."""
+        submission, (unavailable, errors, placeholders) = self._take_allocation()
+        if unavailable is None:
+            return self._show_ui_form(submission, errors, placeholders)
+        self._users_to_configure = submission[CONF_NUM_USERS]
+        self._unavailable = unavailable
+        return await self.async_step_code_slot()
+
+    def _show_ui_form(
+        self,
+        user_input: dict[str, Any] | None,
+        errors: dict[str, str],
+        description_placeholders: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Render the count form, holding whatever was submitted."""
         return self.async_show_form(
             step_id="ui",
             data_schema=self.add_suggested_values_to_schema(
@@ -447,6 +548,8 @@ class LockCodeManagerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_yaml(self, user_input: dict[str, Any] | None = None):
         """Take a block of users, then allocate their numbers."""
+        if (progress := self._allocation_progress("yaml")) is not None:
+            return progress
         errors: dict[str, str] = {}
         description_placeholders: dict[str, Any] = {}
         if not user_input:
@@ -469,27 +572,13 @@ class LockCodeManagerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 # neither can land on one a lock already holds. The ``None``
                 # is the entry the lock reads are made for, which this flow
                 # has not created yet.
-                (
-                    unavailable,
-                    allocation_errors,
-                    allocation_placeholders,
-                ) = await _allocate_for(
-                    self.hass, None, self.data[CONF_LOCKS], len(users)
+                return self._start_allocation(
+                    "yaml",
+                    None,
+                    self.data[CONF_LOCKS],
+                    len(users),
+                    {CONF_USERS: users, "raw": user_input},
                 )
-                if unavailable is None:
-                    return self.async_show_form(
-                        step_id="yaml",
-                        data_schema=self._users_schema(user_input),
-                        errors=allocation_errors,
-                        description_placeholders=allocation_placeholders,
-                        last_step=True,
-                    )
-                self.data[CONF_USERS] = users
-                assignment = SlotAssignment.empty().reconcile(
-                    users, start=1, unavailable=unavailable
-                )
-                self.data[CONF_SLOT_ASSIGNMENT] = dict(assignment.slots)
-                return self.async_create_entry(title=self.title, data=self.data)
 
         return self.async_show_form(
             step_id="yaml",
@@ -498,6 +587,25 @@ class LockCodeManagerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             description_placeholders=description_placeholders,
             last_step=True,
         )
+
+    async def async_step_yaml_allocated(self, user_input: dict[str, Any] | None = None):
+        """Take the finished allocation: create the entry, or back to the editor."""
+        submission, (unavailable, errors, placeholders) = self._take_allocation()
+        if unavailable is None:
+            return self.async_show_form(
+                step_id="yaml",
+                data_schema=self._users_schema(submission["raw"]),
+                errors=errors,
+                description_placeholders=placeholders,
+                last_step=True,
+            )
+        users = submission[CONF_USERS]
+        self.data[CONF_USERS] = users
+        assignment = SlotAssignment.empty().reconcile(
+            users, start=1, unavailable=unavailable
+        )
+        self.data[CONF_SLOT_ASSIGNMENT] = dict(assignment.slots)
+        return self.async_create_entry(title=self.title, data=self.data)
 
     @staticmethod
     def _users_schema(user_input: dict[str, Any]) -> vol.Schema:
@@ -627,13 +735,15 @@ class LockCodeManagerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         return LockCodeManagerOptionsFlow()
 
 
-class LockCodeManagerOptionsFlow(config_entries.OptionsFlow):
+class LockCodeManagerOptionsFlow(_AllocatesInProgress, config_entries.OptionsFlow):
     """Options flow for Lock Code Manager."""
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
     ) -> dict[str, Any]:
         """Edit the entry's users. Numbers are not part of this."""
+        if (progress := self._allocation_progress("init")) is not None:
+            return progress
         errors: dict[str, str] = {}
         description_placeholders: dict[str, Any] = {}
         if not user_input:
@@ -666,41 +776,54 @@ class LockCodeManagerOptionsFlow(config_entries.OptionsFlow):
 
             if not errors:
                 assert users is not None
-                (
-                    unavailable,
-                    allocation_errors,
-                    allocation_placeholders,
-                ) = await _allocate_for(
-                    self.hass,
+                # The users staying keep their numbers by tenure and need no
+                # read; a user leaving in this edit frees theirs.
+                return self._start_allocation(
+                    "init",
                     self.config_entry,
                     user_input[CONF_LOCKS],
                     len(users),
+                    {CONF_USERS: users, "raw": user_input},
+                    held=get_entry_config(self.config_entry).assignment.held_by(users),
                 )
-                if unavailable is None:
-                    errors.update(allocation_errors)
-                    description_placeholders.update(allocation_placeholders)
-                else:
-                    config = get_entry_config(self.config_entry)
-                    # Reconciled against what the entry already holds, so a
-                    # user who was here before keeps their number and only
-                    # newcomers are issued one. Moving somebody would rewrite
-                    # their credential on every lock.
-                    assignment = config.assignment.reconcile(
-                        users, start=1, unavailable=unavailable
-                    )
-                    # Written through EntryConfig so whatever else the entry
-                    # carries survives the edit. Building the dict by hand
-                    # drops every key this form does not ask about.
-                    return self.async_create_entry(
-                        title="",
-                        data=EntryConfig(
-                            locks=tuple(user_input[CONF_LOCKS]),
-                            users=users,
-                            assignment=assignment,
-                            extra=config.extra,
-                        ).to_dict(),
-                    )
 
+        return self._show_init_form(user_input, errors, description_placeholders)
+
+    async def async_step_init_allocated(
+        self, user_input: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        """Take the finished allocation: save the entry, or back to the editor."""
+        submission, (unavailable, errors, placeholders) = self._take_allocation()
+        if unavailable is None:
+            return self._show_init_form(submission["raw"], errors, placeholders)
+        users = submission[CONF_USERS]
+        config = get_entry_config(self.config_entry)
+        # Reconciled against what the entry already holds, so a user who was
+        # here before keeps their number and only newcomers are issued one.
+        # Moving somebody would rewrite their credential on every lock.
+        assignment = config.assignment.reconcile(
+            users, start=1, unavailable=unavailable
+        )
+        # Written through EntryConfig so whatever else the entry carries
+        # survives the edit. Building the dict by hand drops every key this
+        # form does not ask about.
+        return self.async_create_entry(
+            title="",
+            data=EntryConfig(
+                locks=tuple(submission["raw"][CONF_LOCKS]),
+                users=users,
+                assignment=assignment,
+                extra=config.extra,
+            ).to_dict(),
+        )
+
+    def _show_init_form(
+        self,
+        user_input: dict[str, Any],
+        errors: dict[str, str],
+        description_placeholders: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Render the editor, holding whatever was submitted."""
         config = get_entry_config(self.config_entry)
         # Plain dict/list, because the form selectors cannot serialize the
         # deeply read-only mappings EntryConfig uses internally.

--- a/custom_components/lock_code_manager/config_flow.py
+++ b/custom_components/lock_code_manager/config_flow.py
@@ -15,6 +15,7 @@ from homeassistant.components.mqtt import DOMAIN as MQTT_DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_CONDITION, CONF_ENABLED, CONF_NAME, CONF_PIN
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.data_entry_flow import UnknownFlow
 from homeassistant.helpers import (
     config_validation as cv,
     device_registry as dr,
@@ -342,9 +343,25 @@ class _AllocatesInProgress:
         return self.async_show_progress_done(next_step_id=f"{step_id}_allocated")
 
     def _take_allocation(self) -> tuple[dict[str, Any], _AllocationOutcome]:
-        """Return the submission and the finished allocation's outcome, once."""
+        """
+        Return the submission and the finished allocation's outcome, once.
+
+        A second request for a step the first one already answered gets the
+        same answer Home Assistant gives a request for any step that is no
+        longer there. That is reachable: the flow sits on the progress-done
+        step for as long as answering it takes -- creating the entry and
+        setting the integration up -- so a duplicated request or a second
+        open dialog lands here. ``UnknownFlow`` becomes a 404 at the view and
+        leaves the flow alone; raising anything else would reach the user as
+        "Unknown error", which is what this step exists to stop, and aborting
+        would pull the flow out from under the request busy finishing it.
+        """
         task, submission = self._allocation_task, self._allocation_submission
-        assert task is not None and submission is not None
+        if task is None or submission is None:
+            raise UnknownFlow(
+                "Slot numbers for this step were already allocated by another "
+                "request for the same flow"
+            )
         self._allocation_task = None
         self._allocation_submission = None
         return submission, task.result()

--- a/custom_components/lock_code_manager/domain/allocation.py
+++ b/custom_components/lock_code_manager/domain/allocation.py
@@ -424,6 +424,13 @@ async def async_allocate_for(
     releasing in the same edit is not held and is read like any other, so it
     is free for whoever comes next.
 
+    Held numbers are not returned either. ``reconcile`` keeps them for the
+    users holding them, so naming them again would only widen the window as
+    if a stranger held them -- which refuses an entry that is merely full of
+    its own users: ten users on a fifteen-slot lock could not take an
+    eleventh, because the window would reach for twenty-one numbers to place
+    eleven people.
+
     ``progress`` is passed to each read; see ``async_read_occupancy``.
     """
     try:
@@ -441,7 +448,18 @@ async def async_allocate_for(
         raise _too_far(num_users, max_slot, limiting_lock)
 
     held = frozenset(held)
-    unavailable: set[int] = set(held)
+    unavailable: set[int] = set()
+    # Each widening pass takes half of whatever fraction is left, so progress
+    # only ever moves forward: how many passes there will be is not knowable
+    # in advance, and a bar that restarts on each one reads as a hang -- the
+    # symptom this progress exists to remove. Within a pass it is per lock, so
+    # a single-lock entry sees the passes rather than the indices.
+    reported = [0.0, 0.5]
+
+    def _pass_progress(fraction: float) -> None:
+        if progress is not None:
+            progress(reported[0] + fraction * reported[1])
+
     read_up_to = 0
     window = num_users
     while True:
@@ -454,7 +472,7 @@ async def async_allocate_for(
         ]
         if indices:
             occupancy = await async_read_occupancy(
-                hass, config_entry, locks, indices, progress=progress
+                hass, config_entry, locks, indices, progress=_pass_progress
             )
             if not occupancy.is_known:
                 # Unreadable is not free: issuing a number could overwrite a
@@ -463,6 +481,8 @@ async def async_allocate_for(
                     "occupancy_unknown", {"locks": ", ".join(occupancy.unreadable)}
                 )
             unavailable |= occupancy.unavailable
+            reported[0] += reported[1]
+            reported[1] /= 2
         read_up_to = window
 
         taken_in_window = sum(1 for slot in unavailable if slot <= window)
@@ -492,6 +512,9 @@ async def async_allocate_for(
             # come back occupied, forever.
             raise _too_far(num_users, max_slot, limiting_lock, needed=wider)
         window = wider
+
+    if progress is not None:
+        progress(1.0)
 
     # No capacity check here: every window this loop accepted was checked
     # before it was accepted -- the first as the bare count, each wider

--- a/custom_components/lock_code_manager/domain/allocation.py
+++ b/custom_components/lock_code_manager/domain/allocation.py
@@ -10,7 +10,7 @@ would be the more dangerous disagreement.
 
 from __future__ import annotations
 
-from collections.abc import Collection, Iterable, Sequence
+from collections.abc import Callable, Collection, Iterable, Sequence
 import logging
 from typing import Any
 
@@ -192,6 +192,8 @@ async def async_read_occupancy(
     config_entry: ConfigEntry | None,
     locks: Sequence[str],
     indices: Collection[int],
+    *,
+    progress: Callable[[float], None] | None = None,
 ) -> Occupancy:
     """
     Ask every lock in ``locks`` which of ``indices`` it holds.
@@ -207,11 +209,17 @@ async def async_read_occupancy(
     by tenure, released ones are free for whoever comes next. ``None`` is
     an entry still being created, which by the same rule holds nothing and
     so excludes nothing.
+
+    ``progress`` is told, as a fraction, how many of the locks have answered:
+    a lock that answers one index per round trip can take a minute or more,
+    and the flow showing this read should not look frozen while it waits.
     """
     dev_reg = dr.async_get(hass)
     ent_reg = er.async_get(hass)
     lock_occupancies: list[LockOccupancy] = []
-    for lock_entity_id in locks:
+    for done, lock_entity_id in enumerate(locks):
+        if progress is not None:
+            progress(done / len(locks))
         try:
             lock_instance = build_lock_instance(
                 hass, dev_reg, ent_reg, config_entry, lock_entity_id
@@ -273,6 +281,8 @@ async def async_read_occupancy(
                 occupied=occupied,
             )
         )
+    if progress is not None:
+        progress(1.0)
     return Occupancy(
         locks=tuple(lock_occupancies),
         claimed_by_other_entries=frozenset(
@@ -383,6 +393,9 @@ async def async_allocate_for(
     config_entry: ConfigEntry | None,
     locks: Sequence[str],
     num_users: int,
+    *,
+    held: Collection[int] = (),
+    progress: Callable[[float], None] | None = None,
 ) -> frozenset[int]:
     """
     Find numbers for ``num_users``, reading only as far as it has to.
@@ -403,7 +416,15 @@ async def async_allocate_for(
     once they have names.
 
     ``config_entry`` is the entry the numbers are being allocated for, on the
-    terms ``build_lock_instance`` describes.
+    terms ``build_lock_instance`` describes. ``held`` names the numbers its
+    users keep through this edit (``SlotAssignment.held_by``): taken by
+    tenure, so they are not read -- reconcile keeps their users where they
+    are, newcomers avoid them, and a lock answering one index per round trip
+    is spared a read per existing user (issue #1536). A number the entry is
+    releasing in the same edit is not held and is read like any other, so it
+    is free for whoever comes next.
+
+    ``progress`` is passed to each read; see ``async_read_occupancy``.
     """
     try:
         await async_check_slot_capacity(hass, config_entry, locks, [num_users])
@@ -419,23 +440,29 @@ async def async_allocate_for(
         # a lock reading past-end as free would hand back all of it.
         raise _too_far(num_users, max_slot, limiting_lock)
 
-    unavailable: set[int] = set()
+    held = frozenset(held)
+    unavailable: set[int] = set(held)
     read_up_to = 0
     window = num_users
     while True:
         # Only the part nobody has asked about yet; re-reading from one
         # each pass would cost a nearly-full lock several times its own
-        # capacity to place a couple of users.
-        occupancy = await async_read_occupancy(
-            hass, config_entry, locks, range(read_up_to + 1, window + 1)
-        )
-        if not occupancy.is_known:
-            # Unreadable is not free: issuing a number could overwrite a
-            # credential programmed by hand on a lock that did not answer.
-            raise SlotAllocationError(
-                "occupancy_unknown", {"locks": ", ".join(occupancy.unreadable)}
+        # capacity to place a couple of users. Numbers this entry holds are
+        # known taken and need no round trip.
+        indices = [
+            index for index in range(read_up_to + 1, window + 1) if index not in held
+        ]
+        if indices:
+            occupancy = await async_read_occupancy(
+                hass, config_entry, locks, indices, progress=progress
             )
-        unavailable |= occupancy.unavailable
+            if not occupancy.is_known:
+                # Unreadable is not free: issuing a number could overwrite a
+                # credential programmed by hand on a lock that did not answer.
+                raise SlotAllocationError(
+                    "occupancy_unknown", {"locks": ", ".join(occupancy.unreadable)}
+                )
+            unavailable |= occupancy.unavailable
         read_up_to = window
 
         taken_in_window = sum(1 for slot in unavailable if slot <= window)

--- a/custom_components/lock_code_manager/domain/services.py
+++ b/custom_components/lock_code_manager/domain/services.py
@@ -511,7 +511,12 @@ async def async_add_users(
         # One read of the locks for the whole batch, sized to what the entry
         # will hold once it lands.
         unavailable = await async_allocate_for(
-            hass, config_entry, config.locks, len(config.users) + len(additions)
+            hass,
+            config_entry,
+            config.locks,
+            len(config.users) + len(additions),
+            # Everyone already here stays, so their numbers need no read.
+            held=config.assignment.held_by(config.users),
         )
     except SlotAllocationError as err:
         raise ServiceValidationError(

--- a/custom_components/lock_code_manager/domain/slot_assignment.py
+++ b/custom_components/lock_code_manager/domain/slot_assignment.py
@@ -117,6 +117,19 @@ class SlotAssignment:
         """Return the slot ``name`` occupies, or None if they hold none."""
         return self.slots.get(identity(name))
 
+    def held_by(self, names: Iterable[str]) -> frozenset[int]:
+        """
+        Return the numbers the users in ``names`` already hold.
+
+        Tenure in one place: these are the numbers ``reconcile`` will keep,
+        so a caller that must not read them (allocation) and the one that
+        must not move them agree on which they are. A name that is not here
+        yet holds nothing; one that is here and absent from ``names`` is
+        being released, and its number is free for whoever comes next.
+        """
+        surviving = {identity(name) for name in names}
+        return frozenset(slot for name, slot in self.slots.items() if name in surviving)
+
     def reconcile(
         self,
         names: Iterable[str],

--- a/custom_components/lock_code_manager/strings.json
+++ b/custom_components/lock_code_manager/strings.json
@@ -18,7 +18,8 @@
       "slots_already_configured": "The following slots for lock {lock} are already managed by another config entry ({entry_title}) and can't be added to this configuration without being removed from the other one: {common_slots}",
       "too_many_users": "Lock {lock} has {num_slots} PIN code slots, so {num_users} users will not fit. Set up fewer users here, or manage the rest from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity.",
       "unsupported_mqtt_lock": "These MQTT locks are not from a supported bridge (Zigbee2MQTT or Z-Wave JS UI): {locks}",
-      "users_keyed_by_slot": "This looks like the old slot-numbered format. Users are now listed by name, and Lock Code Manager picks the slot numbers itself:\n\nusers:\n  Raman:\n    pin: \"1234\"\n    enabled: true"
+      "users_keyed_by_slot": "This looks like the old slot-numbered format. Users are now listed by name, and Lock Code Manager picks the slot numbers itself:\n\nusers:\n  Raman:\n    pin: \"1234\"\n    enabled: true",
+      "allocation_failed": "Reading the locks failed unexpectedly. Check the Home Assistant logs, then try again."
     },
     "step": {
       "choose_path": {
@@ -68,6 +69,9 @@
         "description": "The lock `{lock}`, in the configuration for `{name}`, is no longer configured in Home Assistant and must be removed from your configuration. Choose new locks that this configuration is for. If you no longer need this configuration, delete the configuration entry.",
         "title": "Update locks for {name}"
       }
+    },
+    "progress": {
+      "allocating": "Reading which slots your locks already hold, so no user is given a number that is taken. A lock that answers one slot at a time can take a minute or more per lock."
     }
   },
   "entity": {
@@ -142,7 +146,8 @@
       "search_limit_reached": "Placing {num_users} users would need slot numbers past {max_slot}, which is as far as Lock Code Manager looks. No lock here reported how many PIN code slots it has, so this limit is Lock Code Manager's own rather than the lock's. Set up fewer users, or re-interview the lock so it reports its capacity.",
       "name_not_unique": "That name is already used by another user in this configuration. Names must be unique.",
       "missing_pin_if_enabled": "PIN must be set if slot is enabled.",
-      "unsupported_mqtt_lock": "These MQTT locks are not from a supported bridge (Zigbee2MQTT or Z-Wave JS UI): {locks}"
+      "unsupported_mqtt_lock": "These MQTT locks are not from a supported bridge (Zigbee2MQTT or Z-Wave JS UI): {locks}",
+      "allocation_failed": "Reading the locks failed unexpectedly. Check the Home Assistant logs, then try again."
     },
     "step": {
       "init": {
@@ -153,6 +158,9 @@
         "description": "Update the locks that are associated with this config entry and/or the users.",
         "title": "Lock Code Manager"
       }
+    },
+    "progress": {
+      "allocating": "Reading which slots your locks already hold, so no user is given a number that is taken. A lock that answers one slot at a time can take a minute or more per lock."
     }
   },
   "services": {

--- a/custom_components/lock_code_manager/translations/en.json
+++ b/custom_components/lock_code_manager/translations/en.json
@@ -18,7 +18,8 @@
       "slots_already_configured": "The following slots for lock {lock} are already managed by another config entry ({entry_title}) and can't be added to this configuration without being removed from the other one: {common_slots}",
       "too_many_users": "Lock {lock} has {num_slots} PIN code slots, so {num_users} users will not fit. Set up fewer users here, or manage the rest from a separate configuration. If the lock really does have more slots than that, re-interview it -- a stale or incomplete interview makes it under-report its capacity.",
       "unsupported_mqtt_lock": "These MQTT locks are not from a supported bridge (Zigbee2MQTT or Z-Wave JS UI): {locks}",
-      "users_keyed_by_slot": "This looks like the old slot-numbered format. Users are now listed by name, and Lock Code Manager picks the slot numbers itself:\n\nusers:\n  Raman:\n    pin: \"1234\"\n    enabled: true"
+      "users_keyed_by_slot": "This looks like the old slot-numbered format. Users are now listed by name, and Lock Code Manager picks the slot numbers itself:\n\nusers:\n  Raman:\n    pin: \"1234\"\n    enabled: true",
+      "allocation_failed": "Reading the locks failed unexpectedly. Check the Home Assistant logs, then try again."
     },
     "step": {
       "choose_path": {
@@ -68,6 +69,9 @@
         "description": "The lock `{lock}`, in the configuration for `{name}`, is no longer configured in Home Assistant and must be removed from your configuration. Choose new locks that this configuration is for. If you no longer need this configuration, delete the configuration entry.",
         "title": "Update locks for {name}"
       }
+    },
+    "progress": {
+      "allocating": "Reading which slots your locks already hold, so no user is given a number that is taken. A lock that answers one slot at a time can take a minute or more per lock."
     }
   },
   "entity": {
@@ -142,7 +146,8 @@
       "search_limit_reached": "Placing {num_users} users would need slot numbers past {max_slot}, which is as far as Lock Code Manager looks. No lock here reported how many PIN code slots it has, so this limit is Lock Code Manager's own rather than the lock's. Set up fewer users, or re-interview the lock so it reports its capacity.",
       "name_not_unique": "That name is already used by another user in this configuration. Names must be unique.",
       "missing_pin_if_enabled": "PIN must be set if slot is enabled.",
-      "unsupported_mqtt_lock": "These MQTT locks are not from a supported bridge (Zigbee2MQTT or Z-Wave JS UI): {locks}"
+      "unsupported_mqtt_lock": "These MQTT locks are not from a supported bridge (Zigbee2MQTT or Z-Wave JS UI): {locks}",
+      "allocation_failed": "Reading the locks failed unexpectedly. Check the Home Assistant logs, then try again."
     },
     "step": {
       "init": {
@@ -153,6 +158,9 @@
         "description": "Update the locks that are associated with this config entry and/or the users.",
         "title": "Lock Code Manager"
       }
+    },
+    "progress": {
+      "allocating": "Reading which slots your locks already hold, so no user is given a number that is taken. A lock that answers one slot at a time can take a minute or more per lock."
     }
   },
   "services": {

--- a/tests/common.py
+++ b/tests/common.py
@@ -20,6 +20,7 @@ from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ENABLED, CONF_ENTITY_ID, CONF_NAME, CONF_PIN
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.util import slugify
@@ -433,3 +434,31 @@ class MockCalendarEntity(CalendarEntity):
                 continue
             events.append(event)
         return events
+
+
+async def async_configure_flow(
+    hass: HomeAssistant, flow_id: str, user_input: dict[str, Any] | None = None
+) -> Any:
+    """
+    Submit to a config flow, waiting out any progress step it shows.
+
+    Allocation runs as a progress task (#1536): the step that takes the
+    submission shows progress, Home Assistant re-enters it when the task is
+    done, and the next result is what the user would see.
+    """
+    result = await hass.config_entries.flow.async_configure(flow_id, user_input)
+    while result["type"] == FlowResultType.SHOW_PROGRESS:
+        await hass.async_block_till_done()
+        result = await hass.config_entries.flow.async_configure(flow_id)
+    return result
+
+
+async def async_configure_options(
+    hass: HomeAssistant, flow_id: str, user_input: dict[str, Any] | None = None
+) -> Any:
+    """Submit to an options flow, waiting out any progress step it shows."""
+    result = await hass.config_entries.options.async_configure(flow_id, user_input)
+    while result["type"] == FlowResultType.SHOW_PROGRESS:
+        await hass.async_block_till_done()
+        result = await hass.config_entries.options.async_configure(flow_id)
+    return result

--- a/tests/providers/virtual/test_e2e.py
+++ b/tests/providers/virtual/test_e2e.py
@@ -45,6 +45,7 @@ from custom_components.lock_code_manager.domain.credentials import (
 from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.domain.sync import TICK_INTERVAL
 from custom_components.lock_code_manager.providers.virtual import VirtualLock
+from tests.common import async_configure_flow
 
 from .conftest import VIRTUAL_LOCK_ENTITY_ID, get_virtual_lock
 
@@ -401,8 +402,8 @@ class TestReauthLockSwap:
         await hass.async_block_till_done()
         [flow] = lcm_config_entry.async_get_active_flows(hass, {SOURCE_REAUTH})
 
-        result = await hass.config_entries.flow.async_configure(
-            flow["flow_id"], {CONF_LOCKS: [replacement.entity_id]}
+        result = await async_configure_flow(
+            hass, flow["flow_id"], {CONF_LOCKS: [replacement.entity_id]}
         )
         assert result["type"] == "abort"
         assert result["reason"] == "locks_updated"

--- a/tests/providers/zigbee2mqtt/test_e2e.py
+++ b/tests/providers/zigbee2mqtt/test_e2e.py
@@ -23,6 +23,7 @@ from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers.zigbee2mqtt import (
     Zigbee2MQTTLock,
 )
+from tests.common import async_configure_flow
 
 from .conftest import Z2M_FULL_TOPIC, Z2M_GET_TOPIC, Z2M_SET_TOPIC, get_z2m_lock
 
@@ -309,16 +310,15 @@ class TestAddingThroughTheUserInterface:
             DOMAIN, context={"source": SOURCE_USER}
         )
         flow_id = result["flow_id"]
-        result = await hass.config_entries.flow.async_configure(
+        result = await async_configure_flow(
+            hass,
             flow_id,
             {CONF_NAME: "z2m", CONF_LOCKS: [mqtt_lock_discovered.entity_id]},
         )
         assert result["step_id"] == "choose_path"
 
-        await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
-        result = await hass.config_entries.flow.async_configure(
-            flow_id, {CONF_NUM_USERS: 2}
-        )
+        await async_configure_flow(hass, flow_id, {"next_step_id": "ui"})
+        result = await async_configure_flow(hass, flow_id, {CONF_NUM_USERS: 2})
 
         assert result["step_id"] == "code_slot"
         assert result["description_placeholders"]["user_num"] == 1

--- a/tests/providers/zwave_js_ui/test_e2e.py
+++ b/tests/providers/zwave_js_ui/test_e2e.py
@@ -44,7 +44,12 @@ from custom_components.lock_code_manager.const import (
 from custom_components.lock_code_manager.domain.credentials import pin_address
 from custom_components.lock_code_manager.domain.models import SlotCredential
 from custom_components.lock_code_manager.providers.zwave_js_ui import ZWaveJSUILock
-from tests.common import code_entity_id, in_sync_entity_id, slot_entity_id
+from tests.common import (
+    async_configure_flow,
+    code_entity_id,
+    in_sync_entity_id,
+    slot_entity_id,
+)
 from tests.conftest import async_advance_time
 
 from .conftest import (
@@ -829,16 +834,15 @@ class TestAddingThroughTheUserInterface:
             DOMAIN, context={"source": SOURCE_USER}
         )
         flow_id = result["flow_id"]
-        result = await hass.config_entries.flow.async_configure(
+        result = await async_configure_flow(
+            hass,
             flow_id,
             {CONF_NAME: "zui", CONF_LOCKS: [zui_lock_discovered.entity_id]},
         )
         assert result["step_id"] == "choose_path"
 
-        await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
-        result = await hass.config_entries.flow.async_configure(
-            flow_id, {CONF_NUM_USERS: 2}
-        )
+        await async_configure_flow(hass, flow_id, {"next_step_id": "ui"})
+        result = await async_configure_flow(hass, flow_id, {CONF_NUM_USERS: 2})
 
         assert result["step_id"] == "code_slot"
         assert result["description_placeholders"]["user_num"] == 1

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -7,11 +7,15 @@ import re
 from unittest.mock import AsyncMock, PropertyMock, patch
 
 import pytest
-from pytest_homeassistant_custom_component.common import MockConfigEntry
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+    async_capture_events,
+)
 
 from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_USER
 from homeassistant.const import CONF_CONDITION, CONF_ENABLED, CONF_NAME, CONF_PIN
 from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import EVENT_DATA_ENTRY_FLOW_PROGRESS_UPDATE
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from custom_components.lock_code_manager.config_flow import _check_common_slots
@@ -41,6 +45,7 @@ from custom_components.lock_code_manager.domain.queries import get_entry_config
 from custom_components.lock_code_manager.domain.slot_assignment import (
     CONF_SLOT_ASSIGNMENT,
 )
+from tests.common import async_configure_flow, async_configure_options
 
 from .common import (
     BASE_CONFIG,
@@ -102,8 +107,8 @@ async def _start_config_flow(hass: HomeAssistant):
     assert result["step_id"] == "user"
     flow_id = result["flow_id"]
 
-    result = await hass.config_entries.flow.async_configure(
-        flow_id, {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
+    result = await async_configure_flow(
+        hass, flow_id, {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
     )
 
     assert result["type"] == "menu"
@@ -116,16 +121,12 @@ async def _start_ui_config_flow(hass: HomeAssistant):
     """Start a UI based config flow."""
     flow_id = await _start_config_flow(hass)
 
-    result = await hass.config_entries.flow.async_configure(
-        flow_id, {"next_step_id": "ui"}
-    )
+    result = await async_configure_flow(hass, flow_id, {"next_step_id": "ui"})
 
     assert result["type"] == "form"
     assert result["step_id"] == "ui"
 
-    result = await hass.config_entries.flow.async_configure(
-        flow_id, {CONF_NUM_USERS: 4}
-    )
+    result = await async_configure_flow(hass, flow_id, {CONF_NUM_USERS: 4})
 
     assert result["type"] == "form"
     assert result["step_id"] == "code_slot"
@@ -143,9 +144,7 @@ async def _start_yaml_config_flow(hass: HomeAssistant):
     """
     flow_id = await _start_config_flow(hass)
 
-    result = await hass.config_entries.flow.async_configure(
-        flow_id, {"next_step_id": "yaml"}
-    )
+    result = await async_configure_flow(hass, flow_id, {"next_step_id": "yaml"})
 
     assert result["type"] == "form"
     assert result["step_id"] == "yaml"
@@ -194,31 +193,25 @@ async def test_every_config_flow_field_has_a_label(
 ):
     """Every field the setup flow shows is named by the strings."""
     flow_id = await _init_flow_to_user_step(hass)
-    result = await hass.config_entries.flow.async_configure(flow_id)
+    result = await async_configure_flow(hass, flow_id)
     _assert_fields_are_labelled(result, "config")
 
-    result = await hass.config_entries.flow.async_configure(
-        flow_id, {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
+    result = await async_configure_flow(
+        hass, flow_id, {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
     )
-    result = await hass.config_entries.flow.async_configure(
-        flow_id, {"next_step_id": "ui"}
-    )
+    result = await async_configure_flow(hass, flow_id, {"next_step_id": "ui"})
     _assert_fields_are_labelled(result, "config")
 
-    result = await hass.config_entries.flow.async_configure(
-        flow_id, {CONF_NUM_USERS: 1}
-    )
+    result = await async_configure_flow(hass, flow_id, {CONF_NUM_USERS: 1})
     _assert_fields_are_labelled(result, "config")
 
     # The yaml path is the ui path's sibling, so reaching it takes a second
     # flow -- under a second name, because the first one holds the unique id.
     flow_id = await _init_flow_to_user_step(hass)
-    await hass.config_entries.flow.async_configure(
-        flow_id, {CONF_NAME: "test2", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
+    await async_configure_flow(
+        hass, flow_id, {CONF_NAME: "test2", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
     )
-    result = await hass.config_entries.flow.async_configure(
-        flow_id, {"next_step_id": "yaml"}
-    )
+    result = await async_configure_flow(hass, flow_id, {"next_step_id": "yaml"})
     _assert_fields_are_labelled(result, "config")
 
 
@@ -245,7 +238,7 @@ async def test_every_reauth_field_has_a_label(
         hass, {SOURCE_REAUTH}
     )
     # The in-progress flow carries no schema, so render the form to get one.
-    result = await hass.config_entries.flow.async_configure(flow["flow_id"])
+    result = await async_configure_flow(hass, flow["flow_id"])
     _assert_fields_are_labelled(result, "config")
 
 
@@ -258,7 +251,8 @@ async def test_config_flow_ui(hass: HomeAssistant, mock_lock_config_entry):
         slot_num = i + 1
         is_last = slot_num == len(pins)
 
-        result = await hass.config_entries.flow.async_configure(
+        result = await async_configure_flow(
+            hass,
             flow_id,
             {CONF_NAME: f"User {slot_num}", CONF_ENABLED: True, CONF_PIN: pin},
         )
@@ -295,8 +289,8 @@ async def test_config_flow_ui_error(hass: HomeAssistant, mock_lock_config_entry)
     """Test error in UI based config flow."""
     flow_id = await _start_ui_config_flow(hass)
 
-    result = await hass.config_entries.flow.async_configure(
-        flow_id, {CONF_NAME: "User 1", CONF_ENABLED: True, CONF_PIN: ""}
+    result = await async_configure_flow(
+        hass, flow_id, {CONF_NAME: "User 1", CONF_ENABLED: True, CONF_PIN: ""}
     )
 
     assert result["type"] == "form"
@@ -310,7 +304,8 @@ async def test_config_flow_yaml(hass: HomeAssistant, mock_lock_config_entry):
     flow_id = await _start_yaml_config_flow(hass)
 
     with _holding():
-        result = await hass.config_entries.flow.async_configure(
+        result = await async_configure_flow(
+            hass,
             flow_id,
             {
                 CONF_USERS: {
@@ -338,7 +333,8 @@ async def test_config_flow_yaml_error(hass: HomeAssistant):
     flow_id = await _start_yaml_config_flow(hass)
 
     with _holding():
-        result = await hass.config_entries.flow.async_configure(
+        result = await async_configure_flow(
+            hass,
             flow_id,
             {CONF_USERS: {"User 1": {CONF_ENABLED: True, CONF_PIN: ""}}},
         )
@@ -359,14 +355,12 @@ async def test_config_flow_ui_stores_a_padded_pin_stripped(
     match -- and the guided form is where a stray space gets typed.
     """
     flow_id = await _start_config_flow(hass)
-    await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
-    result = await hass.config_entries.flow.async_configure(
-        flow_id, {CONF_NUM_USERS: 1}
-    )
+    await async_configure_flow(hass, flow_id, {"next_step_id": "ui"})
+    result = await async_configure_flow(hass, flow_id, {CONF_NUM_USERS: 1})
     assert result["step_id"] == "code_slot"
 
-    result = await hass.config_entries.flow.async_configure(
-        flow_id, {CONF_NAME: "User 1", CONF_ENABLED: True, CONF_PIN: " 1234 "}
+    result = await async_configure_flow(
+        hass, flow_id, {CONF_NAME: "User 1", CONF_ENABLED: True, CONF_PIN: " 1234 "}
     )
 
     assert result["type"] == "create_entry"
@@ -386,11 +380,11 @@ async def test_config_flow_ui_rejects_a_whitespace_only_pin(
     credential no keypad can produce.
     """
     flow_id = await _start_config_flow(hass)
-    await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
-    await hass.config_entries.flow.async_configure(flow_id, {CONF_NUM_USERS: 1})
+    await async_configure_flow(hass, flow_id, {"next_step_id": "ui"})
+    await async_configure_flow(hass, flow_id, {CONF_NUM_USERS: 1})
 
-    result = await hass.config_entries.flow.async_configure(
-        flow_id, {CONF_NAME: "User 1", CONF_ENABLED: True, CONF_PIN: "   "}
+    result = await async_configure_flow(
+        hass, flow_id, {CONF_NAME: "User 1", CONF_ENABLED: True, CONF_PIN: "   "}
     )
 
     assert result["type"] == "form"
@@ -405,7 +399,8 @@ async def test_config_flow_yaml_stores_a_padded_pin_stripped(
     flow_id = await _start_yaml_config_flow(hass)
 
     with _holding():
-        result = await hass.config_entries.flow.async_configure(
+        result = await async_configure_flow(
+            hass,
             flow_id,
             {CONF_USERS: {"User 1": {CONF_ENABLED: True, CONF_PIN: " 1234 "}}},
         )
@@ -423,7 +418,8 @@ async def test_config_flow_yaml_rejects_a_whitespace_only_pin(
     flow_id = await _start_yaml_config_flow(hass)
 
     with _holding():
-        result = await hass.config_entries.flow.async_configure(
+        result = await async_configure_flow(
+            hass,
             flow_id,
             {CONF_USERS: {"User 1": {CONF_ENABLED: True, CONF_PIN: "   "}}},
         )
@@ -458,9 +454,7 @@ async def test_options_flow(hass: HomeAssistant, mock_lock_config_entry):
     assert result["step_id"] == "init"
     flow_id = result["flow_id"]
 
-    result = await hass.config_entries.options.async_configure(
-        flow_id, user_input=new_config
-    )
+    result = await async_configure_options(hass, flow_id, user_input=new_config)
 
     assert result["type"] == "form"
     assert result["step_id"] == "init"
@@ -469,9 +463,7 @@ async def test_options_flow(hass: HomeAssistant, mock_lock_config_entry):
     # Give the enabled user a PIN and it saves.
     new_config[CONF_USERS]["User 3"][CONF_PIN] = "1234"
     with _holding():
-        result = await hass.config_entries.options.async_configure(
-            flow_id, user_input=new_config
-        )
+        result = await async_configure_options(hass, flow_id, user_input=new_config)
 
     assert result["type"] == "create_entry"
     assert result["data"][CONF_USERS] == new_config[CONF_USERS]
@@ -496,8 +488,8 @@ async def test_config_flow_reauth(
     assert result["step_id"] == "reauth_confirm"
     flow_id = result["flow_id"]
 
-    result = await hass.config_entries.flow.async_configure(
-        flow_id, {CONF_LOCKS: [LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID]}
+    result = await async_configure_flow(
+        hass, flow_id, {CONF_LOCKS: [LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID]}
     )
 
     assert result["type"] == "abort"
@@ -521,7 +513,7 @@ async def test_config_flow_reauth_form_refetch(
         hass, {SOURCE_REAUTH}
     )
 
-    result = await hass.config_entries.flow.async_configure(flow["flow_id"], None)
+    result = await async_configure_flow(hass, flow["flow_id"], None)
 
     assert result["type"] == "form"
     assert result["step_id"] == "reauth_confirm"
@@ -553,8 +545,8 @@ async def test_reauth_wins_over_stale_options(
     hass.config_entries.async_update_entry(entry, options=stale_options)
 
     [flow] = entry.async_get_active_flows(hass, {SOURCE_REAUTH})
-    result = await hass.config_entries.flow.async_configure(
-        flow["flow_id"], {CONF_LOCKS: [LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID]}
+    result = await async_configure_flow(
+        hass, flow["flow_id"], {CONF_LOCKS: [LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID]}
     )
     assert result["reason"] == "locks_updated"
     await hass.async_block_till_done()
@@ -576,7 +568,8 @@ async def test_config_flow_slots_already_configured(
     flow_id = await _start_yaml_config_flow(hass)
 
     with _holding():
-        result = await hass.config_entries.flow.async_configure(
+        result = await async_configure_flow(
+            hass,
             flow_id,
             {CONF_USERS: {"User 2": {CONF_ENABLED: False, CONF_PIN: "0123"}}},
         )
@@ -593,7 +586,8 @@ async def test_config_flow_two_entries_same_locks(
     flow_id = await _start_yaml_config_flow(hass)
 
     with _holding():
-        result = await hass.config_entries.flow.async_configure(
+        result = await async_configure_flow(
+            hass,
             flow_id,
             {CONF_USERS: {"User 3": {CONF_ENABLED: False, CONF_PIN: "0123"}}},
         )
@@ -618,7 +612,8 @@ async def test_config_flow_ui_scheduler_entity_excluded(
     flow_id = await _start_ui_config_flow(hass)
 
     # Try to configure slot 1 with a scheduler entity as condition
-    result = await hass.config_entries.flow.async_configure(
+    result = await async_configure_flow(
+        hass,
         flow_id,
         {
             CONF_NAME: "User 1",
@@ -650,23 +645,21 @@ async def test_ui_setup_allocates_around_existing_codes(
     and might have picked one already in use.
     """
     flow_id = await _init_flow_to_user_step(hass)
-    await hass.config_entries.flow.async_configure(
-        flow_id, {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
+    await async_configure_flow(
+        hass, flow_id, {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
     )
-    await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
-    result = await hass.config_entries.flow.async_configure(
-        flow_id, {CONF_NUM_USERS: 2}
-    )
+    await async_configure_flow(hass, flow_id, {"next_step_id": "ui"})
+    result = await async_configure_flow(hass, flow_id, {CONF_NUM_USERS: 2})
 
     # Straight to the first user, with no confirmation in between.
     assert result["type"] == "form"
     assert result["step_id"] == "code_slot"
 
-    await hass.config_entries.flow.async_configure(
-        flow_id, {CONF_NAME: "Raman", CONF_ENABLED: True, CONF_PIN: "1111"}
+    await async_configure_flow(
+        hass, flow_id, {CONF_NAME: "Raman", CONF_ENABLED: True, CONF_PIN: "1111"}
     )
-    result = await hass.config_entries.flow.async_configure(
-        flow_id, {CONF_NAME: "Alice", CONF_ENABLED: True, CONF_PIN: "2222"}
+    result = await async_configure_flow(
+        hass, flow_id, {CONF_NAME: "Alice", CONF_ENABLED: True, CONF_PIN: "2222"}
     )
 
     assert result["type"] == "create_entry"
@@ -687,16 +680,14 @@ async def test_ui_setup_refuses_when_a_lock_cannot_be_read(
     unreachable.
     """
     flow_id = await _start_config_flow(hass)
-    await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
+    await async_configure_flow(hass, flow_id, {"next_step_id": "ui"})
 
     with patch.object(
         MockLCMLock,
         "async_get_usercodes",
         AsyncMock(side_effect=LockDisconnected("asleep")),
     ):
-        result = await hass.config_entries.flow.async_configure(
-            flow_id, {CONF_NUM_USERS: 2}
-        )
+        result = await async_configure_flow(hass, flow_id, {CONF_NUM_USERS: 2})
 
     # Refused before a single name or PIN was collected.
     # A form, not an abort: a lock that is merely asleep must not end setup.
@@ -748,7 +739,8 @@ async def test_options_flow_no_added_pairs_persists_immediately(
 
     # Submit the same locks/slots that already exist on the entry — no diff
     with _holding():
-        result = await hass.config_entries.options.async_configure(
+        result = await async_configure_options(
+            hass,
             flow_id,
             {
                 CONF_LOCKS: [LOCK_1_ENTITY_ID],
@@ -767,7 +759,8 @@ async def test_options_flow_added_pair_no_existing_code_persists(
 
     # Adding slot 2; lock has nothing in slot 2 (only slot 1)
     with _holding():
-        result = await hass.config_entries.options.async_configure(
+        result = await async_configure_options(
+            hass,
             flow_id,
             {
                 CONF_LOCKS: [LOCK_1_ENTITY_ID],
@@ -788,7 +781,8 @@ async def test_options_flow_added_pair_empty_code_persists(
     flow_id, _ = await _start_options_flow(hass)
 
     with _holding():
-        result = await hass.config_entries.options.async_configure(
+        result = await async_configure_options(
+            hass,
             flow_id,
             {
                 CONF_LOCKS: [LOCK_1_ENTITY_ID],
@@ -808,7 +802,8 @@ async def test_options_flow_invalid_yaml_shows_error(
     """Validation error in the YAML keeps the form open with the error."""
     flow_id, _ = await _start_options_flow(hass)
 
-    result = await hass.config_entries.options.async_configure(
+    result = await async_configure_options(
+        hass,
         flow_id,
         {
             CONF_LOCKS: [LOCK_1_ENTITY_ID],
@@ -863,7 +858,8 @@ async def test_config_flow_yaml_rejects_slot_beyond_lock_capacity(
     flow_id = await _start_yaml_config_flow(hass)
 
     with _capacity_probe(return_value=_capabilities_with_slots(30)):
-        result = await hass.config_entries.flow.async_configure(
+        result = await async_configure_flow(
+            hass,
             flow_id,
             {
                 CONF_USERS: {
@@ -886,7 +882,8 @@ async def test_config_flow_yaml_accepts_slot_within_capacity(
     flow_id = await _start_yaml_config_flow(hass)
 
     with _capacity_probe(return_value=_capabilities_with_slots(30)):
-        result = await hass.config_entries.flow.async_configure(
+        result = await async_configure_flow(
+            hass,
             flow_id,
             {CONF_USERS: {"User 30": {CONF_ENABLED: True, CONF_PIN: "2222"}}},
         )
@@ -903,15 +900,13 @@ async def test_setup_refuses_when_a_lock_has_no_provider(
     allocation must not issue numbers it was never able to check against it.
     """
     flow_id = await _start_config_flow(hass)
-    await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
+    await async_configure_flow(hass, flow_id, {"next_step_id": "ui"})
 
     with patch(
         "custom_components.lock_code_manager.domain.allocation.build_lock_instance",
         side_effect=LockQuerySkipped(LOCK_1_ENTITY_ID, managed=True),
     ):
-        result = await hass.config_entries.flow.async_configure(
-            flow_id, {CONF_NUM_USERS: 2}
-        )
+        result = await async_configure_flow(hass, flow_id, {CONF_NUM_USERS: 2})
 
     # A form, not an abort: a lock that is merely asleep must not end setup.
     assert result["type"] == "form"
@@ -925,15 +920,13 @@ async def test_setup_ignores_a_lock_on_an_unsupported_platform(
 ):
     """A lock this integration will not write to cannot constrain numbering."""
     flow_id = await _start_config_flow(hass)
-    await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
+    await async_configure_flow(hass, flow_id, {"next_step_id": "ui"})
 
     with patch(
         "custom_components.lock_code_manager.domain.allocation.build_lock_instance",
         side_effect=LockQuerySkipped(LOCK_1_ENTITY_ID, managed=False),
     ):
-        result = await hass.config_entries.flow.async_configure(
-            flow_id, {CONF_NUM_USERS: 2}
-        )
+        result = await async_configure_flow(hass, flow_id, {CONF_NUM_USERS: 2})
 
     assert result["type"] == "form"
     assert result["step_id"] == "code_slot"
@@ -952,12 +945,10 @@ async def test_setup_reads_the_locks_for_no_entry_at_all(
     name.
     """
     flow_id = await _start_config_flow(hass)
-    await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
+    await async_configure_flow(hass, flow_id, {"next_step_id": "ui"})
 
     with reading_for() as read_for:
-        result = await hass.config_entries.flow.async_configure(
-            flow_id, {CONF_NUM_USERS: 2}
-        )
+        result = await async_configure_flow(hass, flow_id, {CONF_NUM_USERS: 2})
 
     assert result["step_id"] == "code_slot"
     assert read_for, "allocation issued numbers without reading a lock"
@@ -971,7 +962,8 @@ async def test_editing_reads_the_locks_for_the_entry_being_edited(
     flow_id, entry = await _start_options_flow(hass)
 
     with reading_for() as read_for:
-        result = await hass.config_entries.options.async_configure(
+        result = await async_configure_options(
+            hass,
             flow_id,
             {
                 CONF_LOCKS: [LOCK_1_ENTITY_ID],
@@ -1000,8 +992,8 @@ async def test_reauth_reads_the_locks_for_the_entry_it_is_repairing(
     )
 
     with reading_for() as read_for:
-        result = await hass.config_entries.flow.async_configure(
-            flow["flow_id"], {CONF_LOCKS: [LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID]}
+        result = await async_configure_flow(
+            hass, flow["flow_id"], {CONF_LOCKS: [LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID]}
         )
 
     assert result["reason"] == "locks_updated"
@@ -1033,15 +1025,13 @@ async def test_setup_reads_only_as_far_as_it_has_to(
         }
 
     flow_id = await _start_config_flow(hass)
-    await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
+    await async_configure_flow(hass, flow_id, {"next_step_id": "ui"})
 
     with patch.object(MockLCMLock, "async_get_usercodes", _read):
-        result = await hass.config_entries.flow.async_configure(
-            flow_id, {CONF_NUM_USERS: 2}
-        )
+        result = await async_configure_flow(hass, flow_id, {CONF_NUM_USERS: 2})
         for name in ("Raman", "Alice"):
-            result = await hass.config_entries.flow.async_configure(
-                flow_id, {CONF_NAME: name, CONF_ENABLED: True, CONF_PIN: "1111"}
+            result = await async_configure_flow(
+                hass, flow_id, {CONF_NAME: name, CONF_ENABLED: True, CONF_PIN: "1111"}
             )
 
     assert result["type"] == "create_entry"
@@ -1070,10 +1060,10 @@ async def test_setup_does_not_widen_when_nothing_is_in_the_way(
         return dict.fromkeys(scope, SlotCredential.empty())
 
     flow_id = await _start_config_flow(hass)
-    await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
+    await async_configure_flow(hass, flow_id, {"next_step_id": "ui"})
 
     with patch.object(MockLCMLock, "async_get_usercodes", _read):
-        await hass.config_entries.flow.async_configure(flow_id, {CONF_NUM_USERS: 3})
+        await async_configure_flow(hass, flow_id, {CONF_NUM_USERS: 3})
 
     assert windows == [[1, 2, 3]]
 
@@ -1087,13 +1077,11 @@ async def test_config_flow_ui_rejects_more_users_than_the_lock_holds(
     issues, so the answer is known as soon as the count is.
     """
     flow_id = await _start_config_flow(hass)
-    await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
+    await async_configure_flow(hass, flow_id, {"next_step_id": "ui"})
 
     probe_capabilities = _capacity_probe(return_value=_capabilities_with_slots(2))
     with probe_capabilities, _holding():
-        result = await hass.config_entries.flow.async_configure(
-            flow_id, {CONF_NUM_USERS: 3}
-        )
+        result = await async_configure_flow(hass, flow_id, {CONF_NUM_USERS: 3})
 
     # A form, not an abort: the user can lower the count and carry on.
     assert result["type"] == "form"
@@ -1103,9 +1091,7 @@ async def test_config_flow_ui_rejects_more_users_than_the_lock_holds(
     assert result["description_placeholders"]["num_slots"] == "2"
 
     with probe_capabilities, _holding():
-        result = await hass.config_entries.flow.async_configure(
-            flow_id, {CONF_NUM_USERS: 2}
-        )
+        result = await async_configure_flow(hass, flow_id, {CONF_NUM_USERS: 2})
 
     assert result["type"] == "form"
     assert result["step_id"] == "code_slot"
@@ -1126,16 +1112,14 @@ async def test_a_refused_count_reports_only_what_it_can_stand_behind(
     message = strings["config"]["error"]["numbers_needed_exceed_capacity"]
 
     flow_id = await _start_config_flow(hass)
-    await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
+    await async_configure_flow(hass, flow_id, {"next_step_id": "ui"})
 
     # Nine of the ten slots are taken, well past the window the count asks for.
     with (
         _capacity_probe(return_value=_capabilities_with_slots(10)),
         _holding(*range(1, 10)),
     ):
-        result = await hass.config_entries.flow.async_configure(
-            flow_id, {CONF_NUM_USERS: 8}
-        )
+        result = await async_configure_flow(hass, flow_id, {CONF_NUM_USERS: 8})
 
     assert result["errors"] == {"base": "numbers_needed_exceed_capacity"}
     supplied = result["description_placeholders"]
@@ -1158,7 +1142,8 @@ async def test_config_flow_capacity_check_skipped_when_lock_unreachable(
     flow_id = await _start_yaml_config_flow(hass)
 
     with _capacity_probe(side_effect=LockDisconnected("lock asleep")):
-        result = await hass.config_entries.flow.async_configure(
+        result = await async_configure_flow(
+            hass,
             flow_id,
             {CONF_USERS: {"User 50": {CONF_ENABLED: True, CONF_PIN: "2222"}}},
         )
@@ -1173,7 +1158,8 @@ async def test_config_flow_capacity_check_skipped_when_capacity_unknown(
     flow_id = await _start_yaml_config_flow(hass)
 
     with _capacity_probe(return_value=_capabilities_with_slots(0)):
-        result = await hass.config_entries.flow.async_configure(
+        result = await async_configure_flow(
+            hass,
             flow_id,
             {CONF_USERS: {"User 50": {CONF_ENABLED: True, CONF_PIN: "2222"}}},
         )
@@ -1202,7 +1188,8 @@ async def test_config_flow_capacity_check_skipped_when_lock_allocates_index(
         ),
         patch.object(MockLCMLock, "async_get_capabilities", capabilities),
     ):
-        result = await hass.config_entries.flow.async_configure(
+        result = await async_configure_flow(
+            hass,
             flow_id,
             {CONF_USERS: {"User 50": {CONF_ENABLED: True, CONF_PIN: "2222"}}},
         )
@@ -1224,7 +1211,8 @@ async def test_config_flow_capacity_check_survives_unexpected_error(
     flow_id = await _start_yaml_config_flow(hass)
 
     with _capacity_probe(side_effect=RuntimeError("provider blew up")):
-        result = await hass.config_entries.flow.async_configure(
+        result = await async_configure_flow(
+            hass,
             flow_id,
             {CONF_USERS: {"User 50": {CONF_ENABLED: True, CONF_PIN: "2222"}}},
         )
@@ -1244,8 +1232,8 @@ async def test_config_flow_ui_accepts_a_name_containing_a_pipe(
     """
     flow_id = await _start_ui_config_flow(hass)
 
-    result = await hass.config_entries.flow.async_configure(
-        flow_id, {CONF_NAME: "Ra|man", CONF_ENABLED: True, CONF_PIN: "1234"}
+    result = await async_configure_flow(
+        hass, flow_id, {CONF_NAME: "Ra|man", CONF_ENABLED: True, CONF_PIN: "1234"}
     )
 
     assert result["type"] == "form"
@@ -1262,8 +1250,8 @@ async def test_config_flow_ui_rejects_a_missing_name(
     """
     flow_id = await _start_ui_config_flow(hass)
 
-    result = await hass.config_entries.flow.async_configure(
-        flow_id, {CONF_NAME: "   ", CONF_ENABLED: True, CONF_PIN: "1234"}
+    result = await async_configure_flow(
+        hass, flow_id, {CONF_NAME: "   ", CONF_ENABLED: True, CONF_PIN: "1234"}
     )
 
     assert result["type"] == "form"
@@ -1276,14 +1264,14 @@ async def test_config_flow_ui_rejects_duplicate_name(
     """Two slots in one entry cannot share a name, ignoring case."""
     flow_id = await _start_ui_config_flow(hass)
 
-    result = await hass.config_entries.flow.async_configure(
-        flow_id, {CONF_NAME: "Raman", CONF_ENABLED: True, CONF_PIN: "1234"}
+    result = await async_configure_flow(
+        hass, flow_id, {CONF_NAME: "Raman", CONF_ENABLED: True, CONF_PIN: "1234"}
     )
     assert result["type"] == "form"
     assert not result["errors"]
 
-    result = await hass.config_entries.flow.async_configure(
-        flow_id, {CONF_NAME: "  raman  ", CONF_ENABLED: True, CONF_PIN: "5678"}
+    result = await async_configure_flow(
+        hass, flow_id, {CONF_NAME: "  raman  ", CONF_ENABLED: True, CONF_PIN: "5678"}
     )
 
     assert result["type"] == "form"
@@ -1320,9 +1308,7 @@ async def test_config_flow_yaml_enforces_name_rules(
     flow_id = await _start_yaml_config_flow(hass)
 
     with _holding():
-        result = await hass.config_entries.flow.async_configure(
-            flow_id, {CONF_USERS: users}
-        )
+        result = await async_configure_flow(hass, flow_id, {CONF_USERS: users})
 
     assert result["type"] == "form"
     assert result["errors"] == {"base": expected_error}
@@ -1340,8 +1326,8 @@ async def test_a_slot_keyed_block_is_rejected_not_reinterpreted(
     flow_id = await _start_yaml_config_flow(hass)
 
     with _holding():
-        result = await hass.config_entries.flow.async_configure(
-            flow_id, {CONF_USERS: {1: {CONF_ENABLED: True, CONF_PIN: "1234"}}}
+        result = await async_configure_flow(
+            hass, flow_id, {CONF_USERS: {1: {CONF_ENABLED: True, CONF_PIN: "1234"}}}
         )
 
     assert result["type"] == "form"
@@ -1365,9 +1351,9 @@ async def test_every_name_error_supplies_what_its_message_asks_for(
     )
 
     flow_id = await _start_config_flow(hass)
-    await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
+    await async_configure_flow(hass, flow_id, {"next_step_id": "ui"})
     with _holding():
-        await hass.config_entries.flow.async_configure(flow_id, {CONF_NUM_USERS: 2})
+        await async_configure_flow(hass, flow_id, {CONF_NUM_USERS: 2})
 
     for user_input in (
         {CONF_NAME: "", CONF_ENABLED: True, CONF_PIN: "1111"},
@@ -1375,7 +1361,7 @@ async def test_every_name_error_supplies_what_its_message_asks_for(
         {CONF_NAME: "raman ", CONF_ENABLED: True, CONF_PIN: "2222"},
     ):
         with _holding():
-            result = await hass.config_entries.flow.async_configure(flow_id, user_input)
+            result = await async_configure_flow(hass, flow_id, user_input)
         for key in (result.get("errors") or {}).values():
             message = strings["config"]["error"][key]
             supplied = result.get("description_placeholders") or {}
@@ -1405,16 +1391,14 @@ async def test_an_impossible_count_is_refused_without_asking_a_lock(
         return dict.fromkeys(scope, SlotCredential.empty())
 
     flow_id = await _start_config_flow(hass)
-    await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
+    await async_configure_flow(hass, flow_id, {"next_step_id": "ui"})
 
     probe_capabilities = _capacity_probe(return_value=_capabilities_with_slots(3))
     with (
         probe_capabilities,
         patch.object(MockLCMLock, "async_get_usercodes", _read),
     ):
-        result = await hass.config_entries.flow.async_configure(
-            flow_id, {CONF_NUM_USERS: 500}
-        )
+        result = await async_configure_flow(hass, flow_id, {CONF_NUM_USERS: 500})
 
     assert result["errors"] == {"base": "too_many_users"}
     assert reads == [], "the lock was read before the count was refused"
@@ -1438,7 +1422,7 @@ async def test_claims_above_the_window_do_not_widen_the_read(
         return dict.fromkeys(scope, SlotCredential.empty())
 
     flow_id = await _start_config_flow(hass)
-    await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
+    await async_configure_flow(hass, flow_id, {"next_step_id": "ui"})
 
     with (
         patch(
@@ -1447,9 +1431,7 @@ async def test_claims_above_the_window_do_not_widen_the_read(
         ),
         patch.object(MockLCMLock, "async_get_usercodes", _read),
     ):
-        result = await hass.config_entries.flow.async_configure(
-            flow_id, {CONF_NUM_USERS: 3}
-        )
+        result = await async_configure_flow(hass, flow_id, {CONF_NUM_USERS: 3})
 
     assert result["step_id"] == "code_slot"
     assert windows == [3], "another entry's distant claims widened the read"
@@ -1472,7 +1454,7 @@ async def test_a_lock_that_allocates_its_own_index_is_not_asked(
         return dict.fromkeys(scope, SlotCredential.empty())
 
     flow_id = await _start_config_flow(hass)
-    await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
+    await async_configure_flow(hass, flow_id, {"next_step_id": "ui"})
 
     with (
         patch.object(
@@ -1483,9 +1465,7 @@ async def test_a_lock_that_allocates_its_own_index_is_not_asked(
         ),
         patch.object(MockLCMLock, "async_get_usercodes", _read),
     ):
-        result = await hass.config_entries.flow.async_configure(
-            flow_id, {CONF_NUM_USERS: 2}
-        )
+        result = await async_configure_flow(hass, flow_id, {CONF_NUM_USERS: 2})
 
     assert result["step_id"] == "code_slot"
     assert reads == [], "a lock that cannot constrain the numbering was read"
@@ -1508,7 +1488,7 @@ async def test_a_lock_that_fails_unexpectedly_is_unknown_not_empty(
     reading it must never become "no numbers are taken".
     """
     flow_id = await _start_config_flow(hass)
-    await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
+    await async_configure_flow(hass, flow_id, {"next_step_id": "ui"})
 
     if target == "build_lock_instance":
         patcher = patch(
@@ -1519,9 +1499,7 @@ async def test_a_lock_that_fails_unexpectedly_is_unknown_not_empty(
         patcher = patch.object(MockLCMLock, target, AsyncMock(side_effect=boom))
 
     with patcher:
-        result = await hass.config_entries.flow.async_configure(
-            flow_id, {CONF_NUM_USERS: 2}
-        )
+        result = await async_configure_flow(hass, flow_id, {CONF_NUM_USERS: 2})
 
     # A form, not an abort: a lock that is merely asleep must not end setup.
     assert result["type"] == "form"
@@ -1540,14 +1518,12 @@ async def test_a_count_that_fits_can_still_need_numbers_that_do_not(
     where it is refused.
     """
     flow_id = await _start_config_flow(hass)
-    await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
+    await async_configure_flow(hass, flow_id, {"next_step_id": "ui"})
 
     # Three users fit in four slots; slots 1 and 2 are taken, so they would
     # land on 3, 4 and 5 -- and 5 does not exist.
     with _capacity_probe(return_value=_capabilities_with_slots(4)), _holding(1, 2):
-        result = await hass.config_entries.flow.async_configure(
-            flow_id, {CONF_NUM_USERS: 3}
-        )
+        result = await async_configure_flow(hass, flow_id, {CONF_NUM_USERS: 3})
 
     assert result["errors"] == {"base": "numbers_needed_exceed_capacity"}
     # The count the user chose, and the number their last user would need.
@@ -1571,12 +1547,12 @@ async def test_choosing_the_ui_path_reads_no_lock_on_the_way_in(
     )
     flow_id = result["flow_id"]
 
-    result = await hass.config_entries.flow.async_configure(
-        flow_id, {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
+    result = await async_configure_flow(
+        hass, flow_id, {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
     )
     assert result["step_id"] == "choose_path"
 
-    await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
+    await async_configure_flow(hass, flow_id, {"next_step_id": "ui"})
 
     windows: list[list[int]] = []
 
@@ -1586,9 +1562,7 @@ async def test_choosing_the_ui_path_reads_no_lock_on_the_way_in(
         return {slot: SlotCredential.empty() for slot in scope}
 
     with patch.object(MockLCMLock, "async_get_usercodes", _read):
-        result = await hass.config_entries.flow.async_configure(
-            flow_id, {CONF_NUM_USERS: 1}
-        )
+        result = await async_configure_flow(hass, flow_id, {CONF_NUM_USERS: 1})
 
     assert result["step_id"] == "code_slot"
     # Only the numbers it is about to issue were read, not the lock's range.
@@ -1621,12 +1595,10 @@ async def test_a_nearly_full_lock_is_read_once_through(
         }
 
     flow_id = await _start_config_flow(hass)
-    await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
+    await async_configure_flow(hass, flow_id, {"next_step_id": "ui"})
 
     with patch.object(MockLCMLock, "async_get_usercodes", _read):
-        result = await hass.config_entries.flow.async_configure(
-            flow_id, {CONF_NUM_USERS: 2}
-        )
+        result = await async_configure_flow(hass, flow_id, {CONF_NUM_USERS: 2})
 
     assert result["step_id"] == "code_slot"
     # The users land on 30 and 31, so 31 indices are read -- each exactly once.
@@ -1634,8 +1606,8 @@ async def test_a_nearly_full_lock_is_read_once_through(
     assert len(asked) == len(set(asked)), "an index was read more than once"
 
     for name in ("Raman", "Alice"):
-        result = await hass.config_entries.flow.async_configure(
-            flow_id, {CONF_NAME: name, CONF_ENABLED: True, CONF_PIN: "1111"}
+        result = await async_configure_flow(
+            hass, flow_id, {CONF_NAME: name, CONF_ENABLED: True, CONF_PIN: "1111"}
         )
     assert result["type"] == "create_entry"
     assert set(result["data"][CONF_SLOT_ASSIGNMENT].values()) <= set(asked)
@@ -1652,15 +1624,15 @@ async def test_numbers_another_entry_manages_are_stepped_over(
     holding a LOW number the new users have to step over.
     """
     flow_id = await _start_config_flow(hass)
-    await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
+    await async_configure_flow(hass, flow_id, {"next_step_id": "ui"})
 
     # The existing entry manages slots 1 and 2 on this lock; the lock itself
     # holds nothing, so only the neighbour's claim can push the users up.
     with _holding():
-        await hass.config_entries.flow.async_configure(flow_id, {CONF_NUM_USERS: 2})
+        await async_configure_flow(hass, flow_id, {CONF_NUM_USERS: 2})
         for name in ("Raman", "Alice"):
-            result = await hass.config_entries.flow.async_configure(
-                flow_id, {CONF_NAME: name, CONF_ENABLED: True, CONF_PIN: "1111"}
+            result = await async_configure_flow(
+                hass, flow_id, {CONF_NAME: name, CONF_ENABLED: True, CONF_PIN: "1111"}
             )
 
     assert result["type"] == "create_entry"
@@ -1677,7 +1649,8 @@ async def test_a_blank_yaml_name_names_the_slot_it_came_from(
     flow_id = await _start_yaml_config_flow(hass)
 
     with _holding():
-        result = await hass.config_entries.flow.async_configure(
+        result = await async_configure_flow(
+            hass,
             flow_id,
             {CONF_USERS: {"   ": {CONF_ENABLED: True, CONF_PIN: "1234"}}},
         )
@@ -1703,13 +1676,13 @@ async def test_an_empty_lock_numbers_users_from_one(
     was ever read for.
     """
     flow_id = await _start_config_flow(hass)
-    await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
+    await async_configure_flow(hass, flow_id, {"next_step_id": "ui"})
 
     with _holding():
-        await hass.config_entries.flow.async_configure(flow_id, {CONF_NUM_USERS: 3})
+        await async_configure_flow(hass, flow_id, {CONF_NUM_USERS: 3})
         for name in ("Raman", "Alice", "Wren"):
-            result = await hass.config_entries.flow.async_configure(
-                flow_id, {CONF_NAME: name, CONF_ENABLED: True, CONF_PIN: "1111"}
+            result = await async_configure_flow(
+                hass, flow_id, {CONF_NAME: name, CONF_ENABLED: True, CONF_PIN: "1111"}
             )
 
     assert result["type"] == "create_entry"
@@ -1725,12 +1698,10 @@ async def test_a_refused_count_comes_back_in_the_box(
     to work out what they typed before they can adjust it.
     """
     flow_id = await _start_config_flow(hass)
-    await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
+    await async_configure_flow(hass, flow_id, {"next_step_id": "ui"})
 
     with _capacity_probe(return_value=_capabilities_with_slots(2)), _holding():
-        result = await hass.config_entries.flow.async_configure(
-            flow_id, {CONF_NUM_USERS: 8}
-        )
+        result = await async_configure_flow(hass, flow_id, {CONF_NUM_USERS: 8})
 
     assert result["errors"] == {"base": "too_many_users"}
     suggested = [
@@ -1766,15 +1737,13 @@ async def test_the_search_stops_at_the_end_of_the_lock(
         }
 
     flow_id = await _start_config_flow(hass)
-    await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
+    await async_configure_flow(hass, flow_id, {"next_step_id": "ui"})
 
     with (
         patch.object(MockLCMLock, "async_get_max_slot", AsyncMock(return_value=10)),
         patch.object(MockLCMLock, "async_get_usercodes", _read),
     ):
-        result = await hass.config_entries.flow.async_configure(
-            flow_id, {CONF_NUM_USERS: 2}
-        )
+        result = await async_configure_flow(hass, flow_id, {CONF_NUM_USERS: 2})
 
     assert result["errors"] == {"base": "numbers_needed_exceed_capacity"}
     # Two users on a lock whose ten slots are all taken: the second would
@@ -1789,11 +1758,12 @@ async def test_the_smallest_lock_bounds_the_search(
 ):
     """Every lock in an entry gets the same numbers, so the smallest wins."""
     flow_id = await _init_flow_to_user_step(hass)
-    await hass.config_entries.flow.async_configure(
+    await async_configure_flow(
+        hass,
         flow_id,
         {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID, LOCK_2_ENTITY_ID]},
     )
-    await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
+    await async_configure_flow(hass, flow_id, {"next_step_id": "ui"})
 
     limits = {LOCK_1_ENTITY_ID: 30, LOCK_2_ENTITY_ID: 4}
 
@@ -1807,9 +1777,7 @@ async def test_the_smallest_lock_bounds_the_search(
         patch.object(MockLCMLock, "async_get_max_slot", _max_slot),
         _holding(1, 2, 3),
     ):
-        result = await hass.config_entries.flow.async_configure(
-            flow_id, {CONF_NUM_USERS: 2}
-        )
+        result = await async_configure_flow(hass, flow_id, {CONF_NUM_USERS: 2})
 
     # Three taken means the pair would need numbers 4 and 5, and the smaller
     # lock stops at 4.
@@ -1835,15 +1803,13 @@ async def test_a_count_past_the_range_is_refused_before_reading(
         return dict.fromkeys(scope, SlotCredential.empty())
 
     flow_id = await _start_config_flow(hass)
-    await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
+    await async_configure_flow(hass, flow_id, {"next_step_id": "ui"})
 
     with (
         patch.object(MockLCMLock, "async_get_max_slot", AsyncMock(return_value=5)),
         patch.object(MockLCMLock, "async_get_usercodes", _read),
     ):
-        result = await hass.config_entries.flow.async_configure(
-            flow_id, {CONF_NUM_USERS: 20}
-        )
+        result = await async_configure_flow(hass, flow_id, {CONF_NUM_USERS: 20})
 
     assert result["type"] == "form"
     assert result["errors"] == {"base": "too_many_users"}
@@ -1857,16 +1823,16 @@ async def test_the_last_number_a_lock_holds_is_usable(
 ):
     """The bound is the highest usable number, not one past it."""
     flow_id = await _start_config_flow(hass)
-    await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
+    await async_configure_flow(hass, flow_id, {"next_step_id": "ui"})
 
     # Four of five slots taken: the one user must land on 5, the last one.
     with (
         patch.object(MockLCMLock, "async_get_max_slot", AsyncMock(return_value=5)),
         _holding(1, 2, 3, 4),
     ):
-        await hass.config_entries.flow.async_configure(flow_id, {CONF_NUM_USERS: 1})
-        result = await hass.config_entries.flow.async_configure(
-            flow_id, {CONF_NAME: "Raman", CONF_ENABLED: True, CONF_PIN: "1111"}
+        await async_configure_flow(hass, flow_id, {CONF_NUM_USERS: 1})
+        result = await async_configure_flow(
+            hass, flow_id, {CONF_NAME: "Raman", CONF_ENABLED: True, CONF_PIN: "1111"}
         )
 
     assert result["type"] == "create_entry"
@@ -1882,7 +1848,7 @@ async def test_a_lock_that_allocates_its_own_index_does_not_bound_the_search(
     would silently cap every slot number in the entry.
     """
     flow_id = await _start_config_flow(hass)
-    await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
+    await async_configure_flow(hass, flow_id, {"next_step_id": "ui"})
 
     with (
         patch.object(
@@ -1893,9 +1859,7 @@ async def test_a_lock_that_allocates_its_own_index_does_not_bound_the_search(
         ),
         patch.object(MockLCMLock, "async_get_max_slot", AsyncMock(return_value=2)),
     ):
-        result = await hass.config_entries.flow.async_configure(
-            flow_id, {CONF_NUM_USERS: 8}
-        )
+        result = await async_configure_flow(hass, flow_id, {CONF_NUM_USERS: 8})
 
     # Its answer of 2 is not consulted, so eight users are fine.
     assert result["type"] == "form"
@@ -1911,15 +1875,15 @@ async def test_no_lock_that_can_answer_leaves_our_own_limit(
     over a number the lock never reported.
     """
     flow_id = await _start_config_flow(hass)
-    await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
+    await async_configure_flow(hass, flow_id, {"next_step_id": "ui"})
 
     # An ordinary lock that simply does not report a range -- the common
     # case, not an exotic one. It must not be named as the source of a limit
     # it never gave, or the user is sent to re-interview it over a number it
     # never reported.
     with patch.object(MockLCMLock, "async_get_max_slot", AsyncMock(return_value=None)):
-        result = await hass.config_entries.flow.async_configure(
-            flow_id, {CONF_NUM_USERS: MAX_SEARCHED_SLOT + 1}
+        result = await async_configure_flow(
+            hass, flow_id, {CONF_NUM_USERS: MAX_SEARCHED_SLOT + 1}
         )
 
     assert result["errors"] == {"base": "search_limit_reached"}
@@ -1936,17 +1900,16 @@ async def test_a_lock_that_reports_its_range_is_the_one_named(
     has to be named every time rather than whichever came first.
     """
     flow_id = await _init_flow_to_user_step(hass)
-    await hass.config_entries.flow.async_configure(
+    await async_configure_flow(
+        hass,
         flow_id,
         {CONF_NAME: "test", CONF_LOCKS: [LOCK_2_ENTITY_ID, LOCK_1_ENTITY_ID]},
     )
-    await hass.config_entries.flow.async_configure(flow_id, {"next_step_id": "ui"})
+    await async_configure_flow(hass, flow_id, {"next_step_id": "ui"})
 
     # Both answer the same, so the name cannot come from iteration order.
     with patch.object(MockLCMLock, "async_get_max_slot", AsyncMock(return_value=4)):
-        result = await hass.config_entries.flow.async_configure(
-            flow_id, {CONF_NUM_USERS: 9}
-        )
+        result = await async_configure_flow(hass, flow_id, {CONF_NUM_USERS: 9})
 
     assert result["errors"] == {"base": "too_many_users"}
     assert result["description_placeholders"]["num_slots"] == "4"
@@ -2037,7 +2000,8 @@ async def test_setup_refuses_when_a_lock_cannot_be_read(
         raise LockCodeManagerError("lock is asleep")
 
     with patch.object(MockLCMLock, "async_get_usercodes", _unreadable):
-        result = await hass.config_entries.flow.async_configure(
+        result = await async_configure_flow(
+            hass,
             flow_id,
             {CONF_USERS: {"Raman": {CONF_ENABLED: True, CONF_PIN: "1234"}}},
         )
@@ -2056,7 +2020,8 @@ async def test_editing_refuses_when_a_lock_cannot_be_read(
         raise LockCodeManagerError("lock is asleep")
 
     with patch.object(MockLCMLock, "async_get_usercodes", _unreadable):
-        result = await hass.config_entries.options.async_configure(
+        result = await async_configure_options(
+            hass,
             flow_id,
             {
                 CONF_LOCKS: [LOCK_1_ENTITY_ID],
@@ -2134,7 +2099,8 @@ async def test_an_entry_may_reuse_a_number_it_just_released(
     flow_id, _ = await _start_options_flow(hass)
 
     with _holding():
-        result = await hass.config_entries.options.async_configure(
+        result = await async_configure_options(
+            hass,
             flow_id,
             {
                 CONF_LOCKS: [LOCK_1_ENTITY_ID],
@@ -2153,7 +2119,8 @@ async def test_another_entry_still_holds_its_numbers(
     flow_id, _ = await _start_options_flow(hass, locks=[LOCK_1_ENTITY_ID])
 
     with _holding():
-        result = await hass.config_entries.options.async_configure(
+        result = await async_configure_options(
+            hass,
             flow_id,
             {
                 CONF_LOCKS: [LOCK_1_ENTITY_ID],
@@ -2189,7 +2156,8 @@ async def test_editing_keeps_what_the_form_never_asked_about(
     started = await hass.config_entries.options.async_init(entry.entry_id)
 
     with _holding():
-        result = await hass.config_entries.options.async_configure(
+        result = await async_configure_options(
+            hass,
             started["flow_id"],
             {
                 CONF_LOCKS: [LOCK_1_ENTITY_ID],
@@ -2218,7 +2186,8 @@ async def test_the_editor_refuses_a_condition_entity_the_guided_path_would(
 
     flow_id = await _start_yaml_config_flow(hass)
     with _holding():
-        result = await hass.config_entries.flow.async_configure(
+        result = await async_configure_flow(
+            hass,
             flow_id,
             {
                 CONF_USERS: {
@@ -2253,8 +2222,8 @@ async def test_reauth_reports_a_lock_too_small_for_the_existing_slots(
 
     [flow] = entry.async_get_active_flows(hass, {SOURCE_REAUTH})
     with _capacity_probe(return_value=_capabilities_with_slots(1)):
-        result = await hass.config_entries.flow.async_configure(
-            flow["flow_id"], {CONF_LOCKS: [LOCK_1_ENTITY_ID]}
+        result = await async_configure_flow(
+            hass, flow["flow_id"], {CONF_LOCKS: [LOCK_1_ENTITY_ID]}
         )
 
     assert result["errors"] == {"base": "slot_out_of_range"}
@@ -2284,7 +2253,8 @@ async def test_user_step_rejects_unclaimed_mqtt_lock(
     unclaimed = await async_discover_unclaimed_mqtt_lock(hass)
     flow_id = await _init_flow_to_user_step(hass)
 
-    result = await hass.config_entries.flow.async_configure(
+    result = await async_configure_flow(
+        hass,
         flow_id,
         {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID, unclaimed.entity_id]},
     )
@@ -2300,8 +2270,8 @@ async def test_user_step_rejects_unclaimed_mqtt_lock(
         CONF_LOCKS: [LOCK_1_ENTITY_ID, unclaimed.entity_id],
     }
 
-    result = await hass.config_entries.flow.async_configure(
-        flow_id, {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
+    result = await async_configure_flow(
+        hass, flow_id, {CONF_NAME: "test", CONF_LOCKS: [LOCK_1_ENTITY_ID]}
     )
 
     assert result["type"] == "menu"
@@ -2315,8 +2285,8 @@ async def test_user_step_accepts_claimed_mqtt_lock(
     z2m_lock = await async_discover_z2m_lock(hass)
     flow_id = await _init_flow_to_user_step(hass)
 
-    result = await hass.config_entries.flow.async_configure(
-        flow_id, {CONF_NAME: "test", CONF_LOCKS: [z2m_lock.entity_id]}
+    result = await async_configure_flow(
+        hass, flow_id, {CONF_NAME: "test", CONF_LOCKS: [z2m_lock.entity_id]}
     )
 
     assert result["type"] == "menu"
@@ -2336,7 +2306,8 @@ async def test_options_flow_rejects_unclaimed_mqtt_lock(
     flow_id = started["flow_id"]
 
     with _holding():
-        result = await hass.config_entries.options.async_configure(
+        result = await async_configure_options(
+            hass,
             flow_id,
             user_input={
                 CONF_LOCKS: [LOCK_1_ENTITY_ID, unclaimed.entity_id],
@@ -2350,7 +2321,8 @@ async def test_options_flow_rejects_unclaimed_mqtt_lock(
     assert result["description_placeholders"]["locks"] == unclaimed.entity_id
 
     with _holding():
-        result = await hass.config_entries.options.async_configure(
+        result = await async_configure_options(
+            hass,
             flow_id,
             user_input={CONF_LOCKS: [LOCK_1_ENTITY_ID], CONF_USERS: users},
         )
@@ -2386,7 +2358,8 @@ async def test_options_flow_saves_around_a_grandfathered_unclaimed_lock(
     started = await hass.config_entries.options.async_init(entry.entry_id)
 
     with _holding():
-        result = await hass.config_entries.options.async_configure(
+        result = await async_configure_options(
+            hass,
             started["flow_id"],
             user_input={
                 CONF_LOCKS: locks,
@@ -2423,7 +2396,8 @@ async def test_options_flow_still_refuses_a_newly_added_unclaimed_lock(
     started = await hass.config_entries.options.async_init(entry.entry_id)
 
     with _holding():
-        result = await hass.config_entries.options.async_configure(
+        result = await async_configure_options(
+            hass,
             started["flow_id"],
             user_input={
                 CONF_LOCKS: [
@@ -2454,7 +2428,8 @@ async def test_options_flow_renders_lock_and_users_errors_together(
     unclaimed = await async_discover_unclaimed_mqtt_lock(hass)
     flow_id, _ = await _start_options_flow(hass)
 
-    result = await hass.config_entries.options.async_configure(
+    result = await async_configure_options(
+        hass,
         flow_id,
         {
             CONF_LOCKS: [LOCK_1_ENTITY_ID, unclaimed.entity_id],
@@ -2486,8 +2461,8 @@ async def test_reauth_rejects_unclaimed_mqtt_lock(
     await hass.async_block_till_done()
 
     [flow] = entry.async_get_active_flows(hass, {SOURCE_REAUTH})
-    result = await hass.config_entries.flow.async_configure(
-        flow["flow_id"], {CONF_LOCKS: [unclaimed.entity_id]}
+    result = await async_configure_flow(
+        hass, flow["flow_id"], {CONF_LOCKS: [unclaimed.entity_id]}
     )
 
     assert result["type"] == "form"
@@ -2524,9 +2499,112 @@ async def test_reauth_completes_around_a_grandfathered_unclaimed_lock(
     await hass.async_block_till_done()
 
     [flow] = entry.async_get_active_flows(hass, {SOURCE_REAUTH})
-    result = await hass.config_entries.flow.async_configure(
-        flow["flow_id"], {CONF_LOCKS: [LOCK_2_ENTITY_ID, unclaimed.entity_id]}
+    result = await async_configure_flow(
+        hass, flow["flow_id"], {CONF_LOCKS: [LOCK_2_ENTITY_ID, unclaimed.entity_id]}
     )
 
     assert result["type"] == "abort"
     assert result["reason"] == "locks_updated"
+
+
+async def test_ui_allocation_runs_as_a_progress_step(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """The count submission shows progress while the locks are read (#1536).
+
+    A lock that answers one index per round trip can take a minute or more;
+    the dialog reports the read instead of freezing. The read reports how
+    many locks have answered, and the flow moves on once it is done.
+    """
+    flow_id = await _start_config_flow(hass)
+    await async_configure_flow(hass, flow_id, {"next_step_id": "ui"})
+    updates = async_capture_events(hass, EVENT_DATA_ENTRY_FLOW_PROGRESS_UPDATE)
+
+    with _holding():
+        result = await hass.config_entries.flow.async_configure(
+            flow_id, {CONF_NUM_USERS: 2}
+        )
+        assert result["type"] == "progress"
+        assert result["step_id"] == "ui"
+        assert result["progress_action"] == "allocating"
+
+        await hass.async_block_till_done()
+        result = await hass.config_entries.flow.async_configure(flow_id)
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "code_slot"
+    # One lock: reported before it is asked and once it has answered.
+    assert [event.data["progress"] for event in updates] == [0.0, 1.0]
+
+
+async def test_options_allocation_reads_only_numbers_the_entry_does_not_hold(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """Numbers this entry already holds are taken by tenure and are not read (#1536).
+
+    Adding one user to an entry holding 1-3 asks the lock about 4 only; the
+    newcomer is numbered 4 and nobody moves.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="test",
+        data={
+            CONF_LOCKS: [LOCK_1_ENTITY_ID],
+            CONF_USERS: {
+                f"User {n}": {CONF_ENABLED: True, CONF_PIN: f"{n}{n}{n}{n}"}
+                for n in (1, 2, 3)
+            },
+            CONF_SLOT_ASSIGNMENT: {"user 1": 1, "user 2": 2, "user 3": 3},
+        },
+    )
+    entry.add_to_hass(hass)
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    asked: list[frozenset[int]] = []
+
+    async def _read(self, slots=None):
+        asked.append(frozenset(self.managed_slots if slots is None else slots))
+        return {slot: SlotCredential.empty() for slot in asked[-1]}
+
+    with patch.object(MockLCMLock, "async_get_usercodes", _read):
+        result = await async_configure_options(
+            hass,
+            result["flow_id"],
+            {
+                CONF_LOCKS: [LOCK_1_ENTITY_ID],
+                CONF_USERS: {
+                    **{
+                        f"User {n}": {CONF_ENABLED: True, CONF_PIN: f"{n}{n}{n}{n}"}
+                        for n in (1, 2, 3)
+                    },
+                    "User 4": {CONF_ENABLED: True, CONF_PIN: "4444"},
+                },
+            },
+        )
+
+    assert result["type"] == "create_entry"
+    assert asked and all(not scope & {1, 2, 3} for scope in asked)
+    assert 4 in set().union(*asked)
+    assert result["data"][CONF_SLOT_ASSIGNMENT] == {
+        "user 1": 1,
+        "user 2": 2,
+        "user 3": 3,
+        "user 4": 4,
+    }
+
+
+async def test_allocation_failing_unexpectedly_comes_back_to_the_form(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """A read that raises something unforeseen is a form error, not "Unknown error"."""
+    flow_id = await _start_config_flow(hass)
+    await async_configure_flow(hass, flow_id, {"next_step_id": "ui"})
+
+    with patch(
+        "custom_components.lock_code_manager.config_flow.async_allocate_for",
+        AsyncMock(side_effect=RuntimeError("boom")),
+    ):
+        result = await async_configure_flow(hass, flow_id, {CONF_NUM_USERS: 2})
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "ui"
+    assert result["errors"] == {"base": "allocation_failed"}

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -13,10 +13,17 @@ from pytest_homeassistant_custom_component.common import (
     async_capture_events,
 )
 
-from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_USER
+from homeassistant.config_entries import (
+    SOURCE_REAUTH,
+    SOURCE_USER,
+    OptionsFlowManager,
+)
 from homeassistant.const import CONF_CONDITION, CONF_ENABLED, CONF_NAME, CONF_PIN
 from homeassistant.core import HomeAssistant
-from homeassistant.data_entry_flow import EVENT_DATA_ENTRY_FLOW_PROGRESS_UPDATE
+from homeassistant.data_entry_flow import (
+    EVENT_DATA_ENTRY_FLOW_PROGRESS_UPDATE,
+    UnknownFlow,
+)
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from custom_components.lock_code_manager.config_flow import _check_common_slots
@@ -2534,8 +2541,11 @@ async def test_ui_allocation_runs_as_a_progress_step(
 
     assert result["type"] == "form"
     assert result["step_id"] == "code_slot"
-    # One lock: reported before it is asked and once it has answered.
-    assert [event.data["progress"] for event in updates] == [0.0, 1.0]
+    # One lock, one pass: reported before the lock is asked, once it has
+    # answered -- a pass takes half of what is left, since how many passes
+    # there will be is not knowable in advance -- and once the whole
+    # allocation is done.
+    assert [event.data["progress"] for event in updates] == [0.0, 0.5, 1.0]
 
 
 async def test_options_allocation_reads_only_numbers_the_entry_does_not_hold(
@@ -2543,8 +2553,8 @@ async def test_options_allocation_reads_only_numbers_the_entry_does_not_hold(
 ) -> None:
     """Numbers this entry already holds are taken by tenure and are not read (#1536).
 
-    Adding one user to an entry holding 1-3 asks the lock about 4 only; the
-    newcomer is numbered 4 and nobody moves.
+    Adding one user to an entry holding 1-3 asks the lock about 4 and nothing
+    else; the newcomer is numbered 4 and nobody moves.
     """
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -2583,8 +2593,7 @@ async def test_options_allocation_reads_only_numbers_the_entry_does_not_hold(
         )
 
     assert result["type"] == "create_entry"
-    assert asked and all(not scope & {1, 2, 3} for scope in asked)
-    assert 4 in set().union(*asked)
+    assert asked == [frozenset({4})]
     assert result["data"][CONF_SLOT_ASSIGNMENT] == {
         "user 1": 1,
         "user 2": 2,
@@ -2646,3 +2655,134 @@ async def test_reentering_the_step_while_the_read_runs_shows_progress_again(
     assert result["type"] == "form"
     assert result["step_id"] == "code_slot"
     assert len(reads) == 1
+
+
+async def test_an_entry_can_still_add_a_user_when_its_own_users_nearly_fill_the_lock(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """Numbers this entry's own users hold must not push the window past the lock.
+
+    Ten users on a twelve-slot lock, adding an eleventh: the ten numbers are
+    theirs by tenure, so only slot 11 has to be free. Counting them as though
+    a stranger held them reached for twenty-one numbers to place eleven
+    people and refused an entry that was merely full of itself (#1536).
+    """
+    users = {
+        f"User {n}": {CONF_ENABLED: True, CONF_PIN: f"{n:04d}"} for n in range(1, 11)
+    }
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="test",
+        data={
+            CONF_LOCKS: [LOCK_1_ENTITY_ID],
+            CONF_USERS: users,
+            CONF_SLOT_ASSIGNMENT: {f"user {n}": n for n in range(1, 11)},
+        },
+    )
+    entry.add_to_hass(hass)
+    started = await hass.config_entries.options.async_init(entry.entry_id)
+
+    with _holding(), _capacity_probe(return_value=_capabilities_with_slots(12)):
+        result = await async_configure_options(
+            hass,
+            started["flow_id"],
+            {
+                CONF_LOCKS: [LOCK_1_ENTITY_ID],
+                CONF_USERS: {
+                    **users,
+                    "User 11": {CONF_ENABLED: True, CONF_PIN: "1111"},
+                },
+            },
+        )
+
+    assert result["type"] == "create_entry"
+    assert result["data"][CONF_SLOT_ASSIGNMENT]["user 11"] == 11
+
+
+async def test_progress_only_moves_forward_across_widening_passes(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """A read that widens its window does not send the bar back to the start.
+
+    Slots 1 and 2 are taken, so placing two users reads 1-2, finds them
+    occupied and widens to 3-4. How many passes there will be is not knowable
+    in advance, so each takes half of what is left; a fraction that restarted
+    on every pass would read as a hang, which is the symptom the progress
+    exists to remove (#1536).
+    """
+    flow_id = await _start_config_flow(hass)
+    await async_configure_flow(hass, flow_id, {"next_step_id": "ui"})
+    updates = async_capture_events(hass, EVENT_DATA_ENTRY_FLOW_PROGRESS_UPDATE)
+
+    with _holding(1, 2):
+        result = await async_configure_flow(hass, flow_id, {CONF_NUM_USERS: 2})
+
+    assert result["step_id"] == "code_slot"
+    reported = [event.data["progress"] for event in updates]
+    assert len(reported) > 2  # more than one pass was read
+    assert reported == sorted(reported)
+    assert reported[-1] == 1.0
+
+
+async def test_a_second_request_for_an_answered_step_is_not_an_unknown_error(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """A duplicated request reaches a step the first one already took.
+
+    The flow sits on the progress-done step for as long as answering it takes
+    -- saving the entry and setting the integration up -- so a second open
+    dialog or a client retry lands there. It gets the 404 Home Assistant
+    gives any request for a step that is gone, and the request busy saving is
+    left alone to finish (#1536).
+    """
+    flow_id, entry = await _start_options_flow(hass)
+    let_it_read = asyncio.Event()
+    saving = asyncio.Event()
+    let_it_save = asyncio.Event()
+    finish_flow = OptionsFlowManager.async_finish_flow
+
+    async def _slow_read(self, slots=None):
+        await let_it_read.wait()
+        scope = self.managed_slots if slots is None else slots
+        return {slot: SlotCredential.empty() for slot in scope}
+
+    async def _slow_save(self, flow, result):
+        saving.set()
+        await let_it_save.wait()
+        return await finish_flow(self, flow, result)
+
+    with (
+        patch.object(MockLCMLock, "async_get_usercodes", _slow_read),
+        patch.object(OptionsFlowManager, "async_finish_flow", _slow_save),
+    ):
+        result = await hass.config_entries.options.async_configure(
+            flow_id,
+            {
+                CONF_LOCKS: [LOCK_1_ENTITY_ID],
+                CONF_USERS: {
+                    # A newcomer, so there is a slot to read and the flow is
+                    # really left waiting on the lock.
+                    "User 1": {CONF_ENABLED: True, CONF_PIN: "1234"},
+                    "User 2": {CONF_ENABLED: True, CONF_PIN: "5678"},
+                },
+            },
+        )
+        assert result["type"] == "progress"
+
+        # Once the read finishes Home Assistant parks the flow on the
+        # progress-done step; the next request is what runs it. Hold that one
+        # inside the save, with the flow still on that step, and send another.
+        let_it_read.set()
+        await hass.async_block_till_done()
+        saved = hass.async_create_task(
+            hass.config_entries.options.async_configure(flow_id)
+        )
+        await saving.wait()
+
+        with pytest.raises(UnknownFlow):
+            await hass.config_entries.options.async_configure(flow_id)
+
+        let_it_save.set()
+        assert (await saved)["type"] == "create_entry"
+
+    assert entry.options[CONF_SLOT_ASSIGNMENT] == {"user 1": 1, "user 2": 2}

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,5 +1,6 @@
 """Config flow tests."""
 
+import asyncio
 import json
 import logging
 from pathlib import Path
@@ -2608,3 +2609,40 @@ async def test_allocation_failing_unexpectedly_comes_back_to_the_form(
     assert result["type"] == "form"
     assert result["step_id"] == "ui"
     assert result["errors"] == {"base": "allocation_failed"}
+
+
+async def test_reentering_the_step_while_the_read_runs_shows_progress_again(
+    hass: HomeAssistant, mock_lock_config_entry
+) -> None:
+    """A poll of the flow while the locks are still being read stays on progress.
+
+    Home Assistant re-enters the step itself when the task finishes; a client
+    asking earlier must not restart the read or fall through to the form.
+    """
+    flow_id = await _start_config_flow(hass)
+    await async_configure_flow(hass, flow_id, {"next_step_id": "ui"})
+    let_go = asyncio.Event()
+    reads: list[int] = []
+
+    async def _slow_read(self, slots=None):
+        reads.append(1)
+        await let_go.wait()
+        scope = self.managed_slots if slots is None else slots
+        return {slot: SlotCredential.empty() for slot in scope}
+
+    with patch.object(MockLCMLock, "async_get_usercodes", _slow_read):
+        result = await hass.config_entries.flow.async_configure(
+            flow_id, {CONF_NUM_USERS: 2}
+        )
+        assert result["type"] == "progress"
+        result = await hass.config_entries.flow.async_configure(flow_id)
+        assert result["type"] == "progress"
+        assert result["progress_action"] == "allocating"
+
+        let_go.set()
+        await hass.async_block_till_done()
+        result = await hass.config_entries.flow.async_configure(flow_id)
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "code_slot"
+    assert len(reads) == 1

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -2552,7 +2552,7 @@ async def test_the_batch_is_allocated_for_everyone_it_will_add(
     existing = len(get_entry_config(entry).users)
     asked_for: list[int] = []
 
-    async def _spy(hass, config_entry, locks, num_users, config=None):
+    async def _spy(hass, config_entry, locks, num_users, config=None, **kwargs):
         asked_for.append(num_users)
         return frozenset()
 


### PR DESCRIPTION
## Proposed change

Fixes #1536.

### The bug

Both callers of allocation are interactive: the config flow (guided and YAML paths) and the `add_users` action. Each lock's occupancy read is bounded by its provider's budget, but allocation walks locks serially over a window as wide as the users being added, and a lock that answers one index per round trip can take a minute or more per lock. A bulk add against a slow lock left a person in front of a frozen dialog with nothing on screen. #1529 put a 120 s cap over the whole read; every per-operation budget is floored at 600 s, so the cap fired first every time and failed locks that work today.

### The fix

- **Progress instead of a bound.** Allocation runs as a flow progress task in all three steps (guided count, YAML users, options editor). The step that takes the submission starts the task and returns `async_show_progress`; the occupancy read reports the fraction of locks that have answered through `async_update_progress`; Home Assistant parks the flow on a progress-done step when the task completes, and the next request runs a follow-on step (`ui_allocated`, `yaml_allocated`, `init_allocated`) that either proceeds or re-shows the same form with the refusal and the submitted values. No honest read is shortened. The `add_users` action cannot stream and stays blocking.
- **Progress only moves forward.** How many widening passes there will be is not knowable in advance, so each takes half of whatever fraction is left. A bar that restarts on every pass reads as a hang, which is the symptom this exists to remove. Within a pass it is per lock, so a single-lock entry sees the passes rather than the indices.
- **A read that raises something unforeseen** comes back as a form error (`allocation_failed`) rather than the "Unknown error" a progress task would otherwise produce.
- **A duplicated request is a 404, not an error.** The flow sits on the progress-done step for as long as answering it takes -- saving the entry and setting the integration up -- so a second open dialog or a client retry can reach a step the first request already took. It raises `UnknownFlow`, which the view turns into the 404 Home Assistant gives any request for a step that is gone, and which leaves the request busy saving alone; aborting would pull the flow out from under it.
- **Numbers held by tenure are neither read nor counted as occupied.** `SlotAssignment.held_by(names)` says which numbers the users staying through an edit keep. Allocation skips reading them, and does not name them in what it returns: `reconcile` already keeps them for the users holding them, so counting them again only widened the window as though a stranger held them -- ten users on a fifteen-slot lock could not take an eleventh, because placing eleven people reached for twenty-one numbers. A number a user is releasing in the same edit is not held, is read like any other, and stays free for whoever comes next.

With #1553's per-exchange bound a wedged lock is caught within one exchange regardless of window width, so what remains here is a legitimately slow lock, which is what the progress step makes legible. The two PRs are independent and can land in either order.

### Verification

- Full suite green at 100% line coverage. Every flow test that submits through allocation goes through a shared helper that waits out the progress step, so the assertions on the final result are unchanged.
- Ten mutants, each killed by the test written for it: held numbers read anyway; held numbers counted as occupied anyway; no per-lock progress; no completion report; each pass reporting the whole bar again; an unforeseen failure escaping as Unknown error; a duplicate request asserting instead of 404-ing; progress-done routing back to the same step; `held_by` returning every slot; the broad except removed.
- One review round, whose two MEDIUMs are fixed: the duplicate-request assert, and the over-widening described above. Its LOW about a stray late callback re-rendering a blank form is left as it stands -- the window is one event-loop hop, no refresh event is fired, and nothing is lost unless the dialog is reloaded.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #1536
- This PR is related to issue: #1523, #1528, #1529, #1535

🤖 Generated with [Claude Code](https://claude.com/claude-code)
